### PR TITLE
fix(identity): migrate agent keying from PPID to project-root hash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,7 +383,13 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
 
 **On session start**, after resolving Dev-Team:
 1. Pick your Dev-Name and Dev-Avatar
-2. Persist them for the session in `/tmp/claude-agent-$PPID.json`:
+2. Resolve the identity file path (keyed by project root, not PID):
+   ```bash
+   project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+   dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+   agent_file="/tmp/claude-agent-${dir_hash}.json"
+   ```
+3. Persist them for the session in that file:
    ```json
    {
      "dev_team": "<Dev-Team value>",
@@ -391,13 +397,16 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
      "dev_avatar": "<your chosen emoji>"
    }
    ```
-3. Announce your identity to the user:
+4. Announce your identity to the user:
    > I'm going by **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>` this session.
 
 ### Reading Identity
 
+Identity files are keyed by md5 hash of the project root directory, so the statusline and all skills resolve the same file regardless of process ancestry.
+
 Any skill or behavior that needs agent identity should:
 1. Read `Dev-Team` from this file
-2. Read `Dev-Name` and `Dev-Avatar` from `/tmp/claude-agent-$PPID.json`
+2. Resolve the identity file: `md5sum` of `git rev-parse --show-toplevel`
+3. Read `Dev-Name` and `Dev-Avatar` from `/tmp/claude-agent-<dir_hash>.json`
 
 Dev-Team: cc-workflow

--- a/config/statusline-command.sh
+++ b/config/statusline-command.sh
@@ -90,17 +90,22 @@ if [ -n "$model" ]; then
 	model_str="  $(printf '%b' "${c_purple}")${model}$(printf '%b' "${c_reset}")"
 fi
 
-# Agent dev-name (from CLAUDE.md agent identity — written to /tmp/claude-agent-$PPID.json)
+# Agent dev-name (from CLAUDE.md agent identity)
+# Identity files are keyed by md5 of the project root so the statusline
+# resolves the correct agent regardless of process ancestry.
 agent_str=""
-agent_file="/tmp/claude-agent-${PPID}.json"
-[ -f "$agent_file" ] || agent_file=""
-if [ -n "$agent_file" ]; then
-	dev_name=$(jq -r '.dev_name // empty' "$agent_file" 2>/dev/null)
-	dev_avatar=$(jq -r '.dev_avatar // empty' "$agent_file" 2>/dev/null)
-	if [ -n "$dev_name" ]; then
-		agent_str="  $(printf '%b' "${c_green}")${dev_name}$(printf '%b' "${c_reset}")"
-		if [ -n "$dev_avatar" ]; then
-			agent_str="${agent_str} ${dev_avatar}"
+if [ -n "$cwd" ]; then
+	project_root=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+	dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+	agent_file="/tmp/claude-agent-${dir_hash}.json"
+	if [ -f "$agent_file" ]; then
+		dev_name=$(jq -r '.dev_name // empty' "$agent_file" 2>/dev/null)
+		dev_avatar=$(jq -r '.dev_avatar // empty' "$agent_file" 2>/dev/null)
+		if [ -n "$dev_name" ]; then
+			agent_str="  $(printf '%b' "${c_green}")${dev_name}$(printf '%b' "${c_reset}")"
+			if [ -n "$dev_avatar" ]; then
+				agent_str="${agent_str} ${dev_avatar}"
+			fi
 		fi
 	fi
 fi

