### PR TITLE
fix(wave-status): meta-refresh fallback for file:// protocol

### DIFF
--- a/src/wave_status/dashboard/polling.py
+++ b/src/wave_status/dashboard/polling.py
@@ -115,6 +115,14 @@ def render_polling_script() -> str:
           clearInterval(timerId);
           timerId = null;
         }
+        /* Fall back to meta-refresh for file:// protocol */
+        if (window.location.protocol === "file:" &&
+            !document.querySelector('meta[http-equiv="refresh"]')) {
+          var meta = document.createElement("meta");
+          meta.httpEquiv = "refresh";
+          meta.content = "5";
+          document.head.appendChild(meta);
+        }
         var notice = document.querySelector("[data-fallback-notice]");
         if (notice) {
           notice.style.display = "block";


### PR DESCRIPTION
## Summary

When the wave-status dashboard is opened via `file://` protocol, `fetch()` fails due to CORS. This adds a meta-refresh fallback that auto-reloads the page every 5 seconds, so the dashboard stays current without an HTTP server.

## Changes

- Inject `<meta http-equiv="refresh" content="5">` on fetch failure when protocol is `file://`
- Guarded by protocol check — HTTP users keep smooth 3-second polling unchanged
- Idempotent — meta tag only injected once
- Preserved R-28 fallback notice text for test compatibility

## Linked Issues

Closes #162

## Test Plan

- 26/26 polling unit tests pass
- Built zipapp and installed to `~/.local/bin/wave-status`
- Validation: 62/62 passed
- Code review: 3 findings (1 critical, 2 important), all fixed before commit