### PR TITLE
feat(channels): add targeted message filtering to discord-watcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,9 +536,9 @@ If the session was started with `--channels` (or `--dangerously-load-development
 **When you receive a `<channel source="discord_watcher">` notification:**
 
 1. Run `discord-bot read <channel_id> --limit 10` to get the full messages
-2. If a message is addressed to your team (`@<Dev-Team>` or `@all`), process it and respond via `discord-bot send`
+2. If a message is addressed to you (`@<dev-team>`, `@<dev-name>`, or `@all`), process it and respond via `discord-bot send`
 3. If not addressed to you, note it silently — do not act unless the content is clearly relevant to your current work
-4. Ignore messages that contain your own signature (e.g., `— **Beacon**`) to avoid echo loops — other agents' messages (also from `CC Developer`) should be processed normally
+4. Ignore messages that contain your own signature (e.g., `— **beacon**`) to avoid echo loops — other agents' messages (also from `CC Developer`) should be processed normally
 
 **Discord message format — sign every message:**
 
@@ -548,7 +548,7 @@ Your message content here.
 — **<Dev-Name>** <Dev-Avatar> (<Dev-Team>)
 ```
 
-Example: `— **Beacon** :satellite: (cc-workflow)`
+Example: `— **beacon** :satellite: (cc-workflow)`
 
 The signature is used by the watcher to filter your own echoes. Messages without your signature will echo back to you.
 
@@ -556,10 +556,13 @@ The signature is used by the watcher to filter your own echoes. Messages without
 
 | Pattern | Meaning |
 |---------|---------|
-| `@<Dev-Team>` (e.g., `@cc-workflow`) | Addressed to a specific agent/project |
+| `@<dev-team>` (e.g., `@cc-workflow`) | Addressed to a specific agent/project |
+| `@<dev-name>` (e.g., `@beacon`) | Addressed to a specific agent by session name |
 | `@all` | Addressed to all listening agents |
-| No `@` prefix | Informational — read but do not act unless relevant |
-| Human Discord user message | Treat as a request from the user |
+| No `@` prefix | Dropped by the watcher — agents do not receive unaddressed messages |
+| Human Discord user message | Must include `@` addressing to reach agents |
+
+The watcher pre-filters messages: only `@all`, `@<dev-team>`, and `@<dev-name>` notifications are delivered. Set `DISCORD_WATCHER_VERBOSE=1` to bypass filtering and receive all messages.
 
 ---
 
@@ -595,7 +598,7 @@ Agent identity has two layers: **project identity** (persisted here) and **sessi
 Each session, pick a fresh identity for yourself. This is NOT persisted — a new Claude Code window means a new identity.
 
 **Naming rules:**
-- `Dev-Name`: A single memorable name or short phrase (max 3 words). Draw from nerdcore canon — sci-fi, fantasy, comics, gaming, mythology, tech puns, wordplay. The wittier and more specific the reference, the better. Generic names are boring.
+- `Dev-Name`: A single memorable word or hyphenated phrase in **kebab-case** (e.g., `beacon`, `null-pointer`, `mother`). Draw from nerdcore canon — sci-fi, fantasy, comics, gaming, mythology, tech puns, wordplay. The wittier and more specific the reference, the better. Generic names are boring. Kebab-case is required so the name works as a routing key for `@<dev-name>` addressing.
 - `Dev-Avatar`: A Slack emoji string with colons (e.g., `:smiling_imp:`, `:space_invader:`). Should feel like it belongs with the name.
 
 **On session start**, after resolving Dev-Team:

--- a/README.md
+++ b/README.md
@@ -243,17 +243,28 @@ Or set up an alias:
 alias ccode='claude --dangerously-load-development-channels server:discord-watcher'
 ```
 
-The watcher will monitor all text channels on the configured Discord server and push notifications when new messages arrive. Agents sign their messages and the watcher filters self-echoes, enabling multiple agents to communicate through Discord without loops.
+The watcher monitors all text channels on the configured Discord server. Messages are **filtered by addressing** — agents only receive notifications for messages containing `@all`, `@<dev-team>`, or `@<dev-name>`. Self-echoes are suppressed via signature matching.
 
 ### Inter-Agent Communication
 
 With the discord-watcher running in multiple Claude Code sessions, agents can talk to each other:
 
-- **Address a specific agent:** `@cc-workflow check the build status`
+- **Address a specific team:** `@cc-workflow check the build status`
+- **Address a specific agent:** `@beacon what's your current task?`
 - **Address all agents:** `@all report your current status`
-- **Informational (no action expected):** Post without an `@` prefix
+- **Unaddressed messages** are silently dropped (agents don't receive them)
 
-Each agent signs messages with its Dev-Name signature (e.g., `— **Beacon** :satellite: (cc-workflow)`), which the watcher uses to filter self-echoes while allowing messages from other agents through.
+Dev-Names must be **kebab-case** (e.g., `beacon`, `null-pointer`) so they work as routing keys for `@` addressing.
+
+Each agent signs messages with its Dev-Name signature (e.g., `— **beacon** :satellite: (cc-workflow)`), which the watcher uses to filter self-echoes while allowing messages from other agents through.
+
+### Verbose Mode
+
+To bypass filtering and receive all messages (useful for monitoring/debugging):
+
+```bash
+DISCORD_WATCHER_VERBOSE=1 claude --dangerously-load-development-channels server:discord-watcher
+```
 
 ## Dependencies
 

--- a/channels/discord-watcher/index.ts
+++ b/channels/discord-watcher/index.ts
@@ -22,6 +22,7 @@ const API_BASE = "https://discord.com/api/v10";
 const POLL_INTERVAL_MS = 15_000;
 const CHANNEL_REFRESH_MS = 5 * 60_000;
 const MESSAGES_PER_PAGE = 50;
+const VERBOSE = process.env.DISCORD_WATCHER_VERBOSE === "1";
 
 // --- Auth --------------------------------------------------------------------
 
@@ -39,11 +40,16 @@ function loadToken(): string {
   }
 }
 
-// --- Agent identity (self-echo filtering) ------------------------------------
+// --- Agent identity (self-echo filtering + targeted routing) -----------------
 
-let cachedDevName: string | null = null;
+interface AgentIdentity {
+  devName: string | null;
+  devTeam: string | null;
+}
 
-function resolveDevName(): string | null {
+let cachedIdentity: AgentIdentity = { devName: null, devTeam: null };
+
+function resolveIdentity(): AgentIdentity {
   try {
     // Match the agent's identity resolution: git rev-parse, fallback to cwd
     let projectRoot: string;
@@ -58,9 +64,12 @@ function resolveDevName(): string | null {
     const dirHash = createHash("md5").update(projectRoot).digest("hex");
     const agentFile = `/tmp/claude-agent-${dirHash}.json`;
     const data = JSON.parse(readFileSync(agentFile, "utf-8"));
-    return data.dev_name || null;
+    return {
+      devName: data.dev_name || null,
+      devTeam: data.dev_team || null,
+    };
   } catch {
-    return null;
+    return { devName: null, devTeam: null };
   }
 }
 
@@ -177,8 +186,8 @@ async function checkForNewMessages(
   server: Server,
   authHeader: string
 ): Promise<void> {
-  // Refresh Dev-Name each cycle (agent may pick name after server starts)
-  cachedDevName = resolveDevName();
+  // Refresh identity each cycle (agent may pick name after server starts)
+  cachedIdentity = resolveIdentity();
 
   for (const channel of watchedChannels) {
     try {
@@ -210,10 +219,33 @@ async function checkForNewMessages(
       lastSeenMessageId.set(channel.id, messages[0].id);
 
       // Push a wake-up notification for each new message (oldest first)
-      // Filter own messages by Dev-Name prefix; pass through other agents' messages
       for (const msg of messages.reverse()) {
-        if (cachedDevName && msg.content.includes(`— **${cachedDevName}**`)) {
+        // Self-echo filter: skip messages containing our own signature (case-insensitive)
+        if (cachedIdentity.devName &&
+            msg.content.toLowerCase().includes(`— **${cachedIdentity.devName.toLowerCase()}**`)) {
           continue;
+        }
+
+        // Targeted filtering (unless VERBOSE mode bypasses it)
+        if (!VERBOSE) {
+          // If identity hasn't been set yet, fail open — deliver the message
+          if (!cachedIdentity.devName && !cachedIdentity.devTeam) {
+            // No identity resolved yet — deliver all messages until agent sets up
+          } else {
+            const contentLower = msg.content.toLowerCase();
+            const tokens = contentLower.split(/\s+/);
+            const isAddressedToAll = tokens.includes("@all");
+            const isAddressedToTeam = cachedIdentity.devTeam
+              ? tokens.includes(`@${cachedIdentity.devTeam.toLowerCase()}`)
+              : false;
+            const isAddressedToMe = cachedIdentity.devName
+              ? tokens.includes(`@${cachedIdentity.devName.toLowerCase()}`)
+              : false;
+
+            if (!isAddressedToAll && !isAddressedToTeam && !isAddressedToMe) {
+              continue;
+            }
+          }
         }
 
         const preview =
@@ -250,11 +282,11 @@ async function checkForNewMessages(
 
 const INSTRUCTIONS = [
   'Discord messages arrive as <channel source="discord_watcher" channel_name="..." channel_id="..." author="...">.',
+  "Messages are pre-filtered: you only receive messages addressed to @all, @<Dev-Team>, or @<Dev-Name>.",
   "When you see a notification:",
   "1. Run: discord-bot read <channel_id> --limit 10",
-  "2. If a message is addressed to your team (@<Dev-Team> or @all), process and respond via discord-bot send.",
-  "3. If not addressed to you, note it but do not act unless relevant.",
-  '4. Sign every message with: — **<Dev-Name>** <Dev-Avatar> (<Dev-Team>). The watcher filters your own echoes by this signature.',
+  "2. Process the message and respond via discord-bot send if action is needed.",
+  '3. Sign every message with: — **<dev-name>** <dev-avatar> (<dev-team>). The watcher filters your own echoes by this signature.',
 ].join("\n");
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

Adds address-based message filtering to the discord-watcher MCP channel server. Agents only receive notifications for messages containing `@all`, `@<dev-team>`, or `@<dev-name>`, reducing context window clutter in multi-agent setups.

## Changes

- **`channels/discord-watcher/index.ts`** — `resolveDevName()` → `resolveIdentity()` returning both `devName` and `devTeam`. Word-boundary token matching for targeted filtering. Case-insensitive self-echo filter. Fail-open on null identity (startup grace). `DISCORD_WATCHER_VERBOSE=1` env var bypass.
- **`CLAUDE.md`** — Dev-Name requires kebab-case, added `@<dev-name>` addressing, updated convention table and step 2, documented verbose mode
- **`README.md`** — Updated inter-agent communication section with filtering behavior, added verbose mode section

## Linked Issues

Closes #82

## Test Plan

- `bun build` succeeds (216 modules bundled)
- `./scripts/ci/validate.sh` — 52 passed, 0 failed
- `feature-dev:code-reviewer` — 4 findings fixed (case-insensitive echo, null fail-open, substring matching, CLAUDE.md step 2)