### PR TITLE
fix(watcher): strip punctuation from @-addressing tokens

### DIFF
--- a/channels/discord-watcher/index.test.ts
+++ b/channels/discord-watcher/index.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 import type { DiscordMessage, DiscordAttachment } from "./index";
+import { stripTokenPunctuation } from "./index";
 
 // We need to mock fetch and fs before importing the module under test.
 // Bun's mock system lets us intercept global fetch.
@@ -439,6 +440,30 @@ describe("thread polling structure", () => {
     const matches = src.match(echoPattern);
     // Should appear at least twice: once in channel loop, once in thread loop
     expect(matches!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("@-addressing matches when followed by punctuation", async () => {
+    // The watcher tokenizes on whitespace then strips non-routing chars.
+    // "@echo-chamber," should match dev_name "echo-chamber".
+    const tokens = "@echo-chamber, hello @all. @cc-workflow:"
+      .toLowerCase()
+      .split(/\s+/)
+      .map(stripTokenPunctuation);
+
+    expect(tokens).toContain("@echo-chamber");
+    expect(tokens).toContain("@all");
+    expect(tokens).toContain("@cc-workflow");
+  });
+
+  test("@-addressing matches clean tokens without punctuation", async () => {
+    const tokens = "@echo-chamber hello @all @cc-workflow"
+      .toLowerCase()
+      .split(/\s+/)
+      .map(stripTokenPunctuation);
+
+    expect(tokens).toContain("@echo-chamber");
+    expect(tokens).toContain("@all");
+    expect(tokens).toContain("@cc-workflow");
   });
 
   test("thread messages include audio transcription", async () => {

--- a/channels/discord-watcher/index.ts
+++ b/channels/discord-watcher/index.ts
@@ -118,6 +118,11 @@ export interface DiscordMessage {
 
 // --- Voice message STT -------------------------------------------------------
 
+/** Strip punctuation from a lowercased token, keeping only routing-key chars. */
+export function stripTokenPunctuation(token: string): string {
+  return token.replace(/[^a-z0-9@_-]/g, "");
+}
+
 const STT_ENDPOINT = process.env.STT_ENDPOINT ?? "http://archer:8300/v1/audio/transcriptions";
 const STT_MODEL = process.env.STT_MODEL ?? "deepdml/faster-whisper-large-v3-turbo-ct2";
 
@@ -307,7 +312,7 @@ async function checkForNewMessages(
             // No identity resolved yet — deliver all messages until agent sets up
           } else {
             const contentLower = msg.content.toLowerCase();
-            const tokens = contentLower.split(/\s+/);
+            const tokens = contentLower.split(/\s+/).map(stripTokenPunctuation);
             const isAddressedToAll = tokens.includes("@all");
             const isAddressedToTeam = cachedIdentity.devTeam
               ? tokens.includes(`@${cachedIdentity.devTeam.toLowerCase()}`)


### PR DESCRIPTION
## Summary

Tokens like `@echo-chamber,` failed to match dev_name `echo-chamber` because the comma stuck to the token after whitespace splitting. Messages with punctuation after @-mentions were silently dropped.

## Changes

- Extracted `stripTokenPunctuation()` as an exported helper in `index.ts` — strips non-routing characters (`[^a-z0-9@_-]`) from tokens before @-mention matching
- Added 2 tests importing the real function: punctuation-adjacent and clean token cases

## Linked Issues

Closes #107

## Test Plan

- 21/21 bun tests pass (2 new)
- Live verified: watcher delivered `@echo-chamber,` message after fix (previously dropped)
- 59/59 project validation passes