### PR TITLE
docs: update README, skill-reference, getting-started, statusline-indicators, and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,82 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- `ccfold` skill — Merge upstream CLAUDE.md template changes into a project's local CLAUDE.md, preserving project-specific content (Dev-Team, custom sections)
-- `sync.sh` — Reverse-sync: pull local skill/script changes back into the repo
+- **Nerf MCP server** — Deterministic context budget management via `nerf-server` MCP. Includes dart thresholds (soft/hard/ouch), behavior modes (not-too-rough, hurt-me-plenty, ultraviolence), statusline indicators, and a terminal-based scope monitor
+- **`/nerf` skill** — Thin routing stub for the nerf MCP server with `k`/`m` suffix parsing
+- **`/issue` skill** — Create structured issues (feature, bug, chore, docs, epic) with proper templates and labels. Self-contained, dual-platform (GitHub/GitLab)
+- **`/ddd` skill** — Domain-Driven Design facilitation with 8-stage event storming, domain model formalization, and PRD generation
+- **`/man` skill** — Display usage information for any installed skill via SKILL.md frontmatter
+- **`/cryopact` skill** — Background cryo via subagent — preserve state without blocking the main conversation
+- **`/disc` skill** — Unified Discord integration: check-in, send, read, list channels, create threads
+- **`/view` skill** — Open file/URL in a GUI viewer (read-only) with cross-platform file-opener
+- **`/edit` skill** — Open file/URL in a GUI editor for modification
+- **`/vox` skill** — Text-to-speech voice announcements via Chatterbox API with local fallback
+- **`/precheck` skill** — Pre-commit gate: branch/issue compliance, validation, code review, checklist
+- **`/assesswaves` skill** — Quick assessment of wave-pattern suitability for parallel execution
+- **`/ccwork` skill** — Onboarding hub with interactive tours, labs, and setup wizards
+- **`/scpmr` and `/scpmmr` combo skills** — Stage/commit/push/create PR/merge in one command
+- **`/ccfold` skill** — Merge upstream CLAUDE.md template changes into local project CLAUDE.md
+- **`sync.sh`** — Reverse-sync: pull local skill/script changes back into the repo
+- **Context crystallizer** — Session state preservation pipeline: hooks (PostToolUse, SessionStart, SubagentStop), libraries (context-analyzer, crystallizer), CLI tools (cc-context, cc-cleanup). Tracked in `context-crystallizer/` and installed via `--crystallizer`
+- **Discord watcher channel server** — Real-time inter-agent communication via Discord with targeted message filtering, thread polling, voice message STT, and Dev-Name echo suppression
+- **Discord bot** — REST API client for Discord: send, read, create channels/threads, resolve names, with 429 retry handling and kill switch
+- **Discord status post** — Wave-status embed with auto-updating pinned message, debounce, and dev-team fallback
+- **`discord-lock`** — Advisory lock for serializing Discord channel writes across agents
+- **`cc-inspector`** — Context window inspector: mitmproxy + Flask UI for API payload capture
+- **`generate-status-panel`** — HTML status panel generator for wave progress
+- **`worktree-manager`** — Manage isolated worktrees for parallel agent execution
+- **Remote installer** — `scripts/install-remote.sh` for curl-pipe-bash installation from GitHub Releases
+- **MCP manifest** — `mcps.json` with bundle-install architecture for wtf-server, discord-watcher, and nerf-server
+- **GitHub Actions workflow** for GitHub Release packaging
+- **Statusline v2** — Two-line layout with per-session indicators, visual refresh, and JSON-based indicator interface
+- **Introduction system** — First-run introduction.md display for new skills with marker file gating
+- **Work Item Standards** — Label taxonomy (`group::value`), issue templates (feature, bug, chore, docs, epic), and wave-pattern quality requirements in CLAUDE.md
+- **`.claude-project.md`** — Cached platform detection results (GitHub/GitLab, CLI tool, labels, CI)
+- **Agent identity keying** — Migrated from PPID to project-root md5 hash for stable cross-process resolution
+- **PRD template v2.0** — EARS requirements, phased implementation, artifact manifest, CI/CD pipeline, documentation kit, test plan sections, foundation story checklist, one-story-one-repo rule
+- **Getting Started guide** — 15-minute walkthrough of first session
+- **Skill Reference** — Detailed documentation for all skills
+- **Concepts guide** — Architecture overview of the three-layer kit
+- **Troubleshooting guide** — Common issues and fixes
+- **Discord configuration guide** — Bot token, watcher, inter-agent messaging setup
+- **Statusline indicators guide** — Per-session indicator interface documentation
 
 ### Changed
 
 - `install.sh --config` now smart-merges `settings.template.json` into existing `settings.json` — missing hooks, plugins, and permissions are added while user customizations are preserved
