### PR TITLE
feat(skills): polish /ccwork setup discord — invite URL, category, watcher verify

### DIFF
--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -416,6 +416,28 @@ ls -la "$TOKEN_PATH" 2>/dev/null
 
 Record the token path for the final config.
 
+### Step 2b: Generate Bot Invite URL
+
+Ask: *"What's your bot's Application ID? You can find it on the Developer Portal under General Information."*
+
+After receiving the Application ID, compute and display the OAuth2 invite URL:
+
+```
+https://discord.com/oauth2/authorize?client_id=<APP_ID>&permissions=83984&scope=bot
+```
+
+Permissions included: Manage Channels (16), Send Messages (2048), Embed Links (16384), Read Message History (65536).
+
+Tell the user: *"Open this link in your browser to invite the bot to your server. Select the server you want and click 'Authorize'."*
+
+Wait for the user to confirm the bot has been invited before proceeding.
+
+### Step 2c: Server Creation Guidance
+
+If the user says they don't have a Discord server yet:
+
+*"Open Discord, click the **+** button in the server list, choose 'Create My Own', and name it whatever you like. Once created, right-click the server name → Copy Server ID. (You'll need Developer Mode enabled: Settings → Advanced → Developer Mode.)"*
+
 ### Step 3: Collect Guild ID and Discover Channels
 
 Ask: *"What's your Discord server (guild) ID? You can find it by right-clicking the server name in Discord and selecting 'Copy Server ID'. (Requires Developer Mode enabled in Discord settings.)"*
@@ -461,7 +483,17 @@ For each assignment, resolve the user's input (number or name) to the channel's 
 
 ### Step 5: Create Missing Channels
 
-If any required role (`default`, `roll-call`) could not be filled from existing channels, or the user wants channels that don't exist yet, offer to create them:
+If any required role (`default`, `roll-call`) could not be filled from existing channels, or the user wants channels that don't exist yet, offer to create them.
+
+**First, create an "Agent Comms" category** to group agent channels visually:
+
+```bash
+discord-bot create-channel <guild_id> "Agent Comms" --type category
+```
+
+Capture the category ID from the output.
+
+Then for each missing channel, ask:
 
 *"Your server doesn't have a channel for **<role>**. I can create one for you. Want me to create `#<suggested-name>`?"*
 
@@ -474,7 +506,7 @@ Suggested default names per role:
 For each channel the user approves:
 
 ```bash
-discord-bot create-channel <guild_id> <name>
+discord-bot create-channel <guild_id> <name> --category <category_id>
 ```
 
 Capture the channel ID from the command output and use it in the config. If the user declines creation for a required role, ask them to provide an existing channel instead — `default` and `roll-call` are mandatory.
@@ -514,6 +546,19 @@ Resolve the channel name for the confirmation:
 ```bash
 CHANNEL_NAME=$(jq -r '.channels.default.name' ~/.claude/discord.json)
 ```
+
+### Step 8: Verify Discord Watcher
+
+Check that the discord-watcher MCP server is registered so agents receive channel notifications:
+
+```bash
+claude mcp list 2>/dev/null | grep -q discord-watcher
+```
+
+- **If registered:** *"discord-watcher MCP server is registered. You'll receive channel notifications in your Claude Code sessions."*
+- **If not registered:** *"discord-watcher is not registered. To set it up, run the install script or manually add it: `claude mcp add --scope user --transport stdio discord-watcher -- bun <path>/index.ts`"*
+
+This is informational — the setup is complete regardless. The watcher is needed for agents to receive Discord messages during sessions but isn't required for outbound `/disc` calls.
 
 - **If it works:** Confirm: *"Discord configuration complete. Test message sent to #<CHANNEL_NAME>. You can now use `/disc` to interact with your server."*
 - **If it fails:** Help troubleshoot (permissions, channel ID mismatch, token issues). The config file has been written — the user can fix the issue and retry with `/ccwork setup discord`.

--- a/skills/disc/discord-bot
+++ b/skills/disc/discord-bot
@@ -4,7 +4,7 @@
 # Usage:
 #   discord-bot send <channel-id> <message> [--embed title:text] [--attach FILE]
 #   discord-bot read <channel-id> [--limit N] [--after ID]
