### PR TITLE
chore(crystallizer): bring context-crystallizer into repo and wire install.sh

### DIFF
--- a/context-crystallizer/bin/cc-cleanup
+++ b/context-crystallizer/bin/cc-cleanup
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# cc-cleanup - Clean up old crystallized state files
+# Usage: cc-cleanup [days] [--dry-run]
+#
+# Keeps the most recent state file and removes those older than N days (default: 7)
+
+set -uo pipefail
+
+DAYS="${1:-7}"
+DRY_RUN=false
+
+if [[ "${2:-}" == "--dry-run" ]] || [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=true
+    [[ "${1:-}" == "--dry-run" ]] && DAYS=7
+fi
+
+CLAUDE_DIR="${HOME}/.claude"
+
+echo "Context Crystallizer Cleanup"
+echo "============================"
+echo "Retention: ${DAYS} days"
+echo "Dry run: ${DRY_RUN}"
+echo ""
+
+# Find all project directories
+PROJECTS=$(find "$CLAUDE_DIR/projects" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+
+TOTAL_REMOVED=0
+TOTAL_KEPT=0
+
+for PROJECT in $PROJECTS; do
+    STATES_DIR="${PROJECT}/.claude/context-states"
+    
+    if [[ ! -d "$STATES_DIR" ]]; then
+        continue
+    fi
+    
+    PROJECT_NAME=$(basename "$PROJECT")
+    echo "Project: ${PROJECT_NAME}"
+    
+    # Find old state files
+    OLD_FILES=$(find "$STATES_DIR" -name "context-state-*.md" -type f -mtime +${DAYS} 2>/dev/null)
+    CURRENT_FILES=$(find "$STATES_DIR" -name "context-state-*.md" -type f -mtime -${DAYS} 2>/dev/null | wc -l)
+    
+    if [[ -z "$OLD_FILES" ]]; then
+        echo "  No old files to remove (${CURRENT_FILES} current files)"
+        TOTAL_KEPT=$((TOTAL_KEPT + CURRENT_FILES))
+        continue
+    fi
+    
+    COUNT=0
+    while IFS= read -r FILE; do
+        if [[ -n "$FILE" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+                echo "  Would remove: $(basename "$FILE")"
+            else
+                rm -f "$FILE"
+                echo "  Removed: $(basename "$FILE")"
+            fi
+            COUNT=$((COUNT + 1))
+        fi
+    done <<< "$OLD_FILES"
+    
+    TOTAL_REMOVED=$((TOTAL_REMOVED + COUNT))
+    TOTAL_KEPT=$((TOTAL_KEPT + CURRENT_FILES))
+    echo "  Removed: ${COUNT}, Kept: ${CURRENT_FILES}"
+done
+
+echo ""
+echo "Summary"
+echo "-------"
+echo "Total removed: ${TOTAL_REMOVED}"
+echo "Total kept: ${TOTAL_KEPT}"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    echo "(Dry run - no files were actually removed)"
+fi

--- a/context-crystallizer/bin/cc-context
+++ b/context-crystallizer/bin/cc-context
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# cc-context - CLI tool to check Claude Code context status
+# Usage: cc-context [watch] [--log]
+#
+# Features:
+#   - Reverse search (tac) for fast most-recent lookup
+#   - Filters for MAIN agent only (ignores subagent progress messages)
+#   - Caching: shows last known value if fresh data unavailable
+#   - Stale indicator: visual marker when using cached data
+#   - Optional logging: --log to record stale events for debugging
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HISTORY_FILE="${HOME}/.claude/history.jsonl"
+PROJECTS_DIR="${HOME}/.claude/projects"
+
+# Configuration
+CONTEXT_LIMIT="${CONTEXT_LIMIT:-200000}"
+WARN_THRESHOLD="${WARN_THRESHOLD:-70}"
+DANGER_THRESHOLD="${DANGER_THRESHOLD:-85}"
+CRITICAL_THRESHOLD="${CRITICAL_THRESHOLD:-92}"
+
+# Calibration: Our token count appears ~15% lower than Claude Code's native meter
+# This offset aligns our percentage with CC's "Context left until auto-compact"
+CALIBRATION_OFFSET="${CALIBRATION_OFFSET:-15}"
+
+# Cache and logging
+CACHE_FILE="/tmp/cc-context-cache.$$"
+STALE_LOG="${HOME}/.claude/cc-context-stale.log"
+
+# ANSI colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Parse arguments
+MODE="once"
+LOG_MODE=false
+SESSION_ID=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        watch) MODE="watch"; shift ;;
+        --log) LOG_MODE=true; shift ;;
+        --session)
+            if [[ -n "${2:-}" ]]; then
+                SESSION_ID="$2"
+                shift 2
+            else
+                echo "Error: --session requires a session ID argument" >&2
+                exit 1
+            fi
+            ;;
+        -h|--help)
+            echo "Usage: cc-context [watch] [--session <session_id>] [--log]"
+            echo ""
+            echo "Options:"
+            echo "  watch                   - Continuous monitoring mode (updates every 5s)"
+            echo "  --session <session_id>  - Monitor a specific session by ID"
+            echo "  --log                   - Log stale data events to ~/.claude/cc-context-stale.log"
+            echo ""
+            echo "Environment variables:"
+            echo "  CONTEXT_LIMIT      - Context window size (default: 200000)"
+            echo "  WARN_THRESHOLD     - Warning threshold % (default: 70)"
+            echo "  DANGER_THRESHOLD   - Danger threshold % (default: 85)"
+            echo "  CRITICAL_THRESHOLD - Critical threshold % (default: 92)"
+            exit 0
+            ;;
+        *) shift ;;
+    esac
+done
+
+# Cleanup cache on exit
+cleanup() {
+    rm -f "$CACHE_FILE" 2>/dev/null
+}
+trap cleanup EXIT
+
+find_session_by_id() {
+    # Resolve transcript for a specific session ID
+    local SID="$1"
+
+    if [[ -z "$SID" ]]; then
+        echo ""
+        return
+    fi
+
+    # Direct lookup: search all project directories for <session_id>.jsonl
+    local TRANSCRIPT
+    TRANSCRIPT=$(find "$PROJECTS_DIR" -name "${SID}.jsonl" -type f 2>/dev/null | head -1)
+
+    echo "$TRANSCRIPT"
+}
+
+find_current_session() {
+    # If --session was provided, use direct lookup
+    if [[ -n "$SESSION_ID" ]]; then
+        find_session_by_id "$SESSION_ID"
+        return
+    fi
+
+    # Get the most recent session from history
+    if [[ ! -f "$HISTORY_FILE" ]]; then
+        echo ""
+        return
+    fi
+
+    local LAST_ENTRY
+    LAST_ENTRY=$(tail -1 "$HISTORY_FILE" 2>/dev/null)
+
+    if [[ -z "$LAST_ENTRY" ]]; then
+        echo ""
+        return
+    fi
+
+    local SID PROJECT_PATH
+    SID=$(echo "$LAST_ENTRY" | jq -r '.sessionId // empty')
+    PROJECT_PATH=$(echo "$LAST_ENTRY" | jq -r '.project // empty')
+
+    if [[ -z "$SID" || -z "$PROJECT_PATH" ]]; then
+        echo ""
+        return
+    fi
+
+    # Convert project path to folder name (replace / with -)
+    local PROJECT_SLUG="${PROJECT_PATH//\//-}"
+    PROJECT_SLUG="${PROJECT_SLUG#-}"  # Remove leading dash
+
+    local TRANSCRIPT="${PROJECTS_DIR}/-${PROJECT_SLUG}/${SID}.jsonl"
+
+    # Also try without the leading dash
+    if [[ ! -f "$TRANSCRIPT" ]]; then
+        TRANSCRIPT="${PROJECTS_DIR}/${PROJECT_SLUG}/${SID}.jsonl"
+    fi
+
+    # Try finding by session ID directly
+    if [[ ! -f "$TRANSCRIPT" ]]; then
+        TRANSCRIPT=$(find "$PROJECTS_DIR" -name "${SID}.jsonl" -type f 2>/dev/null | head -1)
+    fi
+
+    echo "$TRANSCRIPT"
+}
+
+log_stale_event() {
+    local reason="$1"
+    local transcript="$2"
+    
+    if [[ "$LOG_MODE" != "true" ]]; then
+        return
+    fi
+    
+    local timestamp file_size line_count last_modified
+    timestamp=$(date -Iseconds)
+    file_size=$(stat -c%s "$transcript" 2>/dev/null || echo "unknown")
+    line_count=$(wc -l < "$transcript" 2>/dev/null || echo "unknown")
+    last_modified=$(stat -c%Y "$transcript" 2>/dev/null || echo "unknown")
+    
+    echo "[${timestamp}] STALE: ${reason} | Transcript: $(basename "$transcript") | Size: ${file_size} | Lines: ${line_count} | ModTime: ${last_modified}" >> "$STALE_LOG"
+}
+
+analyze_transcript() {
+    local TRANSCRIPT="$1"
+    local IS_STALE="false"
+    
+    if [[ ! -f "$TRANSCRIPT" ]]; then
+        echo '{"error": "not found", "stale": false}'
+        return
+    fi
+    
+    # Use tac to search from END of file
+    # CRITICAL: Filter for REAL model messages (claude-sonnet), not synthetic placeholders
+    # Synthetic messages have model:"<synthetic>" with all-zero usage data
+    local USAGE_LINE
+    USAGE_LINE=$(tac "$TRANSCRIPT" 2>/dev/null | grep -m1 '"model":"claude-sonnet[^"]*".*"usage"' || echo "")
+    
+    if [[ -z "$USAGE_LINE" ]]; then
+        # No usage found - try cache
+        if [[ -f "$CACHE_FILE" ]]; then
+            local CACHED
+            CACHED=$(cat "$CACHE_FILE" 2>/dev/null)
+            if [[ -n "$CACHED" && "$CACHED" != '{"tokens": 0'* ]]; then
+                log_stale_event "No main agent usage found in transcript" "$TRANSCRIPT"
+                echo "$CACHED" | jq -c '. + {"stale": true}'
+                return
+            fi
+        fi
+        log_stale_event "No main agent usage found and no valid cache" "$TRANSCRIPT"
+        echo '{"tokens": 0, "percent": 0, "action": "unknown", "stale": true}'
+        return
+    fi
+    
+    # Extract usage - it's at .message.usage for main agent messages
+    local USAGE
+    USAGE=$(echo "$USAGE_LINE" | jq -c '.message.usage // empty' 2>/dev/null || echo "")
+    
+    if [[ -z "$USAGE" || "$USAGE" == "null" ]]; then
+        # Parse error - try cache
+        if [[ -f "$CACHE_FILE" ]]; then
+            local CACHED
+            CACHED=$(cat "$CACHE_FILE" 2>/dev/null)
+            if [[ -n "$CACHED" && "$CACHED" != '{"tokens": 0'* ]]; then
+                log_stale_event "Failed to parse main agent usage" "$TRANSCRIPT"
+                echo "$CACHED" | jq -c '. + {"stale": true}'
+                return
+            fi
+        fi
+        log_stale_event "Parse error and no valid cache" "$TRANSCRIPT"
+        echo '{"tokens": 0, "percent": 0, "action": "unknown", "stale": true}'
+        return
+    fi
+    
+    local INPUT CACHE_CREATE CACHE_READ TOTAL PERCENT ACTION
+    INPUT=$(echo "$USAGE" | jq -r '.input_tokens // 0')
+    CACHE_CREATE=$(echo "$USAGE" | jq -r '.cache_creation_input_tokens // 0')
+    CACHE_READ=$(echo "$USAGE" | jq -r '.cache_read_input_tokens // 0')
+    
+    TOTAL=$((INPUT + CACHE_CREATE + CACHE_READ))
+    RAW_PERCENT=$(echo "scale=1; ($TOTAL * 100) / $CONTEXT_LIMIT" | bc)
+    # Apply calibration offset to align with Claude Code's native meter
+    PERCENT=$(echo "scale=1; $RAW_PERCENT + $CALIBRATION_OFFSET" | bc)
+    
+    if (( $(echo "$PERCENT >= $CRITICAL_THRESHOLD" | bc -l) )); then
+        ACTION="critical"
+    elif (( $(echo "$PERCENT >= $DANGER_THRESHOLD" | bc -l) )); then
+        ACTION="danger"
+    elif (( $(echo "$PERCENT >= $WARN_THRESHOLD" | bc -l) )); then
+        ACTION="warn"
+    else
+        ACTION="ok"
+    fi
+    
+    local RESULT="{\"tokens\": $TOTAL, \"percent\": $PERCENT, \"action\": \"$ACTION\", \"stale\": false}"
+    
+    # Cache valid result
+    echo "$RESULT" > "$CACHE_FILE"
+    
+    echo "$RESULT"
+}
+
+load_nerf_config() {
+    # Load nerf config for the current session (if available)
+    # Sets global variables: NERF_MODE, NERF_SOFT, NERF_HARD, NERF_OUCH, NERF_ACTIVE
+    NERF_ACTIVE=false
+    NERF_MODE="hurt-me-plenty"
+    NERF_SOFT=150000
+    NERF_HARD=180000
+    NERF_OUCH=200000
+
+    local SID="$1"
+    if [[ -z "$SID" ]]; then
+        return
+    fi
+
+    local NERF_CONFIG="/tmp/nerf-${SID}.json"
+    if [[ ! -f "$NERF_CONFIG" ]]; then
+        return
+    fi
+
+    NERF_ACTIVE=true
+    NERF_MODE=$(jq -r '.mode // "hurt-me-plenty"' "$NERF_CONFIG" 2>/dev/null || echo "hurt-me-plenty")
+    NERF_SOFT=$(jq -r '.darts.soft // 150000' "$NERF_CONFIG" 2>/dev/null || echo 150000)
+    NERF_HARD=$(jq -r '.darts.hard // 180000' "$NERF_CONFIG" 2>/dev/null || echo 180000)
+    NERF_OUCH=$(jq -r '.darts.ouch // 200000' "$NERF_CONFIG" 2>/dev/null || echo 200000)
+
+    # Override CONTEXT_LIMIT with the nerf'd budget
+    CONTEXT_LIMIT="$NERF_OUCH"
+
+    # Recalculate thresholds as percentages of the nerf'd budget
+    if [[ "$NERF_OUCH" -gt 0 ]]; then
+        WARN_THRESHOLD=$(echo "scale=0; ($NERF_SOFT * 100) / $NERF_OUCH" | bc 2>/dev/null || echo 70)
+        DANGER_THRESHOLD=$(echo "scale=0; ($NERF_HARD * 100) / $NERF_OUCH" | bc 2>/dev/null || echo 85)
+        CRITICAL_THRESHOLD=92
+    fi
+}
+
+format_tokens() {
+    # Format token count for display (e.g., 150000 -> "150k")
+    local val="$1"
+    if [[ "$val" -ge 1000000 ]]; then
+        echo "$(echo "scale=0; $val / 1000000" | bc)M"
+    elif [[ "$val" -ge 1000 ]]; then
+        echo "$(echo "scale=0; $val / 1000" | bc)k"
+    else
+        echo "$val"
+    fi
+}
+
+display_status() {
+    local TRANSCRIPT="$1"
+    local ANALYSIS="$2"
+
+    local TOKENS PERCENT ACTION IS_STALE
+    TOKENS=$(echo "$ANALYSIS" | jq -r '.tokens // 0')
+    PERCENT=$(echo "$ANALYSIS" | jq -r '.percent // 0')
+    ACTION=$(echo "$ANALYSIS" | jq -r '.action // "unknown"')
+    IS_STALE=$(echo "$ANALYSIS" | jq -r '.stale // false')
+
+    local COLOR STATUS_ICON STALE_MARKER
+    case "$ACTION" in
+        "ok") COLOR=$GREEN; STATUS_ICON="✅" ;;
+        "warn") COLOR=$YELLOW; STATUS_ICON="⚠️ " ;;
+        "danger") COLOR=$YELLOW; STATUS_ICON="🔶" ;;
+        "critical") COLOR=$RED; STATUS_ICON="🚨" ;;
+        *) COLOR=$BLUE; STATUS_ICON="❓" ;;
+    esac
+
+    # Stale indicator
+    if [[ "$IS_STALE" == "true" ]]; then
+        STALE_MARKER="${RED}*${NC}"
+    else
+        STALE_MARKER=" "
+    fi
+
+    # Resolve session ID for nerf config lookup
+    local DISPLAY_SID="$SESSION_ID"
+    if [[ -z "$DISPLAY_SID" ]]; then
+        DISPLAY_SID=$(basename "$TRANSCRIPT" .jsonl 2>/dev/null || echo "")
+    fi
+
+    # Load nerf config if available
+    load_nerf_config "$DISPLAY_SID"
+
+    clear
+    echo -e "${COLOR}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${COLOR}║${NC}${BOLD}     Claude Code Context Monitor ${STATUS_ICON}                   ${STALE_MARKER}${COLOR}║${NC}"
+    echo -e "${COLOR}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo -e "  Session: ${BLUE}$(basename "$TRANSCRIPT" .jsonl 2>/dev/null || echo "unknown")${NC}"
+
+    if [[ "$NERF_ACTIVE" == "true" ]]; then
+        local BUDGET_DISPLAY
+        BUDGET_DISPLAY=$(format_tokens "$NERF_OUCH")
+        echo -e "  Budget:  ${BOLD}${BUDGET_DISPLAY}${NC} tokens (real window: 1M)  ${DIM}mode: ${NERF_MODE}${NC}"
+        echo -e "  Tokens:  ${BOLD}${TOKENS}${NC} / ${NERF_OUCH}"
+    else
+        echo -e "  Tokens:  ${BOLD}${TOKENS}${NC} / ${CONTEXT_LIMIT}"
+    fi
+
+    # Show stale warning on usage line if stale
+    if [[ "$IS_STALE" == "true" ]]; then
+        echo -e "  Usage:   ${COLOR}${BOLD}${PERCENT}%${NC} ${DIM}(cached - waiting for fresh data)${NC}"
+    else
+        echo -e "  Usage:   ${COLOR}${BOLD}${PERCENT}%${NC}"
+    fi
+    echo ""
+
+    # Progress bar
+    local BAR_WIDTH=50
+    local FILLED=$(echo "scale=0; ($PERCENT * $BAR_WIDTH) / 100" | bc 2>/dev/null || echo 0)
+    local EMPTY=$((BAR_WIDTH - FILLED))
+
+    printf "  ["
+    printf "${COLOR}%${FILLED}s${NC}" | tr ' ' '█' 2>/dev/null || true
+    printf "%${EMPTY}s" | tr ' ' '░' 2>/dev/null || true
+    printf "]"
+    echo ""
+    echo ""
+
+    # Threshold markers — use dart names when nerf is active
+    if [[ "$NERF_ACTIVE" == "true" ]]; then
+        local SOFT_DISPLAY HARD_DISPLAY OUCH_DISPLAY
+        SOFT_DISPLAY=$(format_tokens "$NERF_SOFT")
+        HARD_DISPLAY=$(format_tokens "$NERF_HARD")
+        OUCH_DISPLAY=$(format_tokens "$NERF_OUCH")
+        echo -e "  Darts: ${GREEN}OK${NC} < ${YELLOW}soft ${SOFT_DISPLAY}${NC} < ${YELLOW}hard ${HARD_DISPLAY}${NC} < ${RED}ouch ${OUCH_DISPLAY}${NC}"
+    else
+        echo -e "  Thresholds: ${GREEN}OK${NC} < ${WARN_THRESHOLD}% < ${YELLOW}WARN${NC} < ${DANGER_THRESHOLD}% < ${YELLOW}DANGER${NC} < ${CRITICAL_THRESHOLD}% < ${RED}CRITICAL${NC}"
+    fi
+    echo ""
+
+    case "$ACTION" in
+        "warn")
+            echo -e "  ${YELLOW}Consider crystallizing state soon.${NC}"
+            ;;
+        "danger")
+            echo -e "  ${YELLOW}${BOLD}State should be auto-crystallizing now.${NC}"
+            echo -e "  ${YELLOW}Prepare to /clear when ready.${NC}"
+            ;;
+        "critical")
+            echo -e "  ${RED}${BOLD}⚡ AUTO-COMPACT IMMINENT!${NC}"
+            echo -e "  ${RED}Run /clear NOW to avoid lossy compaction!${NC}"
+            ;;
+    esac
+
+    # Stale data explanation
+    if [[ "$IS_STALE" == "true" ]]; then
+        echo ""
+        echo -e "  ${DIM}${RED}*${NC}${DIM} = Stale data (Claude may be mid-response or subagent active)${NC}"
+    fi
+
+    echo ""
+    echo -e "  ${BLUE}Press Ctrl+C to exit${NC}"
+}
+
+# Main
+main() {
+    if [[ "$MODE" == "watch" ]]; then
+        echo "Watching for Claude Code sessions... (Ctrl+C to exit)"
+        while true; do
+            TRANSCRIPT=$(find_current_session)
+            if [[ -n "$TRANSCRIPT" && -f "$TRANSCRIPT" ]]; then
+                ANALYSIS=$(analyze_transcript "$TRANSCRIPT")
+                display_status "$TRANSCRIPT" "$ANALYSIS"
+            else
+                clear
+                echo "No active Claude Code session found."
+                echo "Start a Claude Code session and this will update automatically."
+                echo ""
+                echo "Checking: ${HISTORY_FILE}"
+            fi
+            sleep 5
+        done
+    else
+        TRANSCRIPT=$(find_current_session)
+        if [[ -n "$TRANSCRIPT" && -f "$TRANSCRIPT" ]]; then
+            ANALYSIS=$(analyze_transcript "$TRANSCRIPT")
+            display_status "$TRANSCRIPT" "$ANALYSIS"
+        else
+            echo "No active Claude Code session found."
+            echo "Usage: $0 [watch] [--log]"
+            exit 1
+        fi
+    fi
+}
+
+main "$@"

