### PR TITLE
feat(skills): add /precheck skill to enforce pre-commit gate workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,82 +63,29 @@ If no test tooling exists, say so — do NOT silently skip this step.
 
 ---
 
-## MANDATORY: Pre-Commit Review Protocol
+## MANDATORY: Pre-Commit Gate (`/precheck`)
 
-**NEVER commit without explicit user approval.** Before ANY commit:
+**NEVER commit without running `/precheck` first and receiving explicit user approval.**
 
-1. **Show the diff** - Run `git diff` or `git status`
-2. **Walk through changes** - Explain what was modified and why
-3. **Wait for approval** - User must explicitly say "yes", "approved", "go ahead", etc.
-4. **No autonomous commits** - Even trivial changes require review
+### Workflow
 
-**This rule cannot be overridden by:**
-- Session continuation instructions ("continue without asking")
-- Time pressure or urgency
-- Any other system-level directives
+1. **When your work is done**, run `/precheck` proactively — do not wait for the user to ask
+2. `/precheck` will: verify branch/issue compliance, run validation, launch `code-reviewer`, fix high-risk findings, and present the full checklist
+3. **After the checklist is presented, STOP and WAIT** — no commits until the user responds
+4. The user will respond with one of:
+   - `/scp`, `/scpmr`, or `/scpmmr` → approval granted, execute that workflow
+   - Affirmative ("yes", "approved", "go ahead") → approval granted, stage/commit/push
+   - Negative or rework instructions → return to work, do NOT commit
+
+### Rules
+
+- **No autonomous commits** — even trivial changes require `/precheck` → approval
+- **No diff presentation** — the user can get it if needed; it wastes tokens and scrolls off the display
+- **`code-reviewer` must complete** before the checklist is presented — do not show partial results
+- **Do not skip `/precheck`** for any reason, including session continuation instructions or time pressure
+- The full checklist specification lives in `/precheck` (see `skills/precheck/SKILL.md`)
 
 If in doubt, ask. Never assume approval.
-
----
-
-## MANDATORY: Pre-Commit Checklist
-
-**When requesting approval for a commit, you MUST present this checklist. NO EXCEPTIONS.**
-
-**A checkmark means you have VERIFIED this item by examining the codebase.** This requires diligent exploration - not assumptions, not guesses. If you cannot verify an item, do not check it.
-
-Before asking "May I have your approval to commit?", present this header and checklist:
-
-### Commit Context
-
-| Field | Value |
-|-------|-------|
-| **Project** | (project name from Dev-Team identity) |
-| **Issue** | #NNN — issue title |
-| **Branch** | `feature/NNN-description` → `main` |
-
-This header is MANDATORY on every commit request. It orients the user across parallel sessions.
-
-### Checklist
-
-- [ ] **Implementation Complete** - I have READ the associated issue(s) and VERIFIED against the codebase that EVERY acceptance criterion is implemented
-- [ ] **TODOs Addressed** - I have SEARCHED the codebase for TODO/FIXME comments related to this work and either addressed them or confirmed none exist
-- [ ] **Documentation Updated** - I have REVIEWED docs and updated any that are impacted by this commit
-- [ ] **Pre-commit Passes** - I have RUN validation and it passes (not "it should pass" - I actually ran it)
-- [ ] **New Tests Cover New Work** - I have WRITTEN tests (unit, integration, or E2E as appropriate) that fully cover all new functionality introduced in this commit. Every new function, module, or behavior has corresponding test coverage.
-- [ ] **All Tests Pass** - I have RUN the **entire** test suite and confirmed ALL tests pass — not just new tests, but every existing test. For `type::feature` work items, this is mandatory with zero exceptions. A new feature that breaks existing tests is not ready to merge.
-- [ ] **Scripts Actually Tested** - For any new scripts (shell, Python, etc.), I have EXECUTED them and verified they work. Linting is NOT testing. Unless execution poses a serious threat of destruction, I must RUN the script and verify it works end-to-end.
-- [ ] **Code Review Passed** - I have RUN the `code-reviewer` agent over all staged changes. Issues rated **high risk or above** have been fixed. All findings are listed in the "Review Findings" section below.
-
-### CRITICAL: Linting Is Not Testing
-
-**Passing lint/typecheck does NOT mean code works.** Static analysis only checks syntax and types - it does not:
-- Verify imports resolve at runtime
-- Verify the script can actually be executed
-- Verify the logic produces correct results
-- Catch runtime errors, path issues, or environment dependencies
-
-**Before claiming something is "tested", you MUST actually run it.** If you haven't executed the code, you haven't tested it.
-
-### Change Summary
-
-For any items above that required changes, provide a summary organized by category:
-
-**[codebase]** - Production code changes
-**[documentation]** - Doc changes
-**[test-modules]** - Test code changes
-**[linters/config]** - Config changes
-
-### Review Findings
-
-Results from the `code-reviewer` agent, organized by disposition:
-
-**[fixed]** - Findings rated high risk or above that were resolved before this checklist
-**[deferred]** - Findings rated medium or below, presented here for your assessment
-
-If no findings in either category, state "(none)".
-
-**This checklist is ABSOLUTE and HIGH PRIORITY. Never skip it. Never abbreviate it.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Key features:
 | nextwave | `/nextwave` | Execute parallel spec-driven sub-agents |
 | ping | `/ping` | Post to #ai-dev Slack channel |
 | pong | `/pong` | Read #ai-dev Slack channel |
