### PR TITLE
fix(wave-tools): improve help text for status scripts

### DIFF
--- a/scripts/discord-status-post
+++ b/scripts/discord-status-post
@@ -431,7 +431,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--state-dir",
         default=None,
-        help="Path to status directory (default: <git-root>/.claude/status/)",
+        help=(
+            "Path to status directory containing state.json, phases-waves.json, "
+            "and flights.json (default: discovered via "
+            "'git rev-parse --show-toplevel', then <repo>/.claude/status/)"
+        ),
     )
     parser.add_argument(
         "--dev-team",
@@ -454,6 +458,10 @@ def main() -> None:
 
     # Verify state.json exists — exit cleanly if not
     if not (state_dir / "state.json").exists():
+        print(
+            f"discord-status-post: {state_dir / 'state.json'} not found, nothing to post",
+            file=sys.stderr,
+        )
         sys.exit(0)
 
     # Resolve dev-team

--- a/scripts/generate-status-panel
+++ b/scripts/generate-status-panel
@@ -4,11 +4,16 @@
 Reads three JSON config files from <repo>/.claude/status/ and produces a single
 self-contained HTML file with inline CSS/JS, no external dependencies.
 
+Required input files (in --status-dir):
+    - phases-waves.json   Phase/wave/issue plan
+    - state.json          Current execution state
+    - flights.json        Flight assignments per wave
+
 Discovers the project root via `git rev-parse --show-toplevel`, so it works
 from any directory within a git repository.
 
 Usage:
-    generate-status-panel [--output .status-panel.html] [--status-dir .claude/status]
+    generate-status-panel [--output <repo>/.status-panel.html] [--status-dir <repo>/.claude/status]
 """
 
 from __future__ import annotations
@@ -530,7 +535,13 @@ def main() -> None:
     default_status_dir = project_root / ".claude" / "status"
     default_output = project_root / ".status-panel.html"
 
-    parser = argparse.ArgumentParser(description="Generate wave execution status panel")
+    parser = argparse.ArgumentParser(
+        description="Generate wave execution status panel",
+        epilog=(
+            "Required input files in --status-dir: "
+            "phases-waves.json, state.json, flights.json"
+        ),
+    )
     parser.add_argument(
         "--output",
         default=str(default_output),

--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -206,8 +206,13 @@ def _read_json_source(source: str) -> str:
 def _build_parser() -> argparse.ArgumentParser:
     """Construct the argparse parser with all 14 subcommands."""
     parser = argparse.ArgumentParser(
-        prog="wave_status",
+        prog="wave-status",
         description="Wave execution lifecycle CLI",
+        epilog=(
+            "Side effects: the 'flight-done' and 'complete' subcommands "
+            "trigger a best-effort call to discord-status-post to update "
+            "the Discord status embed."
+        ),
     )
     sub = parser.add_subparsers(dest="command")
 
@@ -266,7 +271,8 @@ def _build_parser() -> argparse.ArgumentParser:
     # defer
     p_df = sub.add_parser("defer", help="Append a pending deferral")
     p_df.add_argument("desc", help="Description of the deferred item")
-    p_df.add_argument("risk", help="Risk level: low, medium, high")
+    p_df.add_argument("risk", choices=["low", "medium", "high"],
+                       help="Risk level: low, medium, high")
     p_df.set_defaults(func=_cmd_defer)
 
     # defer-accept


### PR DESCRIPTION
## Summary

Fixes help text inaccuracies in wave-status, discord-status-post, and generate-status-panel.

## Changes

- **wave-status**: Fix prog name (wave_status → wave-status), add epilog about side effects, add choices validation to defer risk arg
- **discord-status-post**: Add stderr info message when state.json missing, expand --state-dir help
- **generate-status-panel**: Update docstring with required input files, add epilog

## Test Plan

- `./scripts/ci/validate.sh` — 59/59 passed
- Manual: `wave-status --help`, `wave-status defer x` (rejected correctly)

Closes #116

Generated with [Claude Code](https://claude.com/claude-code)