### PR TITLE
feat(disc): abstract Discord config into ~/.claude/discord.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -630,9 +630,10 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
    Note: `thread_id` is optional and only present when `afk-notify` has created a session thread.
 4. Announce your identity to the user:
    > I'm going by **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>` this session.
-5. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`:
+5. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`. Read the channel ID from config:
    ```bash
-   discord-bot send 1487382005036617851 "<message>"
+   ROLL_CALL=$(jq -r '.channels["roll-call"].id' ~/.claude/discord.json 2>/dev/null || echo "1487382005036617851")
+   discord-bot send "$ROLL_CALL" "<message>"
    ```
    Message format:
    ```

--- a/channels/discord-watcher/index.test.ts
+++ b/channels/discord-watcher/index.test.ts
@@ -7,8 +7,8 @@
  */
 
 import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
-import type { DiscordMessage, DiscordAttachment } from "./index";
-import { stripTokenPunctuation } from "./index";
+import type { DiscordMessage, DiscordAttachment, DiscordConfig } from "./index";
+import { stripTokenPunctuation, loadConfig } from "./index";
 
 // We need to mock fetch and fs before importing the module under test.
 // Bun's mock system lets us intercept global fetch.
@@ -477,5 +477,93 @@ describe("thread polling structure", () => {
     const sttCalls = src.match(/transcribeAudioAttachments\(msg/g);
     // At least 2: one for channels, one for threads
     expect(sttCalls!.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// --- loadConfig tests --------------------------------------------------------
+
+describe("loadConfig", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env vars
+    process.env.DISCORD_GUILD_ID = originalEnv.DISCORD_GUILD_ID;
+    process.env.DISCORD_TOKEN_PATH = originalEnv.DISCORD_TOKEN_PATH;
+    if (originalEnv.DISCORD_GUILD_ID === undefined) delete process.env.DISCORD_GUILD_ID;
+    if (originalEnv.DISCORD_TOKEN_PATH === undefined) delete process.env.DISCORD_TOKEN_PATH;
+  });
+
+  test("loadConfig returns an object with guildId and tokenPath", () => {
+    const config = loadConfig();
+    expect(config).toHaveProperty("guildId");
+    expect(config).toHaveProperty("tokenPath");
+    expect(typeof config.guildId).toBe("string");
+    expect(typeof config.tokenPath).toBe("string");
+    // Must return non-empty strings (either from config, env, or defaults)
+    expect(config.guildId.length).toBeGreaterThan(0);
+    expect(config.tokenPath.length).toBeGreaterThan(0);
+  });
+
+  test("loadConfig falls back to hardcoded defaults when no config or env", () => {
+    // Temporarily clear env vars
+    delete process.env.DISCORD_GUILD_ID;
+    delete process.env.DISCORD_TOKEN_PATH;
+
+    // loadConfig reads ~/.claude/discord.json if it exists, then env, then defaults.
+    // We cannot remove the user's config file in a test, so we verify the
+    // function at minimum returns valid values (either from config or defaults).
+    const config = loadConfig();
+    // The default guild ID is the Oak and Wave server
+    // If config file exists, it should return the config value; otherwise the default
+    expect(config.guildId).toMatch(/^\d+$/);
+    expect(config.tokenPath).toContain("discord-bot-token");
+  });
+
+  test("loadConfig uses DISCORD_GUILD_ID env var when set", () => {
+    process.env.DISCORD_GUILD_ID = "9999999999999999999";
+    // Re-import to pick up env changes (loadConfig reads env at call time)
+    // Note: if config file exists and has guild_id, that takes precedence.
+    // This test verifies the env var is read when config file value is absent.
+    const { loadConfig: reloadConfig } = require("./index");
+    const config = reloadConfig();
+    // If config file has guild_id, it takes precedence. If not, env var should win.
+    // At minimum, verify the function doesn't throw.
+    expect(typeof config.guildId).toBe("string");
+  });
+
+  test("DiscordConfig interface matches expected schema", () => {
+    // Verify the TypeScript interface at compile time by constructing a valid object
+    const config: DiscordConfig = {
+      guild_id: "123",
+      token_path: "~/secrets/token",
+      channels: {
+        default: { name: "agent-ops", id: "456" },
+        "roll-call": { name: "roll-call", id: "789" },
+      },
+    };
+    expect(config.guild_id).toBe("123");
+    expect(config.channels?.default?.id).toBe("456");
+    expect(config.channels?.["roll-call"]?.id).toBe("789");
+  });
+
+  test("loadConfig source implements three-level fallback chain", () => {
+    // Verify the implementation pattern exists in source
+    const { readFileSync } = require("node:fs");
+    const src = readFileSync(
+      new URL("./index.ts", import.meta.url).pathname,
+      "utf-8"
+    );
+
+    // Config file read
+    expect(src).toContain("discord.json");
+    expect(src).toContain("existsSync");
+
+    // Env var fallback
+    expect(src).toContain("process.env.DISCORD_GUILD_ID");
+    expect(src).toContain("process.env.DISCORD_TOKEN_PATH");
+
+    // Hardcoded defaults
+    expect(src).toContain('DEFAULT_GUILD_ID = "1486516321385578576"');
+    expect(src).toContain('DEFAULT_TOKEN_PATH = "~/secrets/discord-bot-token"');
   });
 });

--- a/channels/discord-watcher/index.ts
+++ b/channels/discord-watcher/index.ts
@@ -11,13 +11,63 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 // --- Configuration -----------------------------------------------------------
 
-const GUILD_ID = "1486516321385578576";
+// Hardcoded defaults (Oak and Wave — last-resort fallback)
+const DEFAULT_GUILD_ID = "1486516321385578576";
+const DEFAULT_TOKEN_PATH = "~/secrets/discord-bot-token";
+
+/** Discord configuration schema as stored in ~/.claude/discord.json */
+export interface DiscordConfig {
+  guild_id?: string;
+  token_path?: string;
+  channels?: {
+    [role: string]: { name: string; id: string };
+  };
+}
+
+/**
+ * Load Discord config using the fallback chain:
+ * 1. ~/.claude/discord.json
+ * 2. Environment variables
+ * 3. Hardcoded defaults
+ */
+export function loadConfig(): { guildId: string; tokenPath: string } {
+  let config: DiscordConfig = {};
+  const configPath = join(homedir(), ".claude", "discord.json");
+
+  // 1. Try config file
+  if (existsSync(configPath)) {
+    try {
+      config = JSON.parse(readFileSync(configPath, "utf-8"));
+    } catch {
+      console.error(`[discord-watcher] Warning: ${configPath} contains invalid JSON, falling back to defaults`);
+    }
+  }
+
+  // 2. Guild ID: config → env → default
+  const guildId =
+    config.guild_id ||
+    process.env.DISCORD_GUILD_ID ||
+    DEFAULT_GUILD_ID;
+
+  // 3. Token path: config → env → default
+  const tokenPath =
+    config.token_path ||
+    process.env.DISCORD_TOKEN_PATH ||
+    DEFAULT_TOKEN_PATH;
+
+  return { guildId, tokenPath };
+}
+
+const { guildId: GUILD_ID, tokenPath: CONFIGURED_TOKEN_PATH } = loadConfig();
+
 const API_BASE = "https://discord.com/api/v10";
 const POLL_INTERVAL_MS = 15_000;
 const CHANNEL_REFRESH_MS = 5 * 60_000;
@@ -30,7 +80,8 @@ function loadToken(): string {
   const envToken = process.env.DISCORD_BOT_TOKEN;
   if (envToken) return envToken.trim();
 
-  const tokenPath = `${process.env.HOME}/secrets/discord-bot-token`;
+  // Expand ~ in configured token path
+  const tokenPath = CONFIGURED_TOKEN_PATH.replace(/^~/, homedir());
   try {
     return readFileSync(tokenPath, "utf-8").replace(/\r?\n/g, "").trim();
   } catch {

--- a/docs/discord-config.md
+++ b/docs/discord-config.md
@@ -1,0 +1,89 @@
+# Discord Configuration
+
+All Discord integration in the Claude Code workflow kit reads server-specific
+values from a user-scoped configuration file. This allows each team to point
+their agents at their own Discord server without modifying source.
+
+## Configuration File
+
+**Location:** `~/.claude/discord.json`
+
+### Schema
+
+```json
+{
+  "guild_id": "1234567890",
+  "token_path": "~/secrets/discord-bot-token",
+  "channels": {
+    "default":         { "name": "agent-ops",        "id": "1234567890" },
+    "roll-call":       { "name": "roll-call",        "id": "1234567890" },
+    "wave-status":     { "name": "wave-status",      "id": "1234567890" },
+    "remote-sessions": { "name": "remote-sessions",  "id": "1234567890" }
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `guild_id` | string | Yes | Discord server (guild) ID |
+| `token_path` | string | No | Path to bot token file (default: `~/secrets/discord-bot-token`) |
+| `channels` | object | Yes | Map of channel roles to channel info |
+| `channels.<role>.name` | string | Yes | Human-readable channel name (without `#`) |
+| `channels.<role>.id` | string | Yes | Discord channel snowflake ID |
+
+### Channel Roles
+
+| Role | Purpose | Used By |
+|------|---------|---------|
+| `default` | General agent communications | `discord-bot`, `disc` skill |
+| `roll-call` | Agent check-in on session start | `disc` skill, `CLAUDE.md` identity |
+| `wave-status` | Auto-updating wave execution status | `discord-status-post` |
+| `remote-sessions` | AFK session relay threads | `afk-notify` |
+
+## Fallback Chain
+
+Every component reads configuration using a three-level fallback:
+
+1. **Config file** (`~/.claude/discord.json`) -- preferred
+2. **Environment variables** -- useful for CI or ephemeral environments
+3. **Hardcoded defaults** -- backward compatibility with the Oak and Wave server
+
+### Environment Variables
+
+| Variable | Overrides | Default |
+|----------|-----------|---------|
+| `DISCORD_GUILD_ID` | `guild_id` | `1486516321385578576` |
+| `DISCORD_DEFAULT_CHANNEL` | `channels.default.id` | `1487288523638837268` |
+| `DISCORD_ROLL_CALL_CHANNEL` | `channels.roll-call.id` | `1487382005036617851` |
+| `DISCORD_WAVE_STATUS_CHANNEL` | `channels.wave-status.id` | `1487386934094462986` |
+| `DISCORD_REMOTE_SESSIONS_CHANNEL` | `channels.remote-sessions.id` | `1487462945972682763` |
+| `DISCORD_TOKEN_PATH` | `token_path` | `~/secrets/discord-bot-token` |
+
+## Per-User Scoping Strategy
+
+When multiple developers share a single Discord server, consider these
+approaches for isolating agent traffic:
+
+### Option A: Per-Team Channel Prefixes
+
+Create team-namespaced channels: `#teamname-agent-ops`,
+`#teamname-roll-call`, etc. Each team member's `discord.json` points to
+their team's channels. Clean separation but more channels to manage.
+
+### Option B: Shared Channels with Identity-Based Routing
+
+Use the existing `@<dev-team>` and `@<dev-name>` addressing convention.
+All agents share the same channels, and the watcher's pre-filtering
+ensures each agent only sees messages addressed to it. Already implemented
+in `discord-watcher`.
+
+### Option C: Both (Recommended for Larger Teams)
+
+Combine per-team channels for noisy traffic (roll-call, status) with
+shared channels for cross-team coordination (agent-ops). This gives clean
+separation where it matters while preserving a single place for
+team-wide announcements.
+
+Implementation of per-team channel auto-creation is a planned follow-up.

--- a/scripts/afk-notify
+++ b/scripts/afk-notify
@@ -14,6 +14,39 @@
 
 set -euo pipefail
 
+# --- Config loading -----------------------------------------------------------
+# Fallback chain: ~/.claude/discord.json → env vars → hardcoded defaults
+_DISCORD_CONFIG_FILE="$HOME/.claude/discord.json"
+_DISCORD_CONFIG=""
+
+load_discord_config() {
+	if [[ -z "$_DISCORD_CONFIG" && -f "$_DISCORD_CONFIG_FILE" ]]; then
+		_DISCORD_CONFIG=$(cat "$_DISCORD_CONFIG_FILE" 2>/dev/null) || _DISCORD_CONFIG=""
+		if [[ -n "$_DISCORD_CONFIG" ]] && ! jq -e . >/dev/null 2>&1 <<<"$_DISCORD_CONFIG"; then
+			_DISCORD_CONFIG=""
+		fi
+	fi
+}
+
+discord_config_get() {
+	local jq_path="$1" env_var="$2" default="$3"
+	load_discord_config
+	if [[ -n "$_DISCORD_CONFIG" ]]; then
+		local val
+		val=$(jq -r "$jq_path // empty" <<<"$_DISCORD_CONFIG" 2>/dev/null)
+		if [[ -n "$val" ]]; then
+			echo "$val"
+			return
+		fi
+	fi
+	local env_val="${!env_var:-}"
+	if [[ -n "$env_val" ]]; then
+		echo "$env_val"
+		return
+	fi
+	echo "$default"
+}
+
 # 1. Read JSON from stdin
 input=$(cat)
 
@@ -51,7 +84,7 @@ dev_team=$(jq -r '.dev_team // "unknown"' "$agent_file")
 dev_avatar=$(jq -r '.dev_avatar // ":robot_face:"' "$agent_file")
 
 # 5. Resolve or create Discord thread
-REMOTE_SESSIONS_CHANNEL="1487462945972682763"
+REMOTE_SESSIONS_CHANNEL=$(discord_config_get '.channels["remote-sessions"].id' 'DISCORD_REMOTE_SESSIONS_CHANNEL' '1487462945972682763')
 
 thread_id=$(jq -r '.thread_id // empty' "$agent_file")
 if [[ -z "$thread_id" ]]; then

--- a/scripts/discord-status-post
+++ b/scripts/discord-status-post
@@ -35,8 +35,46 @@ from pathlib import Path
 # Constants
 # ---------------------------------------------------------------------------
 
-WAVE_STATUS_CHANNEL_ID = "1487386934094462986"
+_DEFAULT_WAVE_STATUS_CHANNEL_ID = "1487386934094462986"
+_DEFAULT_TOKEN_PATH = "~/secrets/discord-bot-token"
 API_BASE = "https://discord.com/api/v10"
+
+
+def load_discord_config() -> dict:
+    """Load Discord config using fallback chain: config file -> env -> defaults."""
+    config: dict = {}
+    config_path = Path.home() / ".claude" / "discord.json"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            print(
+                f"Warning: {config_path} contains invalid JSON, falling back to defaults",
+                file=sys.stderr,
+            )
+    return config
+
+
+def get_discord_channel(role: str, env_var: str, default: str) -> str:
+    """Resolve a channel ID: config file -> env var -> hardcoded default."""
+    config = load_discord_config()
+    # 1. Config file
+    channels = config.get("channels", {})
+    ch = channels.get(role, {})
+    if ch.get("id"):
+        return ch["id"]
+    # 2. Environment variable
+    env_val = os.environ.get(env_var, "")
+    if env_val:
+        return env_val
+    # 3. Hardcoded default
+    return default
+
+
+WAVE_STATUS_CHANNEL_ID = get_discord_channel(
+    "wave-status", "DISCORD_WAVE_STATUS_CHANNEL", _DEFAULT_WAVE_STATUS_CHANNEL_ID
+)
 
 # Action → embed sidebar color (decimal)
 COLOR_MAP: dict[str, int] = {
@@ -89,15 +127,22 @@ def get_project_root() -> Path:
 
 
 def get_token() -> str:
-    """Resolve the Discord bot token from env or file."""
+    """Resolve the Discord bot token from env or file (config-driven)."""
     token = os.environ.get("DISCORD_BOT_TOKEN", "")
     if token:
         return token.strip()
-    token_file = Path.home() / "secrets" / "discord-bot-token"
+    # Resolve token path from config
+    config = load_discord_config()
+    token_path_str = (
+        config.get("token_path")
+        or os.environ.get("DISCORD_TOKEN_PATH")
+        or _DEFAULT_TOKEN_PATH
+    )
+    token_file = Path(os.path.expanduser(token_path_str))
     if token_file.exists():
         return token_file.read_text().strip()
     raise RuntimeError(
-        "DISCORD_BOT_TOKEN not set and ~/secrets/discord-bot-token not found"
+        f"DISCORD_BOT_TOKEN not set and {token_file} not found"
     )
 
 

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -9,10 +9,14 @@ Unified Discord integration for the **Oak and Wave** server. One skill handles s
 
 ## Configuration
 
-```
-Guild ID: 1486516321385578576
-Default channel: #agent-ops (1487288523638837268)
-Token: ~/secrets/discord-bot-token
+Read Discord config from `~/.claude/discord.json`. If the file is missing, fall back to
+environment variables, then to hardcoded defaults. See `docs/discord-config.md` for full schema.
+
+```bash
+# Resolve values at runtime:
+GUILD_ID=$(jq -r '.guild_id' ~/.claude/discord.json 2>/dev/null || echo "1486516321385578576")
+DEFAULT_CHANNEL=$(jq -r '.channels.default.id' ~/.claude/discord.json 2>/dev/null || echo "1487288523638837268")
+ROLL_CALL_CHANNEL=$(jq -r '.channels["roll-call"].id' ~/.claude/discord.json 2>/dev/null || echo "1487382005036617851")
 ```
 
 ## Resolve Intent
@@ -52,11 +56,15 @@ Read `dev_name`, `dev_avatar`, and `dev_team` from that file. If the file doesn'
 When a channel is mentioned by name (e.g., `#dev`, `agent-ops`, `general`):
 
 ```bash
-discord-bot resolve 1486516321385578576 <channel-name>
+GUILD_ID=$(jq -r '.guild_id' ~/.claude/discord.json 2>/dev/null || echo "1486516321385578576")
+discord-bot resolve "$GUILD_ID" <channel-name>
 ```
 
 - If not found, ask if the user wants to create it.
-- If no channel is specified, use the default: `#agent-ops` (`1487288523638837268`).
+- If no channel is specified, use the default channel from config:
+  ```bash
+  DEFAULT_CHANNEL=$(jq -r '.channels.default.id' ~/.claude/discord.json 2>/dev/null || echo "1487288523638837268")
+  ```
 
 ## Send Flow
 
@@ -89,7 +97,8 @@ discord-bot resolve 1486516321385578576 <channel-name>
 2. Optionally parse a topic from the args (e.g., "create #wave-3 for tracking wave 3 progress" → topic = "tracking wave 3 progress")
 3. Create:
    ```bash
-   discord-bot create-channel 1486516321385578576 <name> --topic "<topic>"
+   GUILD_ID=$(jq -r '.guild_id' ~/.claude/discord.json 2>/dev/null || echo "1486516321385578576")
+   discord-bot create-channel "$GUILD_ID" <name> --topic "<topic>"
    ```
 4. Confirm: `Created #<name> (<id>).`
 
@@ -109,7 +118,8 @@ Note: Thread IDs work with `discord-bot read <thread-id>` for reading thread mes
 
 1. List text channels:
    ```bash
-   discord-bot list-channels 1486516321385578576 --type text
+   GUILD_ID=$(jq -r '.guild_id' ~/.claude/discord.json 2>/dev/null || echo "1486516321385578576")
+   discord-bot list-channels "$GUILD_ID" --type text
    ```
 2. Format as a clean list for the user.
 
@@ -117,9 +127,10 @@ Note: Thread IDs work with `discord-bot read <thread-id>` for reading thread mes
 
 1. Resolve agent identity (Dev-Name, Dev-Avatar, Dev-Team)
 2. Resolve the project root path
-3. Post to `#roll-call` (`1487382005036617851`):
+3. Post to `#roll-call` (resolve from config):
    ```bash
-   discord-bot send 1487382005036617851 "<message>"
+   ROLL_CALL=$(jq -r '.channels["roll-call"].id' ~/.claude/discord.json 2>/dev/null || echo "1487382005036617851")
+   discord-bot send "$ROLL_CALL" "<message>"
    ```
    Message format:
    ```

--- a/skills/disc/discord-bot
+++ b/skills/disc/discord-bot
@@ -16,6 +16,66 @@ set -euo pipefail
 
 API_BASE="https://discord.com/api/v10"
 
+# --- Hardcoded defaults (Oak and Wave — last-resort fallback) -----------------
+_DEFAULT_GUILD_ID="1486516321385578576"
+_DEFAULT_CHANNEL_DEFAULT="1487288523638837268"
+_DEFAULT_CHANNEL_ROLL_CALL="1487382005036617851"
+_DEFAULT_CHANNEL_WAVE_STATUS="1487386934094462986"
+_DEFAULT_CHANNEL_REMOTE_SESSIONS="1487462945972682763"
+_DEFAULT_TOKEN_PATH="$HOME/secrets/discord-bot-token"
+
+# --- Config loading -----------------------------------------------------------
+# Fallback chain: ~/.claude/discord.json → env vars → hardcoded defaults
+_DISCORD_CONFIG_FILE="$HOME/.claude/discord.json"
+_DISCORD_CONFIG=""
+
+load_discord_config() {
+	# Load config file once (cached in _DISCORD_CONFIG)
+	if [[ -z "$_DISCORD_CONFIG" && -f "$_DISCORD_CONFIG_FILE" ]]; then
+		_DISCORD_CONFIG=$(cat "$_DISCORD_CONFIG_FILE" 2>/dev/null) || _DISCORD_CONFIG=""
+		# Validate JSON
+		if [[ -n "$_DISCORD_CONFIG" ]] && ! jq -e . >/dev/null 2>&1 <<<"$_DISCORD_CONFIG"; then
+			echo "Warning: $_DISCORD_CONFIG_FILE contains invalid JSON, falling back to defaults" >&2
+			_DISCORD_CONFIG=""
+		fi
+	fi
+}
+
+# Read a value from config → env var → hardcoded default.
+# Usage: discord_config_get <jq_path> <env_var_name> <hardcoded_default>
+discord_config_get() {
+	local jq_path="$1" env_var="$2" default="$3"
+	load_discord_config
+
+	# 1. Config file
+	if [[ -n "$_DISCORD_CONFIG" ]]; then
+		local val
+		val=$(jq -r "$jq_path // empty" <<<"$_DISCORD_CONFIG" 2>/dev/null)
+		if [[ -n "$val" ]]; then
+			echo "$val"
+			return
+		fi
+	fi
+
+	# 2. Environment variable
+	local env_val="${!env_var:-}"
+	if [[ -n "$env_val" ]]; then
+		echo "$env_val"
+		return
+	fi
+
+	# 3. Hardcoded default
+	echo "$default"
+}
+
+# Convenience accessors
+discord_guild_id() { discord_config_get '.guild_id' 'DISCORD_GUILD_ID' "$_DEFAULT_GUILD_ID"; }
+discord_token_path() { discord_config_get '.token_path' 'DISCORD_TOKEN_PATH' "$_DEFAULT_TOKEN_PATH"; }
+discord_channel_default() { discord_config_get '.channels.default.id' 'DISCORD_DEFAULT_CHANNEL' "$_DEFAULT_CHANNEL_DEFAULT"; }
+discord_channel_roll_call() { discord_config_get '.channels["roll-call"].id' 'DISCORD_ROLL_CALL_CHANNEL' "$_DEFAULT_CHANNEL_ROLL_CALL"; }
+discord_channel_wave_status() { discord_config_get '.channels["wave-status"].id' 'DISCORD_WAVE_STATUS_CHANNEL' "$_DEFAULT_CHANNEL_WAVE_STATUS"; }
+discord_channel_remote_sessions() { discord_config_get '.channels["remote-sessions"].id' 'DISCORD_REMOTE_SESSIONS_CHANNEL' "$_DEFAULT_CHANNEL_REMOTE_SESSIONS"; }
+
 # --- Usage --------------------------------------------------------------------
 usage() {
 	sed -n '2,/^[^#]/{ /^#/s/^# \?//p; }' "$0"
@@ -32,7 +92,9 @@ done
 
 # --- Auth ---------------------------------------------------------------------
 if [[ -z "${DISCORD_BOT_TOKEN:-}" ]]; then
-	TOKEN_FILE="$HOME/secrets/discord-bot-token"
+	TOKEN_FILE=$(discord_token_path)
+	# Expand ~ in token_path
+	TOKEN_FILE="${TOKEN_FILE/#\~/$HOME}"
 	[[ -f "$TOKEN_FILE" ]] || {
 		echo "Error: DISCORD_BOT_TOKEN not set and $TOKEN_FILE not found. Save your bot token there." >&2
 		exit 1


### PR DESCRIPTION
## Summary

Replace hardcoded Oak and Wave server IDs with a three-level config fallback chain (`~/.claude/discord.json` → env vars → hardcoded defaults) across all five Discord-consuming components. Enables teams to point agents at their own Discord server without modifying source.

## Changes

- **skills/disc/discord-bot**: `load_discord_config()` + `discord_config_get()` + convenience accessors
- **channels/discord-watcher/index.ts**: `loadConfig()` function, `DiscordConfig` interface (exported)
- **scripts/afk-notify**: Config loading functions for remote-sessions channel
- **scripts/discord-status-post**: Python config loading for wave-status channel
- **skills/disc/SKILL.md**: Hardcoded IDs replaced with jq config reads
- **CLAUDE.md**: Roll-call check-in reads channel from config
- **docs/discord-config.md**: NEW — schema reference, fallback chain, env var table, per-user scoping

## Test Results

- 26/26 bun tests pass (5 new loadConfig tests)
- 59/59 validation checks pass

## Test Plan

- `cd channels/discord-watcher && bun test` — 26/26 pass
- `./scripts/ci/validate.sh` — 59/59 pass

Closes #119

Generated with [Claude Code](https://claude.com/claude-code)