### PR TITLE
feat(statusline): two-line layout, per-session indicators, and visual refresh (#186)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,7 +548,7 @@ Your message content here.
 — **<Dev-Name>** <Dev-Avatar> (<Dev-Team>)
 ```
 
-Example: `— **beacon** :satellite: (cc-workflow)`
+Example: `— **beacon** 📡 (cc-workflow)`
 
 The signature is used by the watcher to filter your own echoes. Messages without your signature will echo back to you.
 
@@ -602,7 +602,7 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
 
 **Naming rules:**
 - `Dev-Name`: A single memorable word or hyphenated phrase in **kebab-case** (e.g., `beacon`, `null-pointer`, `mother`). Draw from nerdcore canon — sci-fi, fantasy, comics, gaming, mythology, tech puns, wordplay. The wittier and more specific the reference, the better. Generic names are boring. Kebab-case is required so the name works as a routing key for `@<dev-name>` addressing.
-- `Dev-Avatar`: A Slack emoji string with colons (e.g., `:smiling_imp:`, `:space_invader:`). Should feel like it belongs with the name.
+- `Dev-Avatar`: A Unicode emoji character (e.g., 🧠, 👾). Should feel like it belongs with the name.
 
 **On session start**, after resolving Dev-Team:
 1. Pick your Dev-Name and Dev-Avatar
@@ -617,7 +617,7 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
    {
      "dev_team": "<Dev-Team value>",
      "dev_name": "<your chosen name>",
-     "dev_avatar": "<your chosen emoji>"
+     "dev_avatar": "🧠"
    }
    ```
 4. Announce your identity to the user:
@@ -626,7 +626,7 @@ Each session, pick a fresh identity for yourself. This is NOT persisted — a ne
    ```
    /rename <Dev-Name> <Dev-Avatar> (<Dev-Team>)
    ```
-   Example: `/rename neuron :zap: (cc-workflow)`. Skip silently if `/rename` is unavailable.
+   Example: `/rename neuron ⚡ (cc-workflow)`. Skip silently if `/rename` is unavailable.
 6. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`. Read the channel ID from config:
    ```bash
    ROLL_CALL=$(jq -r '.channels["roll-call"].id' ~/.claude/discord.json 2>/dev/null || echo "1487382005036617851")

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ With the discord-watcher running in multiple Claude Code sessions, agents can ta
 
 Dev-Names must be **kebab-case** (e.g., `beacon`, `null-pointer`) so they work as routing keys for `@` addressing.
 
-Each agent signs messages with its Dev-Name signature (e.g., `— **beacon** :satellite: (cc-workflow)`), which the watcher uses to filter self-echoes while allowing messages from other agents through.
+Each agent signs messages with its Dev-Name signature (e.g., `— **beacon** 📡 (cc-workflow)`), which the watcher uses to filter self-echoes while allowing messages from other agents through.
 
 ### Wave Status Channel
 

--- a/config/statusline-command.sh
+++ b/config/statusline-command.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Claude Code status line — mirrors ~/.bashrc __build_prompt
+# Claude Code status line — two-line layout with per-session indicators
+#
+# Line 1: [per-session indicators] [pwd] [dev-name] [dev-avatar]
+# Line 2: [git repo @ branch] [git status emoji] [ctx remain] [model]
 
 input=$(cat)
 
@@ -9,6 +12,7 @@ remaining_pct=$(echo "$input" | jq -r '.context_window.remaining_percentage // e
 
 # ANSI colors
 c_purple='\033[38;5;97m'
+c_fuchsia='\033[38;5;13m'
 c_green='\033[01;32m'
 c_blue='\033[01;34m'
 c_cyan='\033[36m'
@@ -19,9 +23,54 @@ c_reset='\033[00m'
 # Shorten path: replace $HOME with ~
 short_cwd="${cwd/#$HOME/\~}"
 
-# Git info
+# --- Agent identity ---
+# Identity files are keyed by md5 of the project root so the statusline
+# resolves the correct agent regardless of process ancestry.
+dev_name=""
+dev_avatar=""
+project_root=""
+if [ -n "$cwd" ]; then
+	project_root=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+	dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+	agent_file="/tmp/claude-agent-${dir_hash}.json"
+	if [ -f "$agent_file" ]; then
+		dev_name=$(jq -r '.dev_name // empty' "$agent_file" 2>/dev/null)
+		dev_avatar=$(jq -r '.dev_avatar // empty' "$agent_file" 2>/dev/null)
+	fi
+fi
+
+# --- Per-session indicators ---
+# Sessions write state to /tmp/claude-statusline-<dev_name>.json
+# Format: {"indicators": ["● REC", "W2 3/5", ...]}
+indicators_str=""
+if [ -n "$dev_name" ]; then
+	session_file="/tmp/claude-statusline-${dev_name}.json"
+	if [ -f "$session_file" ]; then
+		indicators=$(jq -r '.indicators // [] | join(" ")' "$session_file" 2>/dev/null)
+		if [ -n "$indicators" ]; then
+			indicators_str="$(printf '%b' "${c_yellow}")${indicators}$(printf '%b' "${c_reset}") "
+		fi
+	fi
+fi
+
+# --- Agent display string ---
+agent_str=""
+if [ -n "$dev_name" ]; then
+	agent_str="  $(printf '%b' "${c_fuchsia}")${dev_name}$(printf '%b' "${c_reset}")"
+	if [ -n "$dev_avatar" ]; then
+		agent_str="${agent_str} ${dev_avatar}"
+	fi
+fi
+
+# === LINE 1: [indicators] [pwd] [dev-name] [dev-avatar] ===
+printf "%s" "$indicators_str"
+printf '%b' "${c_blue}${short_cwd}${c_reset}"
+printf "%s" "$agent_str"
+printf "\n"
+
+# --- Git info ---
 git_line=""
-if git_output=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" status --porcelain -b 2>/dev/null); then
+if [ -n "$cwd" ] && git_output=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" status --porcelain -b 2>/dev/null); then
 	branch_line="${git_output%%$'\n'*}"
 
 	branch="${branch_line#\#\# }"
@@ -49,7 +98,7 @@ if git_output=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" status --porcelain -b 2>/dev/
 		done <<<"$status_lines"
 	fi
 
-	git_line="  $(printf '%b' "${c_cyan}")${repo} @ ${branch}$(printf '%b' "${c_reset}")"
+	git_line="$(printf '%b' "${c_cyan}")${repo} @ ${branch}$(printf '%b' "${c_reset}")"
 
 	if ((dirty > 0)); then
 		git_line+=" $(printf '%b' "${c_red}")✗$(printf '%b' "${c_reset}")"
@@ -70,7 +119,7 @@ if git_output=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" status --porcelain -b 2>/dev/
 	fi
 fi
 
-# Context remaining indicator (always shown when available)
+# --- Context remaining indicator ---
 ctx_str=""
 if [ -n "$remaining_pct" ]; then
 	remaining_int=${remaining_pct%.*}
@@ -79,40 +128,18 @@ if [ -n "$remaining_pct" ]; then
 	elif ((remaining_int <= 25)); then
 		ctx_color="$c_yellow"
 	else
-		ctx_color="$c_cyan"
+		ctx_color="$c_green"
 	fi
 	ctx_str="  $(printf '%b' "${ctx_color}")ctx remaining: ${remaining_int}%$(printf '%b' "${c_reset}")"
 fi
 
-# Model indicator
+# --- Model indicator ---
 model_str=""
 if [ -n "$model" ]; then
 	model_str="  $(printf '%b' "${c_purple}")${model}$(printf '%b' "${c_reset}")"
 fi
 
-# Agent dev-name (from CLAUDE.md agent identity)
-# Identity files are keyed by md5 of the project root so the statusline
-# resolves the correct agent regardless of process ancestry.
-agent_str=""
-if [ -n "$cwd" ]; then
-	project_root=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
-	dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
-	agent_file="/tmp/claude-agent-${dir_hash}.json"
-	if [ -f "$agent_file" ]; then
-		dev_name=$(jq -r '.dev_name // empty' "$agent_file" 2>/dev/null)
-		dev_avatar=$(jq -r '.dev_avatar // empty' "$agent_file" 2>/dev/null)
-		if [ -n "$dev_name" ]; then
-			agent_str="  $(printf '%b' "${c_green}")${dev_name}$(printf '%b' "${c_reset}")"
-			if [ -n "$dev_avatar" ]; then
-				agent_str="${agent_str} ${dev_avatar}"
-			fi
-		fi
-	fi
-fi
-
-# Assemble output
-printf '%b' "${c_blue}${short_cwd}${c_reset}"
-printf "%s" "$agent_str"
+# === LINE 2: [git repo @ branch] [git status] [ctx remain] [model] ===
 if [ -n "$git_line" ]; then
 	printf "%s" "$git_line"
 fi

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -62,7 +62,7 @@ The identity system has two layers that mirror the distinction between project-l
 
 ### Dev-Name and Dev-Avatar (Ephemeral)
 
-**What:** A memorable name (e.g., `beacon`, `null-pointer`, `mother`) and a Slack-style emoji (e.g., `:satellite:`, `:skull:`, `:crystal_ball:`).
+**What:** A memorable name (e.g., `beacon`, `null-pointer`, `mother`) and a Unicode emoji (e.g., 📡, 💀, 🔮).
 
 **Where it lives:** Written to a temp file at `/tmp/claude-agent-<hash>.json`, where `<hash>` is the md5 of the project root path.
 
@@ -85,7 +85,7 @@ Session start: Claude picks Dev-Name + Dev-Avatar
   {
     "dev_team": "cc-workflow",
     "dev_name": "beacon",
-    "dev_avatar": ":satellite:"
+    "dev_avatar": "📡"
   }
         |
         v

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,7 @@ You provide a short name (e.g., `backend-team`, `cc-workflow`). Claude writes it
 
 Each time you start a new Claude Code session, the agent picks a fresh Dev-Name and Dev-Avatar for itself. You will see something like:
 
-> I'm going by **beacon** :satellite: from team `cc-workflow` this session.
+> I'm going by **beacon** 📡 from team `cc-workflow` this session.
 
 This identity is ephemeral -- a new terminal window means a new name. It exists so that when multiple agents are active (on Discord or Slack), you can tell them apart. The identity is written to a temp file at `/tmp/claude-agent-<hash>.json` where `<hash>` is derived from your project root.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,7 +36,7 @@ For example, `@beacon,` (with a trailing comma) or `@cc-workflow:` (with a trail
 Other causes:
 
 - **Identity not set.** If the agent has not picked a Dev-Name yet (no identity file exists), the watcher has nothing to match against for `@<dev-name>` addressing. `@<dev-team>` and `@all` would still work.
-- **Echo filtering.** Messages that contain the agent's own signature (e.g., `-- **beacon** :satellite: (cc-workflow)`) are suppressed to prevent loops. If you are testing by manually posting a message that includes the agent's signature, it will be filtered.
+- **Echo filtering.** Messages that contain the agent's own signature (e.g., `-- **beacon** 📡 (cc-workflow)`) are suppressed to prevent loops. If you are testing by manually posting a message that includes the agent's signature, it will be filtered.
 - **Watcher not running.** The session must be started with `--dangerously-load-development-channels server:discord-watcher` (or the `--channels` alias) for the watcher to be active.
 
 **Fix:**

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -53,7 +53,7 @@ dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
 agent_file="/tmp/claude-agent-${dir_hash}.json"
 ```
 
-Read `dev_name`, `dev_avatar`, and `dev_team` from that file. If the file doesn't exist, use defaults: name=`Claude`, avatar=`:robot_face:`, team=`unknown`.
+Read `dev_name`, `dev_avatar`, and `dev_team` from that file. If the file doesn't exist, use defaults: name=`Claude`, avatar=`🤖`, team=`unknown`.
 
 ## Resolve Channel
 

--- a/skills/name/SKILL.md
+++ b/skills/name/SKILL.md
@@ -29,7 +29,7 @@ Report the current session identity, or pick one if not yet established.
 
 4. **Pick identity (if needed)**
    - `Dev-Name`: A single memorable name or short phrase (max 3 words). Draw from nerdcore canon — sci-fi, fantasy, comics, gaming, mythology, tech puns, wordplay. The wittier and more specific the reference, the better.
-   - `Dev-Avatar`: A Slack emoji string with colons (e.g., `:smiling_imp:`, `:space_invader:`). Should feel like it belongs with the name.
+   - `Dev-Avatar`: A Unicode emoji character (e.g., 🧠, 👾). Should feel like it belongs with the name.
    - Persist to the resolved identity file:
      ```bash
      cat > "$agent_file" << 'EOF'

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,339 @@
+"""Tests for config/statusline-command.sh — two-line layout, per-session
+indicators, Unicode avatar, and color changes.
+
+Strategy: run the real shell script via subprocess with crafted JSON stdin
+and mock identity/session files in a temp directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path to the statusline script under test
+STATUSLINE_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "config" / "statusline-command.sh"
+)
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
+    return re.sub(r"\033\[[0-9;]*m", "", text)
+
+
+def _run_statusline(
+    input_json: dict,
+    *,
+    cwd: str | Path | None = None,
+    env_override: dict[str, str] | None = None,
+) -> str:
+    """Run the statusline script with JSON piped to stdin.
+
+    Returns raw stdout (with ANSI codes intact).
+    """
+    env = os.environ.copy()
+    if env_override:
+        env.update(env_override)
+
+    result = subprocess.run(
+        ["bash", str(STATUSLINE_SCRIPT)],
+        input=json.dumps(input_json),
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+    )
+    # The script should always succeed
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    return result.stdout
+
+
+class TestStatuslineTwoLines:
+    """Verify the script outputs exactly two lines."""
+
+    def test_statusline_two_lines_minimal(self, tmp_path: Path):
+        """With minimal input (just cwd), output has exactly 2 lines."""
+        output = _run_statusline(
+            {"cwd": str(tmp_path)},
+            cwd=tmp_path,
+        )
+        lines = output.split("\n")
+        # Two content lines plus a trailing empty string from the final \n
+        non_empty = [l for l in lines if l]
+        # Should have at least 1 line (line 1 with pwd); line 2 may be empty
+        # if no git info, no context, no model — but the script always prints
+        # the second \n, so we get 2 lines (second may be blank)
+        assert output.count("\n") == 2, (
+            f"Expected exactly 2 newlines (two-line layout), got {output.count(chr(10))}: {output!r}"
+        )
+
+    def test_statusline_two_lines_with_all_fields(self, tmp_path: Path):
+        """With git, model, and context data, output has exactly 2 lines."""
+        # Init a git repo so the script finds git info
+        subprocess.run(
+            ["git", "init"], cwd=str(tmp_path), capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        # Create an initial commit so branch shows up
+        (tmp_path / "README.md").write_text("hello")
+        subprocess.run(
+            ["git", "add", "."], cwd=str(tmp_path), capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+
+        output = _run_statusline(
+            {
+                "cwd": str(tmp_path),
+                "model": {"display_name": "Claude Sonnet"},
+                "context_window": {"remaining_percentage": 72.5},
+            },
+            cwd=tmp_path,
+        )
+        assert output.count("\n") == 2, (
+            f"Expected 2 lines, got: {output!r}"
+        )
+
+        clean = _strip_ansi(output)
+        lines = clean.split("\n")
+
+        # Line 1 should contain the path
+        assert str(tmp_path) in lines[0] or "~" in lines[0]
+
+        # Line 2 should contain git info, context remaining, and model
+        assert "ctx remaining:" in lines[1]
+        assert "Claude Sonnet" in lines[1]
+
+    def test_line1_has_path_line2_has_git(self, tmp_path: Path):
+        """Path is on line 1, git info is on line 2."""
+        subprocess.run(
+            ["git", "init"], cwd=str(tmp_path), capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        (tmp_path / "README.md").write_text("hello")
+        subprocess.run(
+            ["git", "add", "."], cwd=str(tmp_path), capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+
+        output = _run_statusline({"cwd": str(tmp_path)}, cwd=tmp_path)
+        clean = _strip_ansi(output)
+        lines = clean.split("\n")
+
+        repo_name = tmp_path.name
+        # Line 1: path present
+        assert str(tmp_path) in lines[0] or tmp_path.name in lines[0]
+        # Line 2: git repo @ branch
+        assert f"{repo_name} @" in lines[1] or "@ " in lines[1]
+        # Line 1 should NOT have git repo info
+        assert f"{repo_name} @" not in lines[0]
+
+
+class TestStatuslineSessionIndicator:
+    """Verify per-session indicator file is read and rendered first on line 1."""
+
+    def test_statusline_session_indicator(self, tmp_path: Path):
+        """Per-session file indicators appear as the first element on line 1."""
+        # Create a mock agent identity file
+        project_root = str(tmp_path)
+        import hashlib
+
+        dir_hash = hashlib.md5(project_root.encode()).hexdigest()
+        agent_file = Path(f"/tmp/claude-agent-{dir_hash}.json")
+        agent_file.write_text(
+            json.dumps(
+                {
+                    "dev_team": "test-team",
+                    "dev_name": "test-agent",
+                    "dev_avatar": "🧠",
+                }
+            )
+        )
+
+        # Create per-session indicator file
+        session_file = Path("/tmp/claude-statusline-test-agent.json")
+        session_file.write_text(json.dumps({"indicators": ["● REC", "W2 3/5"]}))
+
+        try:
+            # Init git so the script can resolve project root
+            subprocess.run(
+                ["git", "init"], cwd=str(tmp_path), capture_output=True, check=True
+            )
+
+            output = _run_statusline({"cwd": str(tmp_path)}, cwd=tmp_path)
+            clean = _strip_ansi(output)
+            lines = clean.split("\n")
+
+            # Indicators should be the first thing on line 1
+            assert lines[0].startswith("● REC W2 3/5"), (
+                f"Expected indicators first on line 1, got: {lines[0]!r}"
+            )
+        finally:
+            agent_file.unlink(missing_ok=True)
+            session_file.unlink(missing_ok=True)
+
+    def test_no_session_file_no_indicators(self, tmp_path: Path):
+        """When no session file exists, line 1 starts with the path."""
+        output = _run_statusline({"cwd": str(tmp_path)}, cwd=tmp_path)
+        clean = _strip_ansi(output)
+        lines = clean.split("\n")
+
+        # Should start with the path (or ~-substituted path), not indicators
+        assert "● REC" not in lines[0]
+        # The path should be the first visible content
+        assert str(tmp_path) in lines[0] or "~" in lines[0] or tmp_path.name in lines[0]
+
+
+class TestStatuslineUnicodeAvatar:
+    """Verify Unicode emoji renders in output (not colon notation)."""
+
+    def test_statusline_unicode_avatar(self, tmp_path: Path):
+        """Unicode emoji from identity file renders on line 1."""
+        import hashlib
+
+        project_root = str(tmp_path)
+        dir_hash = hashlib.md5(project_root.encode()).hexdigest()
+        agent_file = Path(f"/tmp/claude-agent-{dir_hash}.json")
+        agent_file.write_text(
+            json.dumps(
+                {
+                    "dev_team": "test-team",
+                    "dev_name": "beacon",
+                    "dev_avatar": "📡",
+                }
+            )
+        )
+
+        try:
+            subprocess.run(
+                ["git", "init"], cwd=str(tmp_path), capture_output=True, check=True
+            )
+
+            output = _run_statusline({"cwd": str(tmp_path)}, cwd=tmp_path)
+            clean = _strip_ansi(output)
+            lines = clean.split("\n")
+
+            # Unicode emoji should be present on line 1
+            assert "📡" in lines[0], (
+                f"Expected Unicode emoji 📡 on line 1, got: {lines[0]!r}"
+            )
+            # Dev name should also be on line 1
+            assert "beacon" in lines[0]
+            # No colon notation should appear
+            assert ":satellite:" not in output
+        finally:
+            agent_file.unlink(missing_ok=True)
+
+
+class TestStatuslineColors:
+    """Verify color codes for dev-name and context remaining."""
+
+    def test_dev_name_fuchsia(self, tmp_path: Path):
+        """Dev-name renders with fuchsia color (38;5;13)."""
+        import hashlib
+
+        project_root = str(tmp_path)
+        dir_hash = hashlib.md5(project_root.encode()).hexdigest()
+        agent_file = Path(f"/tmp/claude-agent-{dir_hash}.json")
+        agent_file.write_text(
+            json.dumps(
+                {
+                    "dev_team": "test-team",
+                    "dev_name": "beacon",
+                    "dev_avatar": "📡",
+                }
+            )
+        )
+
+        try:
+            subprocess.run(
+                ["git", "init"], cwd=str(tmp_path), capture_output=True, check=True
+            )
+
+            output = _run_statusline({"cwd": str(tmp_path)}, cwd=tmp_path)
+            # Fuchsia = \033[38;5;13m
+            assert "\033[38;5;13m" in output, (
+                f"Expected fuchsia ANSI code for dev-name, got: {output!r}"
+            )
+        finally:
+            agent_file.unlink(missing_ok=True)
+
+    def test_ctx_remaining_green_when_safe(self, tmp_path: Path):
+        """Context remaining >25% renders green (01;32)."""
+        output = _run_statusline(
+            {
+                "cwd": str(tmp_path),
+                "context_window": {"remaining_percentage": 50.0},
+            },
+            cwd=tmp_path,
+        )
+        # Green = \033[01;32m
+        assert "\033[01;32m" in output, (
+            f"Expected green ANSI code for safe ctx remaining, got: {output!r}"
+        )
+        # Should NOT contain cyan for ctx remaining
+        clean = _strip_ansi(output)
+        assert "ctx remaining: 50%" in clean
+
+    def test_ctx_remaining_yellow_when_low(self, tmp_path: Path):
+        """Context remaining <=25% renders yellow (33)."""
+        output = _run_statusline(
+            {
+                "cwd": str(tmp_path),
+                "context_window": {"remaining_percentage": 20.0},
+            },
+            cwd=tmp_path,
+        )
+        assert "\033[33m" in output, (
+            f"Expected yellow ANSI code for low ctx remaining, got: {output!r}"
+        )
+
+    def test_ctx_remaining_red_when_critical(self, tmp_path: Path):
+        """Context remaining <=13% renders red (31)."""
+        output = _run_statusline(
+            {
+                "cwd": str(tmp_path),
+                "context_window": {"remaining_percentage": 10.0},
+            },
+            cwd=tmp_path,
+        )
+        assert "\033[31m" in output, (
+            f"Expected red ANSI code for critical ctx remaining, got: {output!r}"
+        )


### PR DESCRIPTION
## Summary

Overhauls the statusline to a two-line layout with per-session show/hide indicators, Unicode emoji avatars, and updated colors. Solves truncation on non-fullscreen terminals.

## Changes

- `config/statusline-command.sh` — two-line layout, per-session indicator reading, fuchsia dev-name, green ctx remaining
- `CLAUDE.md` — Unicode emoji spec for dev_avatar, updated identity examples
- `skills/name/SKILL.md`, `skills/disc/SKILL.md` — avatar format updated
- `README.md`, `docs/concepts.md`, `docs/getting-started.md`, `docs/troubleshooting.md` — emoji examples
- `tests/test_statusline.py` — 10 new tests

## Test Results

- 66/66 validation checks pass
- 725/725 pytest pass

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)