### PR TITLE
feat(disc): change default /disc action from read to check-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Key features:
 | assesswaves | `/assesswaves` | Quick assessment of wave-pattern suitability |
 | ccfold | `/ccfold` | Merge upstream CLAUDE.md template updates into local project |
 | cryo | `/cryo` | Preserve session state before context compaction |
-| disc | `/disc` | Discord integration — send, read, list, resolve channels |
+| disc | `/disc` | Discord integration — check-in, send, read, list, resolve channels |
 | edit | `/edit` | Open file/URL in GUI editor |
 | engage | `/engage` | Load CLAUDE.md, confirm rules of engagement |
 | ibm | `/ibm` | Issue-Branch-PR/MR workflow reminder |

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -20,7 +20,7 @@ Token: ~/secrets/discord-bot-token
 {{#if args}}
 Parse the argument: `{{args}}`
 {{else}}
-No argument — default to reading recent messages from `#agent-ops`.
+No argument — post a check-in to `#roll-call`.
 {{/if}}
 
 Determine what the user wants from the phrasing:
@@ -32,7 +32,8 @@ Determine what the user wants from the phrasing:
 | Starts with "create", "make", "new" + channel name | **create** | `create #wave-3-status`, `new channel test` |
 | Starts with "thread", "create thread", "new thread" + thread name | **create-thread** | `thread "session-123" in #remote-sessions`, `create thread "daily"` |
 | Starts with "list", "show", "channels" | **list** | `list channels`, `show channels` |
-| No args at all | **read** | (reads default channel) |
+| "roll-call", "check in", "sound off" | **check-in** | `roll-call`, `check in`, `sound off` |
+| No args at all | **check-in** | (posts check-in to `#roll-call`) |
 
 ## Resolve Agent Identity
 
@@ -111,3 +112,19 @@ Note: Thread IDs work with `discord-bot read <thread-id>` for reading thread mes
    discord-bot list-channels 1486516321385578576 --type text
    ```
 2. Format as a clean list for the user.
+
+## Check-In Flow
+
+1. Resolve agent identity (Dev-Name, Dev-Avatar, Dev-Team)
+2. Resolve the project root path
+3. Post to `#roll-call` (`1487382005036617851`):
+   ```bash
+   discord-bot send 1487382005036617851 "<message>"
+   ```
+   Message format:
+   ```
+   **<Dev-Name>** <Dev-Avatar> online — team `<Dev-Team>` @ <project-root>
+
+   — **<Dev-Name>** <Dev-Avatar> (<Dev-Team>)
+   ```
+4. Confirm: `Checked in to #roll-call as <Dev-Name> <Dev-Avatar>.`


### PR DESCRIPTION
## Summary

Changes the default (no-args) `/disc` behavior from reading `#agent-ops` to posting a check-in to `#roll-call`. With the discord-watcher MCP delivering messages in real-time, manual reading is a rare edge case — check-in is the most common manual action.

## Changes

- `skills/disc/SKILL.md` — Changed no-args default to check-in, added check-in intent row (patterns: "roll-call", "check in", "sound off"), added Check-In Flow section
- `README.md` — Updated `/disc` description to mention check-in

## Linked Issues

Closes #109

## Test Plan

- Verified intent table consistency with Check-In Flow section
- Confirmed check-in message format matches CLAUDE.md session onboarding format
- 59/59 validation passes
- Code review: no issues found