-- `install.sh --check` now reports missing hooks, plugins, and MCP server registrations in addition to file drift
+- `install.sh --check` now reports missing hooks, plugins, MCP server registrations, and crystallizer drift
+- `install.sh` supports selective flags: `--skills`, `--scripts`, `--config`, `--mcps`, `--crystallizer`
+- Repo restructured: skills carry their own scripts (discord-bot inside disc, file-opener inside view, etc.)
+- `/cryopact` delegates to cryo subagent, removes auto-clear, fixes immediate mode
+- `/disc` default action changed from read to check-in
+- `/nextwave` uses pre-created worktrees instead of isolation worktrees, with granular lifecycle tasks and explicit wave-status calls
+- `/pong` uses priority-ordered default discovery flow (active thread → addressed messages → general history)
+- `/vox` adds `--output FILE` flag for render-to-disk mode
+- Discord config abstracted into `~/.claude/discord.json`
+- Agent check-in on session start via `#roll-call` channel
+- RC display name set to match Dev-Name at session start
+- Introduction-gate marker files use dot prefix for hiding
+- Nerf default thresholds lowered for 200k context window safety
+
+### Fixed
+
+- `install.sh` unbound tmpdir variable on script exit
+- `install.sh` handles `claude mcp add` failure gracefully
+- Discord-bot 429 retry-after handling and JSONL API call logging
+- Discord-bot kill switch to halt all API calls on global 429
+- Discord watcher strips punctuation from @-addressing tokens
+- Vox Bluetooth wake noise prepend to prevent audio clipping
+- Vox help text for `-o` flag and `espeak-ng` fallback
+- Wave-status meta-refresh fallback for `file://` dashboard viewing
+- Wave-status infers phase/wave position when `current_wave` is null
+- Identity keying migrated from PPID to project-root hash (fixes multi-session collisions)
+- Ping/pong channel name corrected and channel ID added
+- `/precheck` runs immediately without asking permission
+- `/issue` removes per-issue approval gate (issues are cheap to edit)
+
+### Removed
+
+- `afk-notify` Stop hook — replaced by kill switch on discord-watcher
 
 ## [0.1.0] - 2026-03-22
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,18 @@ Key features:
 | ccfold | `/ccfold` | Merge upstream CLAUDE.md template updates into local project |
 | ccwork | `/ccwork` | Onboarding hub — tour the kit, run labs, configure integrations |
 | cryo | `/cryo` | Preserve session state before context compaction |
+| cryopact | `/cryopact` | Background cryo via subagent — keep working, append delta, compact when ready |
+| ddd | `/ddd` | Domain-Driven Design facilitation — event storming, domain modeling, PRD generation |
 | disc | `/disc` | Discord integration — check-in, send, read, list, resolve channels |
 | edit | `/edit` | Open file/URL in GUI editor |
 | engage | `/engage` | Load CLAUDE.md, confirm rules of engagement |
 | ibm | `/ibm` | Issue-Branch-PR/MR workflow reminder |
+| issue | `/issue` | Create structured issues (feature, bug, chore, docs, epic) with templates and labels |
 | jfail | `/jfail` | CI job/workflow failure analysis |
+| man | `/man` | Display usage information for any installed skill |
 | mmr | `/mmr` | Merge a PR/MR with squash |
 | name | `/name` | Report or pick agent session identity |
+| nerf | `/nerf` | Context budget system — soft limits, doom modes, scope monitor |
 | nextwave | `/nextwave` | Execute parallel spec-driven sub-agents |
 | ping | `/ping` | Post to #ai-dev Slack channel |
 | pong | `/pong` | Read #ai-dev Slack channel |
@@ -85,6 +90,10 @@ Key features:
 | `file-opener` | `xdg-open` / `open` | Cross-platform file/URL opener for `/view` and `/edit` |
 | `vox` | `curl`, audio player (`aplay`/`afplay`) | Text-to-speech via Chatterbox API, with local fallback (espeak/piper/say) |
 | `statusline-command.sh` | `jq`, `git` | Custom status line: git branch, dirty state, context window remaining, model |
