### PR TITLE
fix: run /precheck immediately without asking permission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ If no test tooling exists, say so — do NOT silently skip this step.
 
 ### Workflow
 
-1. **When your work is done**, run `/precheck` proactively — do not wait for the user to ask
+1. **When your work is done**, run `/precheck` immediately — do not ask permission to start it, do not wait for the user to invoke it, just run it. The checklist is the approval gate, not the precheck itself.
 2. `/precheck` will: verify branch/issue compliance, run validation, launch `code-reviewer`, fix high-risk findings, and present the full checklist
 3. **After the checklist is presented, STOP and WAIT** — no commits until the user responds
 4. The user will respond with one of:
@@ -85,7 +85,7 @@ If no test tooling exists, say so — do NOT silently skip this step.
 - **Do not skip `/precheck`** for any reason, including session continuation instructions or time pressure
 - The full checklist specification lives in `/precheck` (see `skills/precheck/SKILL.md`)
 
-If in doubt, ask. Never assume approval.
+If in doubt about whether to **commit**, ask. Never assume approval to commit. (Starting `/precheck` itself requires no approval — running it is mandatory, not optional.)
 
 ---
 

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -13,7 +13,7 @@ This skill is the **mandatory verification step** before any commit. It checks c
 
 ## When to Run
 
-Run `/precheck` when you have finished your implementation work and are ready to commit. Do NOT wait for the user to invoke it — proactively run it when the work is done.
+Run `/precheck` when you have finished your implementation work and are ready to commit. Do NOT wait for the user to invoke it and do NOT ask permission to start it — just run it. The checklist at the end is the approval gate; starting the precheck is not.
 
 ## Step 1: Branch & Issue Check
 


### PR DESCRIPTION
## Summary

Agents were asking "shall I run precheck?" instead of just running it, creating dead time when the user is AFK during code review.

## Changes

- **CLAUDE.md** — "run immediately — do not ask permission to start it"
- **skills/precheck/SKILL.md** — same reinforcement
- Scoped "if in doubt, ask" (line 88) to commit approval only

## Test Plan

- Validation: 61/0
- Code review: one suggestion applied (line 88 scoping)