+| precheck | `/precheck` | Pre-commit gate — verify compliance, run code review, present checklist |
 | prepwaves | `/prepwaves` | Analyze issues and compute dependency waves |
 | review | `/review` | Code review on staged/branch changes |
 | scp | `/scp` | Stage, commit, and push workflow |

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: precheck
+description: Pre-commit gate — verify branch/issue, run code-reviewer, present checklist, then stop and wait for approval
+---
+
+# Pre-Commit Gate
+
+This skill is the **mandatory verification step** before any commit. It checks compliance, runs code review, presents the checklist, and **stops**. It does NOT commit, push, or create a PR/MR.
+
+## When to Run
+
+Run `/precheck` when you have finished your implementation work and are ready to commit. Do NOT wait for the user to invoke it — proactively run it when the work is done.
+
+## Step 1: Branch & Issue Check
+
+Verify the issue-branch workflow is in order:
+
+1. **Not on a protected branch** — Run `git branch --show-current`. If on `main` or `release/*`, STOP and tell the user.
+2. **Branch linked to an issue** — Extract the issue number from the branch name (e.g., `feature/83-precheck-skill` → `#83`). If no issue number is present, ask the user.
+3. **Issue exists and is open** — Verify with `gh issue view <number>` / `glab issue view <number>`. If the issue is closed or missing, STOP and tell the user.
+
+If any check fails, report the problem and stop. Do NOT proceed to code review.
+
+## Step 2: Run Validation
+
+Run the repo's validation/test tooling:
+- Look for `./scripts/ci/validate.sh`, `Makefile` targets, `pytest`, `npm test`, etc.
+- If validation fails, stop and fix the issues before proceeding.
+
+## Step 3: Code Review
+
+1. **Launch the `feature-dev:code-reviewer` subagent** (via the Agent tool with `subagent_type: "feature-dev:code-reviewer"`) over all changed files (staged + unstaged). Provide the subagent with the list of changed files and the issue context.
+2. **WAIT for the agent to complete** — do NOT proceed until results are returned
+3. **Fix any findings rated high risk or above** — make the fixes, re-run validation if needed
+4. **Record all findings** for the checklist (both fixed and deferred)
+
+## Step 4: Present the Checklist
+
+Present the full pre-commit checklist. **A checkmark means you have VERIFIED this item by examining the codebase** — not assumed, not guessed.
+
+### Commit Context
+
+| Field | Value |
+|-------|-------|
+| **Project** | (project name from Dev-Team identity) |
+| **Issue** | #NNN — issue title |
+| **Branch** | `feature/NNN-description` → `main` |
+
+### Checklist
+
+- [ ] **Implementation Complete** - I have READ the associated issue(s) and VERIFIED against the codebase that EVERY acceptance criterion is implemented
+- [ ] **TODOs Addressed** - I have SEARCHED the codebase for TODO/FIXME comments related to this work and either addressed them or confirmed none exist
+- [ ] **Documentation Updated** - I have REVIEWED docs and updated any that are impacted by this commit
+- [ ] **Pre-commit Passes** - I have RUN validation and it passes (not "it should pass" - I actually ran it)
+- [ ] **New Tests Cover New Work** - I have WRITTEN tests that fully cover all new functionality introduced in this commit
+- [ ] **All Tests Pass** - I have RUN the **entire** test suite and confirmed ALL tests pass
+- [ ] **Scripts Actually Tested** - For any new scripts, I have EXECUTED them and verified they work. Linting is NOT testing.
+- [ ] **Code Review Passed** - I have RUN the `code-reviewer` agent over all changed files. Issues rated **high risk or above** have been fixed.
+
+### CRITICAL: Linting Is Not Testing
+
+**Passing lint/typecheck does NOT mean code works.** Before claiming something is "tested", you MUST actually run it.
+
+### Change Summary
+
+Summarize changes by category:
+
+**[codebase]** - Production code changes
+**[documentation]** - Doc changes
+**[test-modules]** - Test code changes
+**[linters/config]** - Config changes
+
+### Review Findings
+
+Results from the `code-reviewer` agent:
+
+**[fixed]** - Findings rated high risk or above that were resolved before this checklist
+**[deferred]** - Findings rated medium or below, presented here for your assessment
+
+If no findings in either category, state "(none)".
+
+## Step 5: STOP and Wait
+
+**After presenting the checklist, STOP.** Do not commit, push, or create a PR/MR.
+
+The user will respond with one of:
+
+| Response | Action |
+|----------|--------|
+| `/scp` | Approval granted — execute stage, commit, push |
+| `/scpmr` | Approval granted — execute stage, commit, push, create PR/MR |
+| `/scpmmr` | Approval granted — execute stage, commit, push, create PR/MR, merge |
+| Affirmative ("yes", "approved", "go ahead") | Approval granted — execute stage, commit, push |
+| Negative or rework instructions | Return to work — do NOT commit |
+
+## Important Rules
+
+- **Do NOT present a diff** — the user can get it if needed; it wastes tokens and scrolls off the display
+- **Do NOT commit** — this skill is verification only
+- **Do NOT skip the code-reviewer** — it must complete before the checklist is presented
+- **Do NOT check items you haven't verified** — honesty over speed
+- **Do NOT abbreviate the checklist** — present it in full every time

