### PR TITLE
chore(skills): hide introduction-gate marker files with dot prefix

### DIFF
--- a/skills/assesswaves/SKILL.md
+++ b/skills/assesswaves/SKILL.md
@@ -4,8 +4,8 @@ description: Quick assessment of whether a piece of work is suitable for wave-pa
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-assesswaves does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-assesswaves
+     the marker file /tmp/.skill-intro-assesswaves does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-assesswaves
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/ccfold/SKILL.md
+++ b/skills/ccfold/SKILL.md
@@ -4,8 +4,8 @@ description: Merge upstream CLAUDE.md template changes into the current project'
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-ccfold does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-ccfold
+     the marker file /tmp/.skill-intro-ccfold does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-ccfold
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -4,8 +4,8 @@ description: Onboarding hub — tour the kit, run labs, configure integrations
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-ccwork does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-ccwork
+     the marker file /tmp/.skill-intro-ccwork does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-ccwork
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/cryo/SKILL.md
+++ b/skills/cryo/SKILL.md
@@ -4,8 +4,8 @@ description: Cryogenically preserve session state before context compaction — 
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-cryo does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-cryo
+     the marker file /tmp/.skill-intro-cryo does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-cryo
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/cryopact/SKILL.md
+++ b/skills/cryopact/SKILL.md
@@ -4,8 +4,8 @@ description: Background cryo via subagent — keep working, append delta, compac
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-cryopact does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-cryopact
+     the marker file /tmp/.skill-intro-cryopact does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-cryopact
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/ddd/SKILL.md
+++ b/skills/ddd/SKILL.md
@@ -4,8 +4,8 @@ description: Domain-Driven Design facilitation — event storming, domain modeli
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-ddd does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-ddd
+     the marker file /tmp/.skill-intro-ddd does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-ddd
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -4,8 +4,8 @@ description: Send/read messages and manage channels on the Oak and Wave Discord 
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-disc does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-disc
+     the marker file /tmp/.skill-intro-disc does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-disc
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/edit/SKILL.md
+++ b/skills/edit/SKILL.md
@@ -4,8 +4,8 @@ description: Open a file or URL in a GUI editor (modification intent, async)
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-edit does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-edit
+     the marker file /tmp/.skill-intro-edit does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-edit
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/engage/SKILL.md
+++ b/skills/engage/SKILL.md
@@ -4,8 +4,8 @@ description: Read CLAUDE.md, confirm development rules of engagement, and load c
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-engage does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-engage
+     the marker file /tmp/.skill-intro-engage does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-engage
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/ibm/SKILL.md
+++ b/skills/ibm/SKILL.md
@@ -4,8 +4,8 @@ description: Reminder to follow Issue → Branch → PR/MR workflow for the curr
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-ibm does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-ibm
+     the marker file /tmp/.skill-intro-ibm does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-ibm
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -4,8 +4,8 @@ description: Create structured issues (feature, bug, chore, docs, epic) with pro
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-issue does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-issue
+     the marker file /tmp/.skill-intro-issue does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-issue
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/jfail/SKILL.md
+++ b/skills/jfail/SKILL.md
@@ -4,8 +4,8 @@ description: Fetch and analyze a failed CI job (GitLab) or workflow run (GitHub)
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-jfail does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-jfail
+     the marker file /tmp/.skill-intro-jfail does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-jfail
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/mmr/SKILL.md
+++ b/skills/mmr/SKILL.md
@@ -4,8 +4,8 @@ description: Merge a PR/MR with squash and source branch deletion
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-mmr does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-mmr
+     the marker file /tmp/.skill-intro-mmr does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-mmr
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/name/SKILL.md
+++ b/skills/name/SKILL.md
@@ -4,8 +4,8 @@ description: Report or pick the agent's session identity (Dev-Name, Dev-Avatar, 
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-name does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-name
+     the marker file /tmp/.skill-intro-name does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-name
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/nerf/SKILL.md
+++ b/skills/nerf/SKILL.md
@@ -4,8 +4,8 @@ description: Context budget system with soft limits, doom modes, and scope monit
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-nerf does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-nerf
+     the marker file /tmp/.skill-intro-nerf does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-nerf
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -4,8 +4,8 @@ description: Execute the next pending wave of parallel spec-driven sub-agents on
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-nextwave does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-nextwave
+     the marker file /tmp/.skill-intro-nextwave does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-nextwave
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/ping/SKILL.md
+++ b/skills/ping/SKILL.md
@@ -4,8 +4,8 @@ description: Send a message to #ai-dev as this Claude Code agent. Reads agent id
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-ping does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-ping
+     the marker file /tmp/.skill-intro-ping does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-ping
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/pong/SKILL.md
+++ b/skills/pong/SKILL.md
@@ -4,8 +4,8 @@ description: Read recent messages from #ai-dev. Shows what other Claude Code age
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-pong does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-pong
+     the marker file /tmp/.skill-intro-pong does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-pong
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -4,8 +4,8 @@ description: Pre-commit gate — verify branch/issue, run code-reviewer, present
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-precheck does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-precheck
+     the marker file /tmp/.skill-intro-precheck does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-precheck
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -4,8 +4,8 @@ description: Analyze a master issue, validate sub-issue specs, compute dependenc
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-prepwaves does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-prepwaves
+     the marker file /tmp/.skill-intro-prepwaves does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-prepwaves
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -4,8 +4,8 @@ description: Run a code review on staged changes, branch diff, or a specific fil
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-review does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-review
+     the marker file /tmp/.skill-intro-review does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-review
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/scp/SKILL.md
+++ b/skills/scp/SKILL.md
@@ -4,8 +4,8 @@ description: Approve and execute pending commit, or run full stage/commit/push w
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-scp does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-scp
+     the marker file /tmp/.skill-intro-scp does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-scp
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/scpmmr/SKILL.md
+++ b/skills/scpmmr/SKILL.md
@@ -4,8 +4,8 @@ description: Stage, commit, push, create PR/MR, then merge it — full pipeline 
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-scpmmr does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-scpmmr
+     the marker file /tmp/.skill-intro-scpmmr does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-scpmmr
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/scpmr/SKILL.md
+++ b/skills/scpmr/SKILL.md
@@ -4,8 +4,8 @@ description: Stage, commit, push, and create PR/MR — but do not merge
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-scpmr does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-scpmr
+     the marker file /tmp/.skill-intro-scpmr does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-scpmr
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/view/SKILL.md
+++ b/skills/view/SKILL.md
@@ -4,8 +4,8 @@ description: Open a file or URL in a GUI viewer (read-only intent, async)
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-view does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-view
+     the marker file /tmp/.skill-intro-view does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-view
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 

--- a/skills/vox/SKILL.md
+++ b/skills/vox/SKILL.md
@@ -4,8 +4,8 @@ description: Speak to the user via text-to-speech — one-way voice announcement
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
-     the marker file /tmp/skill-intro-vox does NOT exist, read introduction.md,
-     present its contents to the user, then create the marker: touch /tmp/skill-intro-vox
+     the marker file /tmp/.skill-intro-vox does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-vox
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 


### PR DESCRIPTION
## Summary

Prefix all `/tmp/skill-intro-*` marker files with a dot so they become hidden files and don't clutter `/tmp` listings.

## Changes

- 26 `skills/*/SKILL.md` files: `/tmp/skill-intro-<name>` → `/tmp/.skill-intro-<name>`

## Linked Issues

Closes #210

## Test Plan

- Validation passed (72/72)
- Verified 0 old-pattern references remain (`grep -r '/tmp/skill-intro-' skills/` = empty)
- Verified 52 new-pattern references across 26 files (2 per file: existence check + touch)