### PR TITLE
fix(install): unbound tmpdir variable on script exit

### DIFF
--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -25,6 +25,7 @@ CLAUDE_DIR="$HOME/.claude"
 
 VERSION=""
 NO_MCPS=false
+TMPDIR_CLEANUP=""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -194,9 +195,9 @@ do_install() {
 	echo ""
 
 	# Create temp dir for extraction
-	local tmpdir
-	tmpdir=$(mktemp -d)
-	trap 'rm -rf "$tmpdir"' EXIT
+	TMPDIR_CLEANUP=$(mktemp -d)
+	trap 'rm -rf "$TMPDIR_CLEANUP"' EXIT
+	local tmpdir="$TMPDIR_CLEANUP"
 
 	# Download and extract tarball
 	local tarball="$tmpdir/cc-workflow.tar.gz"
@@ -385,13 +386,9 @@ do_check() {
 	fi
 	echo ""
 
-	# Skills: download manifest to check against
+	# Skills
 	echo "Skills"
 	echo "--------------------------------------------"
-	local tmpdir
-	tmpdir=$(mktemp -d)
-	trap 'rm -rf "$tmpdir"' EXIT
-
 	# We check what's installed without downloading
 	local skill_count=0
 	if [[ -d "$SKILLS_DIR" ]]; then


### PR DESCRIPTION
## Summary

Fix `bash: line 1: tmpdir: unbound variable` error at the end of `install-remote.sh`. The trap cleanup referenced a `local` variable that was out of scope at script exit under `set -u`.

## Changes

- Promote temp dir to script-level `TMPDIR_CLEANUP` so the EXIT trap can always reach it
- Remove dead tmpdir code in `do_check()` that was created but never used

## Test Plan

- Reported by BJ during first real install on `mother` — error occurred at script exit after successful install
- validate.sh: 72 passed, 0 failed

Closes #204

Generated with [Claude Code](https://claude.com/claude-code)