### PR TITLE
feat(discord): add --attach and create-thread to discord-bot

### DIFF
--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -30,6 +30,7 @@ Determine what the user wants from the phrasing:
 | Quoted text, or starts with "say", "tell", "post", "send", "announce" | **send** | `"build complete"`, `tell #dev "ready"`, `post "deployed v1.2"` |
 | Starts with "check", "read", "what's", contains `?`, or describes wanting to see messages | **read** | `what's new?`, `check #general`, `read #agent-ops` |
 | Starts with "create", "make", "new" + channel name | **create** | `create #wave-3-status`, `new channel test` |
+| Starts with "thread", "create thread", "new thread" + thread name | **create-thread** | `thread "session-123" in #remote-sessions`, `create thread "daily"` |
 | Starts with "list", "show", "channels" | **list** | `list channels`, `show channels` |
 | No args at all | **read** | (reads default channel) |
 
@@ -65,6 +66,11 @@ discord-bot resolve 1486516321385578576 <channel-name>
    ```bash
    discord-bot send <channel-id> "<formatted message>"
    ```
+   To attach a file (e.g., a voice memo WAV):
+   ```bash
+   discord-bot send <channel-id> "<formatted message>" --attach /path/to/file.wav
+   ```
+   The `--attach` flag uploads the file as a Discord attachment using multipart/form-data. It works with or without `--embed`.
 5. Confirm: `Sent to #<channel-name>.`
 
 ## Read Flow
@@ -85,6 +91,18 @@ discord-bot resolve 1486516321385578576 <channel-name>
    discord-bot create-channel 1486516321385578576 <name> --topic "<topic>"
    ```
 4. Confirm: `Created #<name> (<id>).`
+
+## Create Thread Flow
+
+1. Parse the parent channel ID and thread name from args
+2. Optionally parse `--auto-archive` duration (default: 1440 = 24 hours)
+3. Create:
+   ```bash
+   discord-bot create-thread <channel-id> <name> [--auto-archive 60|1440|4320|10080]
+   ```
+4. Confirm: `Created thread #<name> (<id>).`
+
+Note: Thread IDs work with `discord-bot read <thread-id>` for reading thread messages.
 
 ## List Channels Flow
 

--- a/skills/disc/discord-bot
+++ b/skills/disc/discord-bot
@@ -2,9 +2,10 @@
 # discord-bot — Discord REST API client for Claude Code agents
 #
 # Usage:
-#   discord-bot send <channel-id> <message> [--embed title:text]
+#   discord-bot send <channel-id> <message> [--embed title:text] [--attach FILE]
 #   discord-bot read <channel-id> [--limit N] [--after ID]
 #   discord-bot create-channel <guild-id> <name> [--topic TOPIC] [--category ID]
+#   discord-bot create-thread <channel-id> <name> [--auto-archive 60|1440|4320|10080]
 #   discord-bot list-channels <guild-id> [--type text|voice|category]
 #   discord-bot resolve <guild-id> <channel-name>
 #
@@ -77,7 +78,7 @@ api_post() {
 
 # --- Subcommand: send ---------------------------------------------------------
 cmd_send() {
-	local channel_id="" message="" embed_title="" embed_text=""
+	local channel_id="" message="" embed_title="" embed_text="" attach_file=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -88,6 +89,18 @@ cmd_send() {
 			}
 			embed_title="${2%%:*}"
 			embed_text="${2#*:}"
+			shift 2
+			;;
+		--attach)
+			[[ -z "${2:-}" ]] && {
+				echo "Error: --attach requires a file path." >&2
+				exit 1
+			}
+			attach_file="$2"
+			[[ ! -f "$attach_file" ]] && {
+				echo "Error: attachment file not found: $attach_file" >&2
+				exit 1
+			}
 			shift 2
 			;;
 		*)
