### PR TITLE
feat(build): implement zipapp build pipeline (#24)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,6 +157,25 @@ if [[ "$CHECK_MODE" == true ]]; then
 		do_check "$REPO_DIR/config/statusline-command.sh" "$CLAUDE_DIR/statusline-command.sh" "statusline-command.sh" || drifted=$((drifted + 1))
 	fi
 
+	if [[ -d "$REPO_DIR/src" ]]; then
+		echo ""
+		echo "Packages"
+		echo "──────────────────────────────────────────"
+		# Rebuild to ensure fresh comparison
+		"$REPO_DIR/scripts/ci/build.sh" >/dev/null 2>&1 || true
+		for pkg_dir in "$REPO_DIR"/src/*/; do
+			[[ -f "$pkg_dir/__main__.py" ]] || continue
+			pkg_name="$(basename "$pkg_dir")"
+			artifact_name="${pkg_name//_/-}"
+			src="$REPO_DIR/dist/$artifact_name"
+			dest="$SCRIPTS_DIR/$artifact_name"
+			if [[ -f "$src" ]]; then
+				total=$((total + 1))
+				do_check "$src" "$dest" "$artifact_name" || drifted=$((drifted + 1))
+			fi
+		done
+	fi
+
 	echo ""
 	echo "══════════════════════════════════════════"
 	if [[ $drifted -eq 0 ]]; then
@@ -230,7 +249,36 @@ if [[ "$INSTALL_CONFIG" == true ]]; then
 	fi
 fi
 
-# Package builds added by Story 4.1
+# --- Build and install packages -----------------------------------------------
+if [[ "$INSTALL_SCRIPTS" == true && -d "$REPO_DIR/src" ]]; then
+	echo ""
+	echo "Packages → $SCRIPTS_DIR"
+	echo "──────────────────────────────────────────"
+	# Build from source
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) Would run scripts/ci/build.sh"
+	else
+		"$REPO_DIR/scripts/ci/build.sh"
+	fi
+	# Install built artifacts
+	for pkg_dir in "$REPO_DIR"/src/*/; do
+		[[ -f "$pkg_dir/__main__.py" ]] || continue
+		pkg_name="$(basename "$pkg_dir")"
+		artifact_name="${pkg_name//_/-}"
+		src="$REPO_DIR/dist/$artifact_name"
+		dest="$SCRIPTS_DIR/$artifact_name"
+		if [[ "$DRY_RUN" == true ]]; then
+			info "(dry-run) $src → $dest"
+		else
+			if [[ -f "$src" ]]; then
+				do_copy "$src" "$dest"
+				chmod +x "$dest"
+			else
+				warn "Expected artifact not found: $src"
+			fi
+		fi
+	done
+fi
 
 # --- Summary ------------------------------------------------------------------
 echo ""

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# build.sh — Build zipapp executables from src/ packages
+#
+# Discovers src/*/ directories containing __main__.py and builds each
+# into a standalone executable using python3 -m zipapp.
+#
+# Output: dist/<package-name>  (underscores replaced with hyphens)
+#
+# Usage:
+#   ./scripts/ci/build.sh          Build all packages
+#
+# Exit codes:
+#   0  All packages built successfully
+#   1  One or more builds failed
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+DIST_DIR="$REPO_DIR/dist"
+
+info() { echo "  [+] $*"; }
+err() { echo "  [!] $*"; }
+
+# --- Discover packages --------------------------------------------------------
+echo ""
+echo "Building zipapp packages"
+echo "══════════════════════════════════════════"
+
+packages=()
+for pkg_dir in "$REPO_DIR"/src/*/; do
+	[[ -f "$pkg_dir/__main__.py" ]] || continue
+	packages+=("$pkg_dir")
+done
+
+if [[ ${#packages[@]} -eq 0 ]]; then
+	err "No packages found in src/ with __main__.py"
+	exit 1
+fi
+
+# --- Build --------------------------------------------------------------------
+mkdir -p "$DIST_DIR"
+built=0
+failed=0
+
+for pkg_dir in "${packages[@]}"; do
+	pkg_name="$(basename "$pkg_dir")"
+	# Convert underscores to hyphens for the output name
+	artifact_name="${pkg_name//_/-}"
+	output="$DIST_DIR/$artifact_name"
+
+	echo ""
+	echo "Building: $pkg_name → dist/$artifact_name"
+	echo "──────────────────────────────────────────"
+
+	# Stage a temporary directory with the package as a subdirectory
+	# and a top-level __main__.py that imports it. This ensures
+	# intra-package imports (e.g. "from wave_status import ...") work.
+	staging="$(mktemp -d)"
+	trap 'rm -rf "$staging"' EXIT
+	cp -r "$pkg_dir" "$staging/$pkg_name"
+	cat >"$staging/__main__.py" <<ENTRY
+from ${pkg_name}.__main__ import main
+main()
+ENTRY
+
+	if python3 -m zipapp "$staging" -o "$output" -p '/usr/bin/env python3'; then
+		chmod +x "$output"
+		size=$(wc -c <"$output")
+		info "$artifact_name ($size bytes)"
+		built=$((built + 1))
+	else
+		err "Failed to build $pkg_name"
+		failed=$((failed + 1))
+	fi
+	rm -rf "$staging"
+done
+
+# --- Summary ------------------------------------------------------------------
+echo ""
+echo "══════════════════════════════════════════"
+echo "Built: $built, Failed: $failed"
+
+if [[ $failed -gt 0 ]]; then
+	exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -98,6 +98,19 @@ if [[ "$REMOVE_SCRIPTS" == true ]]; then
 	done
 fi
 
+# --- Remove packages ----------------------------------------------------------
+if [[ "$REMOVE_SCRIPTS" == true && -d "$REPO_DIR/src" ]]; then
+	echo ""
+	echo "Removing packages from $SCRIPTS_DIR"
+	echo "──────────────────────────────────────────"
+	for pkg_dir in "$REPO_DIR"/src/*/; do
+		[[ -f "$pkg_dir/__main__.py" ]] || continue
+		pkg_name="$(basename "$pkg_dir")"
+		artifact_name="${pkg_name//_/-}"
+		do_remove "$SCRIPTS_DIR/$artifact_name"
+	done
+fi
+
 # --- Remove config ------------------------------------------------------------
 if [[ "$REMOVE_CONFIG" == true ]]; then
 	echo ""


### PR DESCRIPTION
## Summary

Creates `scripts/ci/build.sh` — a zipapp build pipeline that discovers Python packages in `src/` and produces standalone executables. Integrates with `install.sh` and `uninstall.sh` for seamless artifact lifecycle management.

## Changes

- **`scripts/ci/build.sh`** (86 lines) — discovers `src/*/` with `__main__.py`, stages package structure, runs `python3 -m zipapp`, outputs to `dist/`
- **`install.sh`** — calls `build.sh`, copies artifacts to `~/.local/bin/` with `chmod +x`; `--check` mode rebuilds before comparing for drift
- **`uninstall.sh`** — removes built artifacts from `~/.local/bin/`

## Test Results

- `scripts/ci/build.sh` produces `dist/wave-status` (78KB zipapp)
- `dist/wave-status --help` shows all 14 subcommands
- `install.sh --dry-run` / `uninstall.sh --dry-run` show correct package sections
- Validation: 40/40 checks pass (shellcheck + shfmt clean)
- 528 tests passing

Closes #24

Generated with [Claude Code](https://claude.com/claude-code)