### PR TITLE
feat(disc): add per-subcommand --help to discord-bot

### DIFF
--- a/skills/disc/discord-bot
+++ b/skills/disc/discord-bot
@@ -139,11 +139,35 @@ api_post() {
 }
 
 # --- Subcommand: send ---------------------------------------------------------
+send_help() {
+	cat <<'HELPTEXT'
+Usage: discord-bot send <channel-id> <message> [OPTIONS]
+
+Send a message to a Discord channel.
+
+Arguments:
+  <channel-id>   The target channel's numeric ID
+  <message>      The message content to send (quote if it contains spaces)
+
+Options:
+  --embed TITLE:TEXT   Attach a rich embed with the given title and description
+  --attach FILE        Upload a file attachment alongside the message
+  -h, --help           Show this help message
+
+Examples:
+  discord-bot send 123456789 "Hello, world!"
+  discord-bot send 123456789 "Deploy report" --embed "Status:All green"
+  discord-bot send 123456789 "See attached" --attach ./report.txt
+HELPTEXT
+	exit 0
+}
+
 cmd_send() {
 	local channel_id="" message="" embed_title="" embed_text="" attach_file=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h) send_help ;;
 		--embed)
 			[[ -z "${2:-}" ]] && {
 				echo "Error: --embed requires title:text argument." >&2
@@ -218,11 +242,34 @@ cmd_send() {
 }
 
 # --- Subcommand: read ---------------------------------------------------------
+read_help() {
+	cat <<'HELPTEXT'
+Usage: discord-bot read <channel-id> [OPTIONS]
+
+Read messages from a Discord channel, printed in chronological order.
+
+Arguments:
+  <channel-id>   The target channel's numeric ID
+
+Options:
+  --limit N      Maximum number of messages to fetch (default: 20)
+  --after ID     Only fetch messages after this message ID (for pagination)
+  -h, --help     Show this help message
+
+Examples:
+  discord-bot read 123456789
+  discord-bot read 123456789 --limit 5
+  discord-bot read 123456789 --after 111222333444555666
+HELPTEXT
+	exit 0
+}
+
 cmd_read() {
 	local channel_id="" limit=20 after=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h) read_help ;;
 		--limit)
 			[[ -z "${2:-}" ]] && {
 				echo "Error: --limit requires a value." >&2
@@ -267,11 +314,35 @@ cmd_read() {
 }
 
 # --- Subcommand: create-channel -----------------------------------------------
+create_channel_help() {
+	cat <<'HELPTEXT'
+Usage: discord-bot create-channel <guild-id> <name> [OPTIONS]
+
+Create a new text channel in a Discord guild.
+
+Arguments:
+  <guild-id>   The guild (server) numeric ID
+  <name>       The channel name (leading # is stripped automatically)
+
+Options:
+  --topic TOPIC      Set the channel's topic/description
+  --category ID      Place the channel under a category by its numeric ID
+  -h, --help         Show this help message
+
+Examples:
+  discord-bot create-channel 987654321 wave-3-status
+  discord-bot create-channel 987654321 deployments --topic "CI/CD notifications"
+  discord-bot create-channel 987654321 dev-chat --category 111222333444555666
+HELPTEXT
+	exit 0
+}
+
 cmd_create_channel() {
 	local guild_id="" name="" topic="" category=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h) create_channel_help ;;
 		--topic)
 			[[ -z "${2:-}" ]] && {
 				echo "Error: --topic requires a value." >&2
@@ -304,7 +375,7 @@ cmd_create_channel() {
 	done
 
 	[[ -z "$guild_id" || -z "$name" ]] && {
-		echo "Error: create-channel requires <guild-id> and <name>. Usage: discord-bot create-channel <guild-id> <name> [--topic TOPIC]" >&2
+		echo "Error: create-channel requires <guild-id> and <name>. Usage: discord-bot create-channel <guild-id> <name> [--topic TOPIC] [--category ID]" >&2
 		exit 1
 	}
 
@@ -323,11 +394,34 @@ cmd_create_channel() {
 }
 
 # --- Subcommand: create-thread ------------------------------------------------
+create_thread_help() {
+	cat <<'HELPTEXT'
+Usage: discord-bot create-thread <channel-id> <name> [OPTIONS]
+
+Create a new thread in a Discord channel.
+
+Arguments:
+  <channel-id>   The parent channel's numeric ID
+  <name>         The thread name
+
+Options:
+  --auto-archive MINUTES   Auto-archive after inactivity: 60, 1440, 4320, or
+                           10080 (default: 1440 = 24 hours)
+  -h, --help               Show this help message
+
+Examples:
+  discord-bot create-thread 123456789 "session-42"
+  discord-bot create-thread 123456789 "daily-standup" --auto-archive 4320
+HELPTEXT
+	exit 0
+}
+
 cmd_create_thread() {
 	local channel_id="" name="" auto_archive="1440"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h) create_thread_help ;;
 		--auto-archive)
 			[[ -z "${2:-}" ]] && {
 				echo "Error: --auto-archive requires a value (60, 1440, 4320, 10080)." >&2
@@ -369,11 +463,33 @@ cmd_create_thread() {
 }
 
 # --- Subcommand: list-channels ------------------------------------------------
+list_channels_help() {
+	cat <<'HELPTEXT'
+Usage: discord-bot list-channels <guild-id> [OPTIONS]
+
+List channels in a Discord guild.
+
+Arguments:
+  <guild-id>   The guild (server) numeric ID
+
+Options:
+  --type TYPE   Filter by channel type: text, voice, or category
+  -h, --help    Show this help message
+
+Examples:
+  discord-bot list-channels 987654321
+  discord-bot list-channels 987654321 --type text
+  discord-bot list-channels 987654321 --type voice
+HELPTEXT
+	exit 0
+}
+
 cmd_list_channels() {
 	local guild_id="" filter_type=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h) list_channels_help ;;
 		--type)
 			case "${2:-}" in
 			text) filter_type="0" ;;
@@ -414,8 +530,35 @@ cmd_list_channels() {
 }
 
 # --- Subcommand: resolve ------------------------------------------------------
+resolve_help() {
+	cat <<'HELPTEXT'
+Usage: discord-bot resolve <guild-id> <channel-name>
+
+Resolve a channel name to its numeric ID. Returns text channels only.
+
+Arguments:
+  <guild-id>       The guild (server) numeric ID
+  <channel-name>   The channel name to look up (leading # is stripped, case-insensitive)
+
+Options:
+  -h, --help   Show this help message
+
+Note:
+  Only text channels (type 0) are searched. Voice channels, categories, and
+  other channel types will not be matched. Use 'list-channels --type text'
+  to see available text channels.
+
+Examples:
+  discord-bot resolve 987654321 general
+  discord-bot resolve 987654321 "#roll-call"
+HELPTEXT
+	exit 0
+}
+
 cmd_resolve() {
 	local guild_id="" channel_name=""
+
+	[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && resolve_help
 
 	[[ $# -ge 2 ]] || {
 		echo "Error: resolve requires <guild-id> and <channel-name>. Usage: discord-bot resolve <guild-id> <channel-name>" >&2

--- a/tests/test_discord_bot_help.py
+++ b/tests/test_discord_bot_help.py
@@ -1,0 +1,279 @@
+"""Tests for discord-bot per-subcommand --help output.
+
+Exercises the real discord-bot script via subprocess, providing a dummy
+DISCORD_BOT_TOKEN to satisfy the auth gate. Only the help output paths are
+tested — no network calls are made.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_REPO_DIR = Path(__file__).resolve().parent.parent
+_DISCORD_BOT = str(_REPO_DIR / "skills" / "disc" / "discord-bot")
+
+_HAS_BASH = shutil.which("bash") is not None
+_HAS_JQ = shutil.which("jq") is not None
+
+_SKIP_NO_BASH = pytest.mark.skipif(not _HAS_BASH, reason="bash not available")
+_SKIP_NO_JQ = pytest.mark.skipif(not _HAS_JQ, reason="jq not available")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_help(subcommand: str) -> subprocess.CompletedProcess[str]:
+    """Run ``discord-bot <subcommand> --help`` and return the result."""
+    env = {**os.environ, "DISCORD_BOT_TOKEN": "test-token-for-help"}
+    return subprocess.run(
+        [_DISCORD_BOT, subcommand, "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _run_short_help(subcommand: str) -> subprocess.CompletedProcess[str]:
+    """Run ``discord-bot <subcommand> -h`` and return the result."""
+    env = {**os.environ, "DISCORD_BOT_TOKEN": "test-token-for-help"}
+    return subprocess.run(
+        [_DISCORD_BOT, subcommand, "-h"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: send --help
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestSendHelp:
+    """AC: discord-bot send --help shows usage with args and flags."""
+
+    def test_send_help_exits_zero(self) -> None:
+        result = _run_help("send")
+        assert result.returncode == 0
+
+    def test_send_help_shows_usage_line(self) -> None:
+        result = _run_help("send")
+        assert "Usage: discord-bot send" in result.stdout
+
+    def test_send_help_shows_channel_id_arg(self) -> None:
+        result = _run_help("send")
+        assert "<channel-id>" in result.stdout
+
+    def test_send_help_shows_message_arg(self) -> None:
+        result = _run_help("send")
+        assert "<message>" in result.stdout
+
+    def test_send_help_shows_embed_flag(self) -> None:
+        result = _run_help("send")
+        assert "--embed" in result.stdout
+
+    def test_send_help_shows_attach_flag(self) -> None:
+        result = _run_help("send")
+        assert "--attach" in result.stdout
+
+    def test_send_short_help_works(self) -> None:
+        result = _run_short_help("send")
+        assert result.returncode == 0
+        assert "Usage: discord-bot send" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: read --help
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestReadHelp:
+    """AC: discord-bot read --help shows usage, mentions default limit."""
+
+    def test_read_help_exits_zero(self) -> None:
+        result = _run_help("read")
+        assert result.returncode == 0
+
+    def test_read_help_shows_usage_line(self) -> None:
+        result = _run_help("read")
+        assert "Usage: discord-bot read" in result.stdout
+
+    def test_read_help_shows_channel_id_arg(self) -> None:
+        result = _run_help("read")
+        assert "<channel-id>" in result.stdout
+
+    def test_read_help_shows_limit_flag(self) -> None:
+        result = _run_help("read")
+        assert "--limit" in result.stdout
+
+    def test_read_help_documents_default_limit(self) -> None:
+        result = _run_help("read")
+        assert "default: 20" in result.stdout
+
+    def test_read_help_shows_after_flag(self) -> None:
+        result = _run_help("read")
+        assert "--after" in result.stdout
+
+    def test_read_short_help_works(self) -> None:
+        result = _run_short_help("read")
+        assert result.returncode == 0
+        assert "Usage: discord-bot read" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: create-channel --help
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestCreateChannelHelp:
+    """AC: discord-bot create-channel --help mentions --category."""
+
+    def test_create_channel_help_exits_zero(self) -> None:
+        result = _run_help("create-channel")
+        assert result.returncode == 0
+
+    def test_create_channel_help_shows_usage_line(self) -> None:
+        result = _run_help("create-channel")
+        assert "Usage: discord-bot create-channel" in result.stdout
+
+    def test_create_channel_help_shows_guild_id_arg(self) -> None:
+        result = _run_help("create-channel")
+        assert "<guild-id>" in result.stdout
+
+    def test_create_channel_help_shows_topic_flag(self) -> None:
+        result = _run_help("create-channel")
+        assert "--topic" in result.stdout
+
+    def test_create_channel_help_shows_category_flag(self) -> None:
+        result = _run_help("create-channel")
+        assert "--category" in result.stdout
+
+    def test_create_channel_short_help_works(self) -> None:
+        result = _run_short_help("create-channel")
+        assert result.returncode == 0
+        assert "Usage: discord-bot create-channel" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: resolve --help
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestResolveHelp:
+    """AC: discord-bot resolve --help notes text-channel-only behavior."""
+
+    def test_resolve_help_exits_zero(self) -> None:
+        result = _run_help("resolve")
+        assert result.returncode == 0
+
+    def test_resolve_help_shows_usage_line(self) -> None:
+        result = _run_help("resolve")
+        assert "Usage: discord-bot resolve" in result.stdout
+
+    def test_resolve_help_shows_guild_id_arg(self) -> None:
+        result = _run_help("resolve")
+        assert "<guild-id>" in result.stdout
+
+    def test_resolve_help_shows_channel_name_arg(self) -> None:
+        result = _run_help("resolve")
+        assert "<channel-name>" in result.stdout
+
+    def test_resolve_help_notes_text_only(self) -> None:
+        result = _run_help("resolve")
+        assert "text channels only" in result.stdout.lower()
+
+    def test_resolve_help_mentions_type_zero(self) -> None:
+        result = _run_help("resolve")
+        assert "type 0" in result.stdout
+
+    def test_resolve_short_help_works(self) -> None:
+        result = _run_short_help("resolve")
+        assert result.returncode == 0
+        assert "Usage: discord-bot resolve" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: create-thread --help (bonus coverage)
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestCreateThreadHelp:
+    """Bonus: create-thread --help shows usage with auto-archive flag."""
+
+    def test_create_thread_help_exits_zero(self) -> None:
+        result = _run_help("create-thread")
+        assert result.returncode == 0
+
+    def test_create_thread_help_shows_usage_line(self) -> None:
+        result = _run_help("create-thread")
+        assert "Usage: discord-bot create-thread" in result.stdout
+
+    def test_create_thread_help_shows_auto_archive(self) -> None:
+        result = _run_help("create-thread")
+        assert "--auto-archive" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: list-channels --help (bonus coverage)
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestListChannelsHelp:
+    """Bonus: list-channels --help shows usage with type filter flag."""
+
+    def test_list_channels_help_exits_zero(self) -> None:
+        result = _run_help("list-channels")
+        assert result.returncode == 0
+
+    def test_list_channels_help_shows_usage_line(self) -> None:
+        result = _run_help("list-channels")
+        assert "Usage: discord-bot list-channels" in result.stdout
+
+    def test_list_channels_help_shows_type_flag(self) -> None:
+        result = _run_help("list-channels")
+        assert "--type" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: create-channel error message mentions --category (Finding 2)
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestCreateChannelErrorMessage:
+    """Finding 2: create-channel error message should mention --category."""
+
+    def test_error_without_args_mentions_category(self) -> None:
+        env = {**os.environ, "DISCORD_BOT_TOKEN": "test-token-for-help"}
+        result = subprocess.run(
+            [_DISCORD_BOT, "create-channel"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode != 0
+        assert "--category" in result.stderr


### PR DESCRIPTION
## Summary

Adds --help/-h output to all 6 discord-bot subcommands and fixes the create-channel error message to mention --category.

## Changes

- Add 6 help functions (send, read, create-channel, create-thread, list-channels, resolve)
- Wire --help/-h into every cmd_* dispatch loop
- Fix create-channel error to mention --category flag
- Add 34 subprocess-based tests covering all help output

## Test Plan

- `./scripts/ci/validate.sh` — 59/59 passed
- `pytest tests/test_discord_bot_help.py` — 34/34 passed
- Manual: `discord-bot send --help`, `discord-bot read -h`, etc.

Closes #114

Generated with [Claude Code](https://claude.com/claude-code)