### PR TITLE
fix(install): improve help text and fix --check side effect

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,14 +9,17 @@
 #   ./install.sh --dry-run    Show what would be done without doing it
 #   ./install.sh --check      Show drift between repo and installed versions
 #   ./install.sh --skills     Install skills only
-#   ./install.sh --scripts    Install scripts only
-#   ./install.sh --config     Install config files only (statusline, settings template)
+#   ./install.sh --scripts    Install scripts only (also builds packages from src/)
+#   ./install.sh --config     Install config files only (smart-merges settings.json)
 #   ./install.sh --channels   Install channel servers only (bun install + MCP registration)
 #
 # Targets:
 #   Skills     → ~/.claude/skills/<name>/SKILL.md
 #   Scripts    → ~/.local/bin/<name>
+#   Packages   → ~/.local/bin/<name> (built from src/ via scripts/ci/build.sh)
 #   Statusline → ~/.claude/statusline-command.sh
+#   Settings   → ~/.claude/settings.json (smart-merged: missing keys added, your
+#                 customizations preserved — see merge_settings() for rules)
 #   Channels   → user-scope MCP servers (claude mcp add --scope user)
 #
 # Existing files are backed up to <file>.bak before overwriting.
@@ -309,22 +312,21 @@ if [[ "$CHECK_MODE" == true ]]; then
 		echo ""
 		echo "Packages"
 		echo "──────────────────────────────────────────"
-		# Rebuild to ensure fresh comparison
-		if ! "$REPO_DIR/scripts/ci/build.sh" >/dev/null 2>&1; then
-			warn "build.sh failed — package drift check may be inaccurate"
-			drifted=$((drifted + 1))
+		if [[ ! -d "$REPO_DIR/dist" ]] || [[ -z "$(ls -A "$REPO_DIR/dist" 2>/dev/null)" ]]; then
+			warn "dist/ is empty — run 'install.sh --scripts' to build packages before checking drift"
+		else
+			for pkg_dir in "$REPO_DIR"/src/*/; do
+				[[ -f "$pkg_dir/__main__.py" ]] || continue
+				pkg_name="$(basename "$pkg_dir")"
+				artifact_name="${pkg_name//_/-}"
+				src="$REPO_DIR/dist/$artifact_name"
+				dest="$SCRIPTS_DIR/$artifact_name"
+				if [[ -f "$src" ]]; then
+					total=$((total + 1))
+					do_check "$src" "$dest" "$artifact_name" || drifted=$((drifted + 1))
+				fi
+			done
 		fi
-		for pkg_dir in "$REPO_DIR"/src/*/; do
-			[[ -f "$pkg_dir/__main__.py" ]] || continue
-			pkg_name="$(basename "$pkg_dir")"
-			artifact_name="${pkg_name//_/-}"
-			src="$REPO_DIR/dist/$artifact_name"
-			dest="$SCRIPTS_DIR/$artifact_name"
-			if [[ -f "$src" ]]; then
-				total=$((total + 1))
-				do_check "$src" "$dest" "$artifact_name" || drifted=$((drifted + 1))
-			fi
-		done
 	fi
 
 	echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,14 +1,27 @@
 #!/usr/bin/env bash
 # uninstall.sh — Remove Claude Code workflow environment
 #
-# Removes skills and scripts installed by install.sh.
+# Removes skills, scripts, config, and channel servers installed by install.sh.
 # Does NOT remove settings.json or credentials.
 #
 # Usage:
-#   ./uninstall.sh              Remove everything
+#   ./uninstall.sh              Remove everything (skills, scripts, config, channels)
 #   ./uninstall.sh --dry-run    Show what would be removed without doing it
 #   ./uninstall.sh --skills     Remove skills only