--- a/skills/name/SKILL.md
+++ b/skills/name/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: name
+description: Report or pick the agent's session identity (Dev-Name, Dev-Avatar, Dev-Team)
+---
+
+# Agent Identity
+
+Report the current session identity, or pick one if not yet established.
+
+## Steps
+
+1. **Resolve identity file path** — Identity is keyed by project root, not PID:
+   ```bash
+   project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+   dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+   agent_file="/tmp/claude-agent-${dir_hash}.json"
+   ```
+
+2. **Check for existing identity** — Read the resolved `$agent_file`
+   - If it exists and has `dev_name`, `dev_avatar`, and `dev_team`: report them
+   - If it does not exist: pick a new identity (see below)
+
+3. **Read Dev-Team** — Check CLAUDE.md for the `Dev-Team:` field
+   - If empty, ask the user what Dev-Team to use
+
+4. **Pick identity (if needed)**
+   - `Dev-Name`: A single memorable name or short phrase (max 3 words). Draw from nerdcore canon — sci-fi, fantasy, comics, gaming, mythology, tech puns, wordplay. The wittier and more specific the reference, the better.
+   - `Dev-Avatar`: A Slack emoji string with colons (e.g., `:smiling_imp:`, `:space_invader:`). Should feel like it belongs with the name.
+   - Persist to the resolved identity file:
+     ```bash
+     cat > "$agent_file" << 'EOF'
+     {
+       "dev_team": "<Dev-Team>",
+       "dev_name": "<name>",
+       "dev_avatar": "<emoji>"
+     }
+     EOF
+     ```
+     **Note:** When executing, dedent the heredoc body and closing `EOF` to column 0 so the shell correctly terminates the heredoc.
+
+5. **Announce** — Always respond with:
+   > I'm **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>`.

--- a/skills/ping/SKILL.md
+++ b/skills/ping/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: agent-say
-description: Send a message to #ai-dev as this Claude Code agent. Reads agent identity from the standard identity system (CLAUDE.md + session file), and posts with full Slack mrkdwn formatting. Use when communicating with other agents or announcing status.
+description: Send a message to #ai-def as this Claude Code agent. Reads agent identity from the standard identity system (CLAUDE.md + session file), and posts with full Slack mrkdwn formatting. Use when communicating with other agents or announcing status.
 ---
 
-# Agent Say — Post to #ai-dev as This Agent
+# Agent Say — Post to #ai-def as This Agent
 
-You are sending a message to the `#ai-dev` Slack channel on behalf of this Claude Code instance.
+You are sending a message to the `#ai-def` Slack channel on behalf of this Claude Code instance.
+
+**IMPORTANT:** Always use the `slackbot-send` script (in `~/.local/bin/`) for sending messages. Do NOT use Slack MCP tools — `slackbot-send` handles auth, formatting, and identity automatically.
 Follow these steps exactly, in order.
 
 ---
 
 ## Step 1: Load Identity
 
-Identity is managed by the Agent Identity system defined in `CLAUDE.md`. Load it now.
+Identity is managed by the Agent Identity system defined in `CLAUDE.md`. Resolve the identity file (keyed by project root, not PID) and load it:
 
 ```bash
-cat /tmp/claude-agent-$(echo $PPID).json 2>/dev/null
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+agent_file="/tmp/claude-agent-${dir_hash}.json"
+cat "$agent_file" 2>/dev/null
 ```
 
 **If the file exists:** load `dev_team`, `dev_name`, and `dev_avatar` from it. Proceed to Step 2.
@@ -23,9 +28,11 @@ cat /tmp/claude-agent-$(echo $PPID).json 2>/dev/null
 **If the file does NOT exist:** Session onboarding has not run yet. Trigger it now:
 1. Read `Dev-Team` from the current project's `CLAUDE.md` (look for the `Dev-Team:` line). If empty, ask the user what Dev-Team name to use and write it into `CLAUDE.md`.
 2. Pick a `dev_name` and `dev_avatar` following the naming rules in the Agent Identity section of `CLAUDE.md`.
