### PR TITLE
feat(cryo): hybrid memory-cryo for /clear survival

### DIFF
--- a/skills/cryo/SKILL.md
+++ b/skills/cryo/SKILL.md
@@ -57,6 +57,70 @@ Before writing anything, gather:
 - Read the existing plan file (if any) to understand its current structure
 - Check TaskList for any active tasks
 
+## Step 1.5: Extract Durable Facts to Memory
+
+Before writing the plan file, identify any **durable knowledge** from this session
+that should persist across all future sessions — not just the next one.
+
+### Tier Classification
+
+| If the fact is... | Tier | Write to |
+|-------------------|------|----------|
+| A design decision with rationale | 1 — Durable | Memory (`type: project`, `decision_<topic>.md`) |
+| A lesson learned / technical gotcha | 1 — Durable | Memory (`type: reference`, `lesson_<topic>.md`) |
+| An architecture summary ("what was built") | 1 — Durable | Memory (`type: project`, `project_<component>.md`) |
+| A completed milestone / work item | 1 — Durable | Memory (update existing `project_upcoming_work.md`) |
+| Current codebase inventory (files/components that exist NOW) | 2 — Ephemeral | Plan file (Step 2) |
+| Current branch, uncommitted state, pending work | 2 — Ephemeral | Plan file (Step 2) |
+| Commits pushed, PR/MR URLs, CI status | 2 — Ephemeral | Plan file (Step 2) |
+| Validation results, next steps | 2 — Ephemeral | Plan file (Step 2) |
+
+**Decision rule:** Would this fact be useful to a future session working on a
+*different task* in the same project? If yes → Tier 1 (memory). If only useful
+for resuming *this specific task* → Tier 2 (plan file).
+
+### Graduation Heuristic
+
+**Tier 1 facts (decisions, lessons, architecture) go to memory immediately.**
+The graduation heuristic does NOT apply to these — they are durable by nature
+and must survive `/clear`.
+
+For **ambiguous facts** that might be Tier 1 or Tier 2: keep them in the plan
+file on the first session. If the same fact survives into a second cryo and is
+still relevant, promote it to memory — it proved durable. This prevents
+transient facts from polluting memory while ensuring truly durable knowledge
+is never lost.
+
+### Writing Memory Files
+
+For each Tier 1 fact:
+
+1. **Check MEMORY.md** — does a memory file already cover this topic?
+2. **If exists and changed:** Read → Edit the file → update MEMORY.md entry if description changed
+3. **If exists and unchanged:** Skip (zero cost)
+4. **If new topic:** Write a new file with frontmatter, add entry to MEMORY.md
+
+Typical cryo produces **0-3 memory writes** — only what actually went dirty.
+
+Memory files go to the project memory directory (the same directory where
+MEMORY.md lives — visible in your system context). Use the standard frontmatter:
+
+```markdown
+---
+name: <descriptive name>
+description: <one-line summary for relevance matching>
+type: project  # or reference for lessons/gotchas
+---
+
+<content>
+```
+
+### Why This Matters
+
+Memory files survive `/clear` and compaction. They load automatically into every
+future session's system prompt at zero tool-call cost. Durable knowledge written
+here is never lost — even if the plan file deploy fails or `/clear` fires early.
+
 ## Step 2: Curate the Plan File
 
 Create the temp file first:
