### PR TITLE
feat(dashboard): implement execution grid and deferral sections

### DIFF
--- a/src/wave_status/dashboard/deferral_sections.py
+++ b/src/wave_status/dashboard/deferral_sections.py
@@ -1,0 +1,126 @@
+"""Dashboard deferral sections component.
+
+Renders the pending and accepted deferral tables.
+
+Pure presentation — receives state_data dict, returns HTML string.
+
+No imports outside Python 3.10+ stdlib [CT-01].
+"""
+
+from __future__ import annotations
+
+import html as _html
+
+from wave_status.deferrals import accepted_list, pending_list
+
+
+def render_pending_deferrals(state_data: dict) -> str:
+    """Render the pending deferrals section as an HTML string.
+
+    The container collapses to zero height (``overflow: hidden; max-height: 0``)
+    when no pending items exist [R-25].  When items exist, the section uses
+    orange-accented styling.
+
+    Parameters
+    ----------
+    state_data:
+        The parsed state.json dict. Must contain a ``deferrals`` list.
+
+    Returns
+    -------
+    str
+        An HTML ``<div class="deferrals-section pending">`` block.
+    """
+    items = pending_list(state_data)
+
+    # Collapse to zero height when empty [R-25].
+    if not items:
+        collapse_style = ' style="overflow: hidden; max-height: 0; padding: 0; margin: 0;"'
+        table_html = ""
+    else:
+        collapse_style = ""
+        rows: list[str] = []
+        for i, deferral in enumerate(items, start=1):
+            wave = _html.escape(deferral.get("wave", ""))
+            description = _html.escape(deferral.get("description", ""))
+            risk = _html.escape(deferral.get("risk", ""))
+            rows.append(
+                f"<tr>\n"
+                f"  <td>{i}</td>\n"
+                f"  <td>{wave}</td>\n"
+                f"  <td>{description}</td>\n"
+                f"  <td>{risk}</td>\n"
+                f"</tr>"
+            )
+
+        table_html = (
+            '<table class="deferrals-table">\n'
+            "<thead><tr>"
+            "<th>#</th><th>Wave</th><th>Description</th><th>Risk</th>"
+            "</tr></thead>\n"
+            "<tbody>\n"
+            + "\n".join(rows)
+            + "\n</tbody>\n"
+            "</table>"
+        )
+
+    return (
+        f'<div class="deferrals-section pending"{collapse_style}>\n'
+        f'  <h2>Pending Deferrals</h2>\n'
+        f"  {table_html}\n"
+        f"</div>"
+    )
+
+
+def render_accepted_deferrals(state_data: dict) -> str:
+    """Render the accepted deferrals section as an HTML string.
+
+    Uses subdued styling (resolved items have less visual urgency).
+    Renders below the execution grid [R-26].
+
+    Parameters
+    ----------
+    state_data:
+        The parsed state.json dict. Must contain a ``deferrals`` list.
+
+    Returns
+    -------
+    str
+        An HTML ``<div class="deferrals-section accepted">`` block.
+    """
+    items = accepted_list(state_data)
+
+    if not items:
+        table_html = ""
+    else:
+        rows: list[str] = []
+        for i, deferral in enumerate(items, start=1):
+            wave = _html.escape(deferral.get("wave", ""))
+            description = _html.escape(deferral.get("description", ""))
+            risk = _html.escape(deferral.get("risk", ""))
+            rows.append(
+                f"<tr>\n"
+                f"  <td>{i}</td>\n"
+                f"  <td>{wave}</td>\n"
+                f"  <td>{description}</td>\n"
+                f"  <td>{risk}</td>\n"
+                f"</tr>"
+            )
+
+        table_html = (
+            '<table class="deferrals-table">\n'
+            "<thead><tr>"
+            "<th>#</th><th>Wave</th><th>Description</th><th>Risk</th>"
+            "</tr></thead>\n"
+            "<tbody>\n"
+            + "\n".join(rows)
+            + "\n</tbody>\n"
+            "</table>"
+        )
+
+    return (
+        f'<div class="deferrals-section accepted">\n'
+        f'  <h2>Accepted Deferrals</h2>\n'
+        f"  {table_html}\n"
+        f"</div>"
+    )