--- a/context-crystallizer/bin/runme.sh
+++ b/context-crystallizer/bin/runme.sh
@@ -1,0 +1,18 @@
+# Find your transcript
+TRANSCRIPT=$(find ~/.claude/projects -name "*.jsonl" -type f -mmin -5 | head -1)
+
+# See if there are ANY lines with "type":"assistant" and "usage"
+echo "=== Lines matching our pattern ==="
+grep '"type":"assistant"' "$TRANSCRIPT" | grep '"usage"' | tail -3
+
+echo ""
+echo "=== Lines matching WITHOUT progress filter ==="
+grep '"type":"assistant".*"usage"' "$TRANSCRIPT" | tail -3
+
+echo ""
+echo "=== What tac + grep finds ==="
+tac "$TRANSCRIPT" | grep -m1 '"type":"assistant".*"usage"'
+
+echo ""
+echo "=== What tac + grep + progress filter finds ==="
+tac "$TRANSCRIPT" | grep -m1 '"type":"assistant".*"usage"' | grep -v '"type":"progress"'

--- a/context-crystallizer/hooks/DISABLE-pre-tool-use-blocking.sh
+++ b/context-crystallizer/hooks/DISABLE-pre-tool-use-blocking.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# pre-tool-use-blocking.sh - BLOCKS tool execution at critical context levels
+# Uses exit code 2 + stderr which DOES get shown to Claude
+#
+# This is aggressive - it will prevent Claude from using tools until context is cleared!
+
+set -uo pipefail
+
+CONTEXT_LIMIT="${CONTEXT_LIMIT:-200000}"
+WARN_THRESHOLD="${WARN_THRESHOLD:-70}"
+DANGER_THRESHOLD="${DANGER_THRESHOLD:-85}"
+CRITICAL_THRESHOLD="${CRITICAL_THRESHOLD:-92}"
+
+# Only block at critical? Set to "true" to allow tools at danger level
+BLOCK_ONLY_CRITICAL="${BLOCK_ONLY_CRITICAL:-false}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/../lib"
+STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude"
+LOG_FILE="${STATE_DIR}/crystallizer.log"
+
+source "${LIB_DIR}/context-analyzer.sh" 2>/dev/null || exit 0
+
+INPUT=$(cat)
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+    exit 0
+fi
+
+# Skip blocking for Read operations - let Claude read the state file!
+if [[ "$TOOL_NAME" == "Read" ]]; then
+    exit 0
+fi
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+mkdir -p "${STATE_DIR}/context-states" 2>/dev/null || true
+
+ANALYSIS=$(analyze_context "$TRANSCRIPT_PATH" "$CONTEXT_LIMIT" "$WARN_THRESHOLD" "$DANGER_THRESHOLD" "$CRITICAL_THRESHOLD")
+
+if [[ -z "$ANALYSIS" ]]; then
+    exit 0
+fi
+
+ACTION=$(echo "$ANALYSIS" | jq -r '.action // "none"')
+PERCENT=$(echo "$ANALYSIS" | jq -r '.percent // 0')
+TOTAL=$(echo "$ANALYSIS" | jq -r '.tokens.total // 0')
+
+SHORT_SESSION="${SESSION_ID:0:8}"
+echo "[$(date -Iseconds)] [${SHORT_SESSION}] [PreToolUse:${TOOL_NAME}:BLOCKING] Context: ${PERCENT}% Action: ${ACTION}" >> "$LOG_FILE" 2>/dev/null || true
+
+case "$ACTION" in
+    "none"|"warn")
+        # Allow tool to proceed
+        exit 0
+        ;;
+    
+    "crystallize")
+        if [[ "$BLOCK_ONLY_CRITICAL" == "true" ]]; then
+            exit 0
+        fi
+        
+        # Crystallize state
+        STATE_SUBDIR="${STATE_DIR}/context-states"
+        CRYSTAL_FILE=$("${LIB_DIR}/crystallizer.sh" "$TRANSCRIPT_PATH" "$STATE_SUBDIR" "${CLAUDE_PROJECT_DIR:-.}" "$SESSION_ID" 2>/dev/null || echo "")
+        
+        if [[ -n "$CRYSTAL_FILE" && -f "$CRYSTAL_FILE" ]]; then
+            ln -sf "$CRYSTAL_FILE" "${STATE_DIR}/context-state.md" 2>/dev/null || true
+        fi
+        
+        # BLOCK with exit 2 - stderr goes to Claude!
+        echo "🔶 CONTEXT DANGER: ${PERCENT}% (${TOTAL} tokens)
+
+Tool execution BLOCKED to prevent context overflow.
+
+State has been saved to: ${CRYSTAL_FILE:-${STATE_DIR}/context-state.md}
+
+To continue:
+1. Run /clear to reset context
+2. Then read ${STATE_DIR}/context-state.md to restore where we left off
+
+This block will lift after /clear." >&2
+        exit 2
+        ;;
+    
+    "critical")
+        # Crystallize state urgently
+        STATE_SUBDIR="${STATE_DIR}/context-states"
+        CRYSTAL_FILE=$("${LIB_DIR}/crystallizer.sh" "$TRANSCRIPT_PATH" "$STATE_SUBDIR" "${CLAUDE_PROJECT_DIR:-.}" "$SESSION_ID" 2>/dev/null || echo "")
+        
+        if [[ -n "$CRYSTAL_FILE" && -f "$CRYSTAL_FILE" ]]; then
+            ln -sf "$CRYSTAL_FILE" "${STATE_DIR}/context-state.md" 2>/dev/null || true
+        fi
+        
+        # BLOCK with exit 2
+        echo "🚨 CRITICAL: ${PERCENT}% - AUTO-COMPACT IMMINENT!
+
+Tool execution BLOCKED - context overflow imminent!
+
+State saved to: ${CRYSTAL_FILE:-${STATE_DIR}/context-state.md}
+
+⚡ IMMEDIATE ACTION REQUIRED:
+1. Run /clear RIGHT NOW
+2. Read ${STATE_DIR}/context-state.md to continue
+
+DO NOT attempt other operations - only /clear will work." >&2
+        exit 2
+        ;;
+esac
+
+exit 0

