### PR TITLE
feat: complete repo scaffolding — CI, settings, sync, uninstall, changelog

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,21 @@
+name: Validate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Install shfmt
+        run: |
+          GOBIN=/usr/local/bin go install mvdan.cc/sh/v3/cmd/shfmt@latest
+
+      - name: Run validation
+        run: ./scripts/ci/validate.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+stages:
+  - validate
+
+validate:
+  stage: validate
+  image: ubuntu:24.04
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq shellcheck golang-go > /dev/null 2>&1
+    - GOBIN=/usr/local/bin go install mvdan.cc/sh/v3/cmd/shfmt@latest
+  script:
+    - ./scripts/ci/validate.sh
+  rules:
+    - if: $CI_MERGE_REQUEST_IID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-03-22
+
+### Added
+
+- **CLAUDE.md template** — Drop-in project instructions with auto-detection for GitHub and GitLab
+  - Platform detection from `git remote -v`
+  - Discovery-based code standards (finds project's own tooling)
+  - Agent identity system (Dev-Team persisted, Dev-Name/Dev-Avatar per-session)
+  - Pre-commit checklist with mandatory verification
+  - Secrets guardrail (warn-and-confirm before staging sensitive files)
+  - PR/MR description format
+
+- **11 custom skills** — All dual-platform (GitHub + GitLab)
+  - `cryo` — Session state preservation before compaction
+  - `engage` — Load rules of engagement
+  - `ibm` — Issue-Branch-PR/MR workflow
+  - `jfail` — CI job/workflow failure analysis
+  - `mmr` — Merge PR/MR with squash
+  - `nextwave` — Parallel sub-agent execution
+  - `ping` — Post to #ai-dev Slack channel
+  - `pong` — Read #ai-dev Slack channel
+  - `prepwaves` — Dependency wave planning
+  - `review` — Code review on staged/branch changes
+  - `scp` — Stage/commit/push workflow
+
+- **Utility scripts**
+  - `slackbot-send` — Send Slack messages as a named Claude Code agent
+  - `job-fetch` — Fetch GitLab CI job traces for analysis
+  - `statusline-command.sh` — Custom status line with git info and context window
+
+- **Deployment tooling**
+  - `install.sh` — Install skills, scripts, and config with backup and diff-skip
+  - `install.sh --check` — Show drift between repo and installed versions
+  - `install.sh --dry-run` — Preview changes without modifying files
+  - `uninstall.sh` — Clean removal of installed components
+  - `settings.template.json` — Portable Claude Code settings template
+
+- **CI and repo scaffolding**
+  - GitHub Actions workflow for PR validation
+  - `validate.sh` — shellcheck + shfmt + SKILL.md frontmatter checks
+  - Issue templates (bug report, feature request)
+  - PR template matching CLAUDE.md conventions
+  - MIT license

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # claudecode-workflow
 
-Portable Claude Code workflow environment — skills, scripts, and a drop-in `CLAUDE.md` template.
+Portable Claude Code workflow environment — skills, scripts, settings, and a drop-in `CLAUDE.md` template.
 
 This repo packages the custom skills, utility scripts, and project instructions that make up a consistent Claude Code development environment. Clone it, run the installer, and you're set up on any machine.
+
+## Quick Start
+
+```bash
+git clone https://github.com/Wave-Engineering/claudecode-workflow.git
+cd claudecode-workflow
+./install.sh
+```
 
 ## What's Included
 
@@ -12,10 +20,11 @@ A drop-in project instructions file that works with both GitHub and GitLab proje
 
 Key features:
 - **Platform detection** — GitHub (`gh`) vs GitLab (`glab`), auto-detected
-- **Discovery-based tooling** — finds the project's linters, formatters, and test runners instead of assuming a stack
+- **Discovery-based code standards** — finds the project's linters, formatters, and test runners instead of assuming a stack
 - **Pre-commit checklist** — enforced review protocol with mandatory verification steps
 - **Agent identity system** — Dev-Team (persisted per-project) + Dev-Name/Dev-Avatar (ephemeral per-session)
 - **Secrets guardrail** — warns before staging sensitive files, confirms with user before proceeding
+- **PR/MR description format** — consistent structure for pull/merge requests
 
 ### Skills
 
@@ -39,53 +48,66 @@ Key features:
 |--------|-------------|-------------|
 | `slackbot-send` | `curl`, `jq`, Slack bot token | Send Slack messages as a named Claude Code agent |
 | `job-fetch` | `glab`, `python3` | Fetch GitLab CI job traces for analysis |
+| `statusline-command.sh` | `jq`, `git` | Custom status line: git branch, dirty state, context window remaining, model |
+
+### Settings Template
+
+`settings.template.json` provides a starting point for `~/.claude/settings.json` with:
+- **Permissions** — Granular tool allowlists for common CLIs (git, gh, glab, docker, terraform, aws, etc.)
+- **Hooks** — PostToolUse, SessionStart, SubagentStop hook structure (requires [context-crystallizer](https://github.com/Wave-Engineering/context-crystallizer) or equivalent)
+- **Status line** — Points to the custom statusline script
+- **Plugins** — Full plugin list (see Plugins section below)
+- **Effort level** — Set to `high` for thorough responses
 
 ## Installation
 
+### Full Install
+
 ```bash
-git clone https://github.com/Wave-Engineering/claudecode-workflow.git
-cd claudecode-workflow
 ./install.sh
 ```
 
-The installer:
-- Copies skills to `~/.claude/skills/`
-- Copies scripts to `~/.local/bin/`
-- Backs up existing files before overwriting (`.bak`)
-- Skips unchanged files
-- Reports missing dependencies
+This will:
+- Copy skills to `~/.claude/skills/`
+- Copy scripts to `~/.local/bin/`
+- Install statusline to `~/.claude/statusline-command.sh`
+- Copy `settings.template.json` → `~/.claude/settings.json` (only if no settings exist yet)
+- Back up existing files before overwriting (`.bak`)
+- Skip unchanged files
+- Report missing dependencies
 
 ### Options
 
 ```bash
-./install.sh --dry-run    # Show what would be done
-./install.sh --skills     # Install skills only
-./install.sh --scripts    # Install scripts only
+./install.sh --dry-run     # Show what would be done
+./install.sh --check       # Show drift between repo and installed versions
+./install.sh --skills      # Install skills only
+./install.sh --scripts     # Install scripts only
+./install.sh --config      # Install config files only
 ```
 
-### Dependencies
+### Check for Drift
 
-| Tool | Required by | Install |
-|------|------------|---------|
-| `gh` | GitHub skills | [cli.github.com](https://cli.github.com) |
-| `glab` | GitLab skills | [gitlab.com/gitlab-org/cli](https://gitlab.com/gitlab-org/cli) |
-| `curl` | slackbot-send | Usually pre-installed |
-| `jq` | slackbot-send | `apt install jq` / `brew install jq` |
-| `python3` | job-fetch | Usually pre-installed |
-| `shellcheck` | Validation | `apt install shellcheck` / `brew install shellcheck` |
-| `shfmt` | Validation | `go install mvdan.cc/sh/v3/cmd/shfmt@latest` |
-
-### Slack Setup (for /ping and /pong)
-
-Create a Slack bot token and save it:
+After making local changes to skills or scripts, see what's out of sync:
 
 ```bash
-mkdir -p ~/secrets
-echo "xoxb-your-token" > ~/secrets/slack-bot-token
-chmod 600 ~/secrets/slack-bot-token
+./install.sh --check
 ```
 
-## Using the CLAUDE.md Template
+This compares every installed file against the repo version and reports `in sync`, `DIFFERS`, or `NOT INSTALLED`.
+
+### Uninstall
+
+```bash
+./uninstall.sh              # Remove everything
+./uninstall.sh --dry-run    # Preview what would be removed
+./uninstall.sh --skills     # Remove skills only
+./uninstall.sh --scripts    # Remove scripts only
+```
+
+Settings and credentials are never removed by the uninstall script.
+
+### Using the CLAUDE.md Template
 
 Copy `CLAUDE.md` into the root of any project:
 
@@ -100,13 +122,71 @@ On first session, Claude will:
 
 No other configuration needed.
 
+## Plugins
+
+The settings template enables these plugins from `claude-plugins-official`:
+
+| Plugin | Purpose |
+|--------|---------|
+| `context7` | Up-to-date library documentation lookup |
+| `code-review` | Structured code review |
+| `github` | GitHub integration |
+| `gitlab` | GitLab integration |
+| `feature-dev` | Guided feature development |
+| `code-simplifier` | Code simplification and cleanup |
+| `commit-commands` | Git commit workflow commands |
+| `pyright-lsp` | Python language server |
+| `explanatory-output-style` | Educational code explanations |
+| `claude-md-management` | CLAUDE.md audit and improvement |
+| `claude-code-setup` | Automation recommendations |
+| `slack` | Slack channel integration (MCP-based) |
+| `frontend-design` | Frontend interface design |
+
+### MCP-Based Integrations
+
+Some plugins provide MCP (Model Context Protocol) server integrations that require OAuth setup on first use:
+
+| Plugin | MCP Capability | Setup |
+|--------|---------------|-------|
+| `slack` | Read/write Slack channels | OAuth — prompted on first `/pong` or `/ping` use |
+| `gitlab` | GitLab API access | OAuth — prompted on first `glab`-based operation |
+| `github` | GitHub API access | Uses existing `gh auth` session |
+
+These authenticate automatically through Claude Code's OAuth flow. No manual token configuration is needed — just approve the OAuth prompt when it appears.
+
+**Exception:** The `slackbot-send` script uses a separate bot token (not the MCP OAuth). See Slack Setup below.
+
+## Slack Setup (for /ping)
+
+The `/ping` skill uses `slackbot-send`, which requires a Slack bot token:
+
+```bash
+mkdir -p ~/secrets
+echo "xoxb-your-token" > ~/secrets/slack-bot-token
+chmod 600 ~/secrets/slack-bot-token
+```
+
+This is separate from the Slack MCP plugin OAuth — `slackbot-send` posts as a custom bot identity (with Dev-Name and Dev-Avatar), while the MCP plugin uses your Slack user identity.
+
+## Dependencies
+
+| Tool | Required by | Install |
+|------|------------|---------|
+| `gh` | GitHub skills | [cli.github.com](https://cli.github.com) |
+| `glab` | GitLab skills | [gitlab.com/gitlab-org/cli](https://gitlab.com/gitlab-org/cli) |
+| `curl` | slackbot-send | Usually pre-installed |
+| `jq` | slackbot-send, statusline | `apt install jq` / `brew install jq` |
+| `python3` | job-fetch | Usually pre-installed |
+| `shellcheck` | Validation | `apt install shellcheck` / `brew install shellcheck` |
+| `shfmt` | Validation | `go install mvdan.cc/sh/v3/cmd/shfmt@latest` |
+
 ## Validation
 
 ```bash
 ./scripts/ci/validate.sh
 ```
 
-Runs shellcheck, shfmt, and SKILL.md frontmatter validation.
+Runs shellcheck, shfmt, and SKILL.md frontmatter validation. Also runs automatically on PRs via GitHub Actions.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 # install.sh — Deploy Claude Code workflow environment
 #
-# Installs skills, scripts, and the CLAUDE.md template from this repo
+# Installs skills, scripts, and config from this repo
 # into the correct locations on the local machine.
 #
 # Usage:
 #   ./install.sh              Install everything
 #   ./install.sh --dry-run    Show what would be done without doing it
+#   ./install.sh --check      Show drift between repo and installed versions
 #   ./install.sh --skills     Install skills only
 #   ./install.sh --scripts    Install scripts only
+#   ./install.sh --config     Install config files only (statusline, settings template)
 #
 # Targets:
-#   Skills  → ~/.claude/skills/<name>/SKILL.md
-#   Scripts → ~/.local/bin/<name>
+#   Skills     → ~/.claude/skills/<name>/SKILL.md
+#   Scripts    → ~/.local/bin/<name>
+#   Statusline → ~/.claude/statusline-command.sh
 #
 # Existing files are backed up to <file>.bak before overwriting.
 
@@ -21,107 +24,200 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$HOME/.claude/skills"
 SCRIPTS_DIR="$HOME/.local/bin"
+CLAUDE_DIR="$HOME/.claude"
 DRY_RUN=false
+CHECK_MODE=false
 INSTALL_SKILLS=true
 INSTALL_SCRIPTS=true
+INSTALL_CONFIG=true
 
 # --- Parse args ---------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --dry-run)  DRY_RUN=true; shift ;;
-    --skills)   INSTALL_SCRIPTS=false; shift ;;
-    --scripts)  INSTALL_SKILLS=false; shift ;;
-    --help|-h)
-      grep '^#' "$0" | sed 's/^# \?//' | tail -n +2
-      exit 0
-      ;;
-    *) echo "Unknown option: $1" >&2; exit 1 ;;
-  esac
+	case "$1" in
+	--dry-run) DRY_RUN=true; shift ;;
+	--check) CHECK_MODE=true; shift ;;
+	--skills) INSTALL_SCRIPTS=false; INSTALL_CONFIG=false; shift ;;
+	--scripts) INSTALL_SKILLS=false; INSTALL_CONFIG=false; shift ;;
+	--config) INSTALL_SKILLS=false; INSTALL_SCRIPTS=false; shift ;;
+	--help | -h)
+		grep '^#' "$0" | sed 's/^# \?//' | tail -n +2
+		exit 0
+		;;
+	*) echo "Unknown option: $1" >&2; exit 1 ;;
+	esac
 done
 
 # --- Helpers ------------------------------------------------------------------