--- a/src/wave_status/dashboard/execution_grid.py
+++ b/src/wave_status/dashboard/execution_grid.py
@@ -1,0 +1,277 @@
+"""Dashboard execution grid component.
+
+Renders the main body of the dashboard: phase sections containing wave cards
+with issue tables and flight badges.
+
+Pure presentation — receives data dicts, returns HTML string.
+
+No imports outside Python 3.10+ stdlib [CT-01].
+"""
+
+from __future__ import annotations
+
+import html as _html
+
+from wave_status.dashboard.theme import PHASE_COLORS
+
+
+def _status_badge(status: str, data_wave: str = "", data_issue: str = "") -> str:
+    """Return an HTML badge span for *status*.
+
+    Parameters
+    ----------
+    status:
+        Raw status string, e.g. ``"pending"``, ``"in_progress"``, ``"completed"``.
+    data_wave:
+        Optional value for a ``data-wave`` attribute.
+    data_issue:
+        Optional value for a ``data-issue`` attribute.
+    """
+    css_class = "badge-" + status.replace("_", "-")
+    label = status.replace("_", " ")
+
+    attrs = f'class="badge {_html.escape(css_class)}"'
+    if data_wave:
+        attrs += f' data-wave="{_html.escape(data_wave)}"'
+    if data_issue:
+        attrs += f' data-issue="{_html.escape(data_issue)}"'
+
+    return f'<span {attrs}>{_html.escape(label)}</span>'
+
+
+def _render_flight_badges(wave_id: str, flights_data: dict) -> str:
+    """Return HTML flight badge spans for the given wave.
+
+    Returns an empty string if no flight plan exists for *wave_id*.
+    """
+    wave_flights = flights_data.get("flights", {}).get(wave_id, [])
+    if not wave_flights:
+        return ""
+
+    badges: list[str] = []
+    wid = _html.escape(wave_id)
+    for i, flight in enumerate(wave_flights, start=1):
+        status = flight.get("status", "pending")
+        css_class = "badge-" + status.replace("_", "-")
+        label = f"flight {i}: {status.replace('_', ' ')}"
+        badges.append(
+            f'<span class="badge {_html.escape(css_class)}"'
+            f' data-wave="{wid}"'
+            f' data-field="flights.{wid}.{i - 1}.status">{_html.escape(label)}</span>'
+        )
+
+    return " ".join(badges)
+
+
+def _render_issue_row(
+    issue_number: int,
+    issue_plan: dict,
+    state_data: dict,
+    wave_id: str,
+) -> str:
+    """Return an HTML ``<tr>`` for a single issue.
+
+    Parameters
+    ----------
+    issue_number:
+        The issue number (int).
+    issue_plan:
+        The issue dict from the plan (with ``number``, ``title``).
+    state_data:
+        The parsed state.json dict.
+    wave_id:
+        The parent wave ID, used for ``data-wave`` on dynamic elements.
+    """
+    title = _html.escape(issue_plan.get("title", f"Issue #{issue_number}"))
+    issue_key = str(issue_number)
+    issue_state = state_data.get("issues", {}).get(issue_key, {})
+    status = issue_state.get("status", "open")
+    wid = _html.escape(wave_id)
+
+    # Normalize status for CSS: "open" maps to badge-pending display.
+    if status == "open":
+        badge_css = "badge-pending"
+        badge_label = "open"
+    elif status == "closed":
+        badge_css = "badge-closed"
+        badge_label = "closed"
+    else:
+        badge_css = "badge-" + status.replace("_", "-")
+        badge_label = status.replace("_", " ")
+
+    status_badge = (
+        f'<span class="badge {_html.escape(badge_css)}"'
+        f' data-wave="{wid}"'
+        f' data-issue="{issue_number}"'
+        f' data-field="issues.{issue_key}.status">{_html.escape(badge_label)}</span>'
+    )
+
+    # MR link — from current wave's mr_urls.
+    mr_urls = state_data.get("waves", {}).get(wave_id, {}).get("mr_urls", {})
+    mr_url = mr_urls.get(issue_key, "")
+    if mr_url:
+        mr_cell = (
+            f'<a href="{_html.escape(mr_url, quote=True)}"'
+            f' data-wave="{wid}"'
+            f' data-issue="{issue_number}"'
+            f' data-field="waves.{wid}.mr_urls.{issue_key}">{_html.escape(mr_url)}</a>'
+        )
+    else:
+        mr_cell = (
+            f'<span class="mr-link" data-wave="{wid}"'
+            f' data-issue="{issue_number}"'
+            f' data-field="waves.{wid}.mr_urls.{issue_key}"></span>'
+        )
+
+    return (
+        f"<tr>\n"
+        f'  <td>#{issue_number}</td>\n'
+        f"  <td>{title}</td>\n"
+        f"  <td>{status_badge}</td>\n"
+        f"  <td>{mr_cell}</td>\n"
+        f"</tr>"
+    )
+
+
+def _render_wave_card(
+    wave_plan: dict,
+    state_data: dict,
+    flights_data: dict,
+) -> str:
+    """Return HTML for a single wave card.
+
+    Parameters
+    ----------
+    wave_plan:
+        Wave dict from the plan with ``id``, ``issues``.
+    state_data:
+        The parsed state.json dict.
+    flights_data:
+        The parsed flights.json dict.
+    """
+    wave_id = wave_plan.get("id", "")
+    issues = wave_plan.get("issues", [])
+    wid = _html.escape(wave_id)
+
+    wave_state = state_data.get("waves", {}).get(wave_id, {})
+    wave_status = wave_state.get("status", "pending")
+    wave_css = "badge-" + wave_status.replace("_", "-")
+    wave_label = wave_status.replace("_", " ")
+
+    status_badge = (
+        f'<span class="badge {_html.escape(wave_css)}"'
+        f' data-wave="{wid}"'
+        f' data-field="waves.{wid}.status">{_html.escape(wave_label)}</span>'
+    )
+
+    # Issue table rows.
+    rows: list[str] = []
+    for issue_plan in issues:
+        issue_number = issue_plan.get("number")
+        if issue_number is not None:
+            rows.append(_render_issue_row(issue_number, issue_plan, state_data, wave_id))
+
+    issue_table = (
+        '<table class="issue-table">\n'
+        "<thead><tr>"
+        '<th>#</th><th>Title</th><th>Status</th><th>MR / PR</th>'
+        "</tr></thead>\n"
+        "<tbody>\n"
+        + "\n".join(rows)
+        + "\n</tbody>\n"
+        "</table>"
+    )
+
+    # Flight badges (if flight plan exists for this wave).
+    flight_badges_html = _render_flight_badges(wave_id, flights_data)
+    flight_row = ""
+    if flight_badges_html:
+        flight_row = (
+            f'\n<div class="flight-badges" data-wave="{wid}">'
+            f"{flight_badges_html}</div>"
+        )
+
+    return (
+        f'<div class="wave-card" data-wave="{wid}">\n'
+        f'  <div class="wave-header">'
+        f'<span class="wave-id">{wid}</span>{status_badge}'
+        f"</div>\n"
+        f"  {issue_table}"
+        f"{flight_row}\n"
+        f"</div>"
+    )
+
+
+def _render_phase_section(
+    phase: dict,
+    phase_index: int,
+    state_data: dict,
+    flights_data: dict,
+) -> str:
+    """Return HTML for a single phase section.
+
+    Parameters
+    ----------
+    phase:
+        Phase dict from the plan with ``name`` and ``waves``.
+    phase_index:
+        0-based index of this phase, used to pick phase color.
+    state_data:
+        The parsed state.json dict.
+    flights_data:
+        The parsed flights.json dict.
+    """
+    phase_name = _html.escape(phase.get("name", f"Phase {phase_index + 1}"))
+    waves = phase.get("waves", [])
+    color_entry = PHASE_COLORS[phase_index % len(PHASE_COLORS)]
+    accent_color = f"var({color_entry['var']})"
+
+    wave_cards = "\n".join(
+        _render_wave_card(wave_plan, state_data, flights_data)
+        for wave_plan in waves
+    )
+
+    return (
+        f'<section class="phase-section" data-phase="{phase_index + 1}">\n'
+        f'  <div class="phase-header" style="border-left: 4px solid {accent_color};">'
+        f'<span class="phase-name">{phase_name}</span>'
+        f"</div>\n"
+        f'  <div class="phase-body">\n'
+        f"    {wave_cards}\n"
+        f"  </div>\n"
+        f"</section>"
+    )
+
+
+def render_execution_grid(
+    phases_data: dict,
+    state_data: dict,
+    flights_data: dict,
+) -> str:
+    """Render the execution grid as an HTML string.
+
+    Parameters
+    ----------
+    phases_data:
+        The parsed phases-waves.json dict. Must contain a ``phases`` list,
+        each entry with ``name`` and ``waves`` (list of dicts with ``id`` and
+        ``issues``).
+    state_data:
+        The parsed state.json dict. Must contain ``current_wave``, ``waves``,
+        ``issues``.
+    flights_data:
+        The parsed flights.json dict. Must contain a ``flights`` dict keyed
+        by wave ID.
+
+    Returns
+    -------
+    str
+        An HTML ``<div class="execution-grid">`` block containing one
+        ``<section class="phase-section">`` per phase.
+    """
+    phases = phases_data.get("phases", [])
+    sections = "\n".join(
+        _render_phase_section(phase, pi, state_data, flights_data)
+        for pi, phase in enumerate(phases)
+    )
+    return f'<div class="execution-grid">\n{sections}\n</div>'

