### PR TITLE
feat(wave-status): extend mode, overwrite guard, discord-lock

### DIFF
--- a/scripts/discord-lock
+++ b/scripts/discord-lock
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# discord-lock — Toggle the Discord bot kill switch
+#
+# Usage:
+#   discord-lock          Toggle on/off
+#   discord-lock on       Engage kill switch
+#   discord-lock off      Remove kill switch
+#   discord-lock status   Show current state
+#
+# The kill switch file is ~/.claude/discord-bot.kill
+# When active, all discord-bot send/read calls are dropped.
+
+KILL_FILE="$HOME/.claude/discord-bot.kill"
+
+case "${1:-toggle}" in
+on)
+	touch "$KILL_FILE"
+	echo "🔒 Discord LOCKED — all API calls dropped"
+	;;
+off)
+	rm -f "$KILL_FILE"
+	echo "🔓 Discord UNLOCKED — API calls resumed"
+	;;
+status)
+	if [[ -f "$KILL_FILE" ]]; then
+		content=$(cat "$KILL_FILE" 2>/dev/null)
+		if [[ -n "$content" && "$content" =~ ^[0-9]+$ ]]; then
+			expires=$(date -d "@$content" '+%H:%M:%S' 2>/dev/null ||
+				date -r "$content" '+%H:%M:%S' 2>/dev/null ||
+				echo "unknown")
+			echo "🔒 LOCKED (auto-ban, expires $expires)"
+		else
+			echo "🔒 LOCKED (manual)"
+		fi
+	else
+		echo "🔓 Unlocked"
+	fi
+	;;
+toggle)
+	if [[ -f "$KILL_FILE" ]]; then
+		rm -f "$KILL_FILE"
+		echo "🔓 Discord UNLOCKED — API calls resumed"
+	else
+		touch "$KILL_FILE"
+		echo "🔒 Discord LOCKED — all API calls dropped"
+	fi
+	;;
+*)
+	echo "Usage: discord-lock [on|off|status|toggle]"
+	exit 1
+	;;
+esac

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -9,12 +9,21 @@ description: Analyze a master issue, validate sub-issue specs, compute dependenc
 
 # PrepWaves: Plan Parallel Execution Waves
 
-Analyze a master issue and its sub-issues, validate they are ready for spec-driven parallel agent execution, compute dependency-ordered waves, and prepare everything for `/nextwave` to execute.
+Analyze epic issues and their sub-issues, validate they are ready for spec-driven parallel agent execution, compute dependency-ordered waves, and prepare everything for `/nextwave` to execute.
 
 ## Prerequisites
 
-- A "master issue" must exist — an epic or parent issue that references sub-issues
-- The user must provide the master issue number (or it must be identifiable from context)
+- One or more **epic issues** must exist, each referencing its sub-issues (stories)
+- The user provides epic issue number(s): `/prepwaves #2` or `/prepwaves #2 #3 #4 #5 #6`
+- Each epic becomes one **phase** in the plan. Multiple epics = multi-phase plan.
+
+## Multi-Phase and Extend Mode
+
+**First run (no existing plan):** Pass one or more epics. Each epic becomes a phase. All phases are initialized together.
+
+**Adding phases later (existing plan):** If `.claude/status/phases-waves.json` already exists, `/prepwaves` automatically uses **extend mode** — new phases are appended to the existing plan without disturbing completed waves or issue state. The agent does NOT need to pass `--extend` manually; the skill detects the existing plan and does the right thing.
+
+**This means it is safe to run `/prepwaves` per-phase.** Run it for Phase 1's epic first, execute those waves, then run it again for Phase 2's epic — the plan grows incrementally.
 
 ## Status Panel
 
@@ -108,9 +117,9 @@ Once approved:
 2. **Do NOT create branches** — Branches are created by `/nextwave` at execution time, not at prep time. This ensures each branch starts from the current main/release branch with all prior waves' merged work included. Creating branches prematurely produces stale branches that require rebasing before every agent can start.
 3. **Capture in task list** — One task per wave with descriptions listing the issues and dependencies. Set up `blockedBy` relationships between wave tasks.
 4. **Update the plan file** — Write the wave execution plan to the active plan file so it survives compaction
