### PR TITLE
fix(install): handle claude mcp add failure gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,11 @@ The discord-watcher is an MCP channel server that polls Discord and pushes real-
 ```bash
 # Install bun (if not already installed)
 curl -fsSL https://bun.sh/install | bash
+```
 
-# Install dependencies
-cd channels/discord-watcher
-bun install
+`./install.sh` automatically runs `bun install` and registers the channel server at user scope via `claude mcp add`. If automatic registration fails, you can register manually:
 
-# Register at user scope (available from any project directory)
+```bash
 claude mcp add --scope user --transport stdio discord-watcher -- \
   bun /path/to/claudecode-workflow/channels/discord-watcher/index.ts
 ```

--- a/install.sh
+++ b/install.sh
@@ -335,9 +335,13 @@ if [[ "$INSTALL_CHANNELS" == true && -d "$REPO_DIR/channels" ]]; then
 				fi
 
 				# Register at user scope (idempotent — overwrites existing)
-				claude mcp add --scope user --transport stdio \
-					"$channel_name" -- bun "$entry_file" 2>/dev/null
-				info "Registered MCP server: $channel_name (user scope)"
+				if claude mcp add --scope user --transport stdio \
+					"$channel_name" -- bun "$entry_file" 2>/dev/null; then
+					info "Registered MCP server: $channel_name (user scope)"
+				else
+					warn "Failed to register MCP server: $channel_name"
+					warn "Run manually: claude mcp add --scope user --transport stdio $channel_name -- bun $entry_file"
+				fi
 			fi
 		done
 	fi


### PR DESCRIPTION
## Summary

Fixes install.sh crash when `claude mcp add` fails (e.g., claude not in PATH inside a container).

## Changes

- Wrapped `claude mcp add` in if/else — warns and prints manual command on failure instead of crashing
- Updated README Discord Setup to note install.sh handles MCP registration automatically

## Linked Issues

Follow-up to #80

## Test Plan

- Bug discovered on Mother's container where `claude mcp add` failed and killed the script
- Validation: 51 passed, 0 failed