--- a/context-crystallizer/hooks/post-tool-use.sh
+++ b/context-crystallizer/hooks/post-tool-use.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# post-tool-use-hook.sh - Monitors context and triggers crystallization
+# This hook runs after every tool use and checks context utilization
+#
+# Edge cases handled:
+# - Multiple CC instances: Each gets correct transcript_path, state files include session ID
+# - Subagents: Detected via path pattern, monitored but don't trigger parent crystallization
+#
+# Modes (set via CRYSTALLIZE_MODE env var):
+# - manual:  Warn only, human decides everything (default)
+# - prompt:  Crystallize + ask Claude to present state and request user confirmation for /clear
+# - yolo:    Crystallize + instruct Claude to run /clear automatically
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Nerf config: session-scoped overrides for thresholds and mode
+# ---------------------------------------------------------------------------
+# If a nerf config exists for this session, read darts + mode from it.
+# Otherwise fall back to env vars / hardcoded defaults.
+#
+# The nerf config is written by the /nerf skill at:
+#   /tmp/nerf-<session_id>.json
+#
+# Format:
+#   { "mode": "hurt-me-plenty",
+#     "darts": { "soft": 150000, "hard": 180000, "ouch": 200000 },
+#     "session_id": "<id>" }
+# ---------------------------------------------------------------------------
+
+# Real context window — always 1M for Opus on the current plan
+REAL_CONTEXT_WINDOW="${REAL_CONTEXT_WINDOW:-1000000}"
+
+# Start with hardcoded defaults (overridden below if nerf config exists)
+_NERF_SOFT=150000
+_NERF_HARD=180000
+_NERF_OUCH=200000
+_NERF_MODE="hurt-me-plenty"
+
+# Configuration - adjust these thresholds as needed
+# CONTEXT_LIMIT is set to the nerf'd budget (ouch dart), NOT the real window
+CONTEXT_LIMIT="${CONTEXT_LIMIT:-200000}"
+WARN_THRESHOLD="${WARN_THRESHOLD:-60}"
+DANGER_THRESHOLD="${DANGER_THRESHOLD:-75}"
+CRITICAL_THRESHOLD="${CRITICAL_THRESHOLD:-85}"
+
+# Crystallization mode: manual, prompt, or yolo
+CRYSTALLIZE_MODE="${CRYSTALLIZE_MODE:-manual}"
+
+# Subagent thresholds (they have smaller context typically)
+SUBAGENT_WARN="${SUBAGENT_WARN:-60}"
+SUBAGENT_DANGER="${SUBAGENT_DANGER:-75}"
+
+# Paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/../lib"
+STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude"
+LOG_FILE="${STATE_DIR}/crystallizer.log"
+
+# Source libraries
+source "${LIB_DIR}/context-analyzer.sh" 2>/dev/null || {
+    # Fallback if not installed in expected location
+    source "$(dirname "$0")/../lib/context-analyzer.sh" 2>/dev/null || {
+        echo '{"error": "could not load context-analyzer.sh"}' >&2
+        exit 0  # Don't block on library errors
+    }
+}
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Extract transcript path and session ID from hook input
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+    # No transcript available, exit silently
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Read session nerf config (if it exists)
+# ---------------------------------------------------------------------------
+if [[ -n "$SESSION_ID" ]]; then
+    NERF_CONFIG="/tmp/nerf-${SESSION_ID}.json"
+    if [[ -f "$NERF_CONFIG" ]]; then
+        # Read darts
+        _NERF_SOFT=$(jq -r '.darts.soft // 150000' "$NERF_CONFIG" 2>/dev/null || echo 150000)
+        _NERF_HARD=$(jq -r '.darts.hard // 180000' "$NERF_CONFIG" 2>/dev/null || echo 180000)
+        _NERF_OUCH=$(jq -r '.darts.ouch // 200000' "$NERF_CONFIG" 2>/dev/null || echo 200000)
+
+        # Read mode and map to CRYSTALLIZE_MODE
+        _NERF_MODE=$(jq -r '.mode // "hurt-me-plenty"' "$NERF_CONFIG" 2>/dev/null || echo "hurt-me-plenty")
+        case "$_NERF_MODE" in
+            "not-too-rough") CRYSTALLIZE_MODE="manual" ;;
+            "hurt-me-plenty") CRYSTALLIZE_MODE="prompt" ;;
+            "ultraviolence")  CRYSTALLIZE_MODE="yolo" ;;
+            *)                CRYSTALLIZE_MODE="prompt" ;;
+        esac
+
+        # Convert absolute darts to percentage thresholds of the real window
+        # The crystallizer uses percentages: (dart / context_limit) * 100
+        # We set CONTEXT_LIMIT to the ouch dart so percentages align
+        CONTEXT_LIMIT="$_NERF_OUCH"
+        if [[ "$_NERF_OUCH" -gt 0 ]]; then
+            WARN_THRESHOLD=$(echo "scale=0; ($_NERF_SOFT * 100) / $_NERF_OUCH" | bc 2>/dev/null || echo 70)
+            DANGER_THRESHOLD=$(echo "scale=0; ($_NERF_HARD * 100) / $_NERF_OUCH" | bc 2>/dev/null || echo 85)
+            CRITICAL_THRESHOLD=85  # Trigger critical with margin for 200k windows
+        fi
+    fi
+fi
+
+# Detect if this is a subagent by checking the path
+IS_SUBAGENT=false
+if [[ "$TRANSCRIPT_PATH" == *"/subagents/"* ]]; then
+    IS_SUBAGENT=true
+    # Use lower thresholds for subagents
+    WARN_THRESHOLD="$SUBAGENT_WARN"
+    DANGER_THRESHOLD="$SUBAGENT_DANGER"
+fi
+
+# Ensure state directory exists
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+mkdir -p "${STATE_DIR}/context-states" 2>/dev/null || true
+
+# Analyze context
+ANALYSIS=$(analyze_context "$TRANSCRIPT_PATH" "$CONTEXT_LIMIT" "$WARN_THRESHOLD" "$DANGER_THRESHOLD" "$CRITICAL_THRESHOLD")
+
+if [[ -z "$ANALYSIS" ]]; then
+    exit 0
+fi
+
+ACTION=$(echo "$ANALYSIS" | jq -r '.action // "none"')
+PERCENT=$(echo "$ANALYSIS" | jq -r '.percent // 0')
+TOTAL=$(echo "$ANALYSIS" | jq -r '.tokens.total // 0')
+
+# Log the check (include session ID for multi-instance debugging)
+SHORT_SESSION="${SESSION_ID:0:8}"
+AGENT_TYPE="main"
+[[ "$IS_SUBAGENT" == "true" ]] && AGENT_TYPE="subagent"
+echo "[$(date -Iseconds)] [${SHORT_SESSION}] [${AGENT_TYPE}] Context: ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT}) Action: ${ACTION}" >> "$LOG_FILE" 2>/dev/null || true
+
+# For subagents, only warn - don't crystallize parent state
+if [[ "$IS_SUBAGENT" == "true" ]]; then
+    case "$ACTION" in
+        "warn"|"crystallize"|"critical")
+            cat << EOF
+{
+    "additionalContext": "⚠️ SUBAGENT CONTEXT: ${PERCENT}% used. Subagent approaching context limit - consider completing this task soon."
+}
+EOF
+            ;;
+    esac
+    exit 0
+fi
+
+# Determine response based on action
+case "$ACTION" in
+    "none")
+        # All good, exit silently
+        exit 0
+        ;;
+    
+    "warn")
+        # Return a warning via additionalContext (message field doesn't work per CC bug)
+        cat << EOF
+{
+    "additionalContext": "⚠️ CONTEXT WARNING: Usage at ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT} tokens). Consider wrapping up current task and crystallizing state soon."
+}
+EOF
+        exit 0
+        ;;
+    
+    "crystallize")
+        # Auto-crystallize and respond based on mode
+        STATE_SUBDIR="${STATE_DIR}/context-states"
+        CRYSTAL_FILE=$("${LIB_DIR}/crystallizer.sh" "$TRANSCRIPT_PATH" "$STATE_SUBDIR" "${CLAUDE_PROJECT_DIR:-.}" "$SESSION_ID" 2>/dev/null || echo "")
+        
+        # Maintain a "latest" symlink for easy access
+        if [[ -n "$CRYSTAL_FILE" && -f "$CRYSTAL_FILE" ]]; then
+            ln -sf "$CRYSTAL_FILE" "${STATE_DIR}/context-state.md" 2>/dev/null || true
+        fi
+        
+        case "$CRYSTALLIZE_MODE" in
+            "yolo")
+                # YOLO mode: Instruct Claude to clear automatically
+                cat << EOF
+{
+    "additionalContext": "🔶 CONTEXT DANGER: ${PERCENT}% used.\n\n**State crystallized to:** ${CRYSTAL_FILE}\n\n🤖 **AUTO-CLEAR ENGAGED (YOLO MODE)**\n\nI have saved the conversation state. Now executing automatic context clear to avoid lossy auto-compact.\n\n**IMPORTANT: Run /clear now, then read ${CRYSTAL_FILE} to restore context and continue.**"
+}
+EOF
+                ;;
+            "prompt")
+                # Prompt mode: Ask Claude to present state and get user confirmation
+                cat << EOF
+{
+    "additionalContext": "🔶 CONTEXT DANGER: ${PERCENT}% used.\n\n**State automatically crystallized to:** ${CRYSTAL_FILE}\n\n📋 **PLEASE REVIEW CRYSTALLIZED STATE:**\n\nRead and summarize the contents of \`${CRYSTAL_FILE}\` for the user, then ask:\n\n\"I've saved our conversation state to avoid losing context. Would you like me to run /clear now and resume from the saved state? (yes/no)\"\n\nIf user confirms, run /clear and then read the state file to continue."
+}
+EOF
+                ;;
+            *)
+                # Manual mode (default): Just warn
+                cat << EOF
+{
+    "additionalContext": "🔶 CONTEXT DANGER: Usage at ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT} tokens).\n\n**State automatically crystallized to:** ${CRYSTAL_FILE}\n\nRecommended actions:\n1. Complete your current atomic task\n2. Review the crystallized state file\n3. Run /clear to reset context\n4. Resume with fresh context (state file will be loaded)"
+}
+EOF
+                ;;
+        esac
+        exit 0
+        ;;
+    
+    "critical")
+        # Critical - crystallize and respond based on mode
+        STATE_SUBDIR="${STATE_DIR}/context-states"
+        CRYSTAL_FILE=$("${LIB_DIR}/crystallizer.sh" "$TRANSCRIPT_PATH" "$STATE_SUBDIR" "${CLAUDE_PROJECT_DIR:-.}" "$SESSION_ID" 2>/dev/null || echo "")
+        
+        # Maintain latest symlink
+        if [[ -n "$CRYSTAL_FILE" && -f "$CRYSTAL_FILE" ]]; then
+            ln -sf "$CRYSTAL_FILE" "${STATE_DIR}/context-state.md" 2>/dev/null || true
+        fi
+        
+        case "$CRYSTALLIZE_MODE" in
+            "yolo")
+                # YOLO mode: Instruct Claude to clear immediately
+                cat << EOF
+{
+    "additionalContext": "🚨 CRITICAL: ${PERCENT}% - AUTO-COMPACT IMMINENT!\n\n**State crystallized to:** ${CRYSTAL_FILE:-FAILED}\n\n🤖 **EMERGENCY AUTO-CLEAR (YOLO MODE)**\n\n**STOP EVERYTHING. Run /clear RIGHT NOW.**\n\nAfter clear, immediately read ${CRYSTAL_FILE} to restore context and continue where we left off."
+}
+EOF
+                ;;
+            "prompt")
+                # Prompt mode: Urgent request for user confirmation
+                cat << EOF
+{
+    "additionalContext": "🚨 CRITICAL: ${PERCENT}% - AUTO-COMPACT IMMINENT!\n\n**State crystallized to:** ${CRYSTAL_FILE:-FAILED}\n\n⚡ **URGENT: We need to /clear NOW to avoid lossy auto-compact!**\n\nQuickly confirm: Should I run /clear and resume from the saved state? We have seconds, not minutes.\n\n(Responding 'yes' or just pressing enter will proceed with /clear)"
+}
+EOF
+                ;;
+            *)
+                # Manual mode: Strong warning
+                cat << EOF
+{
+    "additionalContext": "🚨 CRITICAL CONTEXT ALERT: Usage at ${PERCENT}% - AUTO-COMPACT IMMINENT!\n\n**State crystallized to:** ${CRYSTAL_FILE:-FAILED}\n\n⚡ STOP CURRENT WORK and run /clear NOW to avoid lossy auto-compact!\n\nThe crystallized state file contains your conversation context. After /clear, read that file to resume."
+}
+EOF
+                ;;
+        esac
+        exit 0
+        ;;
+esac
+
+exit 0