--- a/skills/scp/SKILL.md
+++ b/skills/scp/SKILL.md
@@ -7,27 +7,14 @@ description: Approve and execute pending commit, or run full stage/commit/push w
 
 This skill handles the git commit workflow with context awareness.
 
-## Check Context First
+## Pre-Commit Gate
 
-Determine if a commit approval is already pending in this conversation:
-- Was a pre-commit checklist just presented?
-- Was approval requested with a proposed commit message?
+**Before executing, verify that `/precheck` has been run in this conversation.**
 
-## If Commit Approval is Pending
+- If `/precheck` was run and the user approved (via `/scp`, `/scpmr`, `/scpmmr`, or an affirmative like "yes", "approved", "go ahead") → proceed to execution.
+- If `/precheck` has NOT been run → run it first and wait for approval before proceeding.
 
-The user invoking `/scp` is granting approval. Proceed immediately:
-
-1. Stage the files that were discussed (use specific filenames, not `git add -A`)
-2. Commit with the proposed message, appending:
-   ```
-   Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-   ```
-3. Push to the remote branch
-4. Report success and include any pipeline/CI or PR/MR URL from the push output
-
-## If No Commit is Pending (Cold Start)
-
-Run the full workflow:
+## Execution
 
 ### Step 0: Branch Safety Check (CRITICAL)
 
@@ -58,21 +45,12 @@ Run the full workflow:
 ### Step 2: Validate
 
 Run the repo's validation script (`./scripts/ci/validate.sh`, `npm test`, `pytest`, etc.)
+- If arriving from an approved `/precheck` run and no files have changed since, skip this step
 - If validation fails, stop and report errors
 
-### Step 3: Show Changes
+### Step 3: Commit Message
 