-#   discord-bot create-channel <guild-id> <name> [--topic TOPIC] [--category ID]
+#   discord-bot create-channel <guild-id> <name> [--topic TOPIC] [--category ID] [--type text|category]
 #   discord-bot create-thread <channel-id> <name> [--auto-archive 60|1440|4320|10080]
 #   discord-bot list-channels <guild-id> [--type text|voice|category]
 #   discord-bot resolve <guild-id> <channel-name>
@@ -534,7 +534,7 @@ create_channel_help() {
 	cat <<'HELPTEXT'
 Usage: discord-bot create-channel <guild-id> <name> [OPTIONS]
 
-Create a new text channel in a Discord guild.
+Create a new channel in a Discord guild.
 
 Arguments:
   <guild-id>   The guild (server) numeric ID
@@ -543,18 +543,20 @@ Arguments:
 Options:
   --topic TOPIC      Set the channel's topic/description
   --category ID      Place the channel under a category by its numeric ID
+  --type TYPE        Channel type: text (default) or category
   -h, --help         Show this help message
 
 Examples:
   discord-bot create-channel 987654321 wave-3-status
   discord-bot create-channel 987654321 deployments --topic "CI/CD notifications"
   discord-bot create-channel 987654321 dev-chat --category 111222333444555666
+  discord-bot create-channel 987654321 "Agent Comms" --type category
 HELPTEXT
 	exit 0
 }
 
 cmd_create_channel() {
-	local guild_id="" name="" topic="" category=""
+	local guild_id="" name="" topic="" category="" ch_type="text"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -575,6 +577,14 @@ cmd_create_channel() {
 			category="$2"
 			shift 2
 			;;
+		--type)
+			[[ -z "${2:-}" ]] && {
+				echo "Error: --type requires a value (text or category)." >&2
+				exit 1
+			}
+			ch_type="$2"
+			shift 2
+			;;
 		*)
 			if [[ -z "$guild_id" ]]; then
 				guild_id="$1"
@@ -591,12 +601,23 @@ cmd_create_channel() {
 	done
 
 	[[ -z "$guild_id" || -z "$name" ]] && {
-		echo "Error: create-channel requires <guild-id> and <name>. Usage: discord-bot create-channel <guild-id> <name> [--topic TOPIC] [--category ID]" >&2
+		echo "Error: create-channel requires <guild-id> and <name>. Usage: discord-bot create-channel <guild-id> <name> [--topic TOPIC] [--category ID] [--type text|category]" >&2
 		exit 1
 	}
 
+	# Map type name to Discord channel type integer
+	local type_int=0
+	case "$ch_type" in
+	text) type_int=0 ;;
+	category) type_int=4 ;;
+	*)
+		echo "Error: --type must be 'text' or 'category', got '$ch_type'." >&2
+		exit 1
+		;;
+	esac
+
 	local payload
-	payload=$(jq -n --arg name "$name" '{name: $name, type: 0}')
+	payload=$(jq -n --arg name "$name" --argjson type "$type_int" '{name: $name, type: $type}')
 	[[ -n "$topic" ]] && payload=$(jq --arg t "$topic" '. + {topic: $t}' <<<"$payload")
 	[[ -n "$category" ]] && payload=$(jq --arg c "$category" '. + {parent_id: $c}' <<<"$payload")
 


### PR DESCRIPTION
## Summary

- Adds bot invite URL generation, server creation guidance, Agent Comms category creation, and MCP watcher verification to `/ccwork setup discord`
- Adds `--type text|category` flag to `discord-bot create-channel` to support category channel creation

## Changes

- **skills/ccwork/SKILL.md** — Steps 2b (invite URL with permissions=83984), 2c (server creation guidance), 5 (Agent Comms category before channels), 8 (MCP watcher verification)
- **skills/disc/discord-bot** — `create-channel` now accepts `--type text|category` (maps to Discord type 0/4)

## Linked Issues

Closes #149

## Test Plan

- Shellcheck clean on discord-bot
- 670 pytest tests pass
- Code review: 3 findings fixed (permissions integer, --type flag, MCP scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)