### PR TITLE
feat(skills): create /issue skill and add agent identity to vox announcements

### DIFF
--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: issue
+description: Create structured issues (feature, bug, chore, docs, epic) with proper templates and labels. Supports both GitHub (gh) and GitLab (glab). Self-contained — does not depend on CLAUDE.md for templates.
+---
+
+<!-- introduction-gate: If introduction.md exists in this skill's directory, read it,
+     present its contents to the user as a brief welcome, then delete the file.
+     Do this BEFORE executing any skill logic below. -->
+
+# Issue — Structured Issue Creation
+
+Create properly templated and labeled issues from a natural language prompt.
+
+## Usage
+
+```
+/issue feature <prompt>       Create a feature issue
+/issue bug <prompt>            Create a bug issue
+/issue chore <prompt>          Create a chore issue
+/issue docs <prompt>           Create a docs issue
+/issue epic <prompt>           Create an epic issue
+/issue <prompt>                Infer type from the prompt
+/issue                         Infer from recent conversation context
+```
+
+## Step 1: Detect Platform
+
+```bash
+REMOTE_URL=$(git remote get-url origin 2>/dev/null)
+if echo "$REMOTE_URL" | grep -qi github; then
+  PLATFORM="github"; CLI="gh"
+elif echo "$REMOTE_URL" | grep -qi gitlab; then
+  PLATFORM="gitlab"; CLI="glab"
+fi
+```
+
+Or read from `.claude-project.md` if it exists.
+
+## Step 2: Parse Arguments
+
+{{#if args}}
+Parse: `{{args}}`
+{{else}}
+No arguments — infer the issue from the most recent topic of conversation. Determine the type and content from context, then confirm with the user before creating.
+{{/if}}
+
+Extract two things:
+1. **Type** — the first word if it matches: `feature`, `bug`, `chore`, `docs`, `epic`. If it doesn't match a type, treat the entire argument as the prompt and infer the type.
+2. **Prompt** — everything after the type (or the entire argument if no type prefix).
+
+**Type inference rules** (when no explicit type):
+- Mentions broken, fails, crash, error, wrong → `bug`
+- Mentions add, create, build, implement, new → `feature`
+- Mentions update, fix, clean, refactor, rename, move, upgrade → `chore`
+- Mentions document, write docs, README, guide → `docs`
+- Mentions epic, phase, milestone, multi-part → `epic`
+- Ambiguous → ask the user
+
+## Step 3: Draft the Issue
+
+Use the prompt (or conversation context) to fill in the appropriate template below. The agent should flesh out the template sections intelligently — don't just echo the prompt back. Think about what a spec-driven implementing agent would need.
+
+**Quality standard:** Every issue should be detailed enough that a spec-driven agent can execute without making design decisions. Implementation steps should read like paint-by-numbers. Acceptance criteria should be evaluable before PR/MR merge.
+
+### Feature Template
+
+```markdown
+## Summary
+
+[1-2 sentences: what this feature delivers and why]
+
+## Context
+
+[Background, motivation, link to Epic or PRD if applicable]
+
+## Implementation Steps
+
+[Paint-by-numbers instructions. Each step should be unambiguous.]
+
+1. [Exact file paths to create or modify]
+2. [Function signatures and key logic]
+3. [Data structures and schemas]
+4. [How to wire components together]
+
+## Test Procedures
+
+### Unit Tests
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `test_function_name` | [what it verifies] | `tests/test_module.py` |
+
+### Integration/E2E Coverage
+
+- [References to integration tests if applicable]
+
+## Acceptance Criteria
+
+- [ ] [Testable condition — names exact files, functions, commands, or behaviors]
+- [ ] [Testable condition]
+- [ ] [Testable condition]
+
+## Dependencies
+
+- None (or #NNN — description)
+```
+
+### Bug Template
+
+```markdown
+## Summary
+
+[Concise description of the defect]
+
+## Environment
+
+- **Where observed:** [page, component, CLI command, API endpoint]
+- **Version/commit:** [git SHA or release tag]
+- **Frequency:** intermittent | consistent
+
+## Steps to Reproduce
+
+1. [Step one]
+2. [Step two]
+3. [Step three]
+
+## Expected Behavior
+
+[What should happen]
+
+## Actual Behavior
+
+[What actually happens]
+
+## Severity
+
+[`severity::critical` | `severity::major` | `severity::minor` | `severity::cosmetic`]
+
+## Artifacts
+
+- [Links to logs, screenshots, error traces]
+
+## Workaround
+
+[Describe workaround if known, or "None known"]
+```
+
+### Chore Template
+
+```markdown
+## Summary
+
+[Description of the maintenance task and its rationale]
+
+## Implementation Steps
+
+[Mandatory if the chore touches >1 file or has ordering constraints.]
+
+1. [Step]
+2. [Step]
+
+## Acceptance Criteria
+
+- [ ] [Testable condition]
+- [ ] [Testable condition]
+```
+
+### Docs Template
+
+```markdown
+## Summary
+
+[Which document(s) to create or update, and why]
+
+## Target Audience
+
+[Who will read this — developers, operators, end users, agents]
+
+## What's Missing, Outdated, or Incorrect
+
+[Specific gaps or inaccuracies]
+
+## Source Material
+
+- [Pointers to code, PRDs, conversations]
+
+## Acceptance Criteria
+
+- [ ] Content is accurate against current codebase
+- [ ] Coverage is complete for the stated scope
+- [ ] No broken links
+- [ ] [Additional testable conditions]
+```
+
+### Epic Template
+
+```markdown
+## Goal
+
+[One sentence: what this epic proves or delivers]
+
+## Scope
+
+**In scope:**
+- [What is included]
+
+**Out of scope:**
+- [What is explicitly excluded and why]
+
+## Definition of Done
+
+- [ ] [Verifiable condition]
+- [ ] [Verifiable condition]
+- [ ] All sub-issue AC checklists are satisfied
+
+## Sub-Issues
+
+| Order | Issue | Title | Dependencies |
+|-------|-------|-------|-------------|
+| 1 | #NNN | [title] | None |
+| 2 | #NNN | [title] | #NNN |
+
+## Wave Map
+
+| Wave | Issues | Parallel? |
+|------|--------|-----------|
+| 1 | #NNN | Single |
+| 2 | #NNN, #NNN | Yes |
+
+## Success Metrics
+
+[Quantitative or qualitative measures of success]
+```
+
+## Step 4: Determine Labels
+
+Labels use the `group::value` convention. Within each group, labels are mutually exclusive.
+
+### Automatic Labels (always applied)
+
+| Type | Label |
+|------|-------|
+| feature | `type::feature` |
+| bug | `type::bug` |
+| chore | `type::chore` |
+| docs | `type::docs` |
+| epic | `type::epic` |
+
+### Prompted Labels
+
+After drafting, assess and suggest values for these groups. Present your recommendation and let the user confirm or override:
+
+| Group | Values | When Required |
+|-------|--------|---------------|
+| **Priority** | `priority::critical`, `priority::high`, `priority::medium`, `priority::low` | All issues |
+| **Urgency** | `urgency::immediate`, `urgency::soon`, `urgency::normal`, `urgency::eventual` | All issues |
+| **Size** | `size::S`, `size::M`, `size::L`, `size::XL` | Features, chores, docs (optional on bugs, omit for epics) |
+| **Severity** | `severity::critical`, `severity::major`, `severity::minor`, `severity::cosmetic` | Bugs only |
+| **Wave** | `wave::1`, `wave::2`, etc. | Wave-planned issues only — omit otherwise |
+
+**Priority vs Urgency are orthogonal:**
+- **Priority** = business value importance. How much does this matter?
+- **Urgency** = temporal significance. How soon must it be addressed?
+
+Present your assessment concisely:
+
+> **Labels:** `type::feature`, `priority::medium`, `urgency::normal`, `size::M`
+> Agree, or adjust?
+
+## Step 5: Present Draft for Approval
+
+Show the user:
+1. The issue title (following `type(scope): description` convention). Examples:
+   - Feature: `feat(auth): add OAuth2 login flow`
+   - Bug: `fix(search): results page crashes on empty query`
+   - Chore: `chore(deps): update ruff to 0.8.x`
+   - Docs: `docs(api): add endpoint reference for /users`
+   - Epic: `epic(onboarding): user registration and verification`
+2. The full body
+3. The proposed labels
+4. Ask for approval or edits
+
+Do NOT create the issue until the user approves. This is a gate — the user may want to refine the spec.
+
+## Step 6: Create the Issue
+
+After approval:
+
+Write the issue body to a temp file first, then create:
+
+**GitHub:**
+```bash
+# Write body to temp file (avoids shell escaping issues with multi-line markdown)
+cat > /tmp/issue-body.md << 'BODY'
+<the filled-in template>
+BODY
+
+gh issue create --title "<title>" --label "<comma-separated-labels>" --body-file /tmp/issue-body.md
+```
+
+**GitLab:**
+```bash
+glab issue create --title "<title>" --label "<comma-separated-labels>" --description "$(cat /tmp/issue-body.md)"
+```
+
+If a label doesn't exist on the repo, offer to create it:
+
+**GitHub:**
+```bash
+gh label create "type::feature" --description "Feature request" --color "0E8A16"
+```
+
+**GitLab:**
+```bash
+glab label create "type::feature" --description "Feature request" --color "#0E8A16"
+```
+
+## Step 7: Report
+
+Confirm creation with the issue number and URL:
+
+> Created **#NNN** — `type(scope): description`
+> Labels: `type::feature`, `priority::medium`, `urgency::normal`, `size::M`
+
+## Label Color Reference
+
+When creating labels, use these colors for consistency. **Note:** `gh` expects hex without `#` prefix; `glab` expects it with `#`.
+
+| Group | Color (glab) | Color (gh) |
+|-------|-------------|------------|
+| `type::` | `#0E8A16` | `0E8A16` |
+| `priority::` | `#D93F0B` | `D93F0B` |
+| `urgency::` | `#FBCA04` | `FBCA04` |
+| `size::` | `#1D76DB` | `1D76DB` |
+| `severity::` | `#B60205` | `B60205` |
+| `wave::` | `#5319E7` | `5319E7` |

--- a/skills/issue/introduction.md
+++ b/skills/issue/introduction.md
@@ -1,0 +1,17 @@
+<!-- preamble: This file is shown once on first use of the /issue skill, then deleted. -->
+
+# /issue — Structured Issue Creation
+
+Create properly templated issues from natural language:
+
+```
+/issue feature "add dark mode support"
+/issue bug "login fails on Safari"
+/issue chore "update dependencies"
+/issue "the search results are wrong"     ← type inferred
+/issue                                     ← uses conversation context
+```
+
+Every issue gets the right template (feature, bug, chore, docs, epic), the right labels (`type::`, `priority::`, `urgency::`, `size::`, `severity::`), and is written to wave-quality — detailed enough for a spec-driven agent to execute without design decisions.
+
+You review and approve the draft before it's created. Works on both GitHub and GitLab.

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -580,11 +580,17 @@ For each deferred item:
 
 Do NOT let deferred items disappear into the void. Every deferral must be tracked.
 
-6. **Voice announcement** — Announce wave completion via `vox` (best-effort):
+6. **Voice announcement** — Resolve agent identity and announce wave completion via `vox` (best-effort):
    ```bash
-   vox "Hey BJ, wave <N> is complete. <X> issues closed, <Y> flights, all merged to main. Ready for wave <N+1> when you are." 2>/dev/null || true
+   project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+   dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+   DEV_NAME=$(jq -r '.dev_name // "agent"' "/tmp/claude-agent-${dir_hash}.json" 2>/dev/null)
+   DEV_TEAM=$(jq -r '.dev_team // "unknown"' "/tmp/claude-agent-${dir_hash}.json" 2>/dev/null)
+   PROJECT=$(basename "$project_root")
+
+   vox "Hey BJ, this is $DEV_NAME from $DEV_TEAM on $PROJECT. Wave <N> is complete. <X> issues closed, <Y> flights, all merged to main. Ready for wave <N+1> when you are." 2>/dev/null || true
    ```
-   Keep it conversational — summarize the wave outcome in 1-2 sentences for the ear.
+   Keep it conversational — identify yourself, summarize the wave outcome in 1-2 sentences for the ear.
 
 7. **Prompt:** "Wave N complete. Design review for Wave N+1 is done. Run `/nextwave` for Wave N+1, or `/cryo` to preserve state."
 

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -85,13 +85,26 @@ If no findings in either category, state "(none)".
 
 ## Step 5: Voice Announcement
 
-After presenting the checklist, announce completion via `vox` (best-effort — never block on audio):
+After presenting the checklist, announce completion via `vox` (best-effort — never block on audio).
+
+Before announcing, resolve agent identity for the greeting:
 
 ```bash
-vox "Hey BJ, precheck is done for issue <NUMBER>. <SUMMARY>. Ready for your call." 2>/dev/null || true
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+agent_file="/tmp/claude-agent-${dir_hash}.json"
+DEV_NAME=$(jq -r '.dev_name // "agent"' "$agent_file" 2>/dev/null)
+DEV_TEAM=$(jq -r '.dev_team // "unknown"' "$agent_file" 2>/dev/null)
+PROJECT=$(basename "$project_root")
 ```
 
-The announcement should be 1-2 sentences: mention the issue number, a brief summary of what was built, and the checklist status. Write for the ear — conversational, not robotic.
+Then announce:
+
+```bash
+vox "Hey BJ, this is $DEV_NAME from $DEV_TEAM on $PROJECT. Precheck is done for issue <NUMBER>. <SUMMARY>. Ready for your call." 2>/dev/null || true
+```
+
+The announcement should be 1-2 sentences: identify yourself (dev-name, dev-team, project), mention the issue number, a brief summary of what was built, and the checklist status. Write for the ear — conversational, not robotic.
 
 ## Step 6: STOP and Wait
 

--- a/skills/scpmmr/SKILL.md
+++ b/skills/scpmmr/SKILL.md
@@ -27,13 +27,19 @@ If `/precheck` has not been run in this conversation, run it first and wait for 
 
 ## Voice Announcement
 
-After the merge completes successfully, announce via `vox` (best-effort):
+After the merge completes successfully, resolve agent identity and announce via `vox` (best-effort):
 
 ```bash
-vox "Hey BJ, PR <NUMBER> is merged into main for issue <NUMBER>. All done." 2>/dev/null || true
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+DEV_NAME=$(jq -r '.dev_name // "agent"' "/tmp/claude-agent-${dir_hash}.json" 2>/dev/null)
+DEV_TEAM=$(jq -r '.dev_team // "unknown"' "/tmp/claude-agent-${dir_hash}.json" 2>/dev/null)
+PROJECT=$(basename "$project_root")
+
+vox "Hey BJ, this is $DEV_NAME from $DEV_TEAM on $PROJECT. PR <NUMBER> is merged into main for issue <NUMBER>. All done." 2>/dev/null || true
 ```
 
-Keep it brief — issue number, PR number, merged. Write for the ear.
+Keep it brief — identify yourself, issue number, PR number, merged. Write for the ear.
 
 ## Important
 

--- a/skills/scpmr/SKILL.md
+++ b/skills/scpmr/SKILL.md
@@ -26,13 +26,19 @@ If `/precheck` has not been run in this conversation, run it first and wait for 
 
 ## Voice Announcement
 
-After the PR/MR is created and pushed, announce via `vox` (best-effort):
+After the PR/MR is created and pushed, resolve agent identity and announce via `vox` (best-effort):
 
 ```bash
-vox "Hey BJ, PR <NUMBER> is up for issue <NUMBER>. Pushed and CI is running." 2>/dev/null || true
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+DEV_NAME=$(jq -r '.dev_name // "agent"' "/tmp/claude-agent-${dir_hash}.json" 2>/dev/null)
+DEV_TEAM=$(jq -r '.dev_team // "unknown"' "/tmp/claude-agent-${dir_hash}.json" 2>/dev/null)
+PROJECT=$(basename "$project_root")
+
+vox "Hey BJ, this is $DEV_NAME from $DEV_TEAM on $PROJECT. PR <NUMBER> is up for issue <NUMBER>. Pushed and CI is running." 2>/dev/null || true
 ```
 
-Keep it brief — issue number, PR number, status. Write for the ear.
+Keep it brief — identify yourself, issue number, PR number, status. Write for the ear.
 
 ## Important
 


### PR DESCRIPTION
## Summary

New `/issue` skill for structured issue creation with all 5 templates baked in, plus agent identity in vox announcements across 4 skills.

## Changes

- **`skills/issue/SKILL.md`** — New skill: `/issue feature|bug|chore|docs|epic <prompt>` with type inference, label taxonomy, platform detection, body-file creation, and approval gate
- **`skills/issue/introduction.md`** — First-run intro
- **`skills/precheck/SKILL.md`** — Vox announces dev-name, dev-team, project
- **`skills/scpmmr/SKILL.md`** — Same vox identity update
- **`skills/scpmr/SKILL.md`** — Same vox identity update
- **`skills/nextwave/SKILL.md`** — Same vox identity update
- **ccwork-lab templates** — Labs 01, 02, 04 updated to introduce `/issue` in exercise steps

## Linked Issues

Closes #152

## Test Plan

- Validation: 61/0 (new skill validates)
- Code review: 5 findings fixed (body-file, color prefix, wave label, epic size, bug title)
- Lab templates updated on ccwork-lab (issues #1, #2, #4 synced)