-info()  { echo "  [+] $*"; }
-warn()  { echo "  [!] $*"; }
-skip()  { echo "  [-] $*"; }
+info() { echo "  [+] $*"; }
+warn() { echo "  [!] $*"; }
+skip() { echo "  [-] $*"; }
+drift() { echo "  [~] $*"; }
 
 do_copy() {
-  local src="$1" dest="$2"
-  if [[ "$DRY_RUN" == true ]]; then
-    info "(dry-run) $src → $dest"
-    return
-  fi
-  if [[ -f "$dest" ]]; then
-    if diff -q "$src" "$dest" &>/dev/null; then
-      skip "$dest (unchanged)"
-      return
-    fi
-    cp "$dest" "${dest}.bak"
-    warn "Backed up existing: ${dest}.bak"
-  fi
-  mkdir -p "$(dirname "$dest")"
-  cp "$src" "$dest"
-  info "$src → $dest"
+	local src="$1" dest="$2"
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) $src → $dest"
+		return
+	fi
+	if [[ -f "$dest" ]]; then
+		if diff -q "$src" "$dest" &>/dev/null; then
+			skip "$dest (unchanged)"
+			return
+		fi
+		cp "$dest" "${dest}.bak"
+		warn "Backed up existing: ${dest}.bak"
+	fi
+	mkdir -p "$(dirname "$dest")"
+	cp "$src" "$dest"
+	info "$src → $dest"
 }
