### PR TITLE
docs: add getting-started guide and concepts reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ cd claudecode-workflow
 ./install.sh
 ```
 
+**New here?** Read the [Getting Started guide](docs/getting-started.md) for a 15-minute walkthrough of your first session, then [Concepts](docs/concepts.md) for how the pieces fit together.
+
 ## What's Included
 
 ### CLAUDE.md Template

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,238 @@
+# Concepts
+
+This document explains how the pieces of the ccwork kit fit together and why they are designed the way they are. Read this after completing the [Getting Started](getting-started.md) guide.
+
+---
+
+## The Three Layers
+
+The kit is built in three layers, each serving a different purpose. Understanding these layers is the key to understanding everything else.
+
+### Layer 1: Settings
+
+**What:** `~/.claude/settings.json` -- the global configuration file for Claude Code.
+
+**What it controls:** Tool permissions (which CLI tools Claude can run without asking), hooks (automated behaviors triggered by Claude Code events), the status line format, enabled plugins, and effort level.
+
+**Why it exists:** Claude Code out of the box has conservative defaults. The settings layer opens up the permissions Claude needs to be productive (running `git`, `gh`, `glab`, `docker`, etc.) and wires up hooks that automate routine behaviors. Without this layer, Claude would ask permission for every shell command.
+
+The kit ships a `settings.template.json` that gets copied to `~/.claude/settings.json` on first install. After that, you own the file -- the installer will not overwrite it.
+
+### Layer 2: Scripts
+
+**What:** Shell scripts installed to `~/.local/bin/` -- things like `discord-bot`, `slackbot-send`, `vox`, `file-opener`, `afk-notify`, and `statusline-command.sh`.
+
+**What they do:** Provide capabilities that Claude Code does not have natively. `discord-bot` is a REST client for the Discord API. `vox` converts text to speech via a Chatterbox endpoint. `slackbot-send` posts Slack messages as a bot. These are standalone tools that work from the command line independent of Claude Code.
+
+**Why they are scripts, not skills:** Skills are prompts -- they tell Claude *what to do*. Scripts are executables -- they *do things*. A skill like `/disc` (Discord integration) calls the `discord-bot` script under the hood. The skill provides the intelligence (resolving intent, formatting messages, signing with identity), while the script provides the capability (HTTP calls to the Discord API). This separation means scripts can be tested independently, used outside of Claude Code, and updated without changing the skill logic.
+
+### Layer 3: Skills
+
+**What:** Markdown files installed to `~/.claude/skills/<name>/SKILL.md` and invoked with `/command` syntax in Claude Code sessions.
+
+**What they do:** Encode complex multi-step workflows as reusable procedures. When you type `/precheck`, Claude reads the `precheck/SKILL.md` file and follows its instructions step by step -- verifying the branch, running validation, launching a code review sub-agent, and presenting the checklist.
+
+**Why they are markdown, not code:** Skills are instructions for an LLM, not programs for a computer. They describe intent, decision trees, and workflows in natural language. This makes them easy to read, modify, and extend without programming knowledge. A skill file reads like a runbook because that is exactly what it is -- a runbook that Claude Code can execute.
+
+### The Fourth Layer: Channels
+
+**What:** MCP (Model Context Protocol) channel servers that push real-time notifications into Claude Code sessions. Currently the kit ships one: `discord-watcher`.
+
+**What it does:** The discord-watcher polls Discord channels and delivers messages to the Claude Code session as `<channel>` notifications. This enables real-time inter-agent communication -- multiple Claude Code agents running on different machines (or different projects on the same machine) can talk to each other through Discord.
+
+**Why it is a separate layer:** The first three layers are pull-based -- Claude decides when to use a script or skill. Channels are push-based -- external events (a Discord message, a Slack notification) arrive without Claude asking for them. This is a fundamentally different interaction pattern that requires the MCP channel server infrastructure. Not every deployment needs channels -- they add complexity and require a running Discord server with a bot token -- but for teams running multiple agents, they enable coordination that would otherwise require human relay.
+
+---
+
+## Identity System
+
+The identity system has two layers that mirror the distinction between project-level and session-level state.
+
+### Dev-Team (Persisted)
+
+**What:** A short name identifying which project or team this agent belongs to (e.g., `cc-workflow`, `backend-team`, `infra`).
+
+**Where it lives:** Written into the `Dev-Team:` field at the bottom of the project's `CLAUDE.md` file.
+
+**Lifecycle:** Set once on first session in a project, then persisted forever. It survives across sessions, across machines (since `CLAUDE.md` is committed to the repo), and across context compactions. Every agent working on the same project shares the same Dev-Team.
+
+**Why it exists:** When multiple agents are communicating through Discord or Slack, Dev-Team is the routing key for project-level addressing. A message to `@cc-workflow` reaches any agent working on the cc-workflow project, regardless of which specific session identity that agent has.
+
+### Dev-Name and Dev-Avatar (Ephemeral)
+
+**What:** A memorable name (e.g., `beacon`, `null-pointer`, `mother`) and a Slack-style emoji (e.g., `:satellite:`, `:skull:`, `:crystal_ball:`).
+
+**Where it lives:** Written to a temp file at `/tmp/claude-agent-<hash>.json`, where `<hash>` is the md5 of the project root path.
+
+**Lifecycle:** Picked fresh every session. A new Claude Code window means a new identity. The temp file is keyed by project root (not process ID), so the statusline and all skills can find it regardless of process ancestry.
+
+**Why it exists:** Dev-Name provides session-level addressing. When two agents are both working on `cc-workflow`, you need a way to talk to a specific one -- `@beacon` reaches only the agent that picked that name this session. The ephemeral nature is intentional: it prevents stale identity references and makes the channel feel alive rather than static.
+
+**Why kebab-case:** Dev-Names must be kebab-case (lowercase, hyphens between words) because they double as routing keys for `@` addressing in Discord. The watcher tokenizes messages and matches against `@<dev-name>` -- spaces or mixed case would break the matching.
+
+### How Identity Flows
+
+```
+CLAUDE.md (Dev-Team: cc-workflow)
+        |
+        v
+Session start: Claude picks Dev-Name + Dev-Avatar
+        |
+        v
+/tmp/claude-agent-<hash>.json
+  {
+    "dev_team": "cc-workflow",
+    "dev_name": "beacon",
+    "dev_avatar": ":satellite:"
+  }
+        |
+        v
+Used by: /disc, /ping, /pong, /name, statusline,
+         discord-watcher echo filtering, message signatures
+```
+
+Every skill and script that needs identity reads from the same file, resolved the same way. This is why the identity file is keyed by project root hash rather than PID -- it provides a stable rendezvous point for all components.
+
+---
+
+## Mandatory Workflows
+
+The kit enforces several workflows that cannot be skipped. These exist because of real problems encountered in production use -- every mandatory rule was added in response to a specific failure mode.
+
+### No Autonomous Commits
+
+**The rule:** Claude never commits without explicit human approval. Even trivial changes require `/precheck` followed by one of `/scp`, `/scpmr`, or `/scpmmr`.
+
+**Why it exists:** Context compaction (when Claude's context window fills up and gets summarized) causes loss of state. In early use, compaction led to Claude skipping the review checklist and committing directly -- pushing unreviewed code to the remote. The pre-commit gate exists to make this structurally impossible: `/precheck` presents the checklist and then *stops*. Claude cannot proceed until you respond.
+
+### Always Have an Issue
+
+**The rule:** Every piece of work must be tracked by an issue. No code is written until the issue exists and is linked to a branch.
+
+**Why it exists:** Untracked work creates invisible state. If Claude starts implementing a feature without an issue, there is no record of what was requested, no acceptance criteria to verify against, and no way for other team members (human or agent) to know what is in progress. The issue is the contract -- it defines what "done" looks like.
+
+### Test Before Push
+
+**The rule:** Local tests must pass before any `git push`. This is non-negotiable regardless of time pressure or session state.
+
+**Why it exists:** Pushing untested code wastes CI resources, blocks shared pipelines, and creates false signal for other developers. A failed CI run that could have been caught locally costs the team far more time than the seconds it takes to run `./scripts/ci/validate.sh`. Claude enforces this by running validation as part of both `/precheck` and `/scp`.
+
+### Post-Compaction Re-Engagement
+
+**The rule:** After any context compaction, Claude must immediately re-read `CLAUDE.md` and confirm the mandatory rules before doing any other work.
+
+**Why it exists:** Compaction is lossy. Claude's summary of a long conversation may drop critical details like "we are on a feature branch" or "tests must pass before push." The `/engage` skill exists specifically to restore this context. Running it after compaction is the safety net that prevents compaction-induced rule violations.
+
+---
+
+## Skill Taxonomy
+
+The skills are organized into four groups based on their purpose. This is not a rigid hierarchy -- some skills span groups -- but it provides a useful mental model.
+
+### Foundation Skills
+
+These manage the agent's own state and context. You use them at session boundaries and during maintenance.
+
+| Skill | Purpose |
+|-------|---------|
+| `/engage` | Load rules, restore context, confirm ready state. The "thaw" operation. |
+| `/cryo` | Freeze session state before context compaction. The "freeze" operation. |
+| `/ccfold` | Merge upstream CLAUDE.md template changes into a project's local copy. |
+| `/name` | Report or pick the agent's session identity (Dev-Name, Dev-Avatar). |
+
+### Workflow Skills
+
+These drive the development loop: creating issues, committing, reviewing, merging.
+
+| Skill | Purpose |
+|-------|---------|
+| `/precheck` | Pre-commit gate -- the mandatory verification step before any commit. |
+| `/scp` | Stage, commit, push. Creates a PR if one does not exist. |
+| `/scpmr` | Stage, commit, push, create PR/MR -- stops before merging. |
+| `/scpmmr` | Stage, commit, push, create PR/MR, merge -- the full pipeline. |
+| `/mmr` | Merge an existing PR/MR with squash and source branch deletion. |
+| `/ibm` | Issue-Branch-PR/MR workflow reminder. A cheat sheet, not an executor. |
+| `/review` | Run a standalone code review on staged changes, a branch, or a file. |
+| `/jfail` | Fetch and analyze a failed CI job or workflow run. |
+
+### Communication Skills
+
+These handle interaction with external systems: Discord, Slack, voice, and file viewers.
+
+| Skill | Purpose |
+|-------|---------|
+| `/disc` | Discord integration -- send, read, create channels, check in. |
+| `/ping` | Post a message to the `#ai-dev` Slack channel as this agent. |
+| `/pong` | Read recent messages from `#ai-dev` with smart filtering. |
+| `/vox` | Text-to-speech voice announcements. |
+| `/view` | Open a file or URL in a GUI viewer (read-only). |
+| `/edit` | Open a file or URL in a GUI editor (modification intent). |
+
+### Advanced Skills
+
+These enable parallel execution of work across multiple agents -- the "wave pattern."
+
+| Skill | Purpose |
+|-------|---------|
+| `/assesswaves` | Quick assessment of whether work items are suitable for parallel execution. |
+| `/prepwaves` | Full planning: validate sub-issue specs, compute dependency waves, prepare for execution. |
+| `/nextwave` | Execute one wave at a time with isolated worktrees and flight-based conflict avoidance. |
+
+The wave skills form a pipeline: `/assesswaves` decides if parallelism is worth it, `/prepwaves` plans the execution order, and `/nextwave` executes one wave at a time. Each wave can contain multiple "flights" -- groups of issues that can safely run in parallel without file-level conflicts. See the individual [skill files](../skills/) for full documentation.
+
+---
+
+## How CLAUDE.md Works
+
+`CLAUDE.md` is the project instructions file that Claude Code reads at session start. Understanding how it works is important because it is the primary mechanism for controlling Claude's behavior in a project.
+
+### Template vs Per-Project
+
+The ccwork kit ships a `CLAUDE.md` template in the repo root. When you copy it into a project (`cp claudecode-workflow/CLAUDE.md /path/to/your-project/`), it becomes that project's local copy. The template and the local copy are independent files -- changes to one do not affect the other.
+
+Over time, the template evolves (new sections, updated rules, improved workflows). To pull those changes into a project's local copy without losing project-specific customizations, use `/ccfold`. It performs a section-by-section merge: updating sections that have changed upstream, adding new sections, and preserving any sections that exist only in your local copy (like custom team rules or project-specific workflows).
+
+### Platform Detection
+
+The template supports both GitHub and GitLab out of the box. Rather than maintaining two separate templates, it uses runtime platform detection: Claude reads `git remote -v`, identifies the host, and adapts its terminology and CLI commands accordingly. A project on GitHub gets `gh` commands and "Pull Request" terminology. A project on GitLab gets `glab` commands and "Merge Request" terminology. The detection runs once on session start and the result is cached in `.claude-project.md` (generated by `/ccfold`) so it does not repeat every session.
+
+### The `/ccfold` Sync Process
+
+When you run `/ccfold`, it:
+
+1. **Fetches** the latest template from the canonical GitHub repo
+2. **Compares** each section (split on `## ` headers) between upstream and local
+3. **Classifies** sections as identical, updated, new, or local-only
+4. **Presents** a merge plan showing what will change
+5. **Applies** the merge after your approval, preserving project-specific content (Dev-Team, local-only sections)
+6. **Generates** `.claude-project.md` with cached platform detection results
+
+The merge is semantic, not mechanical -- Claude uses judgment to combine content rather than blindly replacing text blocks. When in doubt about whether a local change is intentional customization or just an older template version, it asks.
+
+### What CLAUDE.md Controls
+
+The rules in `CLAUDE.md` are loaded into Claude's context at session start and take precedence over default behaviors. The key sections and what they govern:
+
+| Section | Controls |
+|---------|----------|
+| Platform Detection | Which CLI and terminology to use |
+| Mandatory: Local Testing | Test-before-push enforcement |
+| Mandatory: Pre-Commit Gate | The `/precheck` workflow |
+| Mandatory: Story Completion | Acceptance criteria verification |
+| Mandatory: Issue Tracking | Issue-branch-PR/MR workflow |
+| Work Item Standards | Issue template quality requirements |
+| Branching Strategy | Branch naming and target resolution |
+| Code Standards | Tooling discovery, linter/formatter defaults |
+| Secrets and Sensitive Files | Pre-staging safety net for credentials |
+| Agent Identity | Dev-Team persistence, Dev-Name assignment |
+| Post-Compaction Rules | Re-engagement after context compaction |
+
+All of these can be customized per project. The mandatory rules are written as hard constraints ("NEVER", "NON-NEGOTIABLE") because they protect against failure modes that have actually occurred. Project-specific customizations (like additional team rules or different branching conventions) can be added as new sections -- `/ccfold` will preserve them on future template merges.
+
+---
+
+## What's Next
+
+- **[Getting Started](getting-started.md)** -- if you have not yet done the hands-on walkthrough
+- **[README](../README.md)** -- full component reference (skills table, scripts table, installation options)
+- **[Skill files](../skills/)** -- detailed documentation for each skill (`skills/<name>/SKILL.md`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,248 @@
+# Getting Started with Claude Code Workflow
+
+This guide walks you through your first 15 minutes with the ccwork kit -- from verifying your install to making your first change through the full workflow. By the end, you will have completed a real issue-to-merge cycle and understand how the system works day to day.
+
+**Prerequisites:** You have already cloned the repo and run `./install.sh`. If not, see the [Quick Start](../README.md#quick-start) in the README.
+
+---
+
+## Step 1: Verify Your Install
+
+Run the drift checker to confirm everything landed correctly:
+
+```bash
+cd claudecode-workflow
+./install.sh --check
+```
+
+You will see output like this for each component:
+
+```
+Skills:
+  engage          ... in sync
+  precheck        ... in sync
+  scp             ... in sync
+  ...
+
+Scripts:
+  discord-bot     ... in sync
+  slackbot-send   ... in sync
+  ...
+```
+
+What to look for:
+
+- **in sync** -- the installed version matches the repo. You are good.
+- **DIFFERS** -- your local install has diverged from the repo version. Run `./install.sh` again to update, or `./sync.sh` if you want to pull local edits back into the repo.
+- **NOT INSTALLED** -- this component was not installed. Run `./install.sh` (or `./install.sh --skills`, `./install.sh --scripts` for targeted installs).
+
+If everything shows "in sync", move on.
+
+---
+
+## Step 2: Start Your First Session
+
+Open a terminal in any project that has a `CLAUDE.md` file (or copy the template into one):
+
+```bash
+cd /path/to/your-project
+cp /path/to/claudecode-workflow/CLAUDE.md ./CLAUDE.md
+claude
+```
+
+Three things happen automatically on your first session in a new project:
+
+### Platform Detection
+
+Claude reads `git remote -v` and determines whether you are on GitHub or GitLab. This controls which CLI tool is used (`gh` vs `glab`), which terminology appears (Pull Request vs Merge Request), and how issues and reviews are managed. You do not configure this -- it is automatic.
+
+### Dev-Team Assignment
+
+Claude looks for the `Dev-Team:` field at the bottom of `CLAUDE.md`. On a brand new project this field is empty, so Claude asks you:
+
+> "What Dev-Team name should I use for this project?"
+
+You provide a short name (e.g., `backend-team`, `cc-workflow`). Claude writes it into `CLAUDE.md` and never asks again for this project.
+
+### Session Identity
+
+Each time you start a new Claude Code session, the agent picks a fresh Dev-Name and Dev-Avatar for itself. You will see something like:
+
+> I'm going by **beacon** :satellite: from team `cc-workflow` this session.
+
+This identity is ephemeral -- a new terminal window means a new name. It exists so that when multiple agents are active (on Discord or Slack), you can tell them apart. The identity is written to a temp file at `/tmp/claude-agent-<hash>.json` where `<hash>` is derived from your project root.
+
+See [Identity System](concepts.md#identity-system) in the concepts doc for the full explanation of why this two-layer system exists.
+
+---
+
+## Step 3: Run `/engage`
+
+Once you are in a session, run:
+
+```
+/engage
+```
+
+This is the "rules of engagement" skill. It does three things:
+
+1. **Reads CLAUDE.md** and confirms the mandatory rules are loaded -- things like "never commit without `/precheck`", "always have an issue before starting work", and "test before push".
+2. **Loads the current plan** if one exists (from a prior `/cryo` freeze or plan mode). If no plan exists, it says so.
+3. **Reports ready state** -- your current git branch, any pending work, and asks what you would like to work on.
+
+You should run `/engage` at the start of every session, and especially after context compaction (when Claude's context window fills up and gets summarized). `/engage` is the thaw cycle that restores context after compaction.
+
+---
+
+## Step 4: The Mandatory Workflow
+
+Every change follows the same loop: **issue, branch, code, precheck, ship**. The system enforces this -- if you try to skip steps, Claude will stop you.
+
+### 4a: Start with an Issue
+
+Before writing any code, you need a tracked issue. Either find an existing one or create one:
+
+```
+> Let's work on issue #42
+```
+
+or
+
+```
+> Create an issue for adding retry logic to the upload endpoint
+```
+
+Claude uses `gh issue create` or `glab issue create` depending on your platform. The issue must exist before any code is written -- this is a hard rule.
+
+### 4b: Create a Branch
+
+Claude creates a feature branch linked to the issue:
+
+```bash
+git checkout -b feature/42-add-retry-logic
+```
+
+The branch name includes the issue number so the system can trace work back to its origin. The naming convention is `<type>/<issue-number>-<description>` where type is one of `feature`, `fix`, `chore`, or `docs`.
+
+### 4c: Write Code
+
+This is the part where actual work happens. Claude implements the changes described in the issue. If you are driving, you write the code and Claude assists. If Claude is driving, it implements to the issue spec.
+
+### 4d: Run `/precheck`
+
+When the work is done, run (or Claude proactively runs):
+
+```
+/precheck
+```
+
+This is the pre-commit gate. It runs through a multi-step verification:
+
+1. **Branch and issue check** -- confirms you are on a feature branch linked to an open issue.
+2. **Validation** -- runs `./scripts/ci/validate.sh` or whatever test tooling the project has.
+3. **Code review** -- launches a code-reviewer sub-agent that reviews all changed files and flags issues by severity.
+4. **Fix high-risk findings** -- anything rated high risk or above gets fixed before the checklist is presented.
+5. **Present the checklist** -- a full verification checklist covering implementation completeness, TODOs, docs, tests, and review results.
+
+After the checklist is presented, Claude **stops and waits**. It will not commit until you explicitly approve.
+
+### 4e: Approve and Ship
+
+You have three options for shipping:
+
+| Command | What it does |
+|---------|-------------|
+| `/scp` | Stage, commit, push (creates a PR if one does not exist) |
+| `/scpmr` | Stage, commit, push, create PR/MR -- but do not merge |
+| `/scpmmr` | Stage, commit, push, create PR/MR, and merge -- the full pipeline |
+
+Pick one and the system handles the rest: staging specific files (never `git add -A`), writing a conventional commit message with `Closes #42`, pushing to the remote, and creating or merging the PR/MR.
+
+### The Loop in Practice
+
+Here is what a typical session looks like, end to end:
+
+```
+You:    Let's work on issue #42
+Claude: [reads the issue, creates branch feature/42-add-retry-logic]
+
+You:    Go ahead and implement it
+Claude: [writes code, runs tests]
+
+Claude: /precheck
+Claude: [runs validation, code review, presents checklist]
+Claude: Ready for your call.
+
+You:    /scpmr
+Claude: [commits, pushes, creates PR #58]
+Claude: PR #58 is up: https://github.com/your-org/your-repo/pull/58
+```
+
+---
+
+## Step 5: Explore Further
+
+You now know the core loop. Here is where to go next:
+
+### Understand the Architecture
+
+Read [Concepts](concepts.md) to understand how the three layers (settings, scripts, skills) fit together, why the mandatory workflows exist, and how the skill taxonomy is organized.
+
+### Learn the Skills
+
+The full skill reference is in the [README skills table](../README.md#skills). The most commonly used skills beyond the core workflow:
+
+| Skill | When to use it |
+|-------|---------------|
+| `/cryo` | Before context compaction -- freezes session state so `/engage` can restore it |
+| `/review` | Run a standalone code review on staged changes, a branch diff, or a specific file |
+| `/ibm` | Quick reminder of the Issue-Branch-PR/MR workflow when you need to reset your mental model |
+| `/disc` | Send and read Discord messages, check in to `#roll-call`, manage channels |
+| `/vox` | Text-to-speech announcements ("Hey, the build passed") |
+| `/jfail` | Fetch and analyze a failed CI job or workflow run |
+
+### Advanced: Parallel Execution
+
+For large features that decompose into independent sub-issues, the wave system lets multiple agents work in parallel:
+
+1. `/assesswaves` -- quick assessment of whether work items are suitable for parallel execution
+2. `/prepwaves` -- full planning: validate sub-issue specs, compute dependency waves, partition into flights
+3. `/nextwave` -- execute one wave at a time with isolated worktrees and conflict avoidance
+
+See the [skill SKILL.md files](../skills/) for detailed documentation on each.
+
+### Keep Your Install in Sync
+
+The ccwork kit evolves. To pull in upstream changes:
+
+```bash
+cd claudecode-workflow
+git pull
+./install.sh --check    # see what changed
+./install.sh            # update everything
+```
+
+To fold upstream CLAUDE.md template changes into a project's local copy:
+
+```
+/ccfold
+```
+
+This merges new sections and updates while preserving your project-specific content like Dev-Team and any custom sections you have added.
+
+---
+
+## Quick Reference
+
+| What | How |
+|------|-----|
+| Verify install | `./install.sh --check` |
+| Start a session | `claude` in any project with `CLAUDE.md` |
+| Load rules | `/engage` |
+| Check workflow | `/ibm` |
+| Pre-commit gate | `/precheck` |
+| Ship code | `/scp`, `/scpmr`, or `/scpmmr` |
+| Freeze state | `/cryo` |
+| Restore state | `/engage` |
+| Update kit | `git pull && ./install.sh` |
+| Sync CLAUDE.md | `/ccfold` |


### PR DESCRIPTION
## Summary

Create two onboarding documents for new ccwork kit users: a getting-started walkthrough and a concepts reference explaining how the pieces fit together.

## Changes

- **docs/getting-started.md**: NEW — 15-minute walkthrough from install verification through the full issue-to-merge cycle
- **docs/concepts.md**: NEW — architecture reference covering three layers + channels, identity system, mandatory workflows, skill taxonomy, and how CLAUDE.md works
- **README.md**: Added pointer to new docs in Quick Start section

## Test Results

- 59/59 validation checks pass
- All cross-links verified (docs reference each other and README correctly)

## Test Plan

- `./scripts/ci/validate.sh` — 59/59 pass
- Manual: verified all markdown links resolve correctly

Closes #120

Generated with [Claude Code](https://claude.com/claude-code)