--- a/context-crystallizer/hooks/pre-tool-use-blocking.sh
+++ b/context-crystallizer/hooks/pre-tool-use-blocking.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/context-crystallizer/hooks/pre-tool-use.sh
+++ b/context-crystallizer/hooks/pre-tool-use.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# pre-tool-use.sh - Monitors context and injects warnings BEFORE tool execution
+# Uses hookSpecificOutput.additionalContext format that actually works with PreToolUse
+
+set -uo pipefail
+
+# Configuration
+CONTEXT_LIMIT="${CONTEXT_LIMIT:-200000}"
+WARN_THRESHOLD="${WARN_THRESHOLD:-70}"
+DANGER_THRESHOLD="${DANGER_THRESHOLD:-85}"
+CRITICAL_THRESHOLD="${CRITICAL_THRESHOLD:-92}"
+CRYSTALLIZE_MODE="${CRYSTALLIZE_MODE:-manual}"
+
+# Paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/../lib"
+STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude"
+LOG_FILE="${STATE_DIR}/crystallizer.log"
+
+# Source analyzer
+source "${LIB_DIR}/context-analyzer.sh" 2>/dev/null || exit 0
+
+# Read hook input
+INPUT=$(cat)
+
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+    exit 0
+fi
+
+# Skip if this is a subagent
+if [[ "$TRANSCRIPT_PATH" == *"/subagents/"* ]]; then
+    exit 0
+fi
+
+# Ensure state directory exists
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+mkdir -p "${STATE_DIR}/context-states" 2>/dev/null || true
+
+# Analyze context
+ANALYSIS=$(analyze_context "$TRANSCRIPT_PATH" "$CONTEXT_LIMIT" "$WARN_THRESHOLD" "$DANGER_THRESHOLD" "$CRITICAL_THRESHOLD")
+
+if [[ -z "$ANALYSIS" ]]; then
+    exit 0
+fi
+
+ACTION=$(echo "$ANALYSIS" | jq -r '.action // "none"')
+PERCENT=$(echo "$ANALYSIS" | jq -r '.percent // 0')
+TOTAL=$(echo "$ANALYSIS" | jq -r '.tokens.total // 0')
+
+# Log
+SHORT_SESSION="${SESSION_ID:0:8}"
+echo "[$(date -Iseconds)] [${SHORT_SESSION}] [PreToolUse:${TOOL_NAME}] Context: ${PERCENT}% Action: ${ACTION}" >> "$LOG_FILE" 2>/dev/null || true
+
+# Helper function to output with proper hookSpecificOutput format
+output_context() {
+    local context="$1"
+    cat << EOF
+{
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": "$context"
+    }
+}
+EOF
+}
+
+case "$ACTION" in
+    "none")
+        exit 0
+        ;;
+    
+    "warn")
+        output_context "⚠️ CONTEXT WARNING: ${PERCENT}% used (${TOTAL}/${CONTEXT_LIMIT} tokens). Consider wrapping up current task soon."
+        exit 0
+        ;;
+    
+    "crystallize")
+        # Crystallize state
+        STATE_SUBDIR="${STATE_DIR}/context-states"
+        CRYSTAL_FILE=$("${LIB_DIR}/crystallizer.sh" "$TRANSCRIPT_PATH" "$STATE_SUBDIR" "${CLAUDE_PROJECT_DIR:-.}" "$SESSION_ID" 2>/dev/null || echo "")
+        
+        if [[ -n "$CRYSTAL_FILE" && -f "$CRYSTAL_FILE" ]]; then
+            ln -sf "$CRYSTAL_FILE" "${STATE_DIR}/context-state.md" 2>/dev/null || true
+        fi
+        
+        case "$CRYSTALLIZE_MODE" in
+            "yolo")
+                output_context "🔶 CONTEXT DANGER: ${PERCENT}% used. State saved to ${CRYSTAL_FILE}. AUTO-CLEAR ENGAGED - Run /clear NOW, then read the state file to continue."
+                ;;
+            "prompt")
+                output_context "🔶 CONTEXT DANGER: ${PERCENT}% used. State saved to ${CRYSTAL_FILE}. Please summarize the state file for the user and ask if they want to /clear now."
+                ;;
+            *)
+                output_context "🔶 CONTEXT DANGER: ${PERCENT}% used. State crystallized to ${CRYSTAL_FILE}. Recommend completing current task, then /clear and resume from state file."
+                ;;
+        esac
+        exit 0
+        ;;
+    
+    "critical")
+        # Crystallize state urgently
+        STATE_SUBDIR="${STATE_DIR}/context-states"
+        CRYSTAL_FILE=$("${LIB_DIR}/crystallizer.sh" "$TRANSCRIPT_PATH" "$STATE_SUBDIR" "${CLAUDE_PROJECT_DIR:-.}" "$SESSION_ID" 2>/dev/null || echo "")
+        
+        if [[ -n "$CRYSTAL_FILE" && -f "$CRYSTAL_FILE" ]]; then
+            ln -sf "$CRYSTAL_FILE" "${STATE_DIR}/context-state.md" 2>/dev/null || true
+        fi
+        
+        output_context "🚨 CRITICAL: ${PERCENT}% - AUTO-COMPACT IMMINENT! State saved to ${CRYSTAL_FILE:-FAILED}. STOP and run /clear NOW to avoid losing context!"
+        exit 0
+        ;;
+esac
+
+exit 0

