### PR TITLE
fix(vox): correct help text for -o flag and espeak-ng

### DIFF
--- a/scripts/vox
+++ b/scripts/vox
@@ -11,7 +11,7 @@
 # TTS backend resolution (first match wins):
 #   1. VOX_COMMAND env var   — custom command that accepts text on stdin
 #   2. VOX_ENDPOINT env var  — HTTP endpoint (OpenAI-compatible TTS API)
-#   3. Local fallback        — espeak / piper / say (macOS)
+#   3. Local fallback        — espeak / espeak-ng / piper / say (macOS)
 #
 # Environment:
 #   VOX_COMMAND    Custom TTS command (text on stdin, audio on stdout)
@@ -41,7 +41,7 @@ usage() {
 		  --voice NAME    Voice to use (default: \$VOX_VOICE or ${DEFAULT_VOICE})
 		  --list-voices   List available voices from the TTS endpoint
 		  --bg            Background playback (don't wait for audio to finish)
-		  --output FILE   Write audio to FILE instead of playing (-o for short)
+		  --output, -o FILE  Write audio to FILE instead of playing
 		  -h, --help      Show this help
 
 		Message can be passed as arguments or piped via stdin.
@@ -343,5 +343,5 @@ fi
 # --- No backend available -----------------------------------------------------
 
 echo "Error: no TTS backend available." >&2
-echo "Set VOX_ENDPOINT or VOX_COMMAND, or install espeak/piper/say." >&2
+echo "Set VOX_ENDPOINT or VOX_COMMAND, or install espeak/espeak-ng/piper/say." >&2
 exit 1


### PR DESCRIPTION
## Summary

Three string corrections in scripts/vox to document the -o short flag and espeak-ng fallback.

## Changes

- Header comment: add espeak-ng to local fallback chain
- Usage output: show `--output, -o FILE` instead of hiding -o in prose
- Error message: add espeak-ng to install suggestions

## Test Plan

- `./scripts/ci/validate.sh` — 59/59 passed (shellcheck + shfmt clean)
- Manual: `vox --help` output verified

Closes #115

Generated with [Claude Code](https://claude.com/claude-code)