### PR TITLE
feat(status): Discord wave-status embed with auto-updating pinned message (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Key features:
 | Script | Dependencies | What it does |
 |--------|-------------|-------------|
 | `discord-bot` | `curl`, `jq`, Discord bot token | Discord REST API client — send, read, create channels, resolve names |
+| `discord-status-post` | `python3`, Discord bot token | Post/update wave-status embed in `#wave-status` Discord channel |
 | `slackbot-send` | `curl`, `jq`, Slack bot token | Send Slack messages as a named Claude Code agent |
 | `job-fetch` | `glab`, `python3` | Fetch GitLab CI job traces for analysis |
 | `file-opener` | `xdg-open` / `open` | Cross-platform file/URL opener for `/view` and `/edit` |
@@ -257,6 +258,12 @@ With the discord-watcher running in multiple Claude Code sessions, agents can ta
 Dev-Names must be **kebab-case** (e.g., `beacon`, `null-pointer`) so they work as routing keys for `@` addressing.
 
 Each agent signs messages with its Dev-Name signature (e.g., `— **beacon** :satellite: (cc-workflow)`), which the watcher uses to filter self-echoes while allowing messages from other agents through.
+
+### Wave Status Channel
+
+The `discord-status-post` script posts a rich embed to `#wave-status` whenever the wave state machine transitions. One message per project, edited in place — no spam.
+
+The embed includes phase, wave, action, flight, a Unicode progress bar, and deferrals, with a color-coded sidebar that maps to the current action state. It's invoked automatically by `wave-status` after every state change (best-effort — skipped silently if not installed or Discord is unreachable).
 
 ### Verbose Mode
 

--- a/channels/discord-watcher/index.ts
+++ b/channels/discord-watcher/index.ts
@@ -220,6 +220,11 @@ async function checkForNewMessages(
 
       // Push a wake-up notification for each new message (oldest first)
       for (const msg of messages.reverse()) {
+        // Skip empty-content messages (e.g. bot embeds) — no useful preview
+        if (!msg.content.trim()) {
+          continue;
+        }
+
         // Self-echo filter: skip messages containing our own signature (case-insensitive)
         if (cachedIdentity.devName &&
             msg.content.toLowerCase().includes(`— **${cachedIdentity.devName.toLowerCase()}**`)) {

--- a/scripts/discord-status-post
+++ b/scripts/discord-status-post
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""discord-status-post — Post wave-status embed to Discord.
+
+Reads state.json, phases-waves.json, and flights.json from the project's
+.claude/status/ directory, builds a Discord rich embed, and posts (or edits)
+a message in the #wave-status channel.
+
+One message per project — subsequent calls PATCH in place.  If the cached
+message is gone (deleted, channel cleared), a new one is created.
+
+Usage:
+    discord-status-post [--channel-id ID] [--state-dir DIR] [--dev-team NAME]
+
+Environment:
+    DISCORD_BOT_TOKEN   Bot token (fallback: ~/secrets/discord-bot-token)
+
+Requires Python 3.10+ stdlib only — no external dependencies [CT-01].
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WAVE_STATUS_CHANNEL_ID = "1487386934094462986"
+API_BASE = "https://discord.com/api/v10"
+
+# Action → embed sidebar color (decimal)
+COLOR_MAP: dict[str, int] = {
+    "idle":               9807270,   # #95a5a6 — gray
+    "planning":           3447003,   # #3498db — blue
+    "pre-flight":         1752220,   # #1abc9c — cyan
+    "in-flight":          3066993,   # #2ecc71 — green
+    "merging":            15844367,  # #f1c40f — yellow
+    "post-wave-review":   15105570,  # #e67e22 — orange
+    "waiting-on-meatbag": 15158332,  # #e74c3c — red
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def load_json(path: Path) -> dict:
+    """Load a JSON file, returning an empty dict if missing."""
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data: dict) -> None:
+    """Write JSON atomically via tempfile + os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+    except BaseException:
+        os.unlink(tmp)
+        raise
+
+
+def get_project_root() -> Path:
+    """Discover the git repository root from the current working directory."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        )
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def get_token() -> str:
+    """Resolve the Discord bot token from env or file."""
+    token = os.environ.get("DISCORD_BOT_TOKEN", "")
+    if token:
+        return token.strip()
+    token_file = Path.home() / "secrets" / "discord-bot-token"
+    if token_file.exists():
+        return token_file.read_text().strip()
+    raise RuntimeError(
+        "DISCORD_BOT_TOKEN not set and ~/secrets/discord-bot-token not found"
+    )
+
+
+def progress_bar(pct: int) -> str:
+    """Render a 20-char Unicode block progress bar with cyber styling."""
+    filled = int(pct / 5)
+    bar = "\u2588" * filled + "\u2591" * (20 - filled)
+    return f"\u27e8{bar}\u27e9 {pct}%"
+
+
+# Action → emoji for visual flair
+ACTION_EMOJI: dict[str, str] = {
+    "idle":               "\u23f8\ufe0f",      # ⏸️
+    "planning":           "\U0001f9e0",         # 🧠
+    "pre-flight":         "\U0001f6f0\ufe0f",   # 🛰️
+    "in-flight":          "\u26a1",             # ⚡
+    "merging":            "\U0001f500",         # 🔀
+    "post-wave-review":   "\U0001f50d",         # 🔍
+    "waiting-on-meatbag": "\U0001f6a8",         # 🚨
+}
+
+
+# ---------------------------------------------------------------------------
+# State → summary (mirrors state.show() logic)
+# ---------------------------------------------------------------------------
+
+def compute_summary(state_dir: Path) -> dict:
+    """Read the three JSON files and compute embed-ready summary fields."""
+    state_data = load_json(state_dir / "state.json")
+    plan_data = load_json(state_dir / "phases-waves.json")
+    flights_data = load_json(state_dir / "flights.json")
+
+    current_wave = state_data.get("current_wave")
+
+    # Phase info
+    current_phase_name = ""
+    current_phase_idx = 0
+    total_phases = len(plan_data.get("phases", []))
+    wave_in_phase = 0
+    waves_in_current_phase = 0
+
+    if current_wave is None:
+        # All waves complete
+        current_phase_name = "Complete"
+        current_phase_idx = total_phases
+    else:
+        for pi, phase in enumerate(plan_data.get("phases", [])):
+            phase_wave_ids = [w["id"] for w in phase.get("waves", [])]
+            if current_wave in phase_wave_ids:
+                current_phase_name = phase.get("name", "")
+                current_phase_idx = pi + 1
+                waves_in_current_phase = len(phase_wave_ids)
+                wave_in_phase = phase_wave_ids.index(current_wave) + 1
+                break
+
+    # Flight info
+    wave_flights = flights_data.get("flights", {}).get(current_wave or "", [])
+    total_flights = len(wave_flights)
+    running_flight = None
+    for fi, fl in enumerate(wave_flights):
+        if fl.get("status") == "running":
+            running_flight = fi + 1
+            break
+
+    # Issue counts
+    total_issues = 0
+    closed_issues = 0
+    for phase in plan_data.get("phases", []):
+        for wave in phase.get("waves", []):
+            for issue in wave.get("issues", []):
+                total_issues += 1
+                istate = state_data.get("issues", {}).get(
+                    str(issue["number"]), {}
+                )
+                if istate.get("status") == "closed":
+                    closed_issues += 1
+    pct = round(100 * closed_issues / total_issues) if total_issues else 0
+
+    # Deferrals
+    deferrals_list = state_data.get("deferrals", [])
+    pending_count = sum(1 for d in deferrals_list if d.get("status") == "pending")
+    accepted_count = sum(1 for d in deferrals_list if d.get("status") == "accepted")
+
+    # Action
+    action_obj = state_data.get("current_action", {})
+    action_str = action_obj.get("action", "idle")
+    detail = action_obj.get("detail", "")
+    action_display = f"{action_str} \u2014 {detail}" if detail else action_str
+
+    # Flight display
+    if total_flights == 0:
+        flight_display = "\u2014"
+    elif running_flight is not None:
+        flight_display = f"{running_flight}/{total_flights}"
+    else:
+        flight_display = f"\u2014/{total_flights}"
+
+    return {
+        "project": plan_data.get("project", "unknown"),
+        "phase": f"{current_phase_idx}/{total_phases}",
+        "phase_name": current_phase_name,
+        "wave": f"{wave_in_phase}/{waves_in_current_phase} in phase {current_phase_idx}",
+        "flight": flight_display,
+        "action": action_display,
+        "action_raw": action_str,
+        "progress": f"{closed_issues}/{total_issues} issues",
+        "progress_pct": pct,
+        "deferrals": f"{pending_count} pending, {accepted_count} accepted",
+        "last_updated": state_data.get("last_updated", ""),
+    }
+
+
+def build_embed(summary: dict, dev_team: str) -> dict:
+    """Build a Discord embed payload with cyber-styled fields."""
+    action_raw = summary["action_raw"]
+    color = COLOR_MAP.get(action_raw, COLOR_MAP["idle"])
+    bar = progress_bar(summary["progress_pct"])
+    emoji = ACTION_EMOJI.get(action_raw, "\u2b24")  # ⬤ fallback
+
+    # ANSI escape helpers for ```ansi code blocks
+    # 30=black 31=red 32=green 33=yellow 34=blue 35=magenta 36=cyan 37=white
+    # 1;XX = bold/bright variant
+    cyan = "\033[1;36m"
+    green = "\033[1;32m"
+    magenta = "\033[1;35m"
+    reset = "\033[0m"
+
+    action_display = summary["action"]
+    phase_val = f"{summary['phase']} \u2014 {summary['phase_name']}"
+
+    fields = [
+        {
+            "name": "\U0001f310 Phase",
+            "value": f"```ansi\n{cyan}{phase_val}{reset}\n```",
+            "inline": True,
+        },
+        {
+            "name": "\U0001f30a Wave",
+            "value": f"```ansi\n{cyan}{summary['wave']}{reset}\n```",
+            "inline": True,
+        },
+        {
+            "name": f"{emoji} Action",
+            "value": f"```ansi\n{magenta}{action_display}{reset}\n```",
+            "inline": False,
+        },
+        {
+            "name": "\U0001f680 Flight",
+            "value": f"```ansi\n{green}{summary['flight']}{reset}\n```",
+            "inline": True,
+        },
+        {
+            "name": "\U0001f4ca Progress",
+            "value": f"```ansi\n{green}{bar}{reset}\n```{summary['progress']}",
+            "inline": False,
+        },
+        {
+            "name": "\u23f3 Deferrals",
+            "value": f"```ansi\n{cyan}{summary['deferrals']}{reset}\n```",
+            "inline": True,
+        },
+    ]
+
+    timestamp = summary["last_updated"] or datetime.now(UTC).isoformat()
+
+    return {
+        "title": f"\u25c8 {dev_team} \u2014 Wave Status",
+        "color": color,
+        "fields": fields,
+        "timestamp": timestamp,
+        "footer": {"text": f"\u25b8 {dev_team}"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Discord API
+# ---------------------------------------------------------------------------
+
+def discord_request(
+    method: str,
+    endpoint: str,
+    token: str,
+    payload: dict | None = None,
+) -> tuple[int, dict]:
+    """Make a Discord API request.  Returns (status_code, response_body)."""
+    url = f"{API_BASE}{endpoint}"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+        "User-Agent": "DiscordBot (https://github.com/Wave-Engineering/claudecode-workflow, 1.0)",
+    }
+    data = json.dumps(payload).encode() if payload else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode())
+            return resp.status, body
+    except urllib.error.HTTPError as e:
+        body: dict = {}
+        try:
+            body = json.loads(e.read().decode())
+        except Exception:
+            pass
+        return e.code, body
+    except (urllib.error.URLError, OSError):
+        # Network-level failure (DNS, connection refused, timeout)
+        return 0, {}
+
+
+def post_or_edit(
+    channel_id: str, embed: dict, token: str, cache_file: Path,
+) -> None:
+    """POST a new message or PATCH an existing one.  Caches the message ID."""
+    payload = {"embeds": [embed]}
+
+    # Try to edit an existing message
+    if cache_file.exists():
+        cache = load_json(cache_file)
+        message_id = cache.get("message_id", "")
+        if message_id:
+            status, _resp = discord_request(
+                "PATCH",
+                f"/channels/{channel_id}/messages/{message_id}",
+                token,
+                payload,
+            )
+            if status == 200:
+                cache["updated_at"] = datetime.now(UTC).isoformat()
+                save_json(cache_file, cache)
+                return
+            # 404 or other error — fall through to POST
+
+    # POST a new message
+    status, resp = discord_request(
+        "POST",
+        f"/channels/{channel_id}/messages",
+        token,
+        payload,
+    )
+    if status not in (200, 201):
+        msg = resp.get("message", "unknown error")
+        raise RuntimeError(f"Discord API error {status}: {msg}")
+
+    # Cache the message ID for future edits
+    cache = {
+        "channel_id": channel_id,
+        "message_id": resp["id"],
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    save_json(cache_file, cache)
+
+
+# ---------------------------------------------------------------------------
+# Identity resolution
+# ---------------------------------------------------------------------------
+
+def resolve_dev_team() -> str:
+    """Resolve dev-team from the agent identity file."""
+    try:
+        root = get_project_root()
+        dir_hash = hashlib.md5(str(root).encode()).hexdigest()
+        agent_file = Path(f"/tmp/claude-agent-{dir_hash}.json")
+        if agent_file.exists():
+            data = load_json(agent_file)
+            return data.get("dev_team", "unknown")
+    except Exception:
+        pass
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="discord-status-post",
+        description="Post wave-status embed to Discord",
+    )
+    parser.add_argument(
+        "--channel-id",
+        default=WAVE_STATUS_CHANNEL_ID,
+        help=f"Discord channel ID (default: {WAVE_STATUS_CHANNEL_ID})",
+    )
+    parser.add_argument(
+        "--state-dir",
+        default=None,
+        help="Path to status directory (default: <git-root>/.claude/status/)",
+    )
+    parser.add_argument(
+        "--dev-team",
+        default=None,
+        help="Dev-Team name for embed title (default: resolve from agent identity)",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # Resolve state directory
+    if args.state_dir:
+        state_dir = Path(args.state_dir)
+    else:
+        root = get_project_root()
+        state_dir = root / ".claude" / "status"
+
+    # Verify state.json exists — exit cleanly if not
+    if not (state_dir / "state.json").exists():
+        sys.exit(0)
+
+    # Resolve dev-team
+    dev_team = args.dev_team or resolve_dev_team()
+
+    # Get token — exit 1 if missing
+    try:
+        token = get_token()
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    # Compute summary and build embed
+    summary = compute_summary(state_dir)
+    embed = build_embed(summary, dev_team)
+
+    # Post or edit — failures are non-fatal
+    cache_file = state_dir / "discord-status.json"
+    try:
+        post_or_edit(args.channel_id, embed, token, cache_file)
+    except Exception as e:
+        print(f"discord-status-post: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -52,6 +53,15 @@ def _regenerate_dashboard(root: Path) -> None:
     state_data = load_json(d / "state.json")
     flights_data = load_json(d / "flights.json")
     generate_dashboard(root, phases_data, state_data, flights_data)
+    # Best-effort Discord status update
+    try:
+        subprocess.run(
+            ["discord-status-post", "--state-dir", str(d)],
+            timeout=10,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass  # discord-status-post not installed or timed out — skip silently
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discord_status.py
+++ b/tests/test_discord_status.py
@@ -1,0 +1,413 @@
+"""Tests for scripts/discord-status-post.
+
+Exercises the pure functions (compute_summary, build_embed, progress_bar)
+against real JSON fixtures. Does NOT hit the Discord API.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the script as a module (it has no .py extension)
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "scripts", "discord-status-post"
+)
+_loader = importlib.machinery.SourceFileLoader("discord_status_post", SCRIPT_PATH)
+spec = importlib.util.spec_from_file_location(
+    "discord_status_post", SCRIPT_PATH, loader=_loader,
+)
+dsp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dsp)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+PLAN_DATA = {
+    "project": "test-project",
+    "phases": [
+        {
+            "name": "Foundation",
+            "waves": [
+                {
+                    "id": "p1w1",
+                    "issues": [
+                        {"number": 1, "title": "Issue 1"},
+                        {"number": 2, "title": "Issue 2"},
+                    ],
+                },
+                {
+                    "id": "p1w2",
+                    "issues": [
+                        {"number": 3, "title": "Issue 3"},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "Polish",
+            "waves": [
+                {
+                    "id": "p2w1",
+                    "issues": [
+                        {"number": 4, "title": "Issue 4"},
+                    ],
+                },
+            ],
+        },
+    ],
+}
+
+STATE_DATA = {
+    "current_wave": "p1w1",
+    "current_action": {
+        "action": "in-flight",
+        "label": "In-Flight",
+        "detail": "doing stuff",
+    },
+    "issues": {
+        "1": {"status": "closed"},
+        "2": {"status": "open"},
+        "3": {"status": "open"},
+        "4": {"status": "open"},
+    },
+    "deferrals": [
+        {"status": "pending", "description": "d1"},
+        {"status": "accepted", "description": "d2"},
+        {"status": "pending", "description": "d3"},
+    ],
+    "last_updated": "2026-03-28T12:00:00+00:00",
+}
+
+FLIGHTS_DATA = {
+    "flights": {
+        "p1w1": [
+            {"number": 1, "status": "completed"},
+            {"number": 2, "status": "running"},
+            {"number": 3, "status": "pending"},
+        ],
+    },
+}
+
+
+def _write_fixtures(tmp_path: Path) -> Path:
+    """Write fixture JSON files to tmp_path and return the directory."""
+    (tmp_path / "phases-waves.json").write_text(json.dumps(PLAN_DATA))
+    (tmp_path / "state.json").write_text(json.dumps(STATE_DATA))
+    (tmp_path / "flights.json").write_text(json.dumps(FLIGHTS_DATA))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# progress_bar()
+# ---------------------------------------------------------------------------
+
+
+class TestProgressBar:
+    def test_zero_percent(self) -> None:
+        bar = dsp.progress_bar(0)
+        assert "\u2591" * 20 in bar
+        assert "0%" in bar
+
+    def test_fifty_percent(self) -> None:
+        bar = dsp.progress_bar(50)
+        assert "\u2588" * 10 in bar
+        assert "\u2591" * 10 in bar
+        assert "50%" in bar
+
+    def test_hundred_percent(self) -> None:
+        bar = dsp.progress_bar(100)
+        assert "\u2588" * 20 in bar
+        assert "100%" in bar
+
+    def test_bar_length_always_20(self) -> None:
+        for pct in (0, 25, 50, 75, 100):
+            bar = dsp.progress_bar(pct)
+            # Count block chars (filled + empty = 20)
+            blocks = sum(1 for c in bar if c in ("\u2588", "\u2591"))
+            assert blocks == 20, f"pct={pct} produced {blocks} blocks"
+
+    def test_has_angle_brackets(self) -> None:
+        bar = dsp.progress_bar(50)
+        assert "\u27e8" in bar  # ⟨
+        assert "\u27e9" in bar  # ⟩
+
+
+# ---------------------------------------------------------------------------
+# COLOR_MAP
+# ---------------------------------------------------------------------------
+
+
+class TestColorMapping:
+    """All 7 action states must map to the correct decimal color."""
+
+    EXPECTED = {
+        "idle": 9807270,
+        "planning": 3447003,
+        "pre-flight": 1752220,
+        "in-flight": 3066993,
+        "merging": 15844367,
+        "post-wave-review": 15105570,
+        "waiting-on-meatbag": 15158332,
+    }
+
+    def test_all_actions_present(self) -> None:
+        for action in self.EXPECTED:
+            assert action in dsp.COLOR_MAP, f"Missing color for {action!r}"
+
+    def test_color_values(self) -> None:
+        for action, expected_color in self.EXPECTED.items():
+            assert dsp.COLOR_MAP[action] == expected_color, (
+                f"{action}: expected {expected_color}, got {dsp.COLOR_MAP[action]}"
+            )
+
+    def test_no_extra_actions(self) -> None:
+        assert set(dsp.COLOR_MAP.keys()) == set(self.EXPECTED.keys())
+
+
+# ---------------------------------------------------------------------------
+# compute_summary()
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSummary:
+    def setup_method(self, tmp_path=None) -> None:
+        # tmp_path not available in setup_method; use a class-level fixture
+        pass
+
+    def test_project_name(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["project"] == "test-project"
+
+    def test_phase(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["phase"] == "1/2"
+
+    def test_phase_name(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["phase_name"] == "Foundation"
+
+    def test_wave(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["wave"] == "1/2 in phase 1"
+
+    def test_flight_running(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["flight"] == "2/3"
+
+    def test_action_display(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert "in-flight" in s["action"]
+        assert "doing stuff" in s["action"]
+
+    def test_action_raw(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["action_raw"] == "in-flight"
+
+    def test_progress(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["progress"] == "1/4 issues"
+        assert s["progress_pct"] == 25
+
+    def test_deferrals(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["deferrals"] == "2 pending, 1 accepted"
+
+    def test_last_updated(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        assert s["last_updated"] == "2026-03-28T12:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# build_embed()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEmbed:
+    def _get_embed(self, tmp_path: Path) -> dict:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        return dsp.build_embed(s, "cc-workflow")
+
+    def test_title(self, tmp_path: Path) -> None:
+        embed = self._get_embed(tmp_path)
+        assert "cc-workflow" in embed["title"]
+        assert "Wave Status" in embed["title"]
+
+    def test_color_matches_action(self, tmp_path: Path) -> None:
+        embed = self._get_embed(tmp_path)
+        assert embed["color"] == dsp.COLOR_MAP["in-flight"]
+
+    def test_has_six_fields(self, tmp_path: Path) -> None:
+        embed = self._get_embed(tmp_path)
+        assert len(embed["fields"]) == 6
+
+    def test_field_names_contain_labels(self, tmp_path: Path) -> None:
+        embed = self._get_embed(tmp_path)
+        names = [f["name"] for f in embed["fields"]]
+        for label in ("Phase", "Wave", "Action", "Flight", "Progress", "Deferrals"):
+            assert any(label in n for n in names), f"Missing field containing {label!r}"
+
+    def test_progress_field_has_bar(self, tmp_path: Path) -> None:
+        embed = self._get_embed(tmp_path)
+        progress_field = embed["fields"][4]
+        assert "\u2588" in progress_field["value"]
+        assert "\u2591" in progress_field["value"]
+        assert "25%" in progress_field["value"]
+
+    def test_footer(self, tmp_path: Path) -> None:
+        embed = self._get_embed(tmp_path)
+        assert "cc-workflow" in embed["footer"]["text"]
+
+    def test_timestamp(self, tmp_path: Path) -> None:
+        embed = self._get_embed(tmp_path)
+        assert embed["timestamp"] == "2026-03-28T12:00:00+00:00"
+
+    def test_unknown_action_defaults_to_idle_color(self, tmp_path: Path) -> None:
+        d = _write_fixtures(tmp_path)
+        s = dsp.compute_summary(d)
+        s["action_raw"] = "never-heard-of-this"
+        embed = dsp.build_embed(s, "test")
+        assert embed["color"] == dsp.COLOR_MAP["idle"]
+
+
+# ---------------------------------------------------------------------------
+# Message ID cache round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMessageIdCache:
+    def test_cache_write_and_read(self, tmp_path: Path) -> None:
+        cache_file = tmp_path / "discord-status.json"
+        cache = {
+            "channel_id": "123456",
+            "message_id": "789012",
+            "updated_at": "2026-03-28T12:00:00+00:00",
+        }
+        cache_file.write_text(json.dumps(cache, indent=2) + "\n")
+        loaded = dsp.load_json(cache_file)
+        assert loaded["channel_id"] == "123456"
+        assert loaded["message_id"] == "789012"
+
+    def test_load_json_missing_file(self, tmp_path: Path) -> None:
+        result = dsp.load_json(tmp_path / "nonexistent.json")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_flights_shows_em_dash(self, tmp_path: Path) -> None:
+        (tmp_path / "phases-waves.json").write_text(json.dumps(PLAN_DATA))
+        (tmp_path / "state.json").write_text(json.dumps(STATE_DATA))
+        (tmp_path / "flights.json").write_text(json.dumps({"flights": {}}))
+        s = dsp.compute_summary(tmp_path)
+        assert s["flight"] == "\u2014"
+
+    def test_no_deferrals(self, tmp_path: Path) -> None:
+        state = {**STATE_DATA, "deferrals": []}
+        (tmp_path / "phases-waves.json").write_text(json.dumps(PLAN_DATA))
+        (tmp_path / "state.json").write_text(json.dumps(state))
+        (tmp_path / "flights.json").write_text(json.dumps(FLIGHTS_DATA))
+        s = dsp.compute_summary(tmp_path)
+        assert s["deferrals"] == "0 pending, 0 accepted"
+
+    def test_idle_action_no_detail(self, tmp_path: Path) -> None:
+        state = {
+            **STATE_DATA,
+            "current_action": {"action": "idle", "label": "Idle", "detail": ""},
+        }
+        (tmp_path / "phases-waves.json").write_text(json.dumps(PLAN_DATA))
+        (tmp_path / "state.json").write_text(json.dumps(state))
+        (tmp_path / "flights.json").write_text(json.dumps(FLIGHTS_DATA))
+        s = dsp.compute_summary(tmp_path)
+        assert s["action"] == "idle"
+        assert "\u2014" not in s["action"]
+
+    def test_current_wave_none_all_complete(self, tmp_path: Path) -> None:
+        state = {**STATE_DATA, "current_wave": None}
+        (tmp_path / "phases-waves.json").write_text(json.dumps(PLAN_DATA))
+        (tmp_path / "state.json").write_text(json.dumps(state))
+        (tmp_path / "flights.json").write_text(json.dumps(FLIGHTS_DATA))
+        s = dsp.compute_summary(tmp_path)
+        assert s["phase_name"] == "Complete"
+        assert "0/" not in s["phase"]
+        assert s["phase"] == "2/2"
+
+    def test_all_issues_closed_100_percent(self, tmp_path: Path) -> None:
+        state = {
+            **STATE_DATA,
+            "issues": {
+                "1": {"status": "closed"},
+                "2": {"status": "closed"},
+                "3": {"status": "closed"},
+                "4": {"status": "closed"},
+            },
+        }
+        (tmp_path / "phases-waves.json").write_text(json.dumps(PLAN_DATA))
+        (tmp_path / "state.json").write_text(json.dumps(state))
+        (tmp_path / "flights.json").write_text(json.dumps(FLIGHTS_DATA))
+        s = dsp.compute_summary(tmp_path)
+        assert s["progress_pct"] == 100
+        bar = dsp.progress_bar(100)
+        assert "\u2591" not in bar.split(" ")[0]  # no empty blocks before the %
+
+
+# ---------------------------------------------------------------------------
+# No external dependencies [CT-01]
+# ---------------------------------------------------------------------------
+
+
+class TestNoDependencies:
+    def test_script_imports_only_stdlib(self) -> None:
+        with open(SCRIPT_PATH) as f:
+            source = f.read()
+
+        import_lines = [
+            line.strip()
+            for line in source.splitlines()
+            if line.strip().startswith(("import ", "from "))
+        ]
+
+        stdlib_prefixes = (
+            "from __future__",
+            "import argparse",
+            "import hashlib",
+            "import json",
+            "import os",
+            "import subprocess",
+            "import sys",
+            "import tempfile",
+            "import urllib",
+            "from datetime",
+            "from pathlib",
+        )
+        for line in import_lines:
+            assert any(line.startswith(p) for p in stdlib_prefixes), (
+                f"Non-stdlib import found: {line}"
+            )


### PR DESCRIPTION
## Summary

Add `discord-status-post` script that surfaces wave-status dashboard data as a Discord rich embed in `#wave-status`. One message per project, edited in place on every state transition — cyber-styled with ANSI color-coded fields, action-specific emoji, and Unicode progress bars.

## Changes

- **New `scripts/discord-status-post`** — stdlib-only Python script: reads state.json + phases-waves.json + flights.json, builds Discord embed, POST/PATCH via urllib
  - ANSI-colored fields (cyan, magenta, green), action emoji, `⟨████░░░░⟩` progress bar
  - Atomic cache writes via tempfile + os.replace
  - Handles URLError/OSError for network failures, current_wave=None for all-complete state
- **Modified `src/wave_status/__main__.py`** — best-effort subprocess call to `discord-status-post` in `_regenerate_dashboard()`
- **Modified `channels/discord-watcher/index.ts`** — skip empty-content messages (bot embeds produce useless notification previews)
- **New `tests/test_discord_status.py`** — 34 tests: progress bar, color map, compute_summary, build_embed, edge cases, CT-01 compliance
- **Updated `README.md`** — script in Scripts table, Wave Status Channel section

## Linked Issues

Closes #89

## Test Plan

- 600 tests pass (`python3 -m pytest tests/`)
- 54 validation checks pass (`./scripts/ci/validate.sh`)
- Live tested: POST created embed in #wave-status, PATCH edited same message in place
- Verified cyber styling renders correctly in Discord
- Confirmed User-Agent header required for Discord Cloudflare (error 1010 without it)