--- a/context-crystallizer/hooks/session-start.sh
+++ b/context-crystallizer/hooks/session-start.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# session-start-hook.sh - Loads crystallized state when starting a new session
+# Output from this hook gets injected into Claude's context
+
+set -uo pipefail
+
+STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude"
+STATES_SUBDIR="${STATE_DIR}/context-states"
+LOG_FILE="${STATE_DIR}/crystallizer.log"
+
+# Find the most recent state file
+# Check both the legacy location and the new timestamped directory
+STATE_FILE=""
+
+if [[ -d "$STATES_SUBDIR" ]]; then
+    # Find newest file in context-states directory
+    STATE_FILE=$(find "$STATES_SUBDIR" -name "context-state-*.md" -type f 2>/dev/null | sort -r | head -1)
+fi
+
+# Fallback to legacy location
+if [[ -z "$STATE_FILE" || ! -f "$STATE_FILE" ]] && [[ -f "${STATE_DIR}/context-state.md" ]]; then
+    STATE_FILE="${STATE_DIR}/context-state.md"
+fi
+
+# Check if we have a crystallized state to restore
+if [[ -n "$STATE_FILE" && -f "$STATE_FILE" ]]; then
+    # Check how old the state file is
+    if [[ "$(uname)" == "Darwin" ]]; then
+        FILE_AGE=$(( $(date +%s) - $(stat -f %m "$STATE_FILE") ))
+    else
+        FILE_AGE=$(( $(date +%s) - $(stat -c %Y "$STATE_FILE") ))
+    fi
+    
+    # Only load if less than 24 hours old
+    if [[ $FILE_AGE -lt 86400 ]]; then
+        echo "📋 **RESTORED CONTEXT STATE** (crystallized $(( FILE_AGE / 60 )) minutes ago)"
+        echo ""
+        echo "The following state was preserved from a previous session:"
+        echo ""
+        echo '```markdown'
+        cat "$STATE_FILE"
+        echo '```'
+        echo ""
+        echo "---"
+        echo "Review the above context and continue where we left off. Ask the user for clarification if needed."
+        echo ""
+        
+        # Log the restoration
+        echo "[$(date -Iseconds)] Restored crystallized state (age: ${FILE_AGE}s)" >> "$LOG_FILE" 2>/dev/null || true
+    else
+        # State is old, just note it exists
+        echo "ℹ️ Note: Old context state exists at ${STATE_FILE} ($(( FILE_AGE / 3600 )) hours old)"
+        echo ""
+    fi
+fi
+
+exit 0

