### PR TITLE
chore(gitignore): add Python bytecode patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,9 @@ Thumbs.db
 # Generated files
 .status-panel.html
 
+# Python bytecode
+__pycache__/
+*.pyc
+
 # Build output
 dist/


### PR DESCRIPTION
## Summary

Adds `__pycache__/` and `*.pyc` patterns to `.gitignore` so Python bytecode directories stop showing in `git status`.

## Changes

- Added `# Python bytecode` section to `.gitignore` with `__pycache__/` and `*.pyc` patterns

## Linked Issues

Closes #55

## Test Plan

- Verified patterns match the untracked `__pycache__/` directories reported by `git status`
- Confirmed no existing tracked files are affected

Generated with [Claude Code](https://claude.com/claude-code)