### PR TITLE
feat(skills): /man command for skill usage display via frontmatter

### DIFF
--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: disc
 description: Send/read messages and manage channels on the Oak and Wave Discord server
+usage: |
+  /disc send #channel "message"  Send a message to a channel
+  /disc read #channel            Read recent messages from a channel
+  /disc create #channel-name     Create a new text channel
+  /disc thread "name" in #ch     Create a thread in a channel
+  /disc list channels            List all channels
+  /disc                          Post check-in to #roll-call
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: issue
 description: Create structured issues (feature, bug, chore, docs, epic) with proper templates and labels. Supports both GitHub (gh) and GitLab (glab). Self-contained — does not depend on CLAUDE.md for templates.
+usage: |
+  /issue feature <prompt>  Create a feature issue
+  /issue bug <prompt>      Create a bug issue
+  /issue chore <prompt>    Create a chore issue
+  /issue docs <prompt>     Create a docs issue
+  /issue epic <prompt>     Create an epic issue
+  /issue <prompt>          Infer type from the prompt
+  /issue                   Infer from recent conversation context
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND

--- a/skills/man/SKILL.md
+++ b/skills/man/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: man
+description: Display usage information for any installed skill
+usage: |
+  /man <skill>     Show usage for a skill
+  /man             List all installed skills with descriptions
+---
+
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-man does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-man
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
+# Man: Skill Usage Display
+
+Display usage information for installed skills. Reads the `usage` field from
+SKILL.md frontmatter for fast structured output. Falls back to interpreting the
+full skill file when no `usage` frontmatter exists.
+
+## Execution
+
+### `/man <skill>` — Show usage for a specific skill
+
+1. **Resolve skill path:**
+   ```
+   ~/.claude/skills/<skill>/SKILL.md
+   ```
+   If the file does not exist, report: `No skill found: <skill>`
+
+2. **Read the SKILL.md file.**
+
+3. **Extract frontmatter** — parse the YAML block between the opening and
+   closing `---` delimiters. Pull out `name`, `description`, and `usage`.
+
+4. **If `usage` field exists**, display:
+
+   ```
+   <name> — <description>
+
+   Usage:
+     <usage content, indented 2 spaces>
+   ```
+
+5. **If `usage` field is absent**, interpret usage from the full file:
+   - Look for a `## Subcommands`, `## Usage`, or similar section
+   - Extract the command table or usage patterns
+   - Summarize into a CLI-style help block
+   - Append: `(No usage frontmatter — interpreted from SKILL.md)`
+
+### `/man` — List all installed skills
+
+1. **Scan** `~/.claude/skills/*/SKILL.md`
+2. **Extract** `name` and `description` from each file's frontmatter
+3. **Display** as a formatted table, sorted alphabetically:
+
+   ```
+   Installed Skills
+   ────────────────────────────────────────
+   assesswaves   Quick assessment of wave-pattern suitability
+   ccfold        Merge upstream CLAUDE.md template changes
+   cryo          Cryogenically preserve session state
+   ...
+   ```
+
+## Important
+
+- **Do NOT invoke the target skill.** `/man nerf` reads the file — it does not
+  run `/nerf`. This is a read-only operation.
+- **Keep output concise.** The whole point is to avoid loading the full skill
+  into context. Don't dump the entire SKILL.md.
+- **Frontmatter `usage` field format** is a multi-line string showing invocation
+  patterns, one per line, CLI-style. No markdown formatting — plain text.

--- a/skills/man/introduction.md
+++ b/skills/man/introduction.md
@@ -1,0 +1,12 @@
+## /man — Skill Manual Pages
+
+A nod to Unix `man`. Quick usage reference for any installed skill without
+loading the full skill into context.
+
+```
+/man <skill>     Show usage for a skill
+/man             List all installed skills
+```
+
+Skills with a `usage` field in their SKILL.md frontmatter get fast structured
+output. Skills without it get an interpreted summary.

--- a/skills/nerf/SKILL.md
+++ b/skills/nerf/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: nerf
 description: Context budget system with soft limits, doom modes, and scope monitor
+usage: |
+  /nerf                          Show status (mode, darts, context usage)
+  /nerf status                   Same as /nerf
+  /nerf mode                     Show current behavior mode
+  /nerf mode <mode>              Set mode: not-too-rough | hurt-me-plenty | ultraviolence
+  /nerf darts                    Show current dart thresholds
+  /nerf darts <soft> <hard> <o>  Set all three dart thresholds (e.g. 150k 180k 200k)
+  /nerf <limit>                  Set ouch dart, scale soft/hard proportionally
+  /nerf scope                    Launch context monitor in new terminal
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND


### PR DESCRIPTION
## Summary

Adds `/man <skill>` for quick usage reference without loading the full skill into context. Reads `usage` field from SKILL.md frontmatter for structured output, falls back to interpretation when absent.

## Changes

- New `skills/man/SKILL.md` — skill logic for `/man <skill>` and `/man` (list mode)
- New `skills/man/introduction.md` — first-use intro
- `skills/nerf/SKILL.md` — added `usage` frontmatter (8 subcommands)
- `skills/disc/SKILL.md` — added `usage` frontmatter (6 intents)
- `skills/issue/SKILL.md` — added `usage` frontmatter (7 type variants)

## Linked Issues

Closes #215

## Test Plan

- Validation passed (73/73)
- YAML frontmatter validated via `python3 yaml.safe_load` on all 4 modified files
- Code review: 2 findings fixed (missing `/nerf darts` no-args, false `/disc check response` entry)