### PR TITLE
docs(install): update README and changelog for smart merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ccfold` skill — Merge upstream CLAUDE.md template changes into a project's local CLAUDE.md, preserving project-specific content (Dev-Team, custom sections)
 - `sync.sh` — Reverse-sync: pull local skill/script changes back into the repo
 
+### Changed
+
+- `install.sh --config` now smart-merges `settings.template.json` into existing `settings.json` — missing hooks, plugins, and permissions are added while user customizations are preserved
+- `install.sh --check` now reports missing hooks, plugins, and MCP server registrations in addition to file drift
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The discord-watcher enables real-time inter-agent communication. Multiple Claude
 
 `settings.template.json` provides a starting point for `~/.claude/settings.json` with:
 - **Permissions** — Granular tool allowlists for common CLIs (git, gh, glab, docker, terraform, aws, etc.)
-- **Hooks** — PostToolUse, SessionStart, SubagentStop hook structure (requires [context-crystallizer](https://github.com/Wave-Engineering/context-crystallizer) or equivalent)
+- **Hooks** — PostToolUse, SessionStart, SubagentStop, and Stop hook structure (requires [context-crystallizer](https://github.com/Wave-Engineering/context-crystallizer) for crystallization hooks; Stop runs [afk-notify](#remote-sessions) for idle relay)
 - **Status line** — Points to the custom statusline script
 - **Plugins** — Full plugin list (see Plugins section below)
 - **Effort level** — Set to `high` for thorough responses
@@ -97,7 +97,7 @@ This will:
 - Copy skills to `~/.claude/skills/`
 - Copy scripts to `~/.local/bin/`
 - Install statusline to `~/.claude/statusline-command.sh`
-- Copy `settings.template.json` → `~/.claude/settings.json` (only if no settings exist yet)
+- Smart-merge `settings.template.json` into `~/.claude/settings.json` — missing hooks, plugins, and permissions are added while your existing customizations are preserved. If no settings file exists yet, the template is installed directly (with internal comment keys stripped).
 - Back up existing files before overwriting (`.bak`)
 - Skip unchanged files
 - Report missing dependencies
@@ -120,7 +120,9 @@ After making local changes to skills or scripts, see what's out of sync:
 ./install.sh --check
 ```
 
-This compares every installed file against the repo version and reports `in sync`, `DIFFERS`, or `NOT INSTALLED`.
+This compares every installed file against the repo version and reports `in sync`, `DIFFERS`, or `NOT INSTALLED`. It also checks:
+- **Settings** — reports any hooks or plugins present in the template but missing from your local `settings.json`
+- **Channels** — verifies that each channel server (e.g., discord-watcher) is registered as an MCP server via `claude mcp list`
 
 ### Sync Local Changes Back to Repo
 


### PR DESCRIPTION
## Summary

Updates README.md and CHANGELOG.md to document the smart settings merge behavior and expanded drift checking from #112.

## Changes

- **README.md**: Settings Template hook list adds Stop, Installation describes merge (not copy-only), Check for Drift documents settings.json and MCP checks
- **CHANGELOG.md**: Added Changed section under [Unreleased] for merge and check features

## Test Plan

- `./scripts/ci/validate.sh` — 60/60 passed
- All links verified (local files exist, anchors resolve)
- Code review: fixed "copied as-is" inaccuracy (fresh install strips _comment keys)

Closes #118

Generated with [Claude Code](https://claude.com/claude-code)