--- a/context-crystallizer/hooks/stop.sh
+++ b/context-crystallizer/hooks/stop.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# stop.sh - Fires when Claude finishes responding, injects context for next turn
+
+set -uo pipefail
+
+CONTEXT_LIMIT="${CONTEXT_LIMIT:-200000}"
+WARN_THRESHOLD="${WARN_THRESHOLD:-70}"
+DANGER_THRESHOLD="${DANGER_THRESHOLD:-85}"
+CRITICAL_THRESHOLD="${CRITICAL_THRESHOLD:-92}"
+CRYSTALLIZE_MODE="${CRYSTALLIZE_MODE:-manual}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/../lib"
+STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude"
+LOG_FILE="${STATE_DIR}/crystallizer.log"
+
+source "${LIB_DIR}/context-analyzer.sh" 2>/dev/null || exit 0
+
+INPUT=$(cat)
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+    exit 0
+fi
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+mkdir -p "${STATE_DIR}/context-states" 2>/dev/null || true
+
+ANALYSIS=$(analyze_context "$TRANSCRIPT_PATH" "$CONTEXT_LIMIT" "$WARN_THRESHOLD" "$DANGER_THRESHOLD" "$CRITICAL_THRESHOLD")
+
+if [[ -z "$ANALYSIS" ]]; then
+    exit 0
+fi
+
+ACTION=$(echo "$ANALYSIS" | jq -r '.action // "none"')
+PERCENT=$(echo "$ANALYSIS" | jq -r '.percent // 0')
+
+SHORT_SESSION="${SESSION_ID:0:8}"
+echo "[$(date -Iseconds)] [${SHORT_SESSION}] [Stop] Context: ${PERCENT}% Action: ${ACTION}" >> "$LOG_FILE" 2>/dev/null || true
+
+output_context() {
+    local context="$1"
+    cat << EOF
+{
+    "hookSpecificOutput": {
+        "hookEventName": "Stop",
+        "additionalContext": "$context"
+    }
+}
+EOF
+}
+
+case "$ACTION" in
+    "none")
+        exit 0
+        ;;
+    "warn"|"crystallize"|"critical")
+        # Crystallize if needed
+        if [[ "$ACTION" != "warn" ]]; then
+            STATE_SUBDIR="${STATE_DIR}/context-states"
+            CRYSTAL_FILE=$("${LIB_DIR}/crystallizer.sh" "$TRANSCRIPT_PATH" "$STATE_SUBDIR" "${CLAUDE_PROJECT_DIR:-.}" "$SESSION_ID" 2>/dev/null || echo "")
+            if [[ -n "$CRYSTAL_FILE" && -f "$CRYSTAL_FILE" ]]; then
+                ln -sf "$CRYSTAL_FILE" "${STATE_DIR}/context-state.md" 2>/dev/null || true
+            fi
+        fi
+        
+        output_context "🚨 CONTEXT AT ${PERCENT}% - State saved. Run /clear soon to avoid auto-compact!"
+        exit 0
+        ;;
+esac
+
+exit 0

