### PR TITLE
feat(channels): add Discord watcher for real-time inter-agent communication (#75)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,9 @@ Thumbs.db
 __pycache__/
 *.pyc
 
+# Node/Bun dependencies
+node_modules/
+bun.lock
+
 # Build output
 dist/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "discord-watcher": {
+      "command": "bun",
+      "args": ["channels/discord-watcher/index.ts"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,6 +582,26 @@ When starting a session:
 2. **Resolve identity** — Check Dev-Team, pick session Dev-Name/Dev-Avatar (see Agent Identity)
 3. **Load context** — Check for and read `Docs/implementation-plan.md` (or similar planning documents) for current state and context. If no such file exists, proceed without it.
 
+### Discord Watcher (Channels)
+
+If the session was started with `--channels` (or `--dangerously-load-development-channels`), a Discord watcher channel server pushes notifications when new messages arrive in any Oak and Wave text channel.
+
+**When you receive a `<channel source="discord_watcher">` notification:**
+
+1. Run `discord-bot read <channel_id> --limit 10` to get the full messages
+2. If a message is addressed to your team (`@<Dev-Team>` or `@all`), process it and respond via `discord-bot send`
+3. If not addressed to you, note it silently — do not act unless the content is clearly relevant to your current work
+4. Ignore messages from `CC Developer` (the bot itself) to avoid echo loops
+
+**Message addressing convention:**
+
+| Pattern | Meaning |
+|---------|---------|
+| `@<Dev-Team>` (e.g., `@cc-workflow`) | Addressed to a specific agent/project |
+| `@all` | Addressed to all listening agents |
+| No `@` prefix | Informational — read but do not act unless relevant |
+| Human Discord user message | Treat as a request from the user |
+
 ---
 
 ## MANDATORY: Post-Compaction Rules Confirmation

--- a/channels/discord-watcher/index.ts
+++ b/channels/discord-watcher/index.ts
@@ -1,0 +1,335 @@
+#!/usr/bin/env bun
+/**
+ * discord-watcher — MCP channel server for Claude Code
+ *
+ * Watches all text channels on the Oak and Wave Discord server and pushes
+ * wake-up notifications into the Claude Code session when new messages arrive.
+ *
+ * This is a "doorbell, not a mailroom" — it notifies the agent that something
+ * new appeared, then the agent uses discord-bot read/send to interact.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { readFileSync } from "node:fs";
+
+// --- Configuration -----------------------------------------------------------
+
+const GUILD_ID = "1486516321385578576";
+const API_BASE = "https://discord.com/api/v10";
+const POLL_INTERVAL_MS = 15_000;
+const CHANNEL_REFRESH_MS = 5 * 60_000;
+const MESSAGES_PER_PAGE = 50;
+
+// --- Auth --------------------------------------------------------------------
+
+function loadToken(): string {
+  const envToken = process.env.DISCORD_BOT_TOKEN;
+  if (envToken) return envToken.trim();
+
+  const tokenPath = `${process.env.HOME}/secrets/discord-bot-token`;
+  try {
+    return readFileSync(tokenPath, "utf-8").replace(/\r?\n/g, "").trim();
+  } catch {
+    throw new Error(
+      `DISCORD_BOT_TOKEN not set and ${tokenPath} not found. Save your bot token there.`
+    );
+  }
+}
+
+// --- Discord API helpers -----------------------------------------------------
+
+async function apiGet(
+  endpoint: string,
+  authHeader: string
+): Promise<{ ok: true; data: unknown } | { ok: false; status: number; retryAfter?: number }> {
+  const res = await fetch(`${API_BASE}${endpoint}`, {
+    headers: { Authorization: authHeader },
+  });
+  if (res.status === 429) {
+    const retryAfter = parseFloat(res.headers.get("Retry-After") ?? "5");
+    return { ok: false, status: 429, retryAfter };
+  }
+  if (!res.ok) {
+    return { ok: false, status: res.status };
+  }
+  return { ok: true, data: await res.json() };
+}
+
+interface DiscordChannel {
+  id: string;
+  name: string;
+  type: number;
+}
+
+interface DiscordMessage {
+  id: string;
+  author: { id: string; username: string };
+  content: string;
+  timestamp: string;
+}
+
+// --- State -------------------------------------------------------------------
+
+let botUserId = "";
+let watchedChannels: DiscordChannel[] = [];
+const lastSeenMessageId = new Map<string, string>();
+
+// --- Channel discovery -------------------------------------------------------
+
+async function fetchTextChannels(authHeader: string): Promise<DiscordChannel[]> {
+  const result = await apiGet(`/guilds/${GUILD_ID}/channels`, authHeader);
+  if (!result.ok) {
+    throw new Error(`Failed to fetch channels: HTTP ${result.status}`);
+  }
+  return (result.data as DiscordChannel[]).filter((c) => c.type === 0);
+}
+
+async function fetchBotUserId(authHeader: string): Promise<string> {
+  const result = await apiGet("/users/@me", authHeader);
+  if (!result.ok) {
+    throw new Error(`Failed to fetch bot identity: HTTP ${result.status}`);
+  }
+  return (result.data as { id: string }).id;
+}
+
+async function initializeBaselines(authHeader: string): Promise<void> {
+  for (const channel of watchedChannels) {
+    try {
+      const result = await apiGet(
+        `/channels/${channel.id}/messages?limit=1`,
+        authHeader
+      );
+      if (result.ok) {
+        const messages = result.data as DiscordMessage[];
+        if (messages.length > 0) {
+          lastSeenMessageId.set(channel.id, messages[0].id);
+        }
+      }
+    } catch {
+      // Channel might not be readable — skip it
+    }
+  }
+}
+
+// --- Polling -----------------------------------------------------------------
+
+async function fetchAllNewMessages(
+  channelId: string,
+  afterId: string,
+  authHeader: string
+): Promise<DiscordMessage[]> {
+  const allMessages: DiscordMessage[] = [];
+  let cursor = afterId;
+
+  // Paginate to collect all new messages (prevents silent drops on bursts)
+  while (true) {
+    const result = await apiGet(
+      `/channels/${channelId}/messages?after=${cursor}&limit=${MESSAGES_PER_PAGE}`,
+      authHeader
+    );
+
+    if (!result.ok) {
+      if (result.status === 429 && result.retryAfter) {
+        console.error(
+          `[discord-watcher] Rate limited, waiting ${result.retryAfter}s`
+        );
+        await new Promise((r) => setTimeout(r, result.retryAfter! * 1000));
+        continue;
+      }
+      throw new Error(`Discord API HTTP ${result.status}`);
+    }
+
+    const messages = result.data as DiscordMessage[];
+    if (messages.length === 0) break;
+
+    allMessages.push(...messages);
+
+    // If we got fewer than the limit, we've consumed everything
+    if (messages.length < MESSAGES_PER_PAGE) break;
+
+    // Advance cursor to the newest message (messages are newest-first)
+    cursor = messages[0].id;
+  }
+
+  return allMessages;
+}
+
+async function checkForNewMessages(
+  server: Server,
+  authHeader: string
+): Promise<void> {
+  for (const channel of watchedChannels) {
+    try {
+      const lastId = lastSeenMessageId.get(channel.id);
+
+      // First poll for this channel — just set baseline
+      if (!lastId) {
+        const result = await apiGet(
+          `/channels/${channel.id}/messages?limit=1`,
+          authHeader
+        );
+        if (result.ok) {
+          const msgs = result.data as DiscordMessage[];
+          if (msgs.length > 0) {
+            lastSeenMessageId.set(channel.id, msgs[0].id);
+          }
+        } else if (result.status === 429 && result.retryAfter) {
+          console.error(
+            `[discord-watcher] Rate limited on #${channel.name}, skipping cycle`
+          );
+        }
+        continue;
+      }
+
+      const messages = await fetchAllNewMessages(channel.id, lastId, authHeader);
+      if (messages.length === 0) continue;
+
+      // Update baseline to the newest message (messages are newest-first)
+      lastSeenMessageId.set(channel.id, messages[0].id);
+
+      // Filter out bot's own messages to avoid echo loops
+      const newMessages = messages.filter((m) => m.author.id !== botUserId);
+      if (newMessages.length === 0) continue;
+
+      // Push a wake-up notification for each new message (oldest first)
+      for (const msg of newMessages.reverse()) {
+        const preview =
+          msg.content.length > 100
+            ? msg.content.slice(0, 100) + "…"
+            : msg.content;
+
+        console.error(
+          `[discord-watcher] New message in #${channel.name} from ${msg.author.username}: ${preview}`
+        );
+
+        await server.notification({
+          method: "notifications/claude/channel" as any,
+          params: {
+            content: `New message from ${msg.author.username} in #${channel.name}: ${preview}`,
+            meta: {
+              channel_name: channel.name,
+              channel_id: channel.id,
+              author: msg.author.username,
+              message_id: msg.id,
+            },
+          },
+        });
+      }
+    } catch (err) {
+      console.error(
+        `[discord-watcher] Error polling #${channel.name}: ${err}`
+      );
+    }
+  }
+}
+
+// --- Main --------------------------------------------------------------------
+
+const INSTRUCTIONS = [
+  'Discord messages arrive as <channel source="discord_watcher" channel_name="..." channel_id="..." author="...">.',
+  "When you see a notification:",
+  "1. Run: discord-bot read <channel_id> --limit 10",
+  "2. If a message is addressed to your team (@<Dev-Team> or @all), process and respond via discord-bot send.",
+  "3. If not addressed to you, note it but do not act unless relevant.",
+  '4. Ignore messages from "CC Developer" (the bot itself) to avoid loops.',
+].join("\n");
+
+async function main(): Promise<void> {
+  // Load token early — fail fast before MCP transport setup
+  const token = loadToken();
+  const authHeader = `Bot ${token}`;
+
+  const server = new Server(
+    { name: "discord_watcher", version: "0.1.0" },
+    {
+      capabilities: {
+        experimental: { "claude/channel": {} },
+      },
+      instructions: INSTRUCTIONS,
+    }
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Resolve bot identity and discover channels — fail hard if these fail
+  try {
+    botUserId = await fetchBotUserId(authHeader);
+    watchedChannels = await fetchTextChannels(authHeader);
+    await initializeBaselines(authHeader);
+  } catch (err) {
+    console.error(`[discord-watcher] Initialization failed: ${err}`);
+    console.error(
+      "[discord-watcher] Cannot watch channels without bot identity and channel list. Exiting."
+    );
+    process.exit(1);
+  }
+
+  if (!botUserId) {
+    console.error("[discord-watcher] Failed to resolve bot user ID. Exiting.");
+    process.exit(1);
+  }
+
+  console.error(
+    `[discord-watcher] Bot ID: ${botUserId}`
+  );
+  console.error(
+    `[discord-watcher] Watching ${watchedChannels.length} channels: ${watchedChannels.map((c) => `#${c.name}`).join(", ")}`
+  );
+
+  // Poll for new messages
+  const pollTimer = setInterval(
+    () => checkForNewMessages(server, authHeader),
+    POLL_INTERVAL_MS
+  );
+
+  // Periodically refresh the channel list
+  const refreshTimer = setInterval(async () => {
+    try {
+      const fresh = await fetchTextChannels(authHeader);
+      for (const ch of fresh) {
+        if (!lastSeenMessageId.has(ch.id)) {
+          try {
+            const result = await apiGet(
+              `/channels/${ch.id}/messages?limit=1`,
+              authHeader
+            );
+            if (result.ok) {
+              const msgs = result.data as DiscordMessage[];
+              if (msgs.length > 0) {
+                lastSeenMessageId.set(ch.id, msgs[0].id);
+              }
+            }
+          } catch {
+            // skip unreadable
+          }
+        }
+      }
+      watchedChannels = fresh;
+      console.error(
+        `[discord-watcher] Refreshed: ${fresh.length} channels`
+      );
+    } catch (err) {
+      console.error(`[discord-watcher] Channel refresh failed: ${err}`);
+    }
+  }, CHANNEL_REFRESH_MS);
+
+  // Clean up on exit
+  process.on("SIGINT", () => {
+    clearInterval(pollTimer);
+    clearInterval(refreshTimer);
+    process.exit(0);
+  });
+
+  process.on("SIGTERM", () => {
+    clearInterval(pollTimer);
+    clearInterval(refreshTimer);
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error(`[discord-watcher] Fatal: ${err}`);
+  process.exit(1);
+});

--- a/channels/discord-watcher/package.json
+++ b/channels/discord-watcher/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "discord-watcher",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1"
+  }
+}


### PR DESCRIPTION
## Summary

Adds an MCP channel server that watches all Oak and Wave Discord text channels and pushes real-time wake-up notifications into Claude Code sessions. Enables inter-agent communication and human-to-agent messaging via Discord without polling loops or token overhead.

## Changes

- **`channels/discord-watcher/index.ts`** — Bun-based MCP channel server
  - Polls all text channels every 15 seconds via Discord REST API
  - Pushes `<channel>` notifications when new messages arrive
  - Filters bot's own messages to prevent echo loops
  - Paginates message fetches to handle bursts (no silent drops)
  - Handles Discord 429 rate limits with `Retry-After` backoff
  - Refreshes channel list every 5 minutes (picks up new channels)
  - Exits hard on initialization failure (prevents empty botUserId defeating echo filter)
- **`channels/discord-watcher/package.json`** — Bun project with `@modelcontextprotocol/sdk`
- **`.mcp.json`** — Registers discord-watcher as project MCP server
- **`CLAUDE.md`** — Added "Discord Watcher (Channels)" to Session Onboarding
  - Notification handling instructions
  - Message addressing convention (`@team`, `@all`, unaddressed)
- **`.gitignore`** — Added `node_modules/` and `bun.lock` patterns

## Linked Issues

Closes #75

## Test Plan

- Verified server starts, discovers 2 text channels, resolves bot ID
- Sent bot message → correctly filtered (no notification)
- Ran `validate.sh`: 51 passed, 0 failed
- Ran `pytest`: 564 passed, 0 failed
- Code reviewer: 4 high/critical findings — all fixed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)