### PR TITLE
feat(discord): scream-hole proxy config and discord-bot integration

### DIFF
--- a/docs/discord-config.md
+++ b/docs/discord-config.md
@@ -14,6 +14,7 @@ their agents at their own Discord server without modifying source.
 {
   "guild_id": "1234567890",
   "token_path": "~/secrets/discord-bot-token",
+  "scream_hole_url": "http://scream-hole:3000",
   "channels": {
     "default":         { "name": "agent-ops",        "id": "1234567890" },
     "roll-call":       { "name": "roll-call",        "id": "1234567890" },
@@ -28,6 +29,7 @@ their agents at their own Discord server without modifying source.
 |-------|------|----------|-------------|
 | `guild_id` | string | Yes | Discord server (guild) ID |
 | `token_path` | string | No | Path to bot token file (default: `~/secrets/discord-bot-token`) |
+| `scream_hole_url` | string | No | Base URL of a [scream-hole](https://github.com/Wave-Engineering/scream-hole) proxy (e.g., `http://scream-hole:3000`). When set, `discord-bot` and `discord-watcher` route all Discord REST API calls through the proxy instead of hitting Discord directly. Omit to use direct Discord API. |
 | `channels` | object | Yes | Map of channel roles to channel info |
 | `channels.<role>.name` | string | Yes | Human-readable channel name (without `#`) |
 | `channels.<role>.id` | string | Yes | Discord channel snowflake ID |
@@ -57,6 +59,22 @@ Every component reads configuration using a three-level fallback:
 | `DISCORD_ROLL_CALL_CHANNEL` | `channels.roll-call.id` | `1487382005036617851` |
 | `DISCORD_WAVE_STATUS_CHANNEL` | `channels.wave-status.id` | `1487386934094462986` |
 | `DISCORD_TOKEN_PATH` | `token_path` | `~/secrets/discord-bot-token` |
+| `SCREAM_HOLE_URL` | `scream_hole_url` | *(disabled)* |
+
+## Scream-Hole Proxy
+
+[scream-hole](https://github.com/Wave-Engineering/scream-hole) is a Discord
+REST API caching proxy. A single scream-hole instance polls Discord once and
+serves cached responses to any number of consumers. This eliminates
+rate-limiting issues when multiple agents share the same bot token.
+
+When `scream_hole_url` is set:
+
+- **discord-bot** and **discord-watcher** route all Discord REST API calls
+  through the proxy (reads from cache, writes forwarded to Discord)
+- On startup, both hit `${scream_hole_url}/health` to verify reachability
+- If unreachable, they fall back to direct Discord API with a logged warning
+- No behavior change when the field is omitted (backwards compatible)
 
 ## Per-User Scoping Strategy
 

--- a/skills/disc/discord-bot
+++ b/skills/disc/discord-bot
@@ -22,7 +22,8 @@
 
 set -euo pipefail
 
-API_BASE="https://discord.com/api/v10"
+DISCORD_API_BASE="https://discord.com/api/v10"
+API_BASE="$DISCORD_API_BASE"
 
 # --- Hardcoded defaults (Oak and Wave — last-resort fallback) -----------------
 _DEFAULT_GUILD_ID="1486516321385578576"
@@ -81,6 +82,34 @@ discord_token_path() { discord_config_get '.token_path' 'DISCORD_TOKEN_PATH' "$_
 discord_channel_default() { discord_config_get '.channels.default.id' 'DISCORD_DEFAULT_CHANNEL' "$_DEFAULT_CHANNEL_DEFAULT"; }
 discord_channel_roll_call() { discord_config_get '.channels["roll-call"].id' 'DISCORD_ROLL_CALL_CHANNEL' "$_DEFAULT_CHANNEL_ROLL_CALL"; }
 discord_channel_wave_status() { discord_config_get '.channels["wave-status"].id' 'DISCORD_WAVE_STATUS_CHANNEL' "$_DEFAULT_CHANNEL_WAVE_STATUS"; }
+
+# --- Scream-hole URL resolution -----------------------------------------------
+# Fallback chain: discord.json → SCREAM_HOLE_URL env → disabled (empty)
+discord_scream_hole_url() { discord_config_get '.scream_hole_url' 'SCREAM_HOLE_URL' ""; }
+
+_resolve_api_base() {
+	local scream_hole_url
+	scream_hole_url=$(discord_scream_hole_url)
+	if [[ -z "$scream_hole_url" ]]; then
+		return
+	fi
+
+	# Strip trailing slashes
+	scream_hole_url="${scream_hole_url%/}"
+
+	# Health check — 5s timeout
+	local health_status
+	health_status=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${scream_hole_url}/health" 2>/dev/null) || health_status="000"
+
+	if [[ "$health_status" =~ ^2 ]]; then
+		API_BASE="$scream_hole_url"
+		echo "[discord-bot] Mode: scream-hole proxy (${API_BASE})" >&2
+	else
+		echo "[discord-bot] Warning: scream-hole at ${scream_hole_url} is unreachable (HTTP ${health_status}), falling back to direct Discord API" >&2
+	fi
+}
+
+_resolve_api_base
 
 # --- Usage --------------------------------------------------------------------
 usage() {


### PR DESCRIPTION
## Summary

Adds scream-hole caching proxy support to cc-workflow's Discord integration. When `scream_hole_url` is configured, discord-bot routes all Discord REST API calls through the proxy with startup health check and graceful fallback.

## Changes

- **docs/discord-config.md** — Added `scream_hole_url` to schema example, field table, env var table. New "Scream-Hole Proxy" section explaining architecture and fallback behavior, with link to the scream-hole repo.
- **skills/disc/discord-bot** — Added `discord_scream_hole_url()` accessor, `_resolve_api_base()` with 5s health check, startup resolution. All existing API calls automatically use resolved base URL.

## Test Plan

- `shellcheck skills/disc/discord-bot` — clean
- Backwards compatible: no behavior change when `scream_hole_url` not configured

Ref: Wave-Engineering/scream-hole#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)