@@ -111,18 +124,35 @@ cmd_send() {
 
 	local payload
 	if [[ -n "$embed_title" ]]; then
-		payload=$(jq -n \
+		payload=$(jq -c -n \
 			--arg content "$message" \
 			--arg title "$embed_title" \
 			--arg desc "$embed_text" \
 			'{content: $content, embeds: [{title: $title, description: $desc}]}')
 	else
-		payload=$(jq -n --arg content "$message" '{content: $content}')
+		payload=$(jq -c -n --arg content "$message" '{content: $content}')
 	fi
 
-	local response
-	response=$(api_post "/channels/$channel_id/messages" "$payload")
-	jq -r '.id' <<<"$response"
+	if [[ -n "$attach_file" ]]; then
+		local http_code body
+		body=$(curl -sS -w '\n%{http_code}' -X POST \
+			--config <(echo "$_curl_auth_cfg") \
+			-F "payload_json=$payload" \
+			-F "files[0]=@${attach_file}" \
+			"$API_BASE/channels/$channel_id/messages")
+		http_code=$(tail -1 <<<"$body")
+		body=$(sed '$d' <<<"$body")
+		if [[ "$http_code" -ge 400 ]]; then
+			echo "Error: Discord API returned HTTP $http_code on multipart POST" >&2
+			[[ -n "$body" ]] && echo "$body" | jq -r '.message // empty' 2>/dev/null >&2
+			return 1
+		fi
+		jq -r '.id' <<<"$body"
+	else
+		local response
+		response=$(api_post "/channels/$channel_id/messages" "$payload")
+		jq -r '.id' <<<"$response"
+	fi
 }
 
 # --- Subcommand: read ---------------------------------------------------------
@@ -230,6 +260,52 @@ cmd_create_channel() {
 	echo "#$ch_name ($ch_id)"
 }
 
+# --- Subcommand: create-thread ------------------------------------------------
+cmd_create_thread() {
+	local channel_id="" name="" auto_archive="1440"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--auto-archive)
+			[[ -z "${2:-}" ]] && {
+				echo "Error: --auto-archive requires a value (60, 1440, 4320, 10080)." >&2
+				exit 1
+			}
+			auto_archive="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$channel_id" ]]; then
+				channel_id="$1"
+			elif [[ -z "$name" ]]; then
+				name="$1"
+			else
+				echo "Error: unexpected argument '$1'." >&2
+				exit 1
+			fi
+			shift
+			;;
+		esac
+	done
+
+	[[ -z "$channel_id" || -z "$name" ]] && {
+		echo "Error: create-thread requires <channel-id> and <name>." >&2
+		exit 1
+	}
+
+	local payload
+	payload=$(jq -n --arg name "$name" --argjson archive "$auto_archive" \
+		'{name: $name, type: 11, auto_archive_duration: $archive}')
+
+	local response
+	response=$(api_post "/channels/$channel_id/threads" "$payload")
+
+	local th_name th_id
+	th_name=$(jq -r '.name' <<<"$response")
+	th_id=$(jq -r '.id' <<<"$response")
+	echo "#$th_name ($th_id)"
+}
+
 # --- Subcommand: list-channels ------------------------------------------------
 cmd_list_channels() {
 	local guild_id="" filter_type=""
@@ -317,6 +393,7 @@ case "$1" in
 send) shift && cmd_send "$@" ;;
 read) shift && cmd_read "$@" ;;
 create-channel) shift && cmd_create_channel "$@" ;;
+create-thread) shift && cmd_create_thread "$@" ;;
 list-channels) shift && cmd_list_channels "$@" ;;
 resolve) shift && cmd_resolve "$@" ;;
 --help | -h) usage ;;


### PR DESCRIPTION
## Summary
Adds `--attach FILE` flag to `discord-bot send` for uploading files as Discord attachments via multipart/form-data. Adds `create-thread` subcommand for creating public threads with configurable auto-archive.

## Changes
- `skills/disc/discord-bot`: Added `--attach FILE` to `cmd_send()` with file validation and multipart upload; added `cmd_create_thread()` subcommand with `--auto-archive` flag
- `skills/disc/SKILL.md`: Added thread creation intent pattern, `--attach` docs in Send Flow, new Create Thread Flow section

## Linked Issues
Closes #96

## Test Plan
- `discord-bot send <channel> "test" --attach /tmp/test.wav` — file uploaded as attachment
- `discord-bot send <channel> "test" --attach /nonexistent` — exits 1 with error
- `discord-bot create-thread <channel-id> "test-thread"` — thread created, returns `#name (id)`
- `discord-bot read <thread-id>` — confirms existing read works with thread IDs
- Validation: 57/57 (shellcheck + shfmt clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)