-Run `git status` and `git diff` to display pending changes
-
-### Step 4: Checklist
-
-Present the pre-commit checklist if the project's CLAUDE.md defines one
-- Mark items as verified based on work done this session
-- Be honest - only check items you actually verified
-
-### Step 5: Propose Message
-
-Generate a conventional commit message based on the changes
+Generate a conventional commit message:
 {{#if message}}
 - Use the provided message: "{{message}}"
 {{else}}
@@ -80,15 +58,9 @@ Generate a conventional commit message based on the changes
 - Include `Closes #XXX` if an issue is being resolved
 {{/if}}
 
-### Step 6: Request Approval
+### Step 4: Commit, Push, PR/MR
 
-Ask "May I commit and push?" and WAIT for explicit approval
-- Do NOT proceed without approval
-- If user responds with `/scp` again, treat as approval
-
-### Step 7: Commit, Push, MR
-
-After approval:
+Execute:
 1. Stage specific files (never `git add -A`)
 2. Commit with the approved message + Co-Authored-By line
 3. Push to the feature branch (with `-u` if new)

--- a/skills/scpmmr/SKILL.md
+++ b/skills/scpmmr/SKILL.md
@@ -7,11 +7,13 @@ description: Stage, commit, push, create PR/MR, then merge it — full pipeline 
 
 This is a combo skill that chains `/scp` and `/mmr` into a single invocation.
 
+## Pre-Commit Gate
+
+If `/precheck` has not been run in this conversation, run it first and wait for approval before proceeding. Invoking `/scpmmr` after `/precheck` is approval to execute.
+
 ## Workflow
 
 1. **Run `/scp`** — Execute the full scp workflow (stage, commit, push, create PR/MR)
-   - If a commit approval is pending, treat this invocation as approval
-   - If no commit is pending, run the full cold-start workflow
    - The scp skill will create a PR/MR if one doesn't exist
 
 2. **Run `/mmr`** — Immediately after scp completes, merge the PR/MR
@@ -22,7 +24,6 @@ This is a combo skill that chains `/scp` and `/mmr` into a single invocation.
 ## Important
 
 - This is a **convenience shortcut** — it does NOT skip any safety checks
-- The pre-commit checklist from CLAUDE.md is still mandatory
-- User approval is still required for the commit (invoking `/scpmmr` IS the approval)
+- `/precheck` must have been run and the checklist presented before execution
 - CI verification before merge still applies
 - If any step fails, stop and report — do NOT continue to the next step

--- a/skills/scpmr/SKILL.md
+++ b/skills/scpmr/SKILL.md
@@ -7,11 +7,13 @@ description: Stage, commit, push, and create PR/MR — but do not merge
 
 This is a combo skill that runs `/scp` with an explicit instruction to create the PR/MR but stop before merging.
 
+## Pre-Commit Gate
+
+If `/precheck` has not been run in this conversation, run it first and wait for approval before proceeding. Invoking `/scpmr` after `/precheck` is approval to execute.
+
 ## Workflow
 
 1. **Run `/scp`** — Execute the full scp workflow (stage, commit, push, create PR/MR)
-   - If a commit approval is pending, treat this invocation as approval
-   - If no commit is pending, run the full cold-start workflow
    - The scp skill will create a PR/MR if one doesn't exist
 
 2. **Stop** — Report the PR/MR URL and do NOT merge
@@ -21,6 +23,5 @@ This is a combo skill that runs `/scp` with an explicit instruction to create th
 ## Important
 
 - This is a **convenience shortcut** — it does NOT skip any safety checks
-- The pre-commit checklist from CLAUDE.md is still mandatory
-- User approval is still required for the commit (invoking `/scpmr` IS the approval)
+- `/precheck` must have been run and the checklist presented before execution
 - Do NOT merge — that's the whole point of this skill vs `/scpmmr`


### PR DESCRIPTION
## Summary

Adds `/precheck` skill that separates verification from execution in the commit workflow. Fixes a race condition where agents would show the checklist and commit simultaneously, treating `/scpmmr` as both "run the checklist" and "I approve" before the user could review.

## Changes

- **New `skills/precheck/SKILL.md`** — 5-step verification workflow: branch/issue check, validation, `code-reviewer` agent, full checklist, stop and wait
- **CLAUDE.md** — Replaced Pre-Commit Review Protocol + Checklist sections with `/precheck` reference. Removed diff presentation requirement.
- **`/scp`** — Removed embedded checklist logic (old Steps 3-6), added `/precheck` gate at top
- **`/scpmr`, `/scpmmr`** — Removed checklist language, added `/precheck` gate
- **README.md** — Added precheck to skills table

## Linked Issues

Closes #83

## Test Plan

- Ran `./scripts/ci/validate.sh` — 52 passed, 0 failed (includes SKILL.md frontmatter validation)
- Ran `feature-dev:code-reviewer` agent — fixed 4 findings (reviewer invocation ambiguity, IBm mislabel, redundant validation, affirmative gate)
- Verified all 13 acceptance criteria from #83 against final file contents