+
+do_check() {
+	local src="$1" dest="$2" label="$3"
+	if [[ ! -f "$dest" ]]; then
+		drift "$label — NOT INSTALLED"
+		return 1
+	elif ! diff -q "$src" "$dest" &>/dev/null; then
+		drift "$label — DIFFERS"
+		return 1
+	else
+		info "$label (in sync)"
+		return 0
+	fi
+}
+
+# --- Check mode ---------------------------------------------------------------
+if [[ "$CHECK_MODE" == true ]]; then
+	echo ""
+	echo "Sync check: repo vs installed"
+	echo "══════════════════════════════════════════"
+	total=0
+	drifted=0
+
+	echo ""
+	echo "Skills"
+	echo "──────────────────────────────────────────"
+	for skill_dir in "$REPO_DIR"/skills/*/; do
+		skill_name="$(basename "$skill_dir")"
+		src="$skill_dir/SKILL.md"
+		dest="$SKILLS_DIR/$skill_name/SKILL.md"
+		[[ -f "$src" ]] || continue
+		total=$((total + 1))
+		do_check "$src" "$dest" "$skill_name" || drifted=$((drifted + 1))
+	done
+
+	echo ""
+	echo "Scripts"
+	echo "──────────────────────────────────────────"
+	for script in "$REPO_DIR"/scripts/*; do
+		[[ -f "$script" ]] || continue
+		[[ -d "$script" ]] && continue
+		script_name="$(basename "$script")"
+		dest="$SCRIPTS_DIR/$script_name"
+		total=$((total + 1))
+		do_check "$script" "$dest" "$script_name" || drifted=$((drifted + 1))
+	done
+
+	echo ""
+	echo "Config"
+	echo "──────────────────────────────────────────"
+	if [[ -f "$REPO_DIR/scripts/statusline-command.sh" ]]; then
+		total=$((total + 1))
+		do_check "$REPO_DIR/scripts/statusline-command.sh" "$CLAUDE_DIR/statusline-command.sh" "statusline-command.sh" || drifted=$((drifted + 1))
+	fi
+
+	echo ""
+	echo "══════════════════════════════════════════"
+	if [[ $drifted -eq 0 ]]; then
+		echo "All $total items in sync."
+	else
+		echo "$drifted of $total items out of sync."
+		echo "Run ./install.sh to update."
+	fi
+	exit 0
+fi
 
 # --- Install skills -----------------------------------------------------------
 if [[ "$INSTALL_SKILLS" == true ]]; then
-  echo ""
-  echo "Skills → $SKILLS_DIR"
-  echo "──────────────────────────────────────────"
-  for skill_dir in "$REPO_DIR"/skills/*/; do
-    skill_name="$(basename "$skill_dir")"
-    src="$skill_dir/SKILL.md"
-    dest="$SKILLS_DIR/$skill_name/SKILL.md"
-    [[ -f "$src" ]] && do_copy "$src" "$dest"
-  done
+	echo ""
+	echo "Skills → $SKILLS_DIR"
+	echo "──────────────────────────────────────────"
+	for skill_dir in "$REPO_DIR"/skills/*/; do
+		skill_name="$(basename "$skill_dir")"
+		src="$skill_dir/SKILL.md"
+		dest="$SKILLS_DIR/$skill_name/SKILL.md"
+		[[ -f "$src" ]] && do_copy "$src" "$dest"
+	done
 fi
 
 # --- Install scripts ----------------------------------------------------------
 if [[ "$INSTALL_SCRIPTS" == true ]]; then
-  echo ""
-  echo "Scripts → $SCRIPTS_DIR"
-  echo "──────────────────────────────────────────"
-  for script in "$REPO_DIR"/scripts/*; do
-    [[ -f "$script" ]] || continue
-    script_name="$(basename "$script")"
-    dest="$SCRIPTS_DIR/$script_name"
-    do_copy "$script" "$dest"
-    if [[ "$DRY_RUN" != true ]]; then
-      chmod +x "$dest"
-    fi
-  done
+	echo ""
+	echo "Scripts → $SCRIPTS_DIR"
+	echo "──────────────────────────────────────────"
+	for script in "$REPO_DIR"/scripts/*; do
+		[[ -f "$script" ]] || continue
+		[[ -d "$script" ]] && continue
+		script_name="$(basename "$script")"
+		dest="$SCRIPTS_DIR/$script_name"
+		do_copy "$script" "$dest"
+		if [[ "$DRY_RUN" != true ]]; then
+			chmod +x "$dest"
+		fi
+	done
+fi
+
+# --- Install config -----------------------------------------------------------
+if [[ "$INSTALL_CONFIG" == true ]]; then
+	echo ""
+	echo "Config → $CLAUDE_DIR"
+	echo "──────────────────────────────────────────"
+	if [[ -f "$REPO_DIR/scripts/statusline-command.sh" ]]; then
+		do_copy "$REPO_DIR/scripts/statusline-command.sh" "$CLAUDE_DIR/statusline-command.sh"
+		if [[ "$DRY_RUN" != true ]]; then
+			chmod +x "$CLAUDE_DIR/statusline-command.sh"
+		fi
+	fi
+
+	if [[ -f "$REPO_DIR/settings.template.json" ]]; then
+		if [[ -f "$CLAUDE_DIR/settings.json" ]]; then
+			skip "settings.json already exists (won't overwrite — use settings.template.json as reference)"
+		else
+			do_copy "$REPO_DIR/settings.template.json" "$CLAUDE_DIR/settings.json"
+		fi
+	fi
 fi
 
 # --- Summary ------------------------------------------------------------------
 echo ""
 echo "──────────────────────────────────────────"
 if [[ "$DRY_RUN" == true ]]; then
-  echo "Dry run complete. No files were modified."
+	echo "Dry run complete. No files were modified."
 else
-  echo "Installation complete."
+	echo "Installation complete."
 fi
 
 # --- Dependency check ---------------------------------------------------------
 echo ""
 echo "Dependency check:"
 missing=()
-for cmd in curl jq glab gh python3; do
-  if command -v "$cmd" &>/dev/null; then
-    info "$cmd $(command -v "$cmd")"
-  else
-    warn "$cmd — NOT FOUND"
-    missing+=("$cmd")
-  fi
+for cmd in curl jq glab gh python3 shellcheck shfmt; do
+	if command -v "$cmd" &>/dev/null; then
+		info "$cmd $(command -v "$cmd")"
+	else
+		warn "$cmd — NOT FOUND"
+		missing+=("$cmd")
+	fi
 done
 
 if [[ -f "$HOME/secrets/slack-bot-token" ]]; then
-  info "slack-bot-token found"
+	info "slack-bot-token found"
 else
-  warn "~/secrets/slack-bot-token — NOT FOUND (needed for /ping)"
+	warn "~/secrets/slack-bot-token — NOT FOUND (needed for /ping)"
 fi
 
 if [[ ${#missing[@]} -gt 0 ]]; then
-  echo ""
-  warn "Missing dependencies: ${missing[*]}"
-  echo "  Install them before using the skills that require them."
+	echo ""
+	warn "Missing dependencies: ${missing[*]}"
+	echo "  Install them before using the skills that require them."
 fi

--- a/scripts/statusline-command.sh
+++ b/scripts/statusline-command.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Claude Code status line — mirrors ~/.bashrc __build_prompt
+
+input=$(cat)
+
+cwd=$(echo "$input" | jq -r '.cwd // .workspace.current_dir // ""')
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+remaining_pct=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
+
+# ANSI colors
+c_purple='\033[38;5;97m'
+c_green='\033[01;32m'
+c_blue='\033[01;34m'
+c_cyan='\033[36m'
+c_red='\033[31m'
+c_yellow='\033[33m'
+c_reset='\033[00m'
+
+# Shorten path: replace $HOME with ~
+short_cwd="${cwd/#$HOME/\~}"
+
+# Git info
+git_line=""
+if git_output=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" status --porcelain -b 2>/dev/null); then
+	branch_line="${git_output%%$'\n'*}"
+
+	branch="${branch_line#\#\# }"
+	branch="${branch%%...*}"
+	branch="${branch%% \[*}"
+
+	if [[ "$branch" == "HEAD (no branch)"* ]]; then
+		branch="detached:$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --short HEAD 2>/dev/null)"
+	fi
+
+	repo=$(basename "$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)")
+
+	ahead=0
+	behind=0
+	if [[ "$branch_line" =~ \[ahead\ ([0-9]+) ]]; then ahead="${BASH_REMATCH[1]}"; fi
+	if [[ "$branch_line" =~ behind\ ([0-9]+) ]]; then behind="${BASH_REMATCH[1]}"; fi
+
+	staged=0
+	dirty=0
+	if [[ "$git_output" == *$'\n'* ]]; then
+		status_lines="${git_output#*$'\n'}"
+		while IFS= read -r line; do
+			[[ "${line:0:1}" =~ [MADRC] ]] && ((staged++))
+			[[ "${line:1:1}" =~ [MADRC\?] ]] && ((dirty++))
+		done <<<"$status_lines"
+	fi
+
+	git_line="  $(printf '%b' "${c_cyan}")${repo} @ ${branch}$(printf '%b' "${c_reset}")"
+
+	if ((dirty > 0)); then
+		git_line+=" $(printf '%b' "${c_red}")✗$(printf '%b' "${c_reset}")"
+	else
+		git_line+=" $(printf '%b' "${c_green}")✓$(printf '%b' "${c_reset}")"
+	fi
+
+	if ((staged > 0)); then
+		git_line+=" $(printf '%b' "${c_yellow}")+${staged}$(printf '%b' "${c_reset}")"
+	fi
+
+	if ((ahead > 0)); then
+		git_line+=" $(printf '%b' "${c_yellow}")↑${ahead}$(printf '%b' "${c_reset}")"
+	fi
+
+	if ((behind > 0)); then
+		git_line+=" $(printf '%b' "${c_yellow}")↓${behind}$(printf '%b' "${c_reset}")"
+	fi
+fi
+
+# Context remaining indicator (always shown when available)
+ctx_str=""
+if [ -n "$remaining_pct" ]; then
+	remaining_int=${remaining_pct%.*}
+	if ((remaining_int <= 13)); then
+		ctx_color="$c_red"
+	elif ((remaining_int <= 25)); then
+		ctx_color="$c_yellow"
+	else
+		ctx_color="$c_cyan"
+	fi
+	ctx_str="  $(printf '%b' "${ctx_color}")ctx remaining: ${remaining_int}%$(printf '%b' "${c_reset}")"
+fi
+
+# Model indicator
+model_str=""
+if [ -n "$model" ]; then
+	model_str="  $(printf '%b' "${c_purple}")${model}$(printf '%b' "${c_reset}")"
+fi
+
+# Assemble output
+printf '%b' "${c_blue}${short_cwd}${c_reset}"
+if [ -n "$git_line" ]; then
+	printf "%s" "$git_line"
+fi
+printf "%s" "$ctx_str"
+printf "%s" "$model_str"
+printf "\n"

--- a/settings.template.json
+++ b/settings.template.json
@@ -1,0 +1,93 @@
+{
+  "_comment": "Claude Code settings template. Copy to ~/.claude/settings.json and customize.",
+  "permissions": {
+    "allow": [
+      "Read",
+      "WebFetch",
+      "Bash(curl:*)",
+      "Bash(chmod:*)",
+      "Bash(shellcheck:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(python3:*)",
+      "Bash(python:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(docker compose:*)",
+      "Bash(glab:*)",
+      "Bash(gh:*)",
+      "Bash(terraform:*)",
+      "Bash(aws:*)",
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git push:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git config:*)",
+      "Bash(git rebase:*)",
+      "Bash(git status:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Edit(.claude/plans/*)",
+      "Write(.claude/plans/*)"
+    ]
+  },
+  "model": "opus",
+  "hooks": {
+    "_comment": "Hook commands reference scripts that must exist at the specified paths. Remove or update these if you don't use context-crystallizer.",
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/context-crystallizer/hooks/post-tool-use.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/context-crystallizer/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/context-crystallizer/hooks/subagent-stop.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline-command.sh"
+  },
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "gitlab@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "explanatory-output-style@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "slack@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true
+  },
+  "effortLevel": "high"
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# uninstall.sh — Remove Claude Code workflow environment
+#
+# Removes skills and scripts installed by install.sh.
+# Does NOT remove settings.json or credentials.
+#
+# Usage:
+#   ./uninstall.sh              Remove everything
+#   ./uninstall.sh --dry-run    Show what would be removed without doing it
+#   ./uninstall.sh --skills     Remove skills only
+#   ./uninstall.sh --scripts    Remove scripts only
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$HOME/.claude/skills"
+SCRIPTS_DIR="$HOME/.local/bin"
+CLAUDE_DIR="$HOME/.claude"
+DRY_RUN=false
+REMOVE_SKILLS=true
+REMOVE_SCRIPTS=true
+REMOVE_CONFIG=true
+
+# --- Parse args ---------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--dry-run) DRY_RUN=true; shift ;;
+	--skills) REMOVE_SCRIPTS=false; REMOVE_CONFIG=false; shift ;;
+	--scripts) REMOVE_SKILLS=false; REMOVE_CONFIG=false; shift ;;
+	--help | -h)
+		grep '^#' "$0" | sed 's/^# \?//' | tail -n +2
+		exit 0
+		;;
+	*) echo "Unknown option: $1" >&2; exit 1 ;;
+	esac
+done
+
+# --- Helpers ------------------------------------------------------------------
+info() { echo "  [+] Removed: $*"; }
+skip() { echo "  [-] Not found: $*"; }
+
+do_remove() {
+	local path="$1"
+	if [[ ! -e "$path" ]]; then
+		skip "$path"
+		return
+	fi
+	if [[ "$DRY_RUN" == true ]]; then
+		echo "  [+] (dry-run) Would remove: $path"
+		return
+	fi
+	rm -rf "$path"
+	info "$path"
+}
+
+# --- Remove skills ------------------------------------------------------------
+if [[ "$REMOVE_SKILLS" == true ]]; then
+	echo ""
+	echo "Removing skills from $SKILLS_DIR"
+	echo "──────────────────────────────────────────"
+	for skill_dir in "$REPO_DIR"/skills/*/; do
+		skill_name="$(basename "$skill_dir")"
+		do_remove "$SKILLS_DIR/$skill_name"
+	done
+fi
+
+# --- Remove scripts -----------------------------------------------------------
+if [[ "$REMOVE_SCRIPTS" == true ]]; then
+	echo ""
+	echo "Removing scripts from $SCRIPTS_DIR"
+	echo "──────────────────────────────────────────"
+	for script in "$REPO_DIR"/scripts/*; do
+		[[ -f "$script" ]] || continue
+		[[ -d "$script" ]] && continue
+		script_name="$(basename "$script")"
+		do_remove "$SCRIPTS_DIR/$script_name"
+	done
+fi
+
+# --- Remove config ------------------------------------------------------------
+if [[ "$REMOVE_CONFIG" == true ]]; then
+	echo ""
+	echo "Removing config from $CLAUDE_DIR"
+	echo "──────────────────────────────────────────"
+	do_remove "$CLAUDE_DIR/statusline-command.sh"
+	echo "  [-] settings.json — preserved (not managed by uninstall)"
+fi
+
+# --- Summary ------------------------------------------------------------------
+echo ""
+echo "──────────────────────────────────────────"
+if [[ "$DRY_RUN" == true ]]; then
+	echo "Dry run complete. No files were removed."
+else
+	echo "Uninstall complete."
+fi


### PR DESCRIPTION
## Summary

Rounds out the portable Claude Code workflow environment with CI, settings template, sync tooling, uninstall, and changelog.

## Changes

- **CI**: GitHub Actions workflow + `.gitlab-ci.yml` — both run `validate.sh` on PRs/MRs
- **Settings**: `settings.template.json` with portable permissions, hooks, plugins, statusline config
- **Statusline**: `statusline-command.sh` — custom status line with git info + context window (shellcheck-clean)
- **Sync**: `install.sh --check` shows drift between repo and installed versions
- **Config install**: `install.sh --config` for config-only installs (statusline, settings)
- **Uninstall**: `uninstall.sh` with `--dry-run` and component filtering
- **Changelog**: `CHANGELOG.md` documenting v0.1.0
- **README**: Full rewrite covering plugins, MCP/OAuth setup, Slack bot vs MCP distinction, sync, uninstall

## Linked Issues

Closes #1

## Test Plan

- Ran `./scripts/ci/validate.sh` — 19 passed, 0 failed (shellcheck, shfmt, frontmatter)
- Ran `./install.sh --check` — correctly reports drift between repo and installed versions
- Ran `./install.sh --dry-run` — shows expected install targets including new config items