### PR TITLE
feat(install): register nerf-server in MCP manifest

### DIFF
--- a/mcps.json
+++ b/mcps.json
@@ -9,6 +9,11 @@
       "repo": "Wave-Engineering/mcp-server-discord-watcher",
       "install_url": "https://raw.githubusercontent.com/Wave-Engineering/mcp-server-discord-watcher/main/scripts/install-remote.sh",
       "description": "Discord channel notification server"
+    },
+    "nerf-server": {
+      "repo": "Wave-Engineering/mcp-server-nerf",
+      "install_url": "https://raw.githubusercontent.com/Wave-Engineering/mcp-server-nerf/main/scripts/install-remote.sh",
+      "description": "Deterministic context budget management (nerf darts, modes, statusline)"
     }
   }
 }


### PR DESCRIPTION
## Summary

Add `nerf-server` entry to `mcps.json` so `install.sh --mcps` picks it up alongside the existing MCP servers. Points to the remote installer at `mcp-server-nerf/main/scripts/install-remote.sh`.

## Changes

- **Modified:** `mcps.json` — added `nerf-server` entry with repo URL, install URL, and description

## Test Results

`jq .` validates JSON syntax. `jq -r '.mcps | keys[]'` shows `nerf-server` in the manifest. No code changes to `install.sh` needed (manifest-driven).

Closes #225

Generated with [Claude Code](https://claude.com/claude-code)