-5. **Initialize wave-status** — Build a plan JSON from the approved wave plan and initialize the status dashboard:
+5. **Initialize wave-status** — Build a plan JSON from the approved wave plan and initialize the status dashboard.
 
-   Construct the plan JSON with this structure:
+   Construct the plan JSON with this structure (one phase per epic):
    ```json
    {
      "project": "<Dev-Team from identity>",
@@ -139,12 +148,15 @@ Once approved:
    }
    ```
 
-   Write it to a temp file and initialize:
+   **Check for an existing plan before initializing:**
    ```bash
-   cat > /tmp/wave-plan.json << 'PLAN'
-   <the JSON above>
-   PLAN
-   wave-status init /tmp/wave-plan.json
+   if [ -f .claude/status/phases-waves.json ]; then
+     # Existing plan — use --extend to add new phases
+     wave-status init --extend /tmp/wave-plan.json
+   else
+     # First run — initialize fresh
+     wave-status init /tmp/wave-plan.json
+   fi
    ```
 
    Verify the initialization succeeded:
@@ -154,6 +166,8 @@ Once approved:
    - `.status-panel.html` should exist at the project root
 
    If `wave-status` is not installed (command not found), skip this step and note it to the user.
+
+   **Wave ID uniqueness:** When extending, wave IDs must not collide with existing waves. Use phase-prefixed IDs (e.g., `wave-2a`, `wave-2b` for Phase 2) to avoid collisions with Phase 1's `wave-1a`, `wave-1b`.
 
 ## Step 6: Confirm
 

