### PR TITLE
chore: set RC display name to match Dev-Name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -630,7 +630,12 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
    Note: `thread_id` is optional and only present when `afk-notify` has created a session thread.
 4. Announce your identity to the user:
    > I'm going by **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>` this session.
-5. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`. Read the channel ID from config:
+5. **Set session display name** — So the Remote Control UI shows your identity instead of a truncated prompt:
+   ```
+   /rename <Dev-Name> <Dev-Avatar> (<Dev-Team>)
+   ```
+   Example: `/rename neuron :zap: (cc-workflow)`. Skip silently if `/rename` is unavailable.
+6. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`. Read the channel ID from config:
    ```bash
    ROLL_CALL=$(jq -r '.channels["roll-call"].id' ~/.claude/discord.json 2>/dev/null || echo "1487382005036617851")
    discord-bot send "$ROLL_CALL" "<message>"


### PR DESCRIPTION
## Summary

Adds `/rename` call to session identity setup so the Remote Control UI shows the agent identity instead of a truncated prompt.

## Changes

- `CLAUDE.md`: Added step 5 to session identity setup — `/rename <Dev-Name> <Dev-Avatar> (<Dev-Team>)`

## Linked Issues

Closes #170

## Test Plan

- 64/64 validation passes
- CLAUDE.md instruction only, no testable code