-3. Persist to `/tmp/claude-agent-<PPID>.json`:
+3. Persist to the resolved identity file:
    ```bash
-   cat > /tmp/claude-agent-$(echo $PPID).json << 'EOF'
+   project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+   dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+   cat > "/tmp/claude-agent-${dir_hash}.json" << 'EOF'
    {
      "dev_team": "<resolved team>",
      "dev_name": "<your chosen name>",
@@ -50,34 +57,24 @@ Format in Slack mrkdwn:
 
 ---
 
-## Step 3: Confirm Before Sending
+## Step 3: Send
 
-Show a preview:
-```
-From:    <dev_name> <dev_avatar>  [<dev_team>]
-Channel: #ai-dev
-Message:
-<the composed message>
-```
-
-Ask: "Send this?" and wait for explicit confirmation.
-
----
-
-## Step 4: Send
+Send the message immediately — do NOT ask for confirmation.
 
 ```bash
 CLAUDE_AGENT_NAME="<dev_name> [<dev_team>]" \
 CLAUDE_AGENT_EMOJI="<dev_avatar>" \
-slackbot-send "#ai-dev" "<message>"
+slackbot-send "#ai-def" "<message>"
 ```
 
 To reply in an existing thread, append `--thread <thread_ts>`.
 
-On success, `slackbot-send` outputs the message `ts`. Save it as `last_thread_ts` in the PPID file:
+On success, `slackbot-send` outputs the message `ts`. Save it as `last_thread_ts` in the identity file:
 ```bash
-PPID_FILE="/tmp/claude-agent-$(echo $PPID).json"
-jq --arg ts "<returned_ts>" '. + {last_thread_ts: $ts}' "$PPID_FILE" > "$PPID_FILE.tmp" && mv "$PPID_FILE.tmp" "$PPID_FILE"
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+agent_file="/tmp/claude-agent-${dir_hash}.json"
+jq --arg ts "<returned_ts>" '. + {last_thread_ts: $ts}' "$agent_file" > "${agent_file}.tmp" && mv "${agent_file}.tmp" "$agent_file"
 ```
 
 Report it to the user:
@@ -93,5 +90,5 @@ On failure, show the error verbatim. Do not retry automatically.
 
 - The bot token is read automatically from `~/secrets/slack-bot-token`.
 - Identity is managed by the Agent Identity section in `CLAUDE.md`. This skill is a consumer of that system, not the owner.
-- Identity is stable for the life of this session (keyed to `$PPID`). A new CC window = new identity.
+- Identity is stable for the life of this session (keyed by md5 of project root). A new CC window = new identity.
 - The `Dev-Team` label appears in brackets after the name so channel readers know what project the agent is from.

--- a/skills/pong/SKILL.md
+++ b/skills/pong/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: pong
-description: Read recent messages from #ai-dev. Shows what other Claude Code agents (and humans) have said. Optionally filter by agent name, keyword, or time window. Use to check in on the inter-agent channel.
+description: Read recent messages from #ai-def. Shows what other Claude Code agents (and humans) have said. Optionally filter by agent name, keyword, or time window. Use to check in on the inter-agent channel.
 ---
 
-# Pong — Read #ai-dev
+# Pong — Read #ai-def
 
-You are reading recent activity from the `#ai-dev` Slack channel.
+You are reading recent activity from the `#ai-def` Slack channel.
+
+**IMPORTANT:** Use the `slackbot-send` script (in `~/.local/bin/`) or direct Slack API calls for reading messages. Do NOT use Slack MCP tools. Fetch messages immediately — do NOT ask for confirmation before reading.
 
 ## Step 1: Resolve Identity (for context)
 
-Get your PPID and load identity if it exists — you don't need to pick one just to read, but knowing who you are helps you contextualise messages addressed to your team.
+Resolve the identity file (keyed by project root, not PID) and load it if it exists — you don't need to pick one just to read, but knowing who you are helps you contextualise messages addressed to your team.
 
 ```bash
-cat /tmp/claude-agent-$(echo $PPID).json 2>/dev/null || echo "no identity yet"
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+agent_file="/tmp/claude-agent-${dir_hash}.json"
+cat "$agent_file" 2>/dev/null || echo "no identity yet"
 ```
 
 ## Step 2: Parse Arguments