+| `cc-inspector` | `python3`, `mitmproxy` | Context window inspector — proxy + Flask UI for API payload capture |
+| `discord-lock` | `flock`, `jq` | Advisory lock for serializing Discord channel writes across agents |
+| `generate-status-panel` | `python3` | Generate HTML status panel for wave progress |
+| `worktree-manager` | `git` | Manage isolated worktrees for parallel agent execution |
 
 ### MCP Servers
 
@@ -94,14 +103,25 @@ MCP servers are managed via `mcps.json` and installed from their own repos:
 |--------|------|-------------|
 | `wtf-server` | [mcp-server-wtf](https://github.com/Wave-Engineering/mcp-server-wtf) | Flight recorder for incident troubleshooting |
 | `discord-watcher` | [mcp-server-discord-watcher](https://github.com/Wave-Engineering/mcp-server-discord-watcher) | Discord channel notification server for inter-agent communication |
+| `nerf-server` | [mcp-server-nerf](https://github.com/Wave-Engineering/mcp-server-nerf) | Deterministic context budget management (nerf darts, modes, statusline) |
 
 Each MCP has its own `install-remote.sh` for standalone installation. Running `./install.sh` installs all MCPs from the manifest automatically.
+
+### Context Crystallizer
+
+The `context-crystallizer/` directory contains the hooks and libraries that power session state preservation. It installs to `~/.claude/context-crystallizer/` and provides:
+
+- **Hooks** — SessionStart (restore crystallized state), PostToolUse (auto-crystallize at high context usage), SubagentStop (capture subagent results)
+- **Libraries** — `context-analyzer.sh` (parse API payloads for token counts), `crystallizer.sh` (write crystal files)
+- **CLI** — `cc-context` (watch token usage in a terminal), `cc-cleanup` (prune old crystal files)
+
+Install standalone with `./install.sh --crystallizer`.
 
 ### Settings Template
 
 `settings.template.json` provides a starting point for `~/.claude/settings.json` with:
 - **Permissions** — Granular tool allowlists for common CLIs (git, gh, glab, docker, terraform, aws, etc.)
-- **Hooks** — PostToolUse, SessionStart, and SubagentStop hook structure (requires [context-crystallizer](https://github.com/Wave-Engineering/context-crystallizer) for crystallization hooks)
+- **Hooks** — PostToolUse, SessionStart, and SubagentStop hook structure (requires [context-crystallizer](context-crystallizer/) for crystallization hooks)
 - **Status line** — Points to the custom statusline script
 - **Plugins** — Full plugin list (see Plugins section below)
 - **Effort level** — Set to `high` for thorough responses
@@ -150,8 +170,9 @@ This will:
 ./install.sh --skills      # Install skills only
 ./install.sh --scripts     # Install scripts only
 ./install.sh --config      # Install config files only
-./install.sh --mcps        # Install MCP servers only (via mcps.json manifest)
-./install.sh --no-mcps     # Install everything except MCP servers
+./install.sh --mcps         # Install MCP servers only (via mcps.json manifest)
+./install.sh --crystallizer # Install context-crystallizer only
+./install.sh --no-mcps      # Install everything except MCP servers
 ```
 
 ### Check for Drift

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,13 +108,13 @@ Before writing any code, you need a tracked issue. Either find an existing one o
 > Let's work on issue #42
 ```
 
-or
+or use the `/issue` skill to create a properly templated and labeled issue:
 
 ```
-> Create an issue for adding retry logic to the upload endpoint
+/issue feature add retry logic to the upload endpoint
 ```
 
-Claude uses `gh issue create` or `glab issue create` depending on your platform. The issue must exist before any code is written -- this is a hard rule.
+This detects your platform, applies the correct template (feature, bug, chore, docs, epic), infers labels, and creates the issue. The issue must exist before any code is written -- this is a hard rule.
 
 ### 4b: Create a Branch
 
@@ -198,6 +198,8 @@ The full skill reference is in [Skill Reference](skill-reference.md) with detail
 |-------|---------------|
 | `/cryo` | Before context compaction -- freezes session state so `/engage` can restore it |
 | `/review` | Run a standalone code review on staged changes, a branch diff, or a specific file |
+| `/issue` | Create structured issues with proper templates and labels from natural language |
+| `/nerf` | Context budget management -- check usage, adjust limits, launch scope monitor |
 | `/ibm` | Quick reminder of the Issue-Branch-PR/MR workflow when you need to reset your mental model |
 | `/disc` | Send and read Discord messages, check in to `#roll-call`, manage channels |
 | `/vox` | Text-to-speech announcements ("Hey, the build passed") |
@@ -242,8 +244,10 @@ This merges new sections and updates while preserving your project-specific cont
 | Start a session | `claude` in any project with `CLAUDE.md` |
 | Load rules | `/engage` |
 | Check workflow | `/ibm` |
+| Create an issue | `/issue feature <prompt>` |
 | Pre-commit gate | `/precheck` |
 | Ship code | `/scp`, `/scpmr`, or `/scpmmr` |
+| Context budget | `/nerf` |
 | Freeze state | `/cryo` |
 | Restore state | `/engage` |
 | Update kit | `git pull && ./install.sh` |

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -94,6 +94,48 @@ No arguments. If an identity file exists for this project, it reports the curren
 
 ---
 
+### `/cryopact` -- Background Cryo
+
+Delegates session state preservation to a background subagent so you can keep working. The subagent writes a frozen snapshot to `/tmp`, and when context pressure hits, the main agent appends a short delta and deploys.
+
+**When to use it:**
+- When context is getting high but you are mid-task and do not want to stop
+- As a faster alternative to `/cryo` that does not block the main conversation
+- When autocompact is imminent and you need to preserve state without burning main context
+
+**Examples:**
+
+```
+/cryopact
+```
+
+No arguments. It launches a background cryo subagent, continues working, and merges the result when compaction is needed. In immediate mode (context pressure warning has fired), it writes minimal breadcrumbs and lets the subagent finish in the background.
+
+**Key detail:** `/cryopact` is the non-blocking cousin of `/cryo`. Use `/cryo` when you can afford to pause; use `/cryopact` when you cannot.
+
+---
+
+### `/man` -- Skill Usage Display
+
+Displays the usage information for any installed skill by reading its SKILL.md frontmatter. A quick reference without loading the full skill into context.
+
+**When to use it:**
+- When you need a reminder of a skill's syntax or subcommands
+- To list all installed skills and their descriptions
+- To check what options a skill supports without invoking it
+
+**Examples:**
+
+```
+/man nerf          # Show usage for /nerf
+/man scp           # Show usage for /scp
+/man               # List all installed skills
+```
+
+This is read-only -- it never invokes the target skill. It reads the `usage` frontmatter field for structured output, or interprets the full file when no usage field exists.
+
+---
+
 ### `/ccwork` -- Onboarding Hub
 
 Single entry point for discovering and learning the ccwork kit. Routes to tours, labs, and setup wizards.
@@ -122,6 +164,61 @@ Single entry point for discovering and learning the ccwork kit. Routes to tours,
 ## Workflow Skills
 
 These drive the development loop: issues, commits, reviews, merges.
+
+---
+
+### `/issue` -- Structured Issue Creation
+
+Creates properly templated and labeled issues from a natural language prompt. Detects the platform (GitHub/GitLab), applies the correct template for the issue type, infers labels, and creates the issue directly.
+
+**When to use it:**
+- When you need to create an issue following the project's template and labeling standards
+- When starting new work and an issue does not exist yet
+- When decomposing work into tracked items
+
+**Examples:**
+
+```
+/issue feature add retry logic to the upload endpoint
+/issue bug the login form crashes on empty password
+/issue chore update dependencies to latest patch versions
+/issue docs update the API reference for v2 endpoints
+/issue epic redesign the authentication system
+/issue                   # Infer from recent conversation context
+```
+
+The first word selects the template (feature, bug, chore, docs, epic). If omitted, the type is inferred from the prompt. Issues are created immediately -- the skill does not ask for confirmation since issues are cheap to edit.
+
+**Key detail:** The skill is self-contained -- it carries its own templates rather than depending on CLAUDE.md. Labels follow the `group::value` taxonomy with priority and urgency as orthogonal axes.
+
+---
+
+### `/nerf` -- Context Budget Management
+
+Routes to the `nerf-server` MCP for deterministic context budget control. Manages soft limits (darts), behavior modes, and a scope monitor for tracking token usage over time.
+
+**When to use it:**
+- To check your current context usage and dart thresholds
+- To adjust the context budget (raise or lower limits)
+- To switch behavior modes (more or less aggressive context management)
+- To launch a terminal-based scope monitor for real-time token tracking
+
+**Examples:**
+
+```
+/nerf                          # Show status (mode, darts, context usage)
+/nerf status                   # Same as /nerf
+/nerf mode                     # Show current behavior mode
+/nerf mode hurt-me-plenty      # Set mode
+/nerf darts                    # Show current dart thresholds
+/nerf darts 120k 160k 180k    # Set all three thresholds
+/nerf 200k                     # Set ouch dart, scale soft/hard proportionally
+/nerf scope                    # Launch context monitor in new terminal
+```
+
+All operations are handled by the MCP server -- the skill is a thin routing stub that parses input and calls the appropriate MCP tool. Accepts `k` suffix (e.g., `200k` = 200000).
+
+**Modes:** `not-too-rough` (gentle reminders), `hurt-me-plenty` (firm limits), `ultraviolence` (aggressive compaction pressure).
 
 ---
 
@@ -430,6 +527,36 @@ Opens a file or URL in a GUI editor for modification. Like `/view` but prefers f
 ```
 
 Checks `$VISUAL` and `$EDITOR` environment variables, then user preferences, then suggests by file type. Falls back to `file-opener` or the system default handler.
+
+---
+
+## Advanced Skills -- Domain-Driven Design
+
+---
+
+### `/ddd` -- Domain-Driven Design Facilitation
+
+A structured workflow for domain modeling using event storming. Guides you through 8 stages of domain discovery, formalizes the results into a Domain Model document, and translates it into an implementation-ready PRD.
+
+**When to use it:**
+- When starting a new project and need to discover the domain model
+- When translating business requirements into technical architecture
+- When you want a structured PRD generated from domain analysis
+
+**Examples:**
+
+```
+/ddd begin       # Start interactive event storming session
+/ddd draft       # Formalize sketchbook into Domain Model document
+/ddd accept      # Translate Domain Model to PRD
+/ddd resume      # Resume interrupted event storming session
+```
+
+**The pipeline:** `/ddd begin` (8-stage event storming → `docs/SKETCHBOOK.md`) → `/ddd draft` (formalize → `docs/DOMAIN-MODEL.md`) → `/ddd accept` (translate → `docs/<project>-PRD.md`).
+
+**Event storming stages:** Domain Context → Events (brainstorm) → Events (organize) → Commands → Actors → Policies → Aggregates → Read Models. Progress is checkpointed to the sketchbook after each stage.
+
+**Key detail:** This is a Socratic process — the agent asks probing questions rather than dictating the domain. The best domain models emerge from questioning and challenging assumptions.
 
 ---
 

--- a/docs/statusline-indicators.md
+++ b/docs/statusline-indicators.md
@@ -83,6 +83,10 @@ rm -f "/tmp/claude-statusline-${dev_name}.json"
 | Wave progress | `W2 3/5` | Wave 2, issue 3 of 5 |
 | Recording | `● REC` | Session is being recorded/replayed |
 | Context budget | `🔥 DOOM` | Nerf system in ultraviolence mode |
+| Nerf soft dart | `⚡ 120k` | Approaching soft context limit |
+| Nerf hard dart | `🔥 160k` | Hit hard context limit |
+| Nerf ouch dart | `💀 180k` | At maximum context budget |
+| Nerf mode | `🎯 HMP` | Current nerf mode (hurt-me-plenty) |
 | Timer | `⏱ 12m` | Time remaining on a task |
 | Build status | `✓ BUILD` | Last build passed |
 | Blocked | `⛔ KILL` | Kill switch engaged |


### PR DESCRIPTION
## Summary

Documentation had drifted significantly from actual codebase state — 5 undocumented skills, 1 missing MCP, stale CHANGELOG, and missing references across guides. This PR brings all 5 docs files up to date.

## Changes

- **README.md**: Add 5 missing skills (cryopact, ddd, issue, man, nerf), nerf-server MCP, 4 undocumented scripts (cc-inspector, discord-lock, generate-status-panel, worktree-manager), context crystallizer section, `--crystallizer` install flag, fix crystallizer link
- **docs/skill-reference.md**: Add full reference entries for `/cryopact`, `/ddd`, `/issue`, `/man`, `/nerf` in appropriate categories
- **docs/getting-started.md**: Add `/issue` reference in Step 4a, `/nerf` and `/issue` to explore further table and quick reference
- **docs/statusline-indicators.md**: Add nerf-specific indicator examples (soft/hard/ouch darts, mode)
- **CHANGELOG.md**: Replace sparse Unreleased section with comprehensive entries covering all 108 commits since v0.1.0

## Linked Issues

Closes #234

## Test Plan

- Ran `./scripts/ci/validate.sh` — 73 passed, 0 failed
- Code review via `feature-dev:code-reviewer` — no findings
- Verified all 10 acceptance criteria against actual codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)