### PR TITLE
feat(skills): add /vox skill for agent voice announcements via TTS (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Key features:
 | scpmr | `/scpmr` | Stage, commit, push, and create PR/MR |
 | scpmmr | `/scpmmr` | Stage, commit, push, create PR/MR, and merge |
 | view | `/view` | Open file/URL in GUI viewer (read-only) |
+| vox | `/vox` | Text-to-speech voice announcements for status updates and alerts |
 
 ### Scripts
 
@@ -60,6 +61,7 @@ Key features:
 | `slackbot-send` | `curl`, `jq`, Slack bot token | Send Slack messages as a named Claude Code agent |
 | `job-fetch` | `glab`, `python3` | Fetch GitLab CI job traces for analysis |
 | `file-opener` | `xdg-open` / `open` | Cross-platform file/URL opener for `/view` and `/edit` |
+| `vox` | `curl`, audio player (`aplay`/`afplay`) | Text-to-speech via Chatterbox API, with local fallback (espeak/piper/say) |
 | `statusline-command.sh` | `jq`, `git` | Custom status line: git branch, dirty state, context window remaining, model |
 
 ### Channel Servers

--- a/scripts/vox
+++ b/scripts/vox
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# vox — Text-to-speech announcements for Claude Code agents
+#
+# Usage:
+#   vox "Hey BJ, deployment is done"
+#   echo "Build failed on line 42" | vox
+#   vox --voice Jade "Tests are passing"
+#   vox --list-voices
+#
+# TTS backend resolution (first match wins):
+#   1. VOX_COMMAND env var   — custom command that accepts text on stdin
+#   2. VOX_ENDPOINT env var  — HTTP endpoint (OpenAI-compatible TTS API)
+#   3. Local fallback        — espeak / piper / say (macOS)
+#
+# Environment:
+#   VOX_COMMAND    Custom TTS command (text on stdin, audio on stdout)
+#   VOX_ENDPOINT   HTTP TTS endpoint (default: http://archer:8004/v1/audio/speech)
+#   VOX_VOICE      Default voice name (default: Taylor.wav)
+#   VOX_MODEL      TTS model name (default: chatterbox-turbo)
+#
+# Exit codes:
+#   0  Audio played (or backgrounded) successfully
+#   1  No TTS backend available or request failed
+
+set -euo pipefail
+
+# --- Defaults -----------------------------------------------------------------
+
+DEFAULT_ENDPOINT="http://archer:8004/v1/audio/speech"
+DEFAULT_VOICE="Taylor.wav"
+DEFAULT_MODEL="chatterbox-turbo"
+
+# --- Usage --------------------------------------------------------------------
+
+usage() {
+	cat <<-USAGE
+		Usage: vox [OPTIONS] [MESSAGE...]
+
+		Options:
+		  --voice NAME    Voice to use (default: \$VOX_VOICE or ${DEFAULT_VOICE})
+		  --list-voices   List available voices from the TTS endpoint
+		  --bg            Background playback (don't wait for audio to finish)
+		  -h, --help      Show this help
+
+		Message can be passed as arguments or piped via stdin.
+	USAGE
+	exit 0
+}
+
+# --- Parse args ---------------------------------------------------------------
+
+VOICE="${VOX_VOICE:-$DEFAULT_VOICE}"
+BACKGROUND=false
+
+args=()
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--voice)
+		VOICE="${2:-}"
+		[[ -z "$VOICE" ]] && {
+			echo "Error: --voice requires a name" >&2
+			exit 1
+		}
+		shift 2
+		;;
+	--list-voices)
+		endpoint="${VOX_ENDPOINT:-$DEFAULT_ENDPOINT}"
+		# Derive voices URL from speech endpoint: /v1/audio/speech → /v1/audio/voices
+		voices_url="${endpoint%/speech}/voices"
+		if command -v curl &>/dev/null; then
+			curl -sS "$voices_url" | {
+				if command -v jq &>/dev/null; then
+					jq -r '.voices[] | if type == "object" then .name else . end' 2>/dev/null || cat
+				else
+					cat
+				fi
+			}
+		else
+			echo "Error: curl required for --list-voices" >&2
+			exit 1
+		fi
+		exit 0
+		;;
+	--bg)
+		BACKGROUND=true
+		shift
+		;;
+	-h | --help)
+		usage
+		;;
+	--)
+		shift
+		args+=("$@")
+		break
+		;;
+	-*)
+		echo "Error: unknown option '$1'" >&2
+		exit 1
+		;;
+	*)
+		args+=("$1")
+		shift
+		;;
+	esac
+done
+
+# --- Collect message text -----------------------------------------------------
+
+if [[ ${#args[@]} -gt 0 ]]; then
+	TEXT="${args[*]}"
+elif [[ ! -t 0 ]]; then
+	TEXT="$(cat)"
+else
+	echo "Error: no message provided. Pass as arguments or pipe via stdin." >&2
+	exit 1
+fi
+
+if [[ -z "${TEXT//[$' \t\n\r']/}" ]]; then
+	echo "Error: empty message" >&2
+	exit 1
+fi
+
+# --- Detect audio player ------------------------------------------------------
+
+detect_player() {
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		echo "afplay"
+	elif command -v paplay &>/dev/null; then
+		echo "paplay"
+	elif command -v ffplay &>/dev/null; then
+		echo "ffplay -nodisp -autoexit -loglevel quiet -af adelay=200|200"
+	elif command -v aplay &>/dev/null; then
+		echo "aplay -q"
+	else
+		echo ""
+	fi
+}
+
+# --- Backend 1: VOX_COMMAND ---------------------------------------------------
+
+if [[ -n "${VOX_COMMAND:-}" ]]; then
+	if $BACKGROUND; then
+		echo "$TEXT" | bash -c "$VOX_COMMAND" &>/dev/null &
+		disown
+	else
+		echo "$TEXT" | bash -c "$VOX_COMMAND"
+	fi
+	exit 0
+fi
+
+# --- Backend 2: VOX_ENDPOINT (OpenAI-compatible TTS API) ---------------------
+
+endpoint="${VOX_ENDPOINT:-}"
+
+# If no explicit endpoint, check if the default is reachable
+if [[ -z "$endpoint" ]]; then
+	if command -v curl &>/dev/null; then
+		if curl -s --connect-timeout 2 --max-time 3 "${DEFAULT_ENDPOINT%/speech}" >/dev/null 2>&1; then
+			endpoint="$DEFAULT_ENDPOINT"
+		fi
+	fi
+fi
+
+if [[ -n "$endpoint" ]]; then
+	if ! command -v curl &>/dev/null; then
+		echo "Error: curl required for HTTP TTS endpoint" >&2
+		exit 1
+	fi
+
+	PLAYER=$(detect_player)
+	if [[ -z "$PLAYER" ]]; then
+		echo "Error: no audio player found (need aplay, paplay, afplay, or ffplay)" >&2
+		exit 1
+	fi
+
+	MODEL="${VOX_MODEL:-$DEFAULT_MODEL}"
+
+	# Build JSON payload — escape text for JSON safety
+	json_text=$(printf '%s' "$TEXT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null) || {
+		# Fallback: basic escaping if python3 is unavailable
+		escaped="${TEXT//\\/\\\\}"
+		escaped="${escaped//\"/\\\"}"
+		escaped="${escaped//$'\t'/\\t}"
+		escaped="${escaped//$'\n'/\\n}"
+		escaped="${escaped//$'\r'/\\r}"
+		json_text="\"${escaped}\""
+	}
+
+	if [[ -z "$json_text" || "$json_text" == '""' ]]; then
+		echo "Error: failed to encode message as JSON" >&2
+		exit 1
+	fi
+
+	payload="{\"model\":\"${MODEL}\",\"input\":${json_text},\"voice\":\"${VOICE}\",\"response_format\":\"wav\"}"
+
+	tmpfile="$(mktemp --suffix=.wav)"
+	trap 'rm -f "$tmpfile"' EXIT
+
+	http_code=$(curl -sS -w '%{http_code}' -o "$tmpfile" \
+		-X POST \
+		-H "Content-Type: application/json" \
+		-d "$payload" \
+		--connect-timeout 5 \
+		--max-time 30 \
+		"$endpoint") || {
+		echo "Error: TTS request failed" >&2
+		exit 1
+	}
+
+	if [[ "$http_code" -ge 400 ]]; then
+		echo "Error: TTS endpoint returned HTTP $http_code" >&2
+		cat "$tmpfile" >&2 2>/dev/null
+		exit 1
+	fi
+
+	if [[ ! -s "$tmpfile" ]]; then
+		echo "Error: TTS endpoint returned empty response" >&2
+		exit 1
+	fi
+
+	if $BACKGROUND; then
+		# Detach playback — copy tmpfile since trap will clean it up
+		bgfile="$(mktemp --suffix=.wav)"
+		cp "$tmpfile" "$bgfile"
+		(
+			# shellcheck disable=SC2086
+			timeout 60 $PLAYER "$bgfile"
+			rm -f "$bgfile"
+		) &>/dev/null &
+		disown
+	else
+		# shellcheck disable=SC2086
+		$PLAYER "$tmpfile"
+	fi
+	exit 0
+fi
+
+# --- Backend 3: Local fallback ------------------------------------------------
+
+if command -v espeak &>/dev/null; then
+	if $BACKGROUND; then
+		espeak "$TEXT" &>/dev/null &
+		disown
+	else
+		espeak "$TEXT"
+	fi
+	exit 0
+fi
+
+if command -v espeak-ng &>/dev/null; then
+	if $BACKGROUND; then
+		espeak-ng "$TEXT" &>/dev/null &
+		disown
+	else
+		espeak-ng "$TEXT"
+	fi
+	exit 0
+fi
+
+if command -v piper &>/dev/null; then
+	PLAYER=$(detect_player)
+	if [[ -n "$PLAYER" ]]; then
+		if $BACKGROUND; then
+			# shellcheck disable=SC2086
+			(echo "$TEXT" | piper --output-raw | timeout 60 $PLAYER) &>/dev/null &
+			disown
+		else
+			# shellcheck disable=SC2086
+			echo "$TEXT" | piper --output-raw | $PLAYER
+		fi
+		exit 0
+	fi
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]] && command -v say &>/dev/null; then
+	if $BACKGROUND; then
+		say "$TEXT" &
+		disown
+	else
+		say "$TEXT"
+	fi
+	exit 0
+fi
+
+# --- No backend available -----------------------------------------------------
+
+echo "Error: no TTS backend available." >&2
+echo "Set VOX_ENDPOINT or VOX_COMMAND, or install espeak/piper/say." >&2
+exit 1

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -576,7 +576,13 @@ For each deferred item:
 
 Do NOT let deferred items disappear into the void. Every deferral must be tracked.
 
-6. **Prompt:** "Wave N complete. Design review for Wave N+1 is done. Run `/nextwave` for Wave N+1, or `/cryo` to preserve state."
+6. **Voice announcement** — Announce wave completion via `vox` (best-effort):
+   ```bash
+   vox "Hey BJ, wave <N> is complete. <X> issues closed, <Y> flights, all merged to main. Ready for wave <N+1> when you are." 2>/dev/null || true
+   ```
+   Keep it conversational — summarize the wave outcome in 1-2 sentences for the ear.
+
+7. **Prompt:** "Wave N complete. Design review for Wave N+1 is done. Run `/nextwave` for Wave N+1, or `/cryo` to preserve state."
 
 ---
 

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -79,9 +79,19 @@ Results from the `code-reviewer` agent:
 
 If no findings in either category, state "(none)".
 
-## Step 5: STOP and Wait
+## Step 5: Voice Announcement
 
-**After presenting the checklist, STOP.** Do not commit, push, or create a PR/MR.
+After presenting the checklist, announce completion via `vox` (best-effort — never block on audio):
+
+```bash
+vox "Hey BJ, precheck is done for issue <NUMBER>. <SUMMARY>. Ready for your call." 2>/dev/null || true
+```
+
+The announcement should be 1-2 sentences: mention the issue number, a brief summary of what was built, and the checklist status. Write for the ear — conversational, not robotic.
+
+## Step 6: STOP and Wait
+
+**After presenting the checklist and announcing, STOP.** Do not commit, push, or create a PR/MR.
 
 The user will respond with one of:
 

--- a/skills/scpmmr/SKILL.md
+++ b/skills/scpmmr/SKILL.md
@@ -21,6 +21,16 @@ If `/precheck` has not been run in this conversation, run it first and wait for 
    - Use `--admin` flag if branch protection requires it (same as prior merge patterns in this repo)
    - Follow the full mmr workflow: gather context, verify CI, generate squash message, merge
 
+## Voice Announcement
+
+After the merge completes successfully, announce via `vox` (best-effort):
+
+```bash
+vox "Hey BJ, PR <NUMBER> is merged into main for issue <NUMBER>. All done." 2>/dev/null || true
+```
+
+Keep it brief — issue number, PR number, merged. Write for the ear.
+
 ## Important
 
 - This is a **convenience shortcut** — it does NOT skip any safety checks

--- a/skills/scpmr/SKILL.md
+++ b/skills/scpmr/SKILL.md
@@ -20,6 +20,16 @@ If `/precheck` has not been run in this conversation, run it first and wait for 
    - The user wants to review the PR/MR before merging
    - They can later run `/mmr` to merge when ready
 
+## Voice Announcement
+
+After the PR/MR is created and pushed, announce via `vox` (best-effort):
+
+```bash
+vox "Hey BJ, PR <NUMBER> is up for issue <NUMBER>. Pushed and CI is running." 2>/dev/null || true
+```
+
+Keep it brief — issue number, PR number, status. Write for the ear.
+
 ## Important
 
 - This is a **convenience shortcut** — it does NOT skip any safety checks

--- a/skills/vox/SKILL.md
+++ b/skills/vox/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: vox
+description: Speak to the user via text-to-speech — one-way voice announcements for status updates, approvals, and alerts
+---
+
+# Voice Announcements
+
+Use `vox` to speak to the user when they need to hear something. One-way audio — no mic input, just announcements.
+
+## When to Use
+
+- **Approval needed** — "Hey BJ, the build passed and I'm ready for your review on PR 91"
+- **Work complete** — "All done — 34 tests passing, branch is pushed"
+- **Errors requiring attention** — "Heads up, the deploy failed — looks like a connection timeout"
+- **User explicitly asked to be notified** — "You asked me to let you know when the migration finished — it's done"
+
+## When NOT to Use
+
+- Routine progress updates the user didn't ask for
+- Every commit or push
+- Repeating what's already visible on screen
+- Anything the user hasn't asked to hear about
+
+## How to Use
+
+```bash
+vox "Hey BJ, tests are green and the PR is ready for review"
+```
+
+Options:
+- `--voice NAME` — pick a voice (default: Taylor.wav)
+- `--bg` — background playback so it doesn't block your work
+- `--list-voices` — show available voices
+
+## Tone
+
+**Write for the ear, not the eye.** Brief, conversational, informative. Imagine you're calling across the room.
+
+**Good:**
+> "Hey BJ, PR 91 is merged. All 600 tests passing."
+
+**Bad:**
+> "build.sh exited with code 0. 54 validation checks passed. pytest returned 600 passed 0 failed in 17.53 seconds. gh pr merge completed successfully for pull request number 91."
+
+Keep it to 1-2 sentences. Summarize, don't enumerate.
+
+## Paralinguistic Tags
+
+Chatterbox supports expressive tags — use sparingly for personality:
+
+`[laugh]`, `[sigh]`, `[gasp]`, `[chuckle]`, `[groan]`, `[clear throat]`
+
+Example: `vox "[clear throat] Attention please — the build is on fire."`
+
+## Best-Effort
+
+If `vox` fails (no backend, network down, no speakers), **continue normally**. Never block on audio. Never retry. Just move on.
+
+```bash
+vox "Done!" 2>/dev/null || true
+```
+
+## Voice Selection
+
+28 voices available. Some suggestions:
+- **Taylor** (default) — BJ's pick
+- **Emily** — clear, neutral
+- **Jade** — warm
+- **Adrian** — deep
+- **Olivia** — bright
+
+Use `vox --list-voices` to see all options, or `--voice NAME` to pick one.


### PR DESCRIPTION
## Summary

Add text-to-speech capability for agents to announce status updates, approvals, and alerts via voice. Three-tier TTS backend with Chatterbox as primary, plus voice announcement integration into 4 workflow skills.

## Changes

- **`scripts/vox`** — New bash script: 3-tier TTS backend (VOX_COMMAND → HTTP/Chatterbox → local espeak/piper/say), Taylor default voice, ffplay with 200ms adelay buffer, background mode with disown/timeout, --voice/--bg/--list-voices options
- **`skills/vox/SKILL.md`** — Agent guide: when to use (approval needed, work complete, errors), tone guidance ("write for the ear"), paralinguistic tags, voice selection
- **`skills/precheck/SKILL.md`** — Added Step 5 vox announcement after checklist presentation
- **`skills/scpmr/SKILL.md`** — Added vox announcement after PR creation
- **`skills/scpmmr/SKILL.md`** — Added vox announcement after merge completion
- **`skills/nextwave/SKILL.md`** — Added vox announcement at wave completion (Step 6)
- **`README.md`** — Added vox to Scripts and Skills tables

## Linked Issues

Closes #90

## Test Plan

- Validated 57/57 (shellcheck, shfmt, py_compile, frontmatter)
- 600/600 pytest pass
- Manually tested against live Chatterbox at archer:8004: args mode, stdin pipe, --bg, --list-voices (28 voices), empty message rejection, VOX_COMMAND=cat dry-run, unreachable endpoint error path
- Three rounds of code review with all high+ findings fixed

Generated with [Claude Code](https://claude.com/claude-code)