### PR TITLE
chore(skills): add /scpmmr and /scpmr combo skills (#44)

### DIFF
--- a/skills/scpmmr/SKILL.md
+++ b/skills/scpmmr/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: scpmmr
+description: Stage, commit, push, create PR/MR, then merge it — full pipeline in one command
+---
+
+# Stage, Commit, Push, Create PR/MR, Merge
+
+This is a combo skill that chains `/scp` and `/mmr` into a single invocation.
+
+## Workflow
+
+1. **Run `/scp`** — Execute the full scp workflow (stage, commit, push, create PR/MR)
+   - If a commit approval is pending, treat this invocation as approval
+   - If no commit is pending, run the full cold-start workflow
+   - The scp skill will create a PR/MR if one doesn't exist
+
+2. **Run `/mmr`** — Immediately after scp completes, merge the PR/MR
+   - Target the PR/MR that was just created or already exists for this branch
+   - Use `--admin` flag if branch protection requires it (same as prior merge patterns in this repo)
+   - Follow the full mmr workflow: gather context, verify CI, generate squash message, merge
+
+## Important
+
+- This is a **convenience shortcut** — it does NOT skip any safety checks
+- The pre-commit checklist from CLAUDE.md is still mandatory
+- User approval is still required for the commit (invoking `/scpmmr` IS the approval)
+- CI verification before merge still applies
+- If any step fails, stop and report — do NOT continue to the next step

--- a/skills/scpmr/SKILL.md
+++ b/skills/scpmr/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: scpmr
+description: Stage, commit, push, and create PR/MR — but do not merge
+---
+
+# Stage, Commit, Push, Create PR/MR (No Merge)
+
+This is a combo skill that runs `/scp` with an explicit instruction to create the PR/MR but stop before merging.
+
+## Workflow
+
+1. **Run `/scp`** — Execute the full scp workflow (stage, commit, push, create PR/MR)
+   - If a commit approval is pending, treat this invocation as approval
+   - If no commit is pending, run the full cold-start workflow
+   - The scp skill will create a PR/MR if one doesn't exist
+
+2. **Stop** — Report the PR/MR URL and do NOT merge
+   - The user wants to review the PR/MR before merging
+   - They can later run `/mmr` to merge when ready
+
+## Important
+
+- This is a **convenience shortcut** — it does NOT skip any safety checks
+- The pre-commit checklist from CLAUDE.md is still mandatory
+- User approval is still required for the commit (invoking `/scpmr` IS the approval)
+- Do NOT merge — that's the whole point of this skill vs `/scpmmr`


### PR DESCRIPTION
## Summary

Adds two convenience combo skills that chain existing workflows:

- `/scpmmr` — stage, commit, push, create PR/MR, then merge (chains `/scp` + `/mmr`)
- `/scpmr` — stage, commit, push, create PR/MR, stop before merge

## Changes

- `skills/scpmmr/SKILL.md` — full pipeline combo skill
- `skills/scpmr/SKILL.md` — commit+PR only combo skill

## Test Plan

- Validation: 42/42 checks pass (includes SKILL.md frontmatter validation)
- Skills immediately discoverable by Claude Code after creation

Closes #44

Generated with [Claude Code](https://claude.com/claude-code)