### PR TITLE
docs: update README and CLAUDE.md for remote session relay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,6 +564,15 @@ The signature is used by the watcher to filter your own echoes. Messages without
 
 The watcher pre-filters messages: only `@all`, `@<dev-team>`, and `@<dev-name>` notifications are delivered. Set `DISCORD_WATCHER_VERBOSE=1` to bypass filtering and receive all messages.
 
+**Thread messages (remote sessions):**
+
+When the agent has a `thread_id` in its identity file (set by `afk-notify`),
+the watcher also polls that thread for replies. Thread messages skip the
+@-addressing filter — everything in the agent's thread is addressed to it.
+
+Voice message attachments are automatically transcribed via Whisper STT and
+delivered as `[voice memo from <author>: "<text>"]`.
+
 ---
 
 ## MANDATORY: Post-Compaction Rules Confirmation
@@ -614,9 +623,11 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
    {
      "dev_team": "<Dev-Team value>",
      "dev_name": "<your chosen name>",
-     "dev_avatar": "<your chosen emoji>"
+     "dev_avatar": "<your chosen emoji>",
+     "thread_id": "<Discord thread ID, set by afk-notify>"
    }
    ```
+   Note: `thread_id` is optional and only present when `afk-notify` has created a session thread.
 4. Announce your identity to the user:
    > I'm going by **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>` this session.
 5. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Key features:
 | `slackbot-send` | `curl`, `jq`, Slack bot token | Send Slack messages as a named Claude Code agent |
 | `job-fetch` | `glab`, `python3` | Fetch GitLab CI job traces for analysis |
 | `file-opener` | `xdg-open` / `open` | Cross-platform file/URL opener for `/view` and `/edit` |
+| `afk-notify` | `jq`, `loginctl`, `claude` CLI, `vox`, `discord-bot` | Stop hook — relays agent output to Discord when desktop locked |
 | `vox` | `curl`, audio player (`aplay`/`afplay`) | Text-to-speech via Chatterbox API, with local fallback (espeak/piper/say) |
 | `statusline-command.sh` | `jq`, `git` | Custom status line: git branch, dirty state, context window remaining, model |
 
@@ -266,6 +267,22 @@ Each agent signs messages with its Dev-Name signature (e.g., `— **beacon** :sa
 The `discord-status-post` script posts a rich embed to `#wave-status` whenever the wave state machine transitions. One message per project, edited in place — no spam.
 
 The embed includes phase, wave, action, flight, a Unicode progress bar, and deferrals, with a color-coded sidebar that maps to the current action state. It's invoked automatically by `wave-status` after every state change (best-effort — skipped silently if not installed or Discord is unreachable).
+
+### Remote Sessions
+
+When the desktop is locked, agents automatically relay output to Discord
+via per-session threads in `#remote-sessions`. The user can reply with
+text or voice messages from their phone.
+
+**Setup:**
+1. Run `install.sh` to install the `afk-notify` hook script
+2. Add the Stop hook to your Claude Code settings (see `config/settings.template.json`)
+3. Ensure `claude` CLI is available on PATH (for Haiku summarization)
+4. Ensure `vox` is installed (for voice memo rendering)
+
+**STT Configuration:**
+- `STT_ENDPOINT` — Whisper-compatible endpoint (default: `http://archer:8300/v1/audio/transcriptions`)
+- `STT_MODEL` — Model name (default: `deepdml/faster-whisper-large-v3-turbo-ct2`)
 
 ### Verbose Mode
 


### PR DESCRIPTION
## Summary
Documents the AFK remote session relay feature across README.md and CLAUDE.md — the final issue in the #93 epic.

## Changes
- `README.md`: Added `afk-notify` to Scripts table, new "Remote Sessions" subsection with setup instructions and STT configuration env vars
- `CLAUDE.md`: Added thread polling behavior to Discord Watcher section, documented `thread_id` field in Agent Identity JSON

## Linked Issues
Closes #99

## Test Plan
- Validation: 59/59
- All STT defaults, channel IDs, and dependency lists verified against actual source code
- No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)