### PR TITLE
feat(skills): add /ccwork onboarding hub with tours

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Key features:
 |-------|---------|-------------|
 | assesswaves | `/assesswaves` | Quick assessment of wave-pattern suitability |
 | ccfold | `/ccfold` | Merge upstream CLAUDE.md template updates into local project |
+| ccwork | `/ccwork` | Onboarding hub — tour the kit, run labs, configure integrations |
 | cryo | `/cryo` | Preserve session state before context compaction |
 | disc | `/disc` | Discord integration — check-in, send, read, list, resolve channels |
 | edit | `/edit` | Open file/URL in GUI editor |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,6 +2,8 @@
 
 This document explains how the pieces of the ccwork kit fit together and why they are designed the way they are. Read this after completing the [Getting Started](getting-started.md) guide.
 
+**Prefer interactive walkthroughs?** Run `/ccwork tour` for a guided orientation, `/ccwork tour workflow` for the commit/PR loop, or `/ccwork tour foundations` for the session lifecycle skills. The tours cover the same material as this document but run live commands against your actual setup.
+
 ---
 
 ## The Three Layers

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,6 +92,8 @@ This is the "rules of engagement" skill. It does three things:
 
 You should run `/engage` at the start of every session, and especially after context compaction (when Claude's context window fills up and gets summarized). `/engage` is the thaw cycle that restores context after compaction.
 
+**Want a guided tour instead?** Run `/ccwork tour` for an interactive walkthrough of the kit -- it shows you what is installed, how the pieces connect, and runs live commands against your actual setup. You can also run `/ccwork tour workflow` or `/ccwork tour foundations` for focused deep-dives.
+
 ---
 
 ## Step 4: The Mandatory Workflow

--- a/install.sh
+++ b/install.sh
@@ -237,6 +237,17 @@ if [[ "$CHECK_MODE" == true ]]; then
 			total=$((total + 1))
 			do_check "$helper" "$SCRIPTS_DIR/$helper_name" "$skill_name/$helper_name" || drifted=$((drifted + 1))
 		done
+		# Check content subdirectories (e.g., tours/)
+		for subdir in "$skill_dir"*/; do
+			[[ -d "$subdir" ]] || continue
+			subdir_name="$(basename "$subdir")"
+			for content_file in "$subdir"*; do
+				[[ -f "$content_file" ]] || continue
+				content_name="$(basename "$content_file")"
+				total=$((total + 1))
+				do_check "$content_file" "$SKILLS_DIR/$skill_name/$subdir_name/$content_name" "$skill_name/$subdir_name/$content_name" || drifted=$((drifted + 1))
+			done
+		done
 	done
 
 	echo ""
@@ -358,6 +369,16 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
 			if [[ "$DRY_RUN" != true ]]; then
 				chmod +x "$SCRIPTS_DIR/$helper_name"
 			fi
+		done
+		# Install content subdirectories (e.g., tours/) into the skill dir
+		for subdir in "$skill_dir"*/; do
+			[[ -d "$subdir" ]] || continue
+			subdir_name="$(basename "$subdir")"
+			for content_file in "$subdir"*; do
+				[[ -f "$content_file" ]] || continue
+				content_name="$(basename "$content_file")"
+				do_copy "$content_file" "$SKILLS_DIR/$skill_name/$subdir_name/$content_name"
+			done
 		done
 	done
 fi

--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: ccwork
+description: Onboarding hub — tour the kit, run labs, configure integrations
+---
+
+# CCWork: Onboarding, Education, and Configuration Hub
+
+Single entry point for discovering and learning the Claude Code workflow kit. Routes to tour, lab, and setup subcommands.
+
+## Resolve Intent
+
+{{#if args}}
+Parse the argument: `{{args}}`
+{{else}}
+No argument — show the overview of available subcommands.
+{{/if}}
+
+Determine the subcommand from the phrasing:
+
+| Pattern | Intent | Examples |
+|---------|--------|---------|
+| No args | **overview** | `/ccwork` |
+| `tour` (alone) | **tour-orientation** | `/ccwork tour` |
+| `tour orientation` | **tour-orientation** | `/ccwork tour orientation` |
+| `tour workflow` | **tour-workflow** | `/ccwork tour workflow` |
+| `tour foundations` | **tour-foundations** | `/ccwork tour foundations` |
+| `lab` (alone) | **lab-list** | `/ccwork lab` |
+| `lab "<name>"` or `lab <name>` | **lab-run** | `/ccwork lab "First Workflow"` |
+| `setup discord` | **setup-discord** | `/ccwork setup discord` |
+| `setup` (alone) | **setup-list** | `/ccwork setup` |
+
+---
+
+## Overview (no args)
+
+Present the available subcommands as a concise menu:
+
+```
+/ccwork — Claude Code Workflow Kit
+
+  tour                Full orientation tour (or: tour workflow, tour foundations)
+  lab                 List available labs (or: lab "<name>" to start one)
+  setup discord       Guided Discord configuration
+
+Docs:
+  - Getting Started .... docs/getting-started.md
+  - Concepts ........... docs/concepts.md
+  - Discord Config ..... docs/discord-config.md
+  - README ............. README.md
+```
+
+Do NOT run any commands or start any workflow. Just show the menu and wait.
+
+---
+
+## Tour: Orientation
+
+**Trigger:** `tour` or `tour orientation`
+
+Read and execute the tour script at `skills/ccwork/tours/orientation.md` (relative to the repo root, or resolve via the installed skill path). The tour file contains the full narration and embedded commands to run.
+
+### Resolving Tour Files
+
+Tour files live alongside this SKILL.md in the `tours/` subdirectory. Resolve the path:
+
+```bash
+# Installed location
+TOUR_DIR="$HOME/.claude/skills/ccwork/tours"
+
+# Fallback: repo location (for development)
+if [[ ! -d "$TOUR_DIR" ]]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  TOUR_DIR="$REPO_ROOT/skills/ccwork/tours"
+fi
+```
+
+Read the tour file and follow its instructions step by step.
+
+---
+
+## Tour: Workflow
+
+**Trigger:** `tour workflow`
+
+Read and execute `tours/workflow.md` using the same resolution logic as above.
+
+---
+
+## Tour: Foundations
+
+**Trigger:** `tour foundations`
+
+Read and execute `tours/foundations.md` using the same resolution logic as above.
+
+---
+
+## Lab: List
+
+**Trigger:** `lab` (alone)
+
+Check whether the current repo is a lab repo:
+
+```bash
+# Look for lab indicators
+ls LAB.md .github/ISSUE_TEMPLATE/lab-*.md 2>/dev/null
+```
+
+### If in a lab repo
+
+List available labs from issue templates:
+
+```bash
+ls .github/ISSUE_TEMPLATE/lab-*.md 2>/dev/null
+```
+
+Present them as a numbered list with their titles (read the first `name:` line from each template's frontmatter).
+
+Tell the user: *"Run `/ccwork lab \"<name>\"` to start a lab exercise."*
+
+### If NOT in a lab repo
+
+Tell the user:
+
+> You're not in a lab repo. To get started with hands-on exercises:
+>
+> 1. Fork and clone **ccwork-lab**: `gh repo fork Wave-Engineering/ccwork-lab --clone`
+> 2. `cd ccwork-lab && claude`
+> 3. Run `/ccwork lab` to see available exercises
+>
+> Labs are self-contained issue templates. Each one walks you through a real workflow scenario using the ccwork kit.
+
+---
+
+## Lab: Run
+
+**Trigger:** `lab "<name>"`
+
+1. **Verify lab repo** — same check as lab-list. If not a lab repo, show the fork instructions and stop.
+
+2. **Find the template** — match the name against `.github/ISSUE_TEMPLATE/lab-*.md` files (case-insensitive, partial match OK):
+   ```bash
+   ls .github/ISSUE_TEMPLATE/lab-*.md 2>/dev/null
+   ```
+
+3. **Create the issue** — read the template and create a GitHub issue from it:
+   ```bash
+   gh issue create --title "<lab title>" --body "$(cat <template-file>)"
+   ```
+
+4. **Guide the exercise** — read the created issue and walk the user through it step by step. Each step should be explained, then executed (or the user is prompted to execute it). This is a guided exercise, not a lecture — the user should be doing things, not just reading.
+
+---
+
+## Setup: List
+
+**Trigger:** `setup` (alone)
+
+Show available setup subcommands:
+
+```
+/ccwork setup — Available configuration wizards
+
+  discord       Configure Discord integration (~/.claude/discord.json)
+
+Coming soon:
+  slack         Configure Slack integration
+  ci            Configure CI/CD pipeline integration
+```
+
+---
+
+## Setup: Discord
+
+**Trigger:** `setup discord`
+
+Guide the user through configuring Discord integration. This creates or updates `~/.claude/discord.json`.
+
+### Step 1: Check Current State
+
+```bash
+cat ~/.claude/discord.json 2>/dev/null
+```
+
+If the file exists, show the current configuration and ask if the user wants to reconfigure or update it.
+
+### Step 2: Gather Information
+
+Walk through each field, explaining what it is and where to find it:
+
+1. **Guild ID** — "What's your Discord server (guild) ID? You can find it by right-clicking the server name in Discord and selecting 'Copy Server ID'. (Requires Developer Mode enabled in Discord settings.)"
+
+2. **Bot Token Path** — "Where is your Discord bot token stored? Default is `~/secrets/discord-bot-token`. If you haven't created a bot yet, see: https://discord.com/developers/applications"
+
+3. **Channels** — For each channel role, ask for the channel ID:
+   - `default` (general agent communications)
+   - `roll-call` (agent check-in)
+   - `wave-status` (wave execution status posts)
+   - `remote-sessions` (AFK session relay threads)
+
+   For each: "What's the channel ID for **<role>**? Right-click the channel and 'Copy Channel ID'."
+
+### Step 3: Write Config
+
+Write the collected values to `~/.claude/discord.json`:
+
+```bash
+mkdir -p ~/.claude
+cat > ~/.claude/discord.json << 'EOF'
+{
+  "guild_id": "<collected>",
+  "token_path": "<collected>",
+  "channels": {
+    "default":         { "name": "<name>", "id": "<id>" },
+    "roll-call":       { "name": "<name>", "id": "<id>" },
+    "wave-status":     { "name": "<name>", "id": "<id>" },
+    "remote-sessions": { "name": "<name>", "id": "<id>" }
+  }
+}
+EOF
+```
+
+### Step 4: Verify
+
+Test the configuration:
+
+```bash
+discord-bot read $(jq -r '.channels.default.id' ~/.claude/discord.json) --limit 1
+```
+
+If it works, confirm: *"Discord configuration complete. You can now use `/disc` to interact with your server."*
+
+If it fails, help troubleshoot (missing token, wrong channel ID, bot not in server, etc.).
+
+See [Discord Configuration](docs/discord-config.md) for the full schema reference and per-team scoping strategies.
+
+---
+
+## Important
+
+- Tours are **interactive** — run the embedded commands so the user sees their actual installed state, not canned output.
+- Labs are **guided exercises** — the user does the work, you coach. Don't just dump the issue text.
+- Setup wizards are **conversational** — ask one question at a time, validate each answer before moving on.
+- When linking to documentation, use relative paths from the repo root (e.g., `docs/getting-started.md`).

--- a/skills/ccwork/tours/foundations.md
+++ b/skills/ccwork/tours/foundations.md
@@ -1,0 +1,185 @@
+# Tour: Foundations
+
+A guided walkthrough of the foundational skills — the ones that manage session state, identity, and maintenance. These are the skills you use at session boundaries, not during active development.
+
+**Pace:** Each section covers one skill. Show what it does, run a live command where possible, and explain when to use it.
+
+**Cross-references:** The [Foundation Skills](../../../docs/concepts.md#foundation-skills) table in Concepts provides the quick-reference version of this tour.
+
+---
+
+## Section 1: `/engage` — The Thaw Cycle
+
+Narration: "The most important foundation skill. `/engage` loads your rules, restores context, and confirms ready state. You run it at session start and after every context compaction."
+
+### What it does
+
+1. **Reads CLAUDE.md** and confirms the mandatory rules are loaded
+2. **Loads the current plan** if one exists (from a prior `/cryo` or plan mode)
+3. **Reports ready state** — current branch, pending work, asks what's next
+
+### When to use it
+
+- **Every session start** — first thing you run (or Claude runs it for you)
+- **After context compaction** — when Claude's context window fills and gets summarized, `/engage` is the safety net that restores the rules that compaction may have dropped
+
+### Live check
+
+```bash
+echo "CLAUDE.md location:"
+ls CLAUDE.md .claude/CLAUDE.md 2>/dev/null || echo "  (not found in current directory)"
+```
+
+Narration: "If there's no `CLAUDE.md` in your project, `/engage` still works — it just skips the rules confirmation. Copy the template from the ccwork repo to enable the full workflow."
+
+---
+
+## Section 2: `/cryo` — The Freeze Cycle
+
+Narration: "`/cryo` is the complement to `/engage`. It freezes session state before context compaction hits. Think of it as saving your game."
+
+### What it does
+
+1. **Audits current state** — branch, recent commits, uncommitted work
+2. **Curates the plan file** — rewrites it as a snapshot of where things stand RIGHT NOW
+3. **Prunes the task list** — deletes completed and stale tasks, keeps pending ones
+4. **Confirms** — tells you what was preserved
+
+### When to use it
+
+- **When context is getting full** — you'll notice responses getting shorter or less detailed
+- **Before a long break** — if you're stepping away and want to resume later
+- **Before any operation that might trigger compaction** — large file reads, long conversations
+
+### The cryo-engage cycle
+
+```
+Session start → /engage (thaw)
+     ↓
+  [work]
+     ↓
+Context filling up → /cryo (freeze)
+     ↓
+  [compaction happens]
+     ↓
+/engage (thaw) → resume work
+```
+
+Narration: "`/cryo` writes to the plan file, `/engage` reads from it. They're a matched pair. The plan file is the only thing that survives compaction intact — everything else becomes a lossy summary."
+
+---
+
+## Section 3: `/ccfold` — Template Sync
+
+Narration: "`/ccfold` keeps your project's `CLAUDE.md` in sync with the upstream template. When the kit adds new sections or updates existing ones, `/ccfold` merges them in without overwriting your project-specific content."
+
+### What it does
+
+1. **Fetches** the latest CLAUDE.md template from the canonical repo
+2. **Compares** each section between upstream and local
+3. **Presents** a merge plan — what will be added, updated, or left alone
+4. **Applies** the merge after your approval
+
+### When to use it
+
+- **After pulling kit updates** — `git pull` in the ccwork repo, then `/ccfold` in each project
+- **When a new skill appears** — the template often adds references to new skills
+- **On first setup** — `/ccfold` also generates `.claude-project.md` with cached platform detection
+
+### Check current state
+
+```bash
+test -f .claude-project.md && echo ".claude-project.md: exists (platform cached)" || echo ".claude-project.md: not found (will be generated on next /ccfold)"
+```
+
+For the full explanation of how CLAUDE.md works and what `/ccfold` does, see [How CLAUDE.md Works](../../../docs/concepts.md#how-claudemd-works) in Concepts.
+
+---
+
+## Section 4: `/edit` and `/view` — File Access
+
+Narration: "These two skills open files in your GUI applications. `/view` is read-only, `/edit` is for modification. Both are async — they hand off to the OS and return immediately."
+
+### What they do
+
+| Skill | Intent | Example |
+|-------|--------|---------|
+| `/view` | Read-only viewing | `/view screenshot.png`, `/view https://example.com` |
+| `/edit` | Modification | `/edit config.yaml`, `/edit ~/.claude/settings.json` |
+
+### Check the file opener
+
+```bash
+which file-opener 2>/dev/null && echo "file-opener: installed" || echo "file-opener: not installed"
+```
+
+Narration: "Both skills use the `file-opener` script under the hood, which calls `xdg-open` on Linux or `open` on macOS. You can configure preferred apps per file extension."
+
+---
+
+## Section 5: `/name` — Identity Management
+
+Narration: "`/name` reports or picks your session identity. Every session gets a fresh Dev-Name and Dev-Avatar, but the Dev-Team is persistent."
+
+### Check current identity
+
+```bash
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+agent_file="/tmp/claude-agent-${dir_hash}.json"
+if [[ -f "$agent_file" ]]; then
+  echo "Current identity:"
+  cat "$agent_file"
+else
+  echo "No identity file found. Run /name to create one."
+fi
+```
+
+### Check Dev-Team
+
+```bash
+grep "^Dev-Team:" CLAUDE.md 2>/dev/null || echo "(no Dev-Team field found)"
+```
+
+Narration: "Dev-Team identifies your project — it's the same for every session. Dev-Name is ephemeral — a new terminal means a new name. When multiple agents are running, Dev-Team is how you address a project (`@cc-workflow`) and Dev-Name is how you address a specific session (`@beacon`)."
+
+For the full identity system design, see [Identity System](../../../docs/concepts.md#identity-system) in Concepts.
+
+---
+
+## Section 6: `/ibm` — Workflow Reminder
+
+Narration: "The last foundation skill is `/ibm` — Issue, Branch, Merge. It's a quick-reference cheat sheet for the mandatory workflow. Not an executor — it doesn't do anything, just reminds you of the steps."
+
+### When to use it
+
+- When you start a new piece of work and want to make sure you're following the process
+- When you come back from a break and need to reorient
+- When onboarding someone and want to show them the flow in one page
+
+Narration: "`/ibm` resolves your platform (GitHub vs GitLab), your target branch, and walks you through: issue exists? Branch linked? PR targets the right base? It's the checklist you run through in your head before starting."
+
+---
+
+## Section 7: Summary
+
+Here is the full foundation skill set at a glance:
+
+| Skill | When | What |
+|-------|------|------|
+| `/engage` | Session start, after compaction | Load rules, restore context |
+| `/cryo` | Before compaction, before breaks | Freeze state to plan file |
+| `/ccfold` | After kit updates | Merge upstream CLAUDE.md changes |
+| `/edit` | When you need to modify a file in GUI | Open in editor |
+| `/view` | When you need to view a file in GUI | Open in viewer |
+| `/name` | Check or pick identity | Show/set Dev-Name, Dev-Avatar |
+| `/ibm` | Workflow check | Quick-reference for the dev loop |
+
+---
+
+## What's Next
+
+- **Try the workflow** — `/ccwork tour workflow` for the full issue-to-merge walkthrough
+- **Back to overview** — `/ccwork tour` for the orientation
+- **Read the reference** — [Concepts](../../../docs/concepts.md) covers everything in this tour in written form
+- **Explore a skill** — run any `/command` to see it in action

--- a/skills/ccwork/tours/orientation.md
+++ b/skills/ccwork/tours/orientation.md
@@ -1,0 +1,162 @@
+# Tour: Orientation
+
+A guided walkthrough of the Claude Code workflow kit. This tour shows the user what is installed, how the pieces connect, and where to go next.
+
+**Pace:** Pause after each section. Keep narration conversational — explain what you are about to show, run the command, then explain what the output means.
+
+**Cross-references:** Point users to the detailed docs when appropriate:
+- [Getting Started](../../../docs/getting-started.md) for the hands-on first-session walkthrough
+- [Concepts](../../../docs/concepts.md) for architecture and design rationale
+
+---
+
+## Section 1: What You Have
+
+Narration: "Let's start by seeing what the ccwork kit installed on your machine. There are three layers: settings, scripts, and skills."
+
+### Check installed skills
+
+```bash
+ls ~/.claude/skills/
+```
+
+Narration: "These are your skills — slash commands you can use in any Claude Code session. Each one is a markdown file that tells Claude how to execute a specific workflow."
+
+### Check installed scripts
+
+```bash
+ls ~/.local/bin/discord-bot ~/.local/bin/slackbot-send ~/.local/bin/vox ~/.local/bin/file-opener ~/.local/bin/afk-notify ~/.local/bin/statusline-command.sh 2>/dev/null || echo "(some scripts not installed)"
+```
+
+Narration: "These are your scripts — standalone tools that skills call under the hood. `discord-bot` talks to Discord, `vox` does text-to-speech, `file-opener` opens files in your GUI apps. Skills provide the intelligence; scripts provide the capabilities."
+
+### Check settings
+
+```bash
+jq 'keys' ~/.claude/settings.json 2>/dev/null || echo "(no settings.json found)"
+```
+
+Narration: "Your `settings.json` controls tool permissions, hooks, plugins, and the status line. The kit sets this up on first install — you own the file after that."
+
+### Check for drift
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && ./install.sh --check 2>/dev/null | tail -5 || echo "(install.sh not found in this repo)"
+```
+
+Narration: "The `--check` flag compares what is installed against the repo version. If anything says DIFFERS or NOT INSTALLED, run `./install.sh` to update."
+
+For a deeper explanation of how these three layers work together, see the [Three Layers](../../../docs/concepts.md#the-three-layers) section in Concepts.
+
+---
+
+## Section 2: The Core Loop
+
+Narration: "Every change follows the same loop: issue, branch, code, precheck, ship. Let me show you what that looks like."
+
+### Show current branch and status
+
+```bash
+git branch --show-current
+git status --short
+```
+
+### Show the workflow skills
+
+Narration: "These are the skills that drive the loop:"
+
+Present this table:
+
+| Step | What you do | Skill |
+|------|------------|-------|
+| 1. Track | Create or pick an issue | `gh issue create` / `gh issue view` |
+| 2. Branch | Create a feature branch | `git checkout -b feature/42-description` |
+| 3. Code | Write the implementation | (you or Claude) |
+| 4. Gate | Run the pre-commit checklist | `/precheck` |
+| 5. Ship | Stage, commit, push, PR | `/scp`, `/scpmr`, or `/scpmmr` |
+
+Narration: "The system enforces this loop — if you try to commit without `/precheck`, or start coding without an issue, Claude will stop you. That's by design. See the [Mandatory Workflow](../../../docs/getting-started.md#step-4-the-mandatory-workflow) section in Getting Started for the full walkthrough."
+
+---
+
+## Section 3: Session Lifecycle
+
+Narration: "Sessions have a rhythm: start, work, freeze, compact, thaw. Here's how the lifecycle skills fit in."
+
+| Moment | What happens | Skill |
+|--------|-------------|-------|
+| Session start | Load rules, confirm ready state | `/engage` |
+| Before compaction | Freeze state to plan file | `/cryo` |
+| After compaction | Thaw — restore rules and context | `/engage` |
+| Any time | Check or pick your identity | `/name` |
+| Template update | Merge upstream CLAUDE.md changes | `/ccfold` |
+
+### Show identity
+
+```bash
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+agent_file="/tmp/claude-agent-${dir_hash}.json"
+cat "$agent_file" 2>/dev/null || echo "(no identity file — run /name to create one)"
+```
+
+Narration: "Your identity file tracks who you are this session — Dev-Name, Dev-Avatar, and Dev-Team. It's ephemeral (new session, new name) but the Dev-Team is persisted in CLAUDE.md."
+
+For the full explanation of the two-layer identity system, see [Identity System](../../../docs/concepts.md#identity-system) in Concepts.
+
+---
+
+## Section 4: Communication
+
+Narration: "The kit can talk to Discord and Slack. Let me check what's configured."
+
+### Check Discord config
+
+```bash
+cat ~/.claude/discord.json 2>/dev/null || echo "(no Discord config — run /ccwork setup discord to configure)"
+```
+
+### Check Slack token
+
+```bash
+test -f ~/secrets/slack-bot-token && echo "Slack bot token: found" || echo "Slack bot token: not found"
+```
+
+### Communication skills
+
+| Skill | What it does |
+|-------|-------------|
+| `/disc` | Discord — send, read, check in, create channels |
+| `/ping` | Post to Slack #ai-dev |
+| `/pong` | Read Slack #ai-dev |
+| `/vox` | Text-to-speech announcements |
+
+Narration: "If you're running multiple agents, Discord is how they coordinate. The discord-watcher channel server pushes real-time notifications into your session. See [Discord Configuration](../../../docs/discord-config.md) for setup details and per-team scoping strategies."
+
+---
+
+## Section 5: Advanced — Wave System
+
+Narration: "For large features that decompose into independent sub-issues, the wave system lets multiple agents work in parallel."
+
+| Skill | Purpose |
+|-------|---------|
+| `/assesswaves` | Quick check: is this work suitable for parallel execution? |
+| `/prepwaves` | Full planning: validate specs, compute dependency waves, partition into flights |
+| `/nextwave` | Execute one wave at a time with isolated worktrees |
+
+Narration: "You don't need this for everyday work. It's for when you have a big feature with 5+ sub-issues that can be done in parallel. The wave system manages the complexity — isolated git worktrees, conflict avoidance, progress tracking."
+
+---
+
+## Section 6: What's Next
+
+Narration: "That's the orientation. Here's where to go from here:"
+
+- **Try the workflow** — `/ccwork tour workflow` walks you through a real issue-to-merge cycle
+- **Learn the foundations** — `/ccwork tour foundations` covers the session lifecycle skills in depth
+- **Read the docs** — [Getting Started](../../../docs/getting-started.md) for the hands-on walkthrough, [Concepts](../../../docs/concepts.md) for architecture
+- **Run a lab** — `/ccwork lab` to see available hands-on exercises (requires the ccwork-lab repo)
+- **Explore skills** — run any `/command` to see what it does
+
+Narration: "That's it. You know what's installed, how the loop works, and where the docs live. Ready when you are."

--- a/skills/ccwork/tours/workflow.md
+++ b/skills/ccwork/tours/workflow.md
@@ -1,0 +1,161 @@
+# Tour: Workflow
+
+A guided walkthrough of the issue-to-merge development loop. This tour demonstrates each step of the mandatory workflow using the user's actual project state.
+
+**Pace:** This tour is more hands-on than the orientation. Show each step, explain what it enforces and why, then move to the next.
+
+**Cross-references:** The [Mandatory Workflow](../../../docs/getting-started.md#step-4-the-mandatory-workflow) section in Getting Started covers this same loop as a reference. This tour is the interactive version.
+
+---
+
+## Section 1: The Rule
+
+Narration: "Every change in the ccwork kit follows the same loop: **issue, branch, code, precheck, ship**. The system enforces this — it's not optional. Let me show you why each step matters and what happens when you try to skip one."
+
+For the design rationale behind each mandatory rule, see [Mandatory Workflows](../../../docs/concepts.md#mandatory-workflows) in Concepts.
+
+---
+
+## Section 2: Issue First
+
+Narration: "Step one: you need an issue before any code gets written. The issue is the contract — it defines what 'done' looks like."
+
+### Show how to find or create issues
+
+```bash
+# Platform detection
+REMOTE_URL=$(git remote get-url origin 2>/dev/null)
+if echo "$REMOTE_URL" | grep -qi github; then
+  CLI="gh"
+elif echo "$REMOTE_URL" | grep -qi gitlab; then
+  CLI="glab"
+fi
+
+# List recent issues
+$CLI issue list --limit 5 2>/dev/null || echo "(could not list issues — check CLI auth)"
+```
+
+Narration: "Every issue needs labels (type, priority, urgency) and acceptance criteria. The templates in CLAUDE.md define the format — features get implementation steps and test procedures, bugs get reproduction steps and severity."
+
+### Show the IBm reminder
+
+Narration: "If you ever forget the workflow, `/ibm` is the cheat sheet. It resolves your platform, target branch, and walks you through each step. Try it any time."
+
+---
+
+## Section 3: Branch Linked to Issue
+
+Narration: "Step two: create a feature branch linked to your issue. The branch name includes the issue number so the system can trace work back to its origin."
+
+### Show current branch state
+
+```bash
+git branch --show-current
+echo ""
+echo "Branch naming convention:"
+echo "  feature/<issue-number>-description"
+echo "  fix/<issue-number>-description"
+echo "  chore/<issue-number>-description"
+echo "  docs/<issue-number>-description"
+```
+
+Narration: "The branch name format is `<type>/<issue-number>-<description>`. When `/precheck` runs, it extracts the issue number from your branch name to verify the issue exists and is open. If you're on `main` or a branch without an issue number, it stops you."
+
+---
+
+## Section 4: Code
+
+Narration: "Step three: write the implementation. This is where the actual work happens. You write code, Claude assists — or Claude drives and you review. Either way, the acceptance criteria from the issue define what 'done' means."
+
+### Show the test-before-push rule
+
+```bash
+# Check what test tooling exists
+test -f ./scripts/ci/validate.sh && echo "validate.sh: found" || echo "validate.sh: not found"
+test -f ./Makefile && echo "Makefile: found" || echo "Makefile: not found"
+```
+
+Narration: "Before any push, local tests must pass. This is non-negotiable. The kit looks for `./scripts/ci/validate.sh`, Makefile targets, pytest, npm test — whatever the project provides. If you push untested code, you've wasted CI resources and blocked the pipeline."
+
+---
+
+## Section 5: Precheck Gate
+
+Narration: "Step four: the pre-commit gate. This is the most important skill in the kit. When your work is done, `/precheck` runs a multi-step verification before you can commit."
+
+### Show what precheck does
+
+Present this sequence:
+
+```
+/precheck
+  1. Branch & issue check — are you on a feature branch linked to an open issue?
+  2. Validation — run the project's test tooling
+  3. Code review — launch a code-reviewer sub-agent over all changed files
+  4. Fix high-risk findings — anything critical gets fixed before the checklist
+  5. Present checklist — full verification: implementation, TODOs, docs, tests, review
+  6. STOP and wait — no commit until you explicitly approve
+```
+
+Narration: "After the checklist, Claude stops. It will not commit, push, or create a PR until you respond. This is the safety net that prevents unreviewed code from reaching the remote. You respond with `/scp`, `/scpmr`, or `/scpmmr` to approve."
+
+---
+
+## Section 6: Ship
+
+Narration: "Step five: ship it. You have three options, each one does a bit more."
+
+| Command | What it does |
+|---------|-------------|
+| `/scp` | Stage, commit, push |
+| `/scpmr` | Stage, commit, push, create PR/MR |
+| `/scpmmr` | Stage, commit, push, create PR/MR, merge |
+
+### Show the commit message format
+
+```
+type(scope): brief description
+
+[Optional body]
+
+Closes #42
+```
+
+Narration: "The commit message follows conventional commit format — `feat`, `fix`, `docs`, `chore`, etc. — with `Closes #<number>` to auto-close the linked issue on merge. Claude writes the commit message, stages specific files (never `git add -A`), and handles the push and PR creation."
+
+---
+
+## Section 7: After Merge
+
+Narration: "One more thing: after a PR is merged, all linked issues must be closed. The `Closes #NNN` in the PR description usually handles this automatically, but the kit verifies it. If auto-close fails, Claude closes the issues manually."
+
+### Show the full loop
+
+```
+You:    Let's work on issue #42
+Claude: [reads issue, creates branch feature/42-description]
+
+You:    Go ahead and implement it
+Claude: [writes code, runs tests]
+
+Claude: [runs /precheck — validation, code review, checklist]
+Claude: Ready for your call.
+
+You:    /scpmr
+Claude: [commits, pushes, creates PR #58]
+Claude: PR #58 is up: https://github.com/...
+
+[After merge]
+Claude: [closes issue #42]
+```
+
+Narration: "That's the loop. Issue, branch, code, precheck, ship. Every time, no exceptions. The [Getting Started guide](../../../docs/getting-started.md) covers this same flow as a written reference you can come back to."
+
+---
+
+## Section 8: What's Next
+
+- **Try it for real** — pick an issue (or create one) and go through the full cycle
+- **Tour the foundations** — `/ccwork tour foundations` covers session lifecycle skills
+- **Back to overview** — `/ccwork tour` for the full orientation
+- **Quick reference** — `/ibm` for a one-page workflow reminder


### PR DESCRIPTION
## Summary

Creates the /ccwork skill — a single entry point for onboarding, education, and configuration with interactive tours, lab guidance, and setup wizards.

## Changes

- **skills/ccwork/SKILL.md**: Intent router with 10 subcommand routes (overview, 3 tours, lab list/run, setup list/discord)
- **skills/ccwork/tours/orientation.md**: 6-section kit overview with live commands
- **skills/ccwork/tours/workflow.md**: 8-section issue-to-merge walkthrough
- **skills/ccwork/tours/foundations.md**: 7-section foundation skills deep-dive
- **install.sh**: Subdirectory install/check logic for tour files
- **README.md**: Add ccwork to skills table
- **docs/getting-started.md, docs/concepts.md**: Cross-references to /ccwork tour

## Test Plan

- `./scripts/ci/validate.sh` — 60/60 passed (new SKILL.md adds 1 check)
- Manual: verified install.sh copies tours/ subdirectory correctly

Closes #121

Generated with [Claude Code](https://claude.com/claude-code)