@@ -90,7 +154,7 @@ Structure it as:
 [Organized by component — what exists in the codebase NOW, not what's planned]
 
 ## Key Design Decisions
-[Numbered list of non-obvious choices and WHY they were made]
+[If promoted to memory in Step 1.5, write: "See memory files." Otherwise, list here.]
 
 ## Validation Results
 [What passed, what failed, what was verified]
@@ -102,7 +166,7 @@ Structure it as:
 [Paths, branches, cross-references]
 
 ## Lessons Learned
-[Anything that caused pain — CI quirks, API gotchas, workarounds]
+[If promoted to memory in Step 1.5, write: "See memory files." Otherwise, list here.]
 ```
 
 ### Writing Rules

--- a/skills/cryopact/SKILL.md
+++ b/skills/cryopact/SKILL.md
@@ -26,17 +26,22 @@ with the following brief:
 2. **Pass it a session summary** — a concise brief of what happened this
    session: what was built, key decisions, current branch/issue, what's
    pending. This is the subagent's only window into conversation context.
-3. **Resolve the project root** for the subagent — run
-   `git rev-parse --show-toplevel` and substitute `<PROJECT_ROOT>` in the
-   prompt template.
+3. **Resolve the project root and memory directory** for the subagent — run
+   `git rev-parse --show-toplevel` and find the memory directory path from
+   your system context (the directory where MEMORY.md lives). Substitute
+   `<PROJECT_ROOT>` and `<MEMORY_DIR>` in the prompt template.
 4. **Instruct it to**:
    - Create a temp file: `mktemp /tmp/cryo-XXXXXX.md`
    - Read `skills/cryo/SKILL.md` for the plan template and writing rules
-   - Follow cryo's Step 1 (Audit Current State) and Step 2 (Curate the Plan
-     File) — but **skip Step 3** (task curation is not delegable)
+   - Follow cryo's Step 1 (Audit Current State), **Step 1.5 (Extract Durable
+     Facts to Memory)**, and Step 2 (Curate the Plan File) — but **skip
+     Step 3** (task curation is not delegable)
+   - **Write durable facts directly to memory files** at `<MEMORY_DIR>` using
+     the tier classification rules. These writes are DURABLE — they survive
+     `/clear` and compaction.
+   - Write ONLY ephemeral state to the temp file (branch, commits, pending)
    - Use the plan file path you provided (not discover it from system context)
-   - Write the result to the temp file
-   - **Return the temp file path** in its response
+   - **Return the temp file path AND a list of memory files written/updated**
 
 5. **When the subagent returns**, note the temp file path it gives you. You
    will need this path in Phase 3. Remember it — shell variables do not
@@ -44,25 +49,31 @@ with the following brief:
 
 **Subagent prompt template:**
 
-Before spawning, substitute `<PLAN_PATH>`, `<YOUR_BRIEF>`, and `<PROJECT_ROOT>`
-with real values.
+Before spawning, substitute `<PLAN_PATH>`, `<YOUR_BRIEF>`, `<PROJECT_ROOT>`,
+and `<MEMORY_DIR>` with real values. The subagent receives actual filesystem
+paths, not placeholders.
 
 ```
 You are performing a cryo (context preservation) for the main agent.
 
 Plan file path: <PLAN_PATH>
+Memory directory: <MEMORY_DIR>
 Session summary: <YOUR_BRIEF>
 
 Instructions:
 1. Run: CRYO_TMP=$(mktemp /tmp/cryo-XXXXXX.md) && echo "$CRYO_TMP"
 2. Read the skill file at <PROJECT_ROOT>/skills/cryo/SKILL.md — it contains
-   the plan template structure and writing rules.
-3. Follow cryo's Step 1 (Audit Current State) and Step 2 (Curate the Plan
-   File). SKIP Step 3 (task curation) — you don't have access to TaskList.
-   Use the plan file path above when cryo references "the existing plan file."
-4. Write the result to $CRYO_TMP — do NOT deploy to the plan path. The main
-   agent handles deployment.
-5. Return the temp file path so the main agent can deploy it.
+   the plan template structure, tier classification rules, and writing rules.
+3. Follow cryo's Step 1 (Audit Current State).
+4. Follow cryo's Step 1.5 (Extract Durable Facts to Memory). Write durable
+   facts (design decisions, lessons learned, architecture) DIRECTLY to memory
+   files at <MEMORY_DIR>. These writes survive /clear — this is the whole
+   point. Update MEMORY.md at <MEMORY_DIR>/MEMORY.md for any new files.
+5. Follow cryo's Step 2 (Curate the Plan File) for ONLY ephemeral state
+   (branch, commits, pending, next steps). SKIP Step 3 (task curation) —
+   you don't have access to TaskList. Write to $CRYO_TMP.
+6. Return BOTH the temp file path AND a list of memory files you wrote/updated
+   so the main agent knows what was persisted.
 ```
 
 ## Phase 2: Keep Working

--- a/skills/engage/SKILL.md
+++ b/skills/engage/SKILL.md
@@ -24,12 +24,17 @@ This skill is the post-compaction (or session-start) ritual. It restores context
    - This confirmation is required by the post-compaction protocol
 
 3. **Load Current Plan** - Check for an active plan file
+   - Durable project knowledge (decisions, lessons, architecture) may already
+     be loaded from memory files — check your system context for memory content
    - Look in the plan mode system context for a plan file path
    - If a plan file exists, read it and summarize the current state:
      - What was being worked on
      - What's done vs. pending
      - Any blockers or next steps
-   - If no plan file exists, say "No active plan found."
+   - If no plan file exists but memory files are present, durable context is
+     loaded from memory — report the project knowledge you have and state that
+     no active task context exists (clean slate ready for new work)
+   - If neither exists, say "No active plan or memory context found."
 
 4. **Present Ready State** - End with a brief "ready" message that includes:
    - Current git branch


### PR DESCRIPTION
## Summary

Split cryo output into two tiers so durable knowledge survives `/clear` and compaction. Design decisions, lessons learned, and architecture summaries go directly to memory files (persistent, auto-loaded). Ephemeral state (branch, commits, pending) stays in the plan file.

## Changes

- **skills/cryo/SKILL.md**: Add Step 1.5 — tier classification table, graduation heuristic (Tier 1 goes to memory immediately, ambiguous facts graduate after 2nd cryo), memory write protocol
- **skills/cryopact/SKILL.md**: Subagent writes memory files directly at `<MEMORY_DIR>` instead of queuing instructions in temp file. Returns list of files written.
- **skills/engage/SKILL.md**: Handles memory-without-plan as normal success state (not an error)

## Linked Issues

Closes #236

## Test Plan

- `./scripts/ci/validate.sh` — 73 passed, 0 failed
- Code review: 4 findings fixed (graduation heuristic conflict, tier classification gap, memory path ambiguity, engage framing)
- Manual testing deferred to first real cryo session with new skill files

🤖 Generated with [Claude Code](https://claude.com/claude-code)