### PR TITLE
feat(skills): agent check-in on session start via #roll-call channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,6 +619,17 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
    ```
 4. Announce your identity to the user:
    > I'm going by **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>` this session.
+5. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`:
+   ```bash
+   discord-bot send 1487382005036617851 "<message>"
+   ```
+   Message format:
+   ```
+   **<dev-name>** <dev-avatar> online — team `<dev-team>` @ <project-root>
+
+   — **<dev-name>** <dev-avatar> (<dev-team>)
+   ```
+   If `discord-bot` is not available or the send fails, skip silently — check-in is best-effort, not a blocker.
 
 ### Reading Identity
 


### PR DESCRIPTION
## Summary

Agents now announce themselves in `#roll-call` when they come online, giving a real-time view of active agents across projects.

## Changes

- **CLAUDE.md** — Added step 5 to Session Onboarding: post check-in to `#roll-call` (channel `1487382005036617851`) after identity resolution. Best-effort — silently skips if `discord-bot` unavailable.

## Linked Issues

Closes #87

## Test Plan

- Created `#roll-call` channel via `discord-bot create-channel` — confirmed bot has Manage Channels permission
- Sent test check-in message — confirmed it appears in Discord with correct format and signature
- `./scripts/ci/validate.sh` — 53 passed, 0 failed