### PR TITLE
feat(nextwave): auto-open status panel on Wave 1

### DIFF
--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -47,10 +47,15 @@ Before launching any agents:
    wave-status preflight
    ```
 2. **Identify the next pending wave** — Read the task list, find the first wave task that is not completed
-3. **Verify the main branch is clean** — `git status` shows no uncommitted changes, `git log` confirms previous wave's commits are present
-4. **Verify previous wave is merged** — If this is not Wave 1, confirm that all issues from the prior wave have their code on the main branch
-5. **Verify issue specs** — For each issue in this wave, read it via the platform CLI and confirm it has: Changes, Tests, Acceptance Criteria
-6. **Create feature branches** — For each issue in this wave, create a branch from the current main/release branch. This ensures each branch includes all prior waves' merged work.
+3. **Auto-open status panel (Wave 1 only)** — If the wave identified in step 2 is the lowest-numbered wave in the plan (i.e., this is the first wave execution, not a continuation), open the status panel in the user's browser so they can monitor progress:
+   ```bash
+   xdg-open .status-panel.html 2>/dev/null || open .status-panel.html 2>/dev/null || true
+   ```
+   Skip this step for subsequent waves — the panel is already open from Wave 1.
+4. **Verify the main branch is clean** — `git status` shows no uncommitted changes, `git log` confirms previous wave's commits are present
+5. **Verify previous wave is merged** — If this is not Wave 1, confirm that all issues from the prior wave have their code on the main branch
+6. **Verify issue specs** — For each issue in this wave, read it via the platform CLI and confirm it has: Changes, Tests, Acceptance Criteria
+7. **Create feature branches** — For each issue in this wave, create a branch from the current main/release branch. This ensures each branch includes all prior waves' merged work.
    ```bash
    git checkout main && git pull
    git checkout -b feature/<issue-number>-<description>


### PR DESCRIPTION
## Summary

Adds an auto-open step to the `/nextwave` skill that opens `.status-panel.html` in the default browser when the first wave begins execution. This gives the user visual feedback via the wave-status dashboard from the start.

## Changes

- Added Step 3 in Pre-Flight Checks section of `skills/nextwave/SKILL.md`
- Uses `xdg-open` (Linux) with `open` (macOS) fallback, piped to `|| true` to avoid blocking on failure
- Only triggers on the lowest-numbered wave in the plan (typically Wave 1)

## Linked Issues

Closes #56

## Test Plan

- Verified the skill file renders correctly with the new step numbered and positioned between wave identification and branch verification
- Confirmed `xdg-open` / `open` fallback pattern works on both Linux and macOS
- The `|| true` ensures the wave continues even if no browser is available

Generated with [Claude Code](https://claude.com/claude-code)