--- a/context-crystallizer/hooks/subagent-stop.sh
+++ b/context-crystallizer/hooks/subagent-stop.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# subagent-stop-hook.sh - Monitors subagent context completion
+# This hook runs when a subagent finishes its work
+# It has access to agent_transcript_path for the subagent's own transcript
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/../lib"
+STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude"
+LOG_FILE="${STATE_DIR}/crystallizer.log"
+
+# Source the analyzer
+source "${LIB_DIR}/context-analyzer.sh" 2>/dev/null || exit 0
+
+# Read hook input
+INPUT=$(cat)
+
+# SubagentStop receives agent_transcript_path for the subagent's transcript
+AGENT_TRANSCRIPT=$(echo "$INPUT" | jq -r '.agent_transcript_path // empty')
+AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // "unknown"')
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "unknown"')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+# Ensure log directory exists
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+# If we have the subagent's transcript, analyze it
+if [[ -n "$AGENT_TRANSCRIPT" && -f "$AGENT_TRANSCRIPT" ]]; then
+    ANALYSIS=$(analyze_context "$AGENT_TRANSCRIPT" 200000 60 75 85)
+    PERCENT=$(echo "$ANALYSIS" | jq -r '.percent // 0')
+    TOTAL=$(echo "$ANALYSIS" | jq -r '.tokens.total // 0')
+    
+    SHORT_SESSION="${SESSION_ID:0:8}"
+    echo "[$(date -Iseconds)] [${SHORT_SESSION}] [subagent:${AGENT_TYPE}] Final context: ${PERCENT}% (${TOTAL} tokens) Agent: ${AGENT_ID}" >> "$LOG_FILE" 2>/dev/null || true
+    
+    # If subagent was near its limit, log a note
+    if (( $(echo "$PERCENT >= 75" | bc -l 2>/dev/null || echo 0) )); then
+        echo "[$(date -Iseconds)] [${SHORT_SESSION}] [subagent:${AGENT_TYPE}] WARNING: Subagent finished at high context (${PERCENT}%)" >> "$LOG_FILE" 2>/dev/null || true
+    fi
+fi
+
+# SubagentStop hooks don't inject messages into parent context by default
+# Just log and exit
+exit 0

--- a/context-crystallizer/lib/context-analyzer.sh
+++ b/context-crystallizer/lib/context-analyzer.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# context-analyzer.sh - Core library for context analysis
+# Returns: JSON with context stats and recommended action
+
+analyze_context() {
+    local TRANSCRIPT="$1"
+    local CONTEXT_LIMIT="${2:-200000}"
+    local WARN_THRESHOLD="${3:-70}"
+    local DANGER_THRESHOLD="${4:-85}"
+    local CRITICAL_THRESHOLD="${5:-92}"
+    # Calibration: Our token count appears ~15% lower than Claude Code's native meter
+    local CALIBRATION_OFFSET="${6:-15}"
+    
+    if [[ ! -f "$TRANSCRIPT" ]]; then
+        echo '{"error": "transcript not found"}'
+        return 1
+    fi
+    
+    # Get most recent MAIN AGENT message with usage
+    # CRITICAL: Filter for REAL model messages (claude-*), not synthetic placeholders
+    # Synthetic messages have model:"<synthetic>" with all-zero usage data
+    local USAGE_LINE USAGE
+    USAGE_LINE=$(tac "$TRANSCRIPT" 2>/dev/null | grep -m1 '"model":"claude-[^"]*".*"usage"' || echo "")
+    
+    USAGE=$(echo "$USAGE_LINE" | jq -c '.message.usage // empty' 2>/dev/null || echo "")
+    
+    if [[ -z "$USAGE" ]]; then
+        echo '{"error": "no usage data", "tokens": 0, "percent": 0, "action": "none"}'
+        return 0
+    fi
+    
+    local INPUT CACHE_CREATE CACHE_READ OUTPUT TOTAL PERCENT ACTION
+    INPUT=$(echo "$USAGE" | jq -r '.input_tokens // 0')
+    CACHE_CREATE=$(echo "$USAGE" | jq -r '.cache_creation_input_tokens // 0')
+    CACHE_READ=$(echo "$USAGE" | jq -r '.cache_read_input_tokens // 0')
+    OUTPUT=$(echo "$USAGE" | jq -r '.output_tokens // 0')
+    
+    TOTAL=$((INPUT + CACHE_CREATE + CACHE_READ))
+    RAW_PERCENT=$(echo "scale=1; ($TOTAL * 100) / $CONTEXT_LIMIT" | bc)
+    # Apply calibration offset to align with Claude Code's native meter
+    PERCENT=$(echo "scale=1; $RAW_PERCENT + $CALIBRATION_OFFSET" | bc)
+    
+    # Determine action
+    if (( $(echo "$PERCENT >= $CRITICAL_THRESHOLD" | bc -l) )); then
+        ACTION="critical"
+    elif (( $(echo "$PERCENT >= $DANGER_THRESHOLD" | bc -l) )); then
+        ACTION="crystallize"
+    elif (( $(echo "$PERCENT >= $WARN_THRESHOLD" | bc -l) )); then
+        ACTION="warn"
+    else
+        ACTION="none"
+    fi
+    
+    # Output JSON
+    jq -n \
+        --argjson input "$INPUT" \
+        --argjson cache_create "$CACHE_CREATE" \
+        --argjson cache_read "$CACHE_READ" \
+        --argjson output "$OUTPUT" \
+        --argjson total "$TOTAL" \
+        --argjson limit "$CONTEXT_LIMIT" \
+        --arg percent "$PERCENT" \
+        --arg action "$ACTION" \
+        '{
+            tokens: {
+                input: $input,
+                cache_create: $cache_create,
+                cache_read: $cache_read,
+                output: $output,
+                total: $total
+            },
+            limit: $limit,
+            percent: ($percent | tonumber),
+            action: $action
+        }'
+}
+
+# Allow sourcing or direct execution
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    analyze_context "$@"
+fi