--- a/tests/test_deferral_sections.py
+++ b/tests/test_deferral_sections.py
@@ -1,0 +1,323 @@
+"""Tests for wave_status.dashboard.deferral_sections module.
+
+Exercises REAL code paths — no mocking of the module under test.
+Validates all acceptance criteria from Issue #21 (Story 2.3).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import sys
+
+# Ensure src/ is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wave_status.dashboard.deferral_sections import (
+    render_accepted_deferrals,
+    render_pending_deferrals,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+STATE_NO_DEFERRALS = {
+    "current_wave": "wave-1",
+    "waves": {"wave-1": {"status": "in_progress", "mr_urls": {}}},
+    "issues": {},
+    "deferrals": [],
+}
+
+STATE_PENDING_ONLY = {
+    **STATE_NO_DEFERRALS,
+    "deferrals": [
+        {"wave": "wave-1", "description": "Fix login timeout", "risk": "high", "status": "pending"},
+        {"wave": "wave-1", "description": "Add retry logic", "risk": "medium", "status": "pending"},
+    ],
+}
+
+STATE_ACCEPTED_ONLY = {
+    **STATE_NO_DEFERRALS,
+    "deferrals": [
+        {"wave": "wave-1", "description": "Refactor config", "risk": "low", "status": "accepted"},
+        {"wave": "wave-2", "description": "Update docs", "risk": "low", "status": "accepted"},
+    ],
+}
+
+STATE_MIXED = {
+    **STATE_NO_DEFERRALS,
+    "deferrals": [
+        {"wave": "wave-1", "description": "Fix login timeout", "risk": "high", "status": "pending"},
+        {"wave": "wave-1", "description": "Refactor config", "risk": "low", "status": "accepted"},
+        {"wave": "wave-2", "description": "Add retry logic", "risk": "medium", "status": "pending"},
+        {"wave": "wave-2", "description": "Update docs", "risk": "low", "status": "accepted"},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# render_pending_deferrals() tests  [R-25]
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPendingDeferralsEmpty:
+    """Pending section collapses to zero height when empty [R-25]."""
+
+    def setup_method(self) -> None:
+        self.html = render_pending_deferrals(STATE_NO_DEFERRALS)
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_has_deferrals_section_class(self) -> None:
+        assert 'class="deferrals-section pending"' in self.html
+
+    def test_collapses_to_zero_height_when_empty(self) -> None:
+        # Container must have max-height: 0 style when no items [R-25]
+        assert "max-height: 0" in self.html
+
+    def test_overflow_hidden_when_empty(self) -> None:
+        assert "overflow: hidden" in self.html
+
+    def test_padding_zero_when_empty(self) -> None:
+        assert "padding: 0" in self.html
+
+    def test_no_table_when_empty(self) -> None:
+        assert "<table" not in self.html
+
+    def test_has_heading(self) -> None:
+        assert "Pending Deferrals" in self.html
+
+
+class TestRenderPendingDeferralsWithItems:
+    """Pending section is visible and shows items when they exist [R-25]."""
+
+    def setup_method(self) -> None:
+        self.html = render_pending_deferrals(STATE_PENDING_ONLY)
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_has_deferrals_section_class(self) -> None:
+        assert 'class="deferrals-section pending"' in self.html
+
+    def test_does_not_collapse_when_items_exist(self) -> None:
+        # No collapse style when pending items present
+        assert "max-height: 0" not in self.html
+
+    def test_has_table(self) -> None:
+        assert '<table class="deferrals-table"' in self.html
+
+    def test_has_table_headers(self) -> None:
+        assert "<th>#</th>" in self.html
+        assert "<th>Wave</th>" in self.html
+        assert "<th>Description</th>" in self.html
+        assert "<th>Risk</th>" in self.html
+
+    def test_1based_index_first_row(self) -> None:
+        assert "<td>1</td>" in self.html
+
+    def test_1based_index_second_row(self) -> None:
+        assert "<td>2</td>" in self.html
+
+    def test_wave_column_present(self) -> None:
+        assert "<td>wave-1</td>" in self.html
+
+    def test_description_column_present(self) -> None:
+        assert "Fix login timeout" in self.html
+        assert "Add retry logic" in self.html
+
+    def test_risk_column_present(self) -> None:
+        assert "<td>high</td>" in self.html
+        assert "<td>medium</td>" in self.html
+
+    def test_has_heading(self) -> None:
+        assert "Pending Deferrals" in self.html
+
+    def test_only_pending_items_shown(self) -> None:
+        """Only items with status=pending should appear."""
+        html = render_pending_deferrals(STATE_MIXED)
+        # 2 pending items
+        assert html.count("<tr>") == 3  # 1 header row + 2 data rows
+
+    def test_does_not_include_accepted_items(self) -> None:
+        html = render_pending_deferrals(STATE_MIXED)
+        assert "Refactor config" not in html
+        assert "Update docs" not in html
+
+
+class TestRenderPendingDeferralsOrangeAccent:
+    """Orange-accented styling markers."""
+
+    def test_pending_class_allows_orange_css_accent(self) -> None:
+        """The 'pending' class on deferrals-section enables orange border per theme CSS."""
+        html = render_pending_deferrals(STATE_PENDING_ONLY)
+        # The CSS from theme.py applies border-left: 4px solid var(--orange) to .deferrals-section.pending
+        # We verify the class is present to hook the CSS.
+        assert "deferrals-section pending" in html
+
+
+# ---------------------------------------------------------------------------
+# render_accepted_deferrals() tests  [R-26]
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAcceptedDeferralsEmpty:
+    """Accepted section renders even when empty [R-26]."""
+
+    def setup_method(self) -> None:
+        self.html = render_accepted_deferrals(STATE_NO_DEFERRALS)
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_has_deferrals_section_accepted_class(self) -> None:
+        assert 'class="deferrals-section accepted"' in self.html
+
+    def test_has_heading(self) -> None:
+        assert "Accepted Deferrals" in self.html
+
+    def test_no_table_when_empty(self) -> None:
+        assert "<table" not in self.html
+
+    def test_no_collapse_style(self) -> None:
+        # Accepted section never collapses — always visible
+        assert "max-height: 0" not in self.html
+
+
+class TestRenderAcceptedDeferralsWithItems:
+    """Accepted section shows items with subdued styling [R-26]."""
+
+    def setup_method(self) -> None:
+        self.html = render_accepted_deferrals(STATE_ACCEPTED_ONLY)
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_has_deferrals_section_accepted_class(self) -> None:
+        assert 'class="deferrals-section accepted"' in self.html
+
+    def test_has_table(self) -> None:
+        assert '<table class="deferrals-table"' in self.html
+
+    def test_has_table_headers(self) -> None:
+        assert "<th>#</th>" in self.html
+        assert "<th>Wave</th>" in self.html
+        assert "<th>Description</th>" in self.html
+        assert "<th>Risk</th>" in self.html
+
+    def test_1based_index_first_row(self) -> None:
+        assert "<td>1</td>" in self.html
+
+    def test_1based_index_second_row(self) -> None:
+        assert "<td>2</td>" in self.html
+
+    def test_wave_column_present(self) -> None:
+        assert "<td>wave-1</td>" in self.html
+        assert "<td>wave-2</td>" in self.html
+
+    def test_description_column_present(self) -> None:
+        assert "Refactor config" in self.html
+        assert "Update docs" in self.html
+
+    def test_risk_column_present(self) -> None:
+        assert "<td>low</td>" in self.html
+
+    def test_has_heading(self) -> None:
+        assert "Accepted Deferrals" in self.html
+
+    def test_only_accepted_items_shown(self) -> None:
+        """Only items with status=accepted should appear."""
+        html = render_accepted_deferrals(STATE_MIXED)
+        # 2 accepted items
+        assert html.count("<tr>") == 3  # 1 header row + 2 data rows
+
+    def test_does_not_include_pending_items(self) -> None:
+        html = render_accepted_deferrals(STATE_MIXED)
+        assert "Fix login timeout" not in html
+        assert "Add retry logic" not in html
+
+
+class TestRenderAcceptedDeferralsSubduedStyling:
+    """Accepted section uses subdued (accepted) CSS class."""
+
+    def test_accepted_class_not_pending(self) -> None:
+        html = render_accepted_deferrals(STATE_ACCEPTED_ONLY)
+        assert "deferrals-section accepted" in html
+        # Must not have the orange-accent 'pending' class
+        assert "deferrals-section pending" not in html
+
+
+# ---------------------------------------------------------------------------
+# Both sections together — ordering and independence
+# ---------------------------------------------------------------------------
+
+
+class TestBothSectionsTogether:
+    """Pending appears above, accepted below [R-25, R-26]."""
+
+    def test_pending_section_structure(self) -> None:
+        p_html = render_pending_deferrals(STATE_MIXED)
+        a_html = render_accepted_deferrals(STATE_MIXED)
+        # Both are independent HTML strings — can be concatenated in correct order
+        combined = p_html + a_html
+        pending_pos = combined.index("Pending Deferrals")
+        accepted_pos = combined.index("Accepted Deferrals")
+        assert pending_pos < accepted_pos
+
+    def test_pending_section_shows_pending_count(self) -> None:
+        html = render_pending_deferrals(STATE_MIXED)
+        assert "Fix login timeout" in html
+        assert "Add retry logic" in html
+
+    def test_accepted_section_shows_accepted_count(self) -> None:
+        html = render_accepted_deferrals(STATE_MIXED)
+        assert "Refactor config" in html
+        assert "Update docs" in html
+
+
+# ---------------------------------------------------------------------------
+# CT-01: No non-stdlib imports
+# ---------------------------------------------------------------------------
+
+
+class TestNoNonStdlibImports:
+    """CT-01: module uses only Python 3.10+ stdlib (plus wave_status internals)."""
+
+    def test_module_importable_without_third_party(self) -> None:
+        import wave_status.dashboard.deferral_sections as ds  # noqa: F401
+
+        assert hasattr(ds, "render_pending_deferrals")
+        assert hasattr(ds, "render_accepted_deferrals")
+
+    def test_module_has_no_non_stdlib_imports(self) -> None:
+        src = (
+            pathlib.Path(__file__).parent.parent
+            / "src"
+            / "wave_status"
+            / "dashboard"
+            / "deferral_sections.py"
+        )
+        tree = ast.parse(src.read_text())
+        stdlib_prefixes = {
+            "__future__", "ast", "os", "sys", "pathlib", "json", "re",
+            "html", "datetime", "collections", "itertools", "functools",
+            "typing", "types", "abc", "io", "math", "copy", "string",
+            "textwrap", "enum", "dataclasses", "contextlib",
+        }
+        external = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top = alias.name.split(".")[0]
+                    if top not in stdlib_prefixes:
+                        external.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    top = node.module.split(".")[0]
+                    if top not in stdlib_prefixes and top != "wave_status":
+                        external.append(node.module)
+        assert external == [], f"Non-stdlib imports found: {external}"

--- a/tests/test_execution_grid.py
+++ b/tests/test_execution_grid.py
@@ -1,0 +1,590 @@
+"""Tests for wave_status.dashboard.execution_grid module.
+
+Exercises REAL code paths — no mocking of the module under test.
+Validates all acceptance criteria from Issue #21 (Story 2.3).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import sys
+
+# Ensure src/ is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wave_status.dashboard.execution_grid import (
+    _render_flight_badges,
+    _render_issue_row,
+    _render_phase_section,
+    _render_wave_card,
+    _status_badge,
+    render_execution_grid,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+PHASES_DATA = {
+    "project": "test-proj",
+    "phases": [
+        {
+            "name": "Foundation",
+            "waves": [
+                {
+                    "id": "wave-1",
+                    "issues": [
+                        {"number": 1, "title": "Bootstrap repo"},
+                        {"number": 2, "title": "Add CI"},
+                    ],
+                },
+                {
+                    "id": "wave-2",
+                    "issues": [
+                        {"number": 3, "title": "Auth module"},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "Core",
+            "waves": [
+                {
+                    "id": "wave-3",
+                    "issues": [
+                        {"number": 4, "title": "Dashboard"},
+                    ],
+                },
+            ],
+        },
+    ],
+}
+
+STATE_DATA_BASE = {
+    "current_wave": "wave-1",
+    "waves": {
+        "wave-1": {"status": "in_progress", "mr_urls": {}},
+        "wave-2": {"status": "pending", "mr_urls": {}},
+        "wave-3": {"status": "pending", "mr_urls": {}},
+    },
+    "issues": {
+        "1": {"status": "open"},
+        "2": {"status": "open"},
+        "3": {"status": "open"},
+        "4": {"status": "open"},
+    },
+    "deferrals": [],
+}
+
+FLIGHTS_DATA_EMPTY = {"flights": {}}
+
+FLIGHTS_DATA_WAVE1 = {
+    "flights": {
+        "wave-1": [
+            {"issues": [1, 2], "status": "running"},
+            {"issues": [3], "status": "pending"},
+        ]
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# _status_badge() tests
+# ---------------------------------------------------------------------------
+
+
+class TestStatusBadge:
+    """Badge HTML generation."""
+
+    def test_returns_string(self) -> None:
+        html = _status_badge("pending")
+        assert isinstance(html, str)
+
+    def test_badge_class_present(self) -> None:
+        html = _status_badge("pending")
+        assert 'class="badge badge-pending"' in html
+
+    def test_in_progress_maps_to_hyphenated_class(self) -> None:
+        html = _status_badge("in_progress")
+        assert "badge-in-progress" in html
+
+    def test_label_uses_spaces(self) -> None:
+        html = _status_badge("in_progress")
+        assert "in progress" in html
+
+    def test_data_wave_attribute_when_provided(self) -> None:
+        html = _status_badge("completed", data_wave="wave-1")
+        assert 'data-wave="wave-1"' in html
+
+    def test_data_issue_attribute_when_provided(self) -> None:
+        html = _status_badge("open", data_issue="7")
+        assert 'data-issue="7"' in html
+
+    def test_no_data_attrs_when_not_provided(self) -> None:
+        html = _status_badge("pending")
+        assert "data-wave" not in html
+        assert "data-issue" not in html
+
+
+# ---------------------------------------------------------------------------
+# _render_flight_badges() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFlightBadges:
+    """Flight badge HTML for a wave."""
+
+    def test_empty_when_no_flight_plan(self) -> None:
+        result = _render_flight_badges("wave-1", FLIGHTS_DATA_EMPTY)
+        assert result == ""
+
+    def test_empty_when_wave_not_in_flights(self) -> None:
+        result = _render_flight_badges("wave-99", FLIGHTS_DATA_WAVE1)
+        assert result == ""
+
+    def test_returns_badge_per_flight(self) -> None:
+        result = _render_flight_badges("wave-1", FLIGHTS_DATA_WAVE1)
+        assert result.count("flight 1") == 1
+        assert result.count("flight 2") == 1
+
+    def test_running_flight_gets_running_class(self) -> None:
+        result = _render_flight_badges("wave-1", FLIGHTS_DATA_WAVE1)
+        assert "badge-running" in result
+
+    def test_pending_flight_gets_pending_class(self) -> None:
+        result = _render_flight_badges("wave-1", FLIGHTS_DATA_WAVE1)
+        assert "badge-pending" in result
+
+    def test_data_wave_attribute_present(self) -> None:
+        result = _render_flight_badges("wave-1", FLIGHTS_DATA_WAVE1)
+        assert 'data-wave="wave-1"' in result
+
+    def test_data_field_attribute_present(self) -> None:
+        result = _render_flight_badges("wave-1", FLIGHTS_DATA_WAVE1)
+        assert "data-field=" in result
+
+    def test_data_field_references_flights_path(self) -> None:
+        result = _render_flight_badges("wave-1", FLIGHTS_DATA_WAVE1)
+        assert "flights.wave-1." in result
+
+    def test_completed_flight_badge(self) -> None:
+        flights = {
+            "flights": {
+                "wave-1": [
+                    {"issues": [1], "status": "completed"},
+                ]
+            }
+        }
+        result = _render_flight_badges("wave-1", flights)
+        assert "badge-completed" in result
+        assert "completed" in result
+
+
+# ---------------------------------------------------------------------------
+# _render_issue_row() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderIssueRow:
+    """Issue table row HTML."""
+
+    def setup_method(self) -> None:
+        self.html = _render_issue_row(1, {"number": 1, "title": "Bootstrap repo"}, STATE_DATA_BASE, "wave-1")
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_is_tr_element(self) -> None:
+        assert self.html.startswith("<tr>")
+        assert "</tr>" in self.html
+
+    def test_contains_issue_number(self) -> None:
+        assert "#1" in self.html
+
+    def test_contains_title(self) -> None:
+        assert "Bootstrap repo" in self.html
+
+    def test_status_badge_present(self) -> None:
+        assert 'class="badge' in self.html
+
+    def test_open_status_renders_as_open(self) -> None:
+        assert "open" in self.html
+
+    def test_data_wave_on_status_badge(self) -> None:
+        assert 'data-wave="wave-1"' in self.html
+
+    def test_data_issue_on_status_badge(self) -> None:
+        assert 'data-issue="1"' in self.html
+
+    def test_data_field_on_status_badge(self) -> None:
+        assert 'data-field="issues.1.status"' in self.html
+
+    def test_mr_cell_empty_when_no_mr(self) -> None:
+        # No MR URL -> empty span with data attributes
+        assert 'data-field="waves.wave-1.mr_urls.1"' in self.html
+        assert "<a href=" not in self.html
+
+    def test_closed_issue_shows_closed_badge(self) -> None:
+        state = {
+            **STATE_DATA_BASE,
+            "issues": {"1": {"status": "closed"}},
+        }
+        html = _render_issue_row(1, {"number": 1, "title": "Bootstrap repo"}, state, "wave-1")
+        assert "badge-closed" in html
+        assert "closed" in html
+
+    def test_mr_link_renders_when_recorded(self) -> None:
+        state = {
+            **STATE_DATA_BASE,
+            "waves": {
+                "wave-1": {"status": "in_progress", "mr_urls": {"1": "https://github.com/org/repo/pull/42"}},
+                "wave-2": {"status": "pending", "mr_urls": {}},
+                "wave-3": {"status": "pending", "mr_urls": {}},
+            },
+        }
+        html = _render_issue_row(1, {"number": 1, "title": "Bootstrap repo"}, state, "wave-1")
+        assert '<a href="https://github.com/org/repo/pull/42"' in html
+        assert 'data-field="waves.wave-1.mr_urls.1"' in html
+
+    def test_issue_without_title_uses_fallback(self) -> None:
+        html = _render_issue_row(99, {"number": 99}, STATE_DATA_BASE, "wave-1")
+        assert "Issue #99" in html
+
+    def test_unknown_issue_in_state_defaults_to_open(self) -> None:
+        # Issue 999 not in state dict -> defaults to "open"
+        html = _render_issue_row(999, {"number": 999, "title": "Mystery"}, STATE_DATA_BASE, "wave-1")
+        assert "open" in html
+
+
+# ---------------------------------------------------------------------------
+# _render_wave_card() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderWaveCard:
+    """Wave card HTML structure."""
+
+    def setup_method(self) -> None:
+        wave_plan = PHASES_DATA["phases"][0]["waves"][0]
+        self.html = _render_wave_card(wave_plan, STATE_DATA_BASE, FLIGHTS_DATA_EMPTY)
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_has_wave_card_class(self) -> None:
+        assert 'class="wave-card"' in self.html
+
+    def test_data_wave_attribute(self) -> None:
+        assert 'data-wave="wave-1"' in self.html
+
+    def test_has_wave_header(self) -> None:
+        assert 'class="wave-header"' in self.html
+
+    def test_wave_id_in_header(self) -> None:
+        assert "wave-1" in self.html
+
+    def test_status_badge_in_header(self) -> None:
+        assert 'class="badge' in self.html
+
+    def test_wave_status_badge_has_data_field(self) -> None:
+        assert 'data-field="waves.wave-1.status"' in self.html
+
+    def test_has_issue_table(self) -> None:
+        assert 'class="issue-table"' in self.html
+
+    def test_all_issues_rendered(self) -> None:
+        assert "#1" in self.html
+        assert "#2" in self.html
+        assert "Bootstrap repo" in self.html
+        assert "Add CI" in self.html
+
+    def test_no_flight_badges_when_no_flights(self) -> None:
+        assert "flight-badges" not in self.html
+
+    def test_flight_badges_when_flights_exist(self) -> None:
+        wave_plan = PHASES_DATA["phases"][0]["waves"][0]
+        html = _render_wave_card(wave_plan, STATE_DATA_BASE, FLIGHTS_DATA_WAVE1)
+        assert "flight-badges" in html
+        assert "flight 1" in html
+        assert "flight 2" in html
+
+    def test_completed_wave_status_badge(self) -> None:
+        state = {
+            **STATE_DATA_BASE,
+            "waves": {
+                "wave-1": {"status": "completed", "mr_urls": {}},
+                "wave-2": {"status": "pending", "mr_urls": {}},
+                "wave-3": {"status": "pending", "mr_urls": {}},
+            },
+        }
+        wave_plan = PHASES_DATA["phases"][0]["waves"][0]
+        html = _render_wave_card(wave_plan, state, FLIGHTS_DATA_EMPTY)
+        assert "badge-completed" in html
+
+
+# ---------------------------------------------------------------------------
+# _render_phase_section() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPhaseSection:
+    """Phase section HTML structure."""
+
+    def setup_method(self) -> None:
+        phase = PHASES_DATA["phases"][0]
+        self.html = _render_phase_section(phase, 0, STATE_DATA_BASE, FLIGHTS_DATA_EMPTY)
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_has_phase_section_class(self) -> None:
+        assert 'class="phase-section"' in self.html
+
+    def test_data_phase_attribute(self) -> None:
+        assert 'data-phase="1"' in self.html
+
+    def test_phase_name_in_header(self) -> None:
+        assert "Foundation" in self.html
+
+    def test_phase_color_applied_as_border(self) -> None:
+        # Phase 0 -> fuchsia, var(--fuchsia)
+        assert "var(--fuchsia)" in self.html
+
+    def test_second_phase_uses_cyan(self) -> None:
+        phase = PHASES_DATA["phases"][1]
+        html = _render_phase_section(phase, 1, STATE_DATA_BASE, FLIGHTS_DATA_EMPTY)
+        assert "var(--cyan)" in html
+
+    def test_phase_index_wraps_mod_4(self) -> None:
+        # Phase index 4 wraps to fuchsia again
+        phase = PHASES_DATA["phases"][0]
+        html = _render_phase_section(phase, 4, STATE_DATA_BASE, FLIGHTS_DATA_EMPTY)
+        assert "var(--fuchsia)" in html
+
+    def test_contains_wave_cards_for_all_waves_in_phase(self) -> None:
+        assert 'data-wave="wave-1"' in self.html
+        assert 'data-wave="wave-2"' in self.html
+
+    def test_does_not_contain_wave_from_other_phase(self) -> None:
+        assert 'data-wave="wave-3"' not in self.html
+
+    def test_has_phase_body(self) -> None:
+        assert 'class="phase-body"' in self.html
+
+
+# ---------------------------------------------------------------------------
+# render_execution_grid() tests  [R-29, R-04, R-07, R-08]
+# ---------------------------------------------------------------------------
+
+
+class TestRenderExecutionGrid:
+    """Full integration tests for render_execution_grid()."""
+
+    def setup_method(self) -> None:
+        self.html = render_execution_grid(
+            PHASES_DATA, STATE_DATA_BASE, FLIGHTS_DATA_EMPTY
+        )
+
+    def test_returns_string(self) -> None:
+        assert isinstance(self.html, str)
+
+    def test_nonempty(self) -> None:
+        assert len(self.html) > 0
+
+    def test_has_execution_grid_wrapper(self) -> None:
+        assert 'class="execution-grid"' in self.html
+
+    # --- All phases rendered ---
+
+    def test_renders_all_phases(self) -> None:
+        assert "Foundation" in self.html
+        assert "Core" in self.html
+
+    def test_renders_both_phase_sections(self) -> None:
+        assert self.html.count('class="phase-section"') == 2
+
+    # --- All waves rendered [AC: Execution grid renders all phases, waves, issues, flights] ---
+
+    def test_renders_all_waves(self) -> None:
+        assert 'data-wave="wave-1"' in self.html
+        assert 'data-wave="wave-2"' in self.html
+        assert 'data-wave="wave-3"' in self.html
+
+    # --- All issues rendered ---
+
+    def test_renders_all_issues(self) -> None:
+        assert "#1" in self.html
+        assert "#2" in self.html
+        assert "#3" in self.html
+        assert "#4" in self.html
+        assert "Bootstrap repo" in self.html
+        assert "Add CI" in self.html
+        assert "Auth module" in self.html
+        assert "Dashboard" in self.html
+
+    # --- Issue row: number, title, status badge, MR link [R-07, R-08] ---
+
+    def test_issue_rows_have_status_badges(self) -> None:
+        assert 'class="badge' in self.html
+
+    def test_issue_rows_have_mr_cells(self) -> None:
+        # MR cells present (data-field for mr_urls)
+        assert "mr_urls" in self.html
+
+    def test_issue_rows_show_number_and_title(self) -> None:
+        assert "#1" in self.html
+        assert "Bootstrap repo" in self.html
+
+    # --- R-29: data-wave, data-issue, data-field attributes ---
+
+    def test_data_wave_attributes_present(self) -> None:
+        assert self.html.count("data-wave=") >= 3  # at least one per wave
+
+    def test_data_issue_attributes_present(self) -> None:
+        assert self.html.count("data-issue=") >= 4  # at least one per issue
+
+    def test_data_field_attributes_present(self) -> None:
+        assert self.html.count("data-field=") >= 4  # at least one per issue status
+
+    def test_data_field_references_issues_status(self) -> None:
+        assert 'data-field="issues.1.status"' in self.html
+
+    def test_data_field_references_wave_status(self) -> None:
+        assert 'data-field="waves.wave-1.status"' in self.html
+
+    def test_data_field_references_mr_urls(self) -> None:
+        assert "waves.wave-1.mr_urls" in self.html
+
+    # --- Phase color cycle ---
+
+    def test_phase_1_uses_fuchsia(self) -> None:
+        assert "var(--fuchsia)" in self.html
+
+    def test_phase_2_uses_cyan(self) -> None:
+        assert "var(--cyan)" in self.html
+
+    # --- Empty phases_data ---
+
+    def test_empty_phases_returns_grid_wrapper(self) -> None:
+        html = render_execution_grid(
+            {"phases": []}, STATE_DATA_BASE, FLIGHTS_DATA_EMPTY
+        )
+        assert 'class="execution-grid"' in html
+        assert "phase-section" not in html
+
+
+class TestRenderExecutionGridWithFlights:
+    """Execution grid with flight plan — verifies flight badges [R-04]."""
+
+    def setup_method(self) -> None:
+        self.html = render_execution_grid(
+            PHASES_DATA, STATE_DATA_BASE, FLIGHTS_DATA_WAVE1
+        )
+
+    def test_flight_badges_present(self) -> None:
+        assert "flight 1" in self.html
+        assert "flight 2" in self.html
+
+    def test_flight_badge_class_running(self) -> None:
+        assert "badge-running" in self.html
+
+    def test_flight_badge_class_pending(self) -> None:
+        assert "badge-pending" in self.html
+
+    def test_flight_data_wave_attribute(self) -> None:
+        assert 'data-wave="wave-1"' in self.html
+
+    def test_flight_data_field_attribute(self) -> None:
+        assert "flights.wave-1." in self.html
+
+
+class TestRenderExecutionGridWithMRLinks:
+    """Execution grid with MR URLs recorded — verifies MR link rendering [R-08]."""
+
+    def setup_method(self) -> None:
+        state = {
+            **STATE_DATA_BASE,
+            "waves": {
+                "wave-1": {
+                    "status": "in_progress",
+                    "mr_urls": {"1": "https://github.com/org/repo/pull/10"},
+                },
+                "wave-2": {"status": "pending", "mr_urls": {}},
+                "wave-3": {"status": "pending", "mr_urls": {}},
+            },
+        }
+        self.html = render_execution_grid(PHASES_DATA, state, FLIGHTS_DATA_EMPTY)
+
+    def test_mr_link_href_present(self) -> None:
+        assert 'href="https://github.com/org/repo/pull/10"' in self.html
+
+    def test_mr_link_data_field_attribute(self) -> None:
+        assert 'data-field="waves.wave-1.mr_urls.1"' in self.html
+
+
+class TestRenderExecutionGridWithClosedIssues:
+    """Execution grid with closed issues — verifies closed status badge [R-07]."""
+
+    def setup_method(self) -> None:
+        state = {
+            **STATE_DATA_BASE,
+            "issues": {
+                "1": {"status": "closed"},
+                "2": {"status": "open"},
+                "3": {"status": "open"},
+                "4": {"status": "open"},
+            },
+        }
+        self.html = render_execution_grid(PHASES_DATA, state, FLIGHTS_DATA_EMPTY)
+
+    def test_closed_issue_shows_closed_badge(self) -> None:
+        assert "badge-closed" in self.html
+
+    def test_open_issue_shows_open_badge(self) -> None:
+        assert "badge-pending" in self.html or "open" in self.html
+
+
+# ---------------------------------------------------------------------------
+# CT-01: No non-stdlib imports
+# ---------------------------------------------------------------------------
+
+
+class TestNoNonStdlibImports:
+    """CT-01: module uses only Python 3.10+ stdlib (plus wave_status internals)."""
+
+    def test_module_importable_without_third_party(self) -> None:
+        import wave_status.dashboard.execution_grid as eg  # noqa: F401
+
+        assert hasattr(eg, "render_execution_grid")
+
+    def test_module_has_no_non_stdlib_imports(self) -> None:
+        src = (
+            pathlib.Path(__file__).parent.parent
+            / "src"
+            / "wave_status"
+            / "dashboard"
+            / "execution_grid.py"
+        )
+        tree = ast.parse(src.read_text())
+        stdlib_prefixes = {
+            "__future__", "ast", "os", "sys", "pathlib", "json", "re",
+            "html", "datetime", "collections", "itertools", "functools",
+            "typing", "types", "abc", "io", "math", "copy", "string",
+            "textwrap", "enum", "dataclasses", "contextlib",
+        }
+        external = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top = alias.name.split(".")[0]
+                    if top not in stdlib_prefixes:
+                        external.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    top = node.module.split(".")[0]
+                    if top not in stdlib_prefixes and top != "wave_status":
+                        external.append(node.module)
+        assert external == [], f"Non-stdlib imports found: {external}"


### PR DESCRIPTION
## Summary

Two dashboard components: execution grid (phase sections with wave cards, issue tables, flight badges, MR links) and deferral sections (pending with zero-height collapse, accepted with subdued styling). All user-supplied strings escaped via html.escape().

## Changes

- `src/wave_status/dashboard/execution_grid.py` — `render_execution_grid(phases_data, state_data, flights_data)`
- `src/wave_status/dashboard/deferral_sections.py` — `render_pending_deferrals(state_data)`, `render_accepted_deferrals(state_data)`
- `tests/test_execution_grid.py` — 82 tests
- `tests/test_deferral_sections.py` — 44 tests

## Test Plan

- `python3 -m pytest tests/test_execution_grid.py tests/test_deferral_sections.py -v` — 126/126 pass
- `./scripts/ci/validate.sh` — 34/34 pass

Closes #21

Generated with [Claude Code](https://claude.com/claude-code)