### PR TITLE
fix(channels): add server-side echo filtering via Dev-Name signature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,7 +591,19 @@ If the session was started with `--channels` (or `--dangerously-load-development
 1. Run `discord-bot read <channel_id> --limit 10` to get the full messages
 2. If a message is addressed to your team (`@<Dev-Team>` or `@all`), process it and respond via `discord-bot send`
 3. If not addressed to you, note it silently — do not act unless the content is clearly relevant to your current work
-4. Ignore messages that start with your own bold Dev-Name (e.g., `**Beacon**`) to avoid echo loops — other agents' messages (also from `CC Developer`) should be processed normally
+4. Ignore messages that contain your own signature (e.g., `— **Beacon**`) to avoid echo loops — other agents' messages (also from `CC Developer`) should be processed normally
+
+**Discord message format — sign every message:**
+
+```
+Your message content here.
+
+— **<Dev-Name>** <Dev-Avatar> (<Dev-Team>)
+```
+
+Example: `— **Beacon** :satellite: (cc-workflow)`
+
+The signature is used by the watcher to filter your own echoes. Messages without your signature will echo back to you.
 
 **Message addressing convention:**
 

--- a/channels/discord-watcher/index.ts
+++ b/channels/discord-watcher/index.ts
@@ -12,6 +12,8 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 
 // --- Configuration -----------------------------------------------------------
 
@@ -34,6 +36,31 @@ function loadToken(): string {
     throw new Error(
       `DISCORD_BOT_TOKEN not set and ${tokenPath} not found. Save your bot token there.`
     );
+  }
+}
+
+// --- Agent identity (self-echo filtering) ------------------------------------
+
+let cachedDevName: string | null = null;
+
+function resolveDevName(): string | null {
+  try {
+    // Match the agent's identity resolution: git rev-parse, fallback to cwd
+    let projectRoot: string;
+    try {
+      projectRoot = execSync("git rev-parse --show-toplevel", {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+    } catch {
+      projectRoot = process.cwd();
+    }
+    const dirHash = createHash("md5").update(projectRoot).digest("hex");
+    const agentFile = `/tmp/claude-agent-${dirHash}.json`;
+    const data = JSON.parse(readFileSync(agentFile, "utf-8"));
+    return data.dev_name || null;
+  } catch {
+    return null;
   }
 }
 
@@ -150,6 +177,9 @@ async function checkForNewMessages(
   server: Server,
   authHeader: string
 ): Promise<void> {
+  // Refresh Dev-Name each cycle (agent may pick name after server starts)
+  cachedDevName = resolveDevName();
+
   for (const channel of watchedChannels) {
     try {
       const lastId = lastSeenMessageId.get(channel.id);
@@ -180,8 +210,12 @@ async function checkForNewMessages(
       lastSeenMessageId.set(channel.id, messages[0].id);
 
       // Push a wake-up notification for each new message (oldest first)
-      // No bot-level filtering — agents self-filter by Dev-Name prefix
+      // Filter own messages by Dev-Name prefix; pass through other agents' messages
       for (const msg of messages.reverse()) {
+        if (cachedDevName && msg.content.includes(`— **${cachedDevName}**`)) {
+          continue;
+        }
+
         const preview =
           msg.content.length > 100
             ? msg.content.slice(0, 100) + "…"
@@ -220,7 +254,7 @@ const INSTRUCTIONS = [
   "1. Run: discord-bot read <channel_id> --limit 10",
   "2. If a message is addressed to your team (@<Dev-Team> or @all), process and respond via discord-bot send.",
   "3. If not addressed to you, note it but do not act unless relevant.",
-  "4. Ignore messages that start with your own bold Dev-Name (e.g. **YourName**) to avoid echo loops.",
+  '4. Sign every message with: — **<Dev-Name>** <Dev-Avatar> (<Dev-Team>). The watcher filters your own echoes by this signature.',
 ].join("\n");
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

Adds server-side self-echo suppression to the discord-watcher. The watcher reads the agent's identity file (`/tmp/claude-agent-<hash>.json`) and filters notifications for messages containing the agent's own signature (`— **DevName**`), eliminating cosmetic echo noise from the chat window.

## Changes

- Added `resolveDevName()` — resolves agent identity via project root hash, with `git rev-parse` → `process.cwd()` fallback for non-git-repo sessions
- Messages matching `— **<cachedDevName>**` are suppressed before notification delivery
- Added Discord message signing convention to CLAUDE.md (format template + example)
- Updated embedded server instructions to document the signature requirement

## Linked Issues

Follow-up to #77

## Test Plan

- Live tested across two concurrent sessions: Beacon (cc-workflow, git repo) and Null Pointer (sysadmin, non-git directory)
- Verified: no self-echoes in either chat window, inter-agent messages delivered cleanly in both directions
- Validation: 51 passed, 0 failed