-#   ./uninstall.sh --scripts    Remove scripts only
+#   ./uninstall.sh --scripts    Remove scripts and packages only
+#   ./uninstall.sh --config     Remove config files only (statusline-command.sh)
+#   ./uninstall.sh --channels   Remove MCP server registrations only
+#
+# What full uninstall removes:
+#   Skills      → ~/.claude/skills/<name>/
+#   Scripts     → ~/.local/bin/<name>
+#   Packages    → ~/.local/bin/<name> (built artifacts)
+#   Config      → ~/.claude/statusline-command.sh
+#   Channels    → MCP server registrations (claude mcp remove)
+#
+# What full uninstall preserves:
+#   Settings    → ~/.claude/settings.json (user-customized)
+#   Credentials → ~/secrets/ (not managed by install.sh)
 
 set -euo pipefail
 
@@ -20,6 +33,7 @@ DRY_RUN=false
 REMOVE_SKILLS=true
 REMOVE_SCRIPTS=true
 REMOVE_CONFIG=true
+REMOVE_CHANNELS=true
 
 # --- Parse args ---------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
@@ -31,10 +45,24 @@ while [[ $# -gt 0 ]]; do
 	--skills)
 		REMOVE_SCRIPTS=false
 		REMOVE_CONFIG=false
+		REMOVE_CHANNELS=false
 		shift
 		;;
 	--scripts)
 		REMOVE_SKILLS=false
+		REMOVE_CONFIG=false
+		REMOVE_CHANNELS=false
+		shift
+		;;
+	--config)
+		REMOVE_SKILLS=false
+		REMOVE_SCRIPTS=false
+		REMOVE_CHANNELS=false
+		shift
+		;;
+	--channels)
+		REMOVE_SKILLS=false
+		REMOVE_SCRIPTS=false
 		REMOVE_CONFIG=false
 		shift
 		;;
@@ -121,6 +149,35 @@ if [[ "$REMOVE_CONFIG" == true ]]; then
 		do_remove "$CLAUDE_DIR/statusline-command.sh"
 	fi
 	echo "  [-] settings.json — preserved (not managed by uninstall)"
+fi
+
+# --- Remove channel servers ---------------------------------------------------
+if [[ "$REMOVE_CHANNELS" == true ]]; then
+	echo ""
+	echo "Removing channel servers"
+	echo "──────────────────────────────────────────"
+	if command -v claude &>/dev/null; then
+		mcp_list=$(claude mcp list 2>/dev/null || true)
+		for channel_dir in "$REPO_DIR"/channels/*/; do
+			[[ -f "$channel_dir/package.json" ]] || continue
+			channel_name="$(basename "$channel_dir")"
+			if echo "$mcp_list" | grep -q "$channel_name"; then
+				if [[ "$DRY_RUN" == true ]]; then
+					echo "  [+] (dry-run) Would remove MCP server: $channel_name"
+				else
+					if claude mcp remove --scope user "$channel_name" 2>/dev/null; then
+						info "$channel_name (MCP server)"
+					else
+						echo "  [!] Failed to remove MCP server: $channel_name"
+					fi
+				fi
+			else
+				skip "$channel_name (MCP server not registered)"
+			fi
+		done
+	else
+		echo "  [!] claude CLI not found — cannot remove MCP servers"
+	fi
 fi
 
 # --- Summary ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes help text inaccuracies in install.sh and uninstall.sh, removes the build.sh side effect from --check mode, and adds --config/--channels flags to uninstall.sh.

## Changes

- **install.sh**: Update header to document --scripts build, packages target, --config merge
- **install.sh**: Remove build.sh call from --check (read-only should not build)
- **uninstall.sh**: Add --config and --channels flags
- **uninstall.sh**: Add MCP server removal logic for channel servers
- **uninstall.sh**: Expand header with what-removes/what-preserves documentation

## Test Plan

- `./scripts/ci/validate.sh` — 59/59 passed (shellcheck + shfmt clean)
- Manual: verified `--help` output for both scripts

Closes #113

Generated with [Claude Code](https://claude.com/claude-code)