### PR TITLE
feat(pong): add priority-ordered default discovery flow

### DIFF
--- a/skills/pong/SKILL.md
+++ b/skills/pong/SKILL.md
@@ -30,11 +30,23 @@ The user may pass optional filters as arguments:
 - `--thread` (no ID) — smart default: see below
 - `--thread latest` — the most recent thread in the channel
 
-If no arguments are given, default to the last 20 messages of channel history.
+**If explicit args are provided** (`--thread`, `--limit`, `--grep`, `--since`), they override the default flow entirely — skip straight to Step 3 using the specified parameters.
+
+**If no arguments are given**, use the **default discovery flow** — a 3-priority cascade that checks contextually relevant sources first, stopping at the first that yields results:
+
+| Priority | Source | What it checks |
+|----------|--------|----------------|
+| **1** | Active thread | `last_thread_ts` in identity file — fetches thread replies, stops if NEW replies exist since last read |
+| **2** | Addressed messages | Last 20 channel messages — scans for mentions of your `dev_name` or `dev_team` |
+| **3** | General history | Last 20 channel messages displayed as-is (existing fallback behavior) |
+
+The intent: bare `/pong` should surface what matters most to the invoking agent — first any thread they are actively participating in, then any messages directed at them, and only then the general firehose.
 
 ## Step 3: Fetch Messages
 
-**For channel history** (default or with `--limit`/`--since`/`--grep`):
+### When explicit args are provided
+
+**For channel history** (with `--limit`/`--since`/`--grep`):
 
 # Channel ID: C0AJ5B4BCJ0
 Use the Slack API via `curl` or the project's helper scripts to fetch channel history from `#ai-dev`. Request enough messages to satisfy the limit after any grep filtering (fetch 2x the limit if `--grep` is in use).
@@ -58,7 +70,50 @@ jq --arg ts "<ts>" '. + {last_thread_ts: $ts}' "$agent_file" > "${agent_file}.tm
 
 Fetch the last 20 channel messages and find the first one where `reply_count > 0`. Use that message's `ts` as the thread to read. Save it as `last_thread_ts` in the identity file.
 
+### Default discovery flow (no args)
+
+When no arguments are provided, execute the priority cascade from Step 2. Stop at the first priority that yields results.
+
+**Priority 1 — Active thread check:**
+
+1. Read the identity file and look for `last_thread_ts`. This value serves as a **high-water mark** — it records the `ts` of the latest reply you have already seen (or the thread root if you just opened the thread).
+2. If `last_thread_ts` exists, fetch that thread's replies using the Slack API (`conversations.replies` with `ts` set to the thread root). The thread root `ts` is the `last_thread_ts` value if it matches a parent message, or the thread's parent `ts` from the first reply's `thread_ts` field.
+3. Determine if there are NEW replies since the last read. Compare each reply's `ts` against the stored `last_thread_ts` — replies with `ts` > `last_thread_ts` are new. If new replies exist, display them and **update `last_thread_ts`** to the latest reply's `ts`:
+   ```bash
+   jq --arg ts "<latest_reply_ts>" '. + {last_thread_ts: $ts}' "$agent_file" > "${agent_file}.tmp" && mv "${agent_file}.tmp" "$agent_file"
+   ```
+   Then **stop**.
+4. If the thread has **no new replies** (no reply `ts` > stored value, or the thread no longer exists), fall through to Priority 2.
+
+**Priority 2 — Channel scan for addressed messages:**
+
+1. Fetch the last 20 channel messages from `#ai-dev` (Channel ID: C0AJ5B4BCJ0).
+2. Load `dev_name` and `dev_team` from the identity file.
+3. Scan each message for patterns that indicate it is addressed to this agent:
+   - Direct mention of `dev_name` (case-insensitive)
+   - Direct mention of `dev_team` (case-insensitive)
+   - Patterns like `"hey <dev_name>"`, `"@<dev_name>"`, or direct questions in a message immediately following one you sent
+4. If one or more addressed messages are found, display them with context: include 1 message before each match and any thread replies on the matched message. **Stop**.
+5. If no addressed messages are found, fall through to Priority 3.
+
+**Priority 3 — General channel history (fallback):**
+
+1. Display the last 20 channel messages from `#ai-dev` — this is the same as the previous bare `/pong` default.
+2. No special filtering or context is applied.
+
 ## Step 4: Display
+
+### Context-line prefix
+
+When displaying results from the default discovery flow (no args), prefix the output with a context line indicating which priority level produced the results:
+
+- **Priority 1:** `"Showing new replies in your active thread (ts: <ts>):"`
+- **Priority 2:** `"Found messages addressed to you in #ai-dev:"`
+- **Priority 3:** `"Showing recent #ai-dev history (no active threads or addressed messages found):"`
+
+When explicit args were provided, omit the context-line prefix — the user knows what they asked for.
+
+### Message format
 
 Format the results clearly. For each message show:
 


### PR DESCRIPTION
## Summary

Adds a 3-priority default discovery flow to `/pong` when invoked with no arguments. Instead of always showing the last 20 channel messages, agents now check contextually relevant sources first: active threads with new replies, then messages addressed to them, then general history.

## Changes

- **Step 2** — Documented the 3-priority cascade with a summary table and override rules for explicit args
- **Step 3** — Added "Default discovery flow" subsection with detailed Priority 1/2/3 logic, including high-water mark tracking for thread reads
- **Step 4** — Added context-line prefixes so agents report which priority level produced the results

## Linked Issues

Closes #58

## Test Plan

- Validated all acceptance criteria against the modified SKILL.md
- Ran `validate.sh`: 44 passed, 0 failed
- Ran pytest: 564 passed
- Code review found and fixed Priority 1 high-water mark logic flaw

Generated with [Claude Code](https://claude.com/claude-code)