--- a/context-crystallizer/lib/crystallizer.sh
+++ b/context-crystallizer/lib/crystallizer.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# crystallizer.sh - Extracts critical state from transcript and saves to file
+# This is the heart of the context preservation system
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+crystallize() {
+    local TRANSCRIPT="$1"
+    local OUTPUT_DIR="${2:-.claude}"
+    local PROJECT_DIR="${3:-$(pwd)}"
+    local SESSION_ID="${4:-}"
+    
+    # Generate unique filename with timestamp and session
+    local TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    local SHORT_SESSION="${SESSION_ID:0:8}"
+    local FILENAME="context-state"
+    
+    if [[ -n "$SHORT_SESSION" ]]; then
+        FILENAME="context-state-${TIMESTAMP}-${SHORT_SESSION}.md"
+    else
+        FILENAME="context-state-${TIMESTAMP}.md"
+    fi
+    
+    local OUTPUT_FILE="${OUTPUT_DIR}/${FILENAME}"
+    local TIMESTAMP_ISO=$(date -Iseconds)
+    local FULL_SESSION_ID="${SESSION_ID:-$(basename "$TRANSCRIPT" .jsonl)}"
+    
+    # Create output directory if needed
+    mkdir -p "$OUTPUT_DIR"
+    
+    # Extract recent conversation context
+    # Get last 50 user messages and assistant responses
+    local USER_MESSAGES ASSISTANT_MESSAGES TOOL_USES FILES_MODIFIED
+    
+    # Recent user prompts (last 10)
+    USER_MESSAGES=$(tail -500 "$TRANSCRIPT" | \
+        jq -r 'select(.type == "user" and .message.content) | 
+               .message.content | 
+               if type == "array" then 
+                   map(select(.type == "text") | .text) | join("\n") 
+               elif type == "string" then . 
+               else empty end' 2>/dev/null | \
+        tail -20 | head -10)
+    
+    # Recent assistant responses (summaries)
+    ASSISTANT_MESSAGES=$(tail -500 "$TRANSCRIPT" | \
+        jq -r 'select(.type == "assistant" and .message.content) |
+               .message.content |
+               if type == "array" then
+                   map(select(.type == "text") | .text) | join("\n")
+               elif type == "string" then .
+               else empty end' 2>/dev/null | \
+        tail -30 | head -15)
+    
+    # Files that were modified (from tool uses)
+    FILES_MODIFIED=$(tail -1000 "$TRANSCRIPT" | \
+        jq -r 'select(.type == "assistant") |
+               .message.content[]? |
+               select(.type == "tool_use") |
+               select(.name == "Write" or .name == "Edit" or .name == "MultiEdit") |
+               .input.file_path // .input.filePath // empty' 2>/dev/null | \
+        sort -u | tail -20)
+    
+    # Recent tool operations
+    TOOL_USES=$(tail -500 "$TRANSCRIPT" | \
+        jq -r 'select(.type == "assistant") |
+               .message.content[]? |
+               select(.type == "tool_use") |
+               "\(.name): \(.input | keys | join(", "))"' 2>/dev/null | \
+        tail -15)
+    
+    # Get current git branch if in a repo
+    local GIT_BRANCH=""
+    if git rev-parse --git-dir > /dev/null 2>&1; then
+        GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+    fi
+    
+    # Build the crystallized state file
+    cat > "$OUTPUT_FILE" << CRYSTAL
+# Context State - Crystallized ${TIMESTAMP_ISO}
+
+> **AUTO-GENERATED**: This file was created by the Context Crystallizer to preserve
+> working state before context compaction. Read this to restore context.
+
+## Session Info
+- **Session ID**: ${FULL_SESSION_ID}
+- **Crystallized**: ${TIMESTAMP_ISO}
+- **Project**: ${PROJECT_DIR}
+- **Git Branch**: ${GIT_BRANCH:-N/A}
+
+## Files Modified This Session
+\`\`\`
+${FILES_MODIFIED:-No files modified}
+\`\`\`
+
+## Recent Tool Operations
+\`\`\`
+${TOOL_USES:-No tool operations recorded}
+\`\`\`
+
+## Recent User Instructions
+The user's recent requests (most recent last):
+
+${USER_MESSAGES:-No recent messages captured}
+
+## Recent Assistant Context
+Key points from recent responses:
+
+${ASSISTANT_MESSAGES:-No recent responses captured}
+
+## Recovery Instructions
+
+When resuming after context clear:
+1. Read this file to understand what was in progress
+2. Check the files listed above for current state  
+3. Continue from where we left off
+4. Ask the user for clarification if context is unclear
+
+---
+*Crystallized by context-crystallizer v1.0*
+CRYSTAL
+
+    echo "$OUTPUT_FILE"
+}
+
+# Direct execution
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ $# -lt 1 ]]; then
+        echo "Usage: $0 <transcript.jsonl> [output_dir] [project_dir]"
+        exit 1
+    fi
+    crystallize "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -12,16 +12,18 @@
 #   ./install.sh --scripts    Install scripts only (also builds packages from src/)
 #   ./install.sh --config     Install config files only (smart-merges settings.json)
 #   ./install.sh --mcps       Install MCP servers only (via mcps.json manifest)
+#   ./install.sh --crystallizer Install context-crystallizer only
 #   ./install.sh --no-mcps    Install everything except MCP servers
 #
 # Targets:
-#   Skills     → ~/.claude/skills/<name>/SKILL.md
-#   Scripts    → ~/.local/bin/<name>
-#   Packages   → ~/.local/bin/<name> (built from src/ via scripts/ci/build.sh)
-#   Statusline → ~/.claude/statusline-command.sh
-#   Settings   → ~/.claude/settings.json (smart-merged: missing keys added, your
-#                 customizations preserved — see merge_settings() for rules)
-#   MCPs       → user-scope MCP servers (installed via each MCP's install-remote.sh)
+#   Skills        → ~/.claude/skills/<name>/SKILL.md
+#   Scripts       → ~/.local/bin/<name>
+#   Packages      → ~/.local/bin/<name> (built from src/ via scripts/ci/build.sh)
+#   Statusline    → ~/.claude/statusline-command.sh
+#   Settings      → ~/.claude/settings.json (smart-merged: missing keys added, your
+#                    customizations preserved — see merge_settings() for rules)
+#   MCPs          → user-scope MCP servers (installed via each MCP's install-remote.sh)
+#   Crystallizer  → ~/.claude/context-crystallizer/ (hooks, lib, bin)
 #
 # Existing files are backed up to <file>.bak before overwriting.
 
@@ -37,6 +39,7 @@ INSTALL_SKILLS=true
 INSTALL_SCRIPTS=true
 INSTALL_CONFIG=true
 INSTALL_MCPS=true
+INSTALL_CRYSTALLIZER=true
 
 # --- Parse args ---------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
@@ -53,24 +56,35 @@ while [[ $# -gt 0 ]]; do
 		INSTALL_SCRIPTS=false
 		INSTALL_CONFIG=false
 		INSTALL_MCPS=false
+		INSTALL_CRYSTALLIZER=false
 		shift
 		;;
 	--scripts)
 		INSTALL_SKILLS=false
 		INSTALL_CONFIG=false
 		INSTALL_MCPS=false
+		INSTALL_CRYSTALLIZER=false
 		shift
 		;;
 	--config)
 		INSTALL_SKILLS=false
 		INSTALL_SCRIPTS=false
 		INSTALL_MCPS=false
+		INSTALL_CRYSTALLIZER=false
 		shift
 		;;
 	--mcps)
 		INSTALL_SKILLS=false
 		INSTALL_SCRIPTS=false
 		INSTALL_CONFIG=false
+		INSTALL_CRYSTALLIZER=false
+		shift
+		;;
+	--crystallizer)
+		INSTALL_SKILLS=false
+		INSTALL_SCRIPTS=false
+		INSTALL_CONFIG=false
+		INSTALL_MCPS=false
 		shift
 		;;
 	--no-mcps)
@@ -309,6 +323,20 @@ if [[ "$CHECK_MODE" == true ]]; then
 		done
 	fi
 
+	# Crystallizer
+	if [[ -d "$REPO_DIR/context-crystallizer" ]]; then
+		echo ""
+		echo "Crystallizer"
+		echo "──────────────────────────────────────────"
+		CRYST_DEST="$CLAUDE_DIR/context-crystallizer"
+		for src_file in $(find "$REPO_DIR/context-crystallizer" -type f | sort); do
+			rel="${src_file#"$REPO_DIR"/context-crystallizer/}"
+			dest="$CRYST_DEST/$rel"
+			total=$((total + 1))
+			do_check "$src_file" "$dest" "crystallizer/$rel" || drifted=$((drifted + 1))
+		done
+	fi
+
 	# MCPs: check each MCP's install-remote.sh --check
 	if [[ -f "$REPO_DIR/mcps.json" ]] && command -v claude &>/dev/null; then
 		echo ""
@@ -445,6 +473,24 @@ if [[ "$INSTALL_CONFIG" == true ]]; then
 			fi
 		fi
 	fi
+fi
+
+# --- Install context-crystallizer ----------------------------------------------
+if [[ "$INSTALL_CRYSTALLIZER" == true && -d "$REPO_DIR/context-crystallizer" ]]; then
+	echo ""
+	echo "Crystallizer → $CLAUDE_DIR/context-crystallizer"
+	echo "──────────────────────────────────────────"
+	CRYST_DEST="$CLAUDE_DIR/context-crystallizer"
+	for src_file in $(find "$REPO_DIR/context-crystallizer" -type f | sort); do
+		rel="${src_file#"$REPO_DIR"/context-crystallizer/}"
+		dest="$CRYST_DEST/$rel"
+		do_copy "$src_file" "$dest"
+		if [[ "$DRY_RUN" != true ]]; then
+			case "$dest" in
+			*.sh | */bin/*) chmod +x "$dest" ;;
+			esac
+		fi
+	done
 fi
 
 # --- Build and install packages -----------------------------------------------


### PR DESCRIPTION
## Summary

Brings the 12 context-crystallizer files (hooks, lib, bin) into the repo — they were previously untracked at `~/.claude/context-crystallizer/`. Wires them into `install.sh` with install, drift check, and selective `--crystallizer` flag.

## Changes

- **12 new files** under `context-crystallizer/` (bin/3, hooks/7, lib/2)
- **install.sh** gains crystallizer install + check sections + `--crystallizer` flag
- **Shebang fix** — all 11 scripts standardized to `#!/usr/bin/env bash`
- **chmod fix** — scoped to `*.sh` and `*/bin/*` only (not indiscriminate)
- **Model pattern fix** — `context-analyzer.sh` broadened from `claude-sonnet` to `claude-*` for Opus support

## Linked Issues

Closes #230

## Test Plan

- Ran `./install.sh --crystallizer` — deploys all 12 files
- Ran `./install.sh --check` — 100/100 items in sync
- Ran `./scripts/ci/validate.sh` — 73/73 passed
- Code review: 2 high-risk findings fixed (shebangs, chmod scope)