### PR TITLE
fix(skills): correct #ai-def typo to #ai-dev in ping/pong

### DIFF
--- a/skills/ping/SKILL.md
+++ b/skills/ping/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agent-say
-description: Send a message to #ai-def as this Claude Code agent. Reads agent identity from the standard identity system (CLAUDE.md + session file), and posts with full Slack mrkdwn formatting. Use when communicating with other agents or announcing status.
+description: Send a message to #ai-dev as this Claude Code agent. Reads agent identity from the standard identity system (CLAUDE.md + session file), and posts with full Slack mrkdwn formatting. Use when communicating with other agents or announcing status.
 ---
 
-# Agent Say — Post to #ai-def as This Agent
+# Agent Say — Post to #ai-dev as This Agent
 
-You are sending a message to the `#ai-def` Slack channel on behalf of this Claude Code instance.
+You are sending a message to the `#ai-dev` Slack channel on behalf of this Claude Code instance.
 
 **IMPORTANT:** Always use the `slackbot-send` script (in `~/.local/bin/`) for sending messages. Do NOT use Slack MCP tools — `slackbot-send` handles auth, formatting, and identity automatically.
 Follow these steps exactly, in order.
@@ -62,9 +62,10 @@ Format in Slack mrkdwn:
 Send the message immediately — do NOT ask for confirmation.
 
 ```bash
+# Channel ID: C0AJ5B4BCJ0
 CLAUDE_AGENT_NAME="<dev_name> [<dev_team>]" \
 CLAUDE_AGENT_EMOJI="<dev_avatar>" \
-slackbot-send "#ai-def" "<message>"
+slackbot-send "#ai-dev" "<message>"
 ```
 
 To reply in an existing thread, append `--thread <thread_ts>`.

--- a/skills/pong/SKILL.md
+++ b/skills/pong/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pong
-description: Read recent messages from #ai-def. Shows what other Claude Code agents (and humans) have said. Optionally filter by agent name, keyword, or time window. Use to check in on the inter-agent channel.
+description: Read recent messages from #ai-dev. Shows what other Claude Code agents (and humans) have said. Optionally filter by agent name, keyword, or time window. Use to check in on the inter-agent channel.
 ---
 
-# Pong — Read #ai-def
+# Pong — Read #ai-dev
 
-You are reading recent activity from the `#ai-def` Slack channel.
+You are reading recent activity from the `#ai-dev` Slack channel.
 
 **IMPORTANT:** Use the `slackbot-send` script (in `~/.local/bin/`) or direct Slack API calls for reading messages. Do NOT use Slack MCP tools. Fetch messages immediately — do NOT ask for confirmation before reading.
 
@@ -36,7 +36,8 @@ If no arguments are given, default to the last 20 messages of channel history.
 
 **For channel history** (default or with `--limit`/`--since`/`--grep`):
 
-Use the Slack API via `curl` or the project's helper scripts to fetch channel history from `#ai-def`. Request enough messages to satisfy the limit after any grep filtering (fetch 2x the limit if `--grep` is in use).
+# Channel ID: C0AJ5B4BCJ0
+Use the Slack API via `curl` or the project's helper scripts to fetch channel history from `#ai-dev`. Request enough messages to satisfy the limit after any grep filtering (fetch 2x the limit if `--grep` is in use).
 
 **For `--thread <ts>` (explicit timestamp):**
 
@@ -72,4 +73,4 @@ Format the results clearly. For each message show:
 If `--grep` was specified, only show matching messages and note how many were filtered out.
 
 After displaying, summarise:
-> "Showing N messages from #ai-def. Use `/ping` to respond, or `/pong --thread <ts>` to read a thread."
+> "Showing N messages from #ai-dev. Use `/ping` to respond, or `/pong --thread <ts>` to read a thread."


### PR DESCRIPTION
## Summary

Fixes a channel name typo in both the `/ping` and `/pong` skill files — `#ai-def` was changed to `#ai-dev` (the correct Slack channel name). Also adds the channel ID comment for consistency.

## Changes

- `skills/ping/SKILL.md`: Fixed 4 occurrences of `ai-def` → `ai-dev`, added `# Channel ID: C0AJ5B4BCJ0` comment
- `skills/pong/SKILL.md`: Fixed 4 occurrences of `ai-def` → `ai-dev`, added `# Channel ID: C0AJ5B4BCJ0` comment

## Linked Issues

Closes #57

## Test Plan

- Verified all occurrences of `ai-def` are replaced in both files
- Confirmed channel ID `C0AJ5B4BCJ0` matches the actual `#ai-dev` channel
- Grep confirmed zero remaining instances of `ai-def` in the skill files

Generated with [Claude Code](https://claude.com/claude-code)