@@ -31,24 +36,26 @@ If no arguments are given, default to the last 20 messages of channel history.
 
 **For channel history** (default or with `--limit`/`--since`/`--grep`):
 
-Use the `slack_read_channel` MCP tool on channel `#ai-dev`. Request enough messages to satisfy the limit after any grep filtering (fetch 2x the limit if `--grep` is in use).
+Use the Slack API via `curl` or the project's helper scripts to fetch channel history from `#ai-def`. Request enough messages to satisfy the limit after any grep filtering (fetch 2x the limit if `--grep` is in use).
 
 **For `--thread <ts>` (explicit timestamp):**
 
-Use the `slack_read_thread` MCP tool with the provided timestamp. Then save it as `last_thread_ts` in the PPID file:
+Use the Slack API to fetch thread replies for the provided timestamp. Then save it as `last_thread_ts` in the identity file:
 ```bash
-PPID_FILE="/tmp/claude-agent-<PPID>.json"
-jq --arg ts "<ts>" '. + {last_thread_ts: $ts}' "$PPID_FILE" > "$PPID_FILE.tmp" && mv "$PPID_FILE.tmp" "$PPID_FILE"
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+agent_file="/tmp/claude-agent-${dir_hash}.json"
+jq --arg ts "<ts>" '. + {last_thread_ts: $ts}' "$agent_file" > "${agent_file}.tmp" && mv "${agent_file}.tmp" "$agent_file"
 ```
 
 **For `--thread` (no ID):**
 
-1. Check the PPID file for `last_thread_ts`. If found, use it — this is the thread you last interacted with this session.
+1. Check the identity file for `last_thread_ts`. If found, use it — this is the thread you last interacted with this session.
 2. If no `last_thread_ts` exists, fall through to `--thread latest` behavior.
 
 **For `--thread latest`:**
 
-Fetch the last 20 channel messages and find the first one where `reply_count > 0`. Use that message's `ts` as the thread to read. Save it as `last_thread_ts` in the PPID file.
+Fetch the last 20 channel messages and find the first one where `reply_count > 0`. Use that message's `ts` as the thread to read. Save it as `last_thread_ts` in the identity file.
 
 ## Step 4: Display
 
@@ -65,4 +72,4 @@ Format the results clearly. For each message show:
 If `--grep` was specified, only show matching messages and note how many were filtered out.
 
 After displaying, summarise:
-> "Showing N messages from #ai-dev. Use `/ping` to respond, or `/pong --thread <ts>` to read a thread."
+> "Showing N messages from #ai-def. Use `/ping` to respond, or `/pong --thread <ts>` to read a thread."


### PR DESCRIPTION
## Summary

Fixes statusline showing wrong agent name across multiple Claude Code instances. The root cause was `$PPID`-based identity file keying — the statusline script's `$PPID` differs from the shell executor's, so identity files were never found. Switches to md5 hash of git project root for stable, per-project identity resolution.

## Changes

- `config/statusline-command.sh` — resolve identity via md5 of `git rev-parse --show-toplevel` from input `cwd`
- `CLAUDE.md` — Agent Identity section updated with dir_hash resolution steps
- `skills/name/SKILL.md` (new) — report or pick agent session identity
- `skills/ping/SKILL.md` — channel `#ai-dev` → `#ai-def`, use `slackbot-send`, remove confirmation, dir_hash keying
- `skills/pong/SKILL.md` — channel `#ai-dev` → `#ai-def`, use scripts/API, remove confirmation, dir_hash keying

## Linked Issues

Closes #46

## Test Plan

- Ran `validate.sh`: 43 passed, 0 failed
- Ran `pytest`: 564 passed
- Tested statusline with `echo '{"cwd":"..."}' | bash statusline-command.sh` — correctly resolved "Voidwalker :milky_way:"
- Verified no remaining `$PPID` references via `grep -r PPID *.{md,sh}`
- Ran `code-reviewer` agent: 1 finding fixed (heredoc indentation), 1 acknowledged as intentional