--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -25,6 +25,7 @@ from wave_status.dashboard.generator import generate_dashboard
 from wave_status.state import (
     close_issue,
     complete,
+    extend_state,
     flight,
     flight_done,
     get_project_root,
@@ -70,10 +71,21 @@ def _regenerate_dashboard(root: Path) -> None:
 
 def _cmd_init(args: argparse.Namespace) -> None:
     """Handle ``init <file|->``."""
+    if args.extend and args.force:
+        print(
+            "Error: --extend and --force are mutually exclusive. "
+            "Use --extend to add phases, or --force to overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     root = get_project_root()
     raw = _read_json_source(args.file)
     plan_data = json.loads(raw)
-    init_state(plan_data, root)
+    if args.extend:
+        extend_state(plan_data, root)
+    else:
+        init_state(plan_data, root, force=args.force)
     _regenerate_dashboard(root)
 
 
@@ -219,6 +231,10 @@ def _build_parser() -> argparse.ArgumentParser:
     # init
     p_init = sub.add_parser("init", help="Initialize state from a plan JSON file")
     p_init.add_argument("file", help="Path to plan JSON file, or '-' for stdin")
+    p_init.add_argument("--extend", action="store_true",
+                        help="Add phases to an existing plan instead of overwriting")
+    p_init.add_argument("--force", action="store_true",
+                        help="Overwrite an existing plan (default: refuse)")
     p_init.set_defaults(func=_cmd_init)
 
     # flight-plan

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -151,12 +151,15 @@ def _find_next_pending_wave(state_data: dict, wave_ids: list[str]) -> str | None
 # State-machine operations
 # ---------------------------------------------------------------------------
 
-def init_state(plan_data: dict, root: Path) -> None:
+def init_state(plan_data: dict, root: Path, *, force: bool = False) -> None:
     """Validate *plan_data*, write ``phases-waves.json``, ``state.json``,
     and ``flights.json`` under ``<root>/.claude/status/`` [R-02].
 
     *plan_data* must contain ``project`` (str) and ``phases`` (list).
     Raises ``ValueError`` on validation failure [R-32].
+
+    If a plan already exists, raises ``ValueError`` unless *force* is True.
+    Use ``extend_state()`` to add phases to an existing plan.
     """
     # --- validation ---
     if "project" not in plan_data:
@@ -172,8 +175,16 @@ def init_state(plan_data: dict, root: Path) -> None:
 
     d = ensure_status_dir(root)
 
+    # --- overwrite guard ---
+    phases_path = d / "phases-waves.json"
+    if phases_path.exists() and not force:
+        raise ValueError(
+            "Error: plan already initialized. Use 'init --extend' to add "
+            "phases, or 'init --force' to overwrite the existing plan."
+        )
+
     # --- phases-waves.json (structure, written once) ---
-    save_json(d / "phases-waves.json", plan_data)
+    save_json(phases_path, plan_data)
 
     # --- state.json (dynamic runtime state) ---
     wave_ids = _all_wave_ids(plan_data)
@@ -201,6 +212,72 @@ def init_state(plan_data: dict, root: Path) -> None:
 
     # --- flights.json (empty initially) ---
     save_json(d / "flights.json", {"flights": {}})
+
+
+def extend_state(plan_data: dict, root: Path) -> None:
+    """Append new phases from *plan_data* to an existing plan.
+
+    Merges into ``phases-waves.json`` and ``state.json`` without disturbing
+    existing phase/wave/issue state.  Raises ``ValueError`` if no existing
+    plan is found or if wave IDs collide.
+    """
+    if "phases" not in plan_data or not isinstance(plan_data["phases"], list):
+        raise ValueError(
+            "Error: plan is missing required field 'phases'. "
+            "Provide a plan JSON with 'project' and 'phases' keys."
+        )
+
+    d = status_dir(root)
+    phases_path = d / "phases-waves.json"
+    state_path = d / "state.json"
+
+    if not phases_path.exists() or not state_path.exists():
+        raise ValueError(
+            "Error: no existing plan found (or state files incomplete). "
+            "Use 'init' first, then 'init --extend' to add phases."
+        )
+
+    existing_plan = load_json(phases_path)
+    existing_state = load_json(state_path)
+
+    # Check for wave ID collisions
+    existing_wave_ids = set(_all_wave_ids(existing_plan))
+    new_wave_ids = set(_all_wave_ids(plan_data))
+    wave_collisions = existing_wave_ids & new_wave_ids
+    if wave_collisions:
+        raise ValueError(
+            f"Error: wave ID collision — {wave_collisions} already exist in the plan. "
+            "Use unique wave IDs for new phases."
+        )
+
+    # Check for issue number collisions
+    existing_issue_nums = _all_issue_numbers(existing_plan)
+    new_issue_nums = _all_issue_numbers(plan_data)
+    issue_collisions = existing_issue_nums & new_issue_nums
+    if issue_collisions:
+        raise ValueError(
+            f"Error: issue number collision — {issue_collisions} already exist in the plan. "
+            "Each issue should belong to exactly one phase."
+        )
+
+    # Merge phases into plan
+    existing_plan["phases"].extend(plan_data["phases"])
+    save_json(phases_path, existing_plan)
+
+    # Add new waves and issues to state (preserve existing)
+    for wid in _all_wave_ids(plan_data):
+        if wid not in existing_state["waves"]:
+            existing_state["waves"][wid] = {"status": "pending", "mr_urls": {}}
+
+    for phase in plan_data["phases"]:
+        for wave in phase.get("waves", []):
+            for issue in wave.get("issues", []):
+                issue_key = str(issue["number"])
+                if issue_key not in existing_state["issues"]:
+                    existing_state["issues"][issue_key] = {"status": "open"}
+
+    existing_state["last_updated"] = _now_iso()
+    save_json(state_path, existing_state)
 
 
 def store_flight_plan(flights_data: list, root: Path) -> None:


### PR DESCRIPTION
## Summary

Adds `wave-status init --extend` to append phases to existing plans without overwriting, plus an overwrite guard and a `discord-lock` kill switch toggle script.

## Changes

- `state.py`: `extend_state()` merges new phases with wave ID + issue number collision detection; `init_state()` overwrite guard with `--force` bypass
- `__main__.py`: `--extend` and `--force` CLI flags, mutually exclusive
- `skills/prepwaves/SKILL.md`: multi-epic input, extend mode docs, wave ID guidance
- `scripts/discord-lock`: kill switch toggle (on/off/status/toggle)

## Linked Issues

Closes #166

## Test Plan

- 64/64 validation passes
- 89/91 tests pass (2 pre-existing `defer` failures)
- Manually tested: init, overwrite guard, --force, --extend (single + multi-phase)
- discord-lock tested all 4 modes
- Code review: 5 findings (2 critical, 3 important), all fixed