### PR TITLE
fix(vox): prepend Bluetooth wake noise to prevent audio clipping

### DIFF
--- a/scripts/vox
+++ b/scripts/vox
@@ -147,6 +147,33 @@ detect_player() {
 	fi
 }
 
+# --- Wake noise (Bluetooth A2DP preamble) ------------------------------------
+
+# Prepend ~500ms of low-amplitude white noise to a WAV file. This wakes up
+# Bluetooth audio sinks that sleep when idle, preventing the first syllable
+# from being clipped. Only applied to playback paths — --output stays clean.
+prepend_wake_noise() {
+	local wavfile="$1"
+	python3 -c '
+import wave, random, sys
+with wave.open(sys.argv[1], "rb") as w:
+    p = w.getparams()
+    frames = w.readframes(w.getnframes())
+sw = p.sampwidth
+n = int(p.framerate * 0.5) * p.nchannels
+max_amp = (1 << (8 * sw - 1)) - 1
+scale = max(1, max_amp // 55)  # ~-35 dB below full scale
+bias = 128 if sw == 1 else 0  # 8-bit WAV is unsigned (silence=128)
+raw = b"".join(
+    ((random.randint(-scale, scale) + bias) & ((1 << (8 * sw)) - 1))
+    .to_bytes(sw, "little") for _ in range(n)
+)
+with wave.open(sys.argv[1], "wb") as w:
+    w.setparams(p)
+    w.writeframes(raw + frames)
+' "$wavfile" 2>/dev/null || true # best-effort — play unmodified if python3 fails
+}
+
 # --- Backend 1: VOX_COMMAND ---------------------------------------------------
 
 if [[ -n "${VOX_COMMAND:-}" ]]; then
@@ -229,6 +256,9 @@ if [[ -n "$endpoint" ]]; then
 		cp "$tmpfile" "$OUTPUT_FILE"
 		exit 0
 	fi
+
+	# Wake Bluetooth A2DP sinks before real audio starts
+	prepend_wake_noise "$tmpfile"
 
 	PLAYER=$(detect_player)
 	if [[ -z "$PLAYER" ]]; then


### PR DESCRIPTION
## Summary

Bluetooth A2DP headsets clip the first ~500ms of vox audio because the sink sleeps when idle. This adds a low-amplitude white noise preamble (~-35 dB) to WAV files before playback, forcing the A2DP link active before speech starts.

## Changes

- Added `prepend_wake_noise()` function to `scripts/vox` — uses python3 `wave` module to prepend 500ms of white noise, adapting to any sample width (8/16/24/32-bit)
- Called in HTTP backend playback path, after `--output` early-exit (saved files stay clean) but before player detection
- Best-effort with `|| true` — python3 failure just skips the preamble

## Linked Issues

Closes #105

## Test Plan

- Validated with shellcheck and shfmt (59/59 pass)
- Verified WAV duration: clean=1.54s → with noise=2.04s (+0.50s exact)
- Verified `--output` produces clean audio without preamble
- Live Bluetooth playback confirmed by user — no clipping
- Discord voice call-and-response round-trip tested successfully