### PR TITLE
feat(waves): support serial wave topology — tracking without parallelism (#250)

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -172,15 +172,15 @@ These handle interaction with external systems: Discord, Slack, voice, and file 
 
 ### Advanced Skills
 
-These enable parallel execution of work across multiple agents -- the "wave pattern."
+The "wave pattern" provides lifecycle tracking, dashboard visibility, and audit trails for structured work -- parallel, serial, or mixed.
 
 | Skill | Purpose |
 |-------|---------|
-| `/assesswaves` | Quick assessment of whether work items are suitable for parallel execution. |
+| `/assesswaves` | Quick assessment of whether work items are suitable for wave-pattern execution (parallel, serial, or mixed). |
 | `/prepwaves` | Full planning: validate sub-issue specs, compute dependency waves, prepare for execution. |
-| `/nextwave` | Execute one wave at a time with isolated worktrees and flight-based conflict avoidance. |
+| `/nextwave` | Execute one wave at a time -- parallel flights use isolated worktrees, serial flights use a streamlined fast-path. |
 
-The wave skills form a pipeline: `/assesswaves` decides if parallelism is worth it, `/prepwaves` plans the execution order, and `/nextwave` executes one wave at a time. Each wave can contain multiple "flights" -- groups of issues that can safely run in parallel without file-level conflicts. See the individual [skill files](../skills/) for full documentation.
+The wave skills form a pipeline: `/assesswaves` determines the topology, `/prepwaves` plans the execution order, and `/nextwave` executes one wave at a time. Parallel flights use isolated worktrees with flight-based conflict avoidance. Serial flights (1 issue per flight) skip worktree isolation and conflict detection. See the individual [skill files](../skills/) for full documentation.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -205,13 +205,13 @@ The full skill reference is in [Skill Reference](skill-reference.md) with detail
 | `/vox` | Text-to-speech announcements ("Hey, the build passed") |
 | `/jfail` | Fetch and analyze a failed CI job or workflow run |
 
-### Advanced: Parallel Execution
+### Advanced: Wave-Pattern Execution
 
-For large features that decompose into independent sub-issues, the wave system lets multiple agents work in parallel:
+For structured work (parallel, serial, or mixed), the wave system provides lifecycle tracking, a dashboard, and an audit trail:
 
-1. `/assesswaves` -- quick assessment of whether work items are suitable for parallel execution
+1. `/assesswaves` -- quick assessment of topology (parallel, serial, or mixed) and whether wave tracking is worth it
 2. `/prepwaves` -- full planning: validate sub-issue specs, compute dependency waves, partition into flights
-3. `/nextwave` -- execute one wave at a time with isolated worktrees and conflict avoidance
+3. `/nextwave` -- execute one wave at a time; parallel flights use isolated worktrees, serial flights use a streamlined fast-path
 
 See the [Skill Reference](skill-reference.md) for detailed documentation on each, or the [skill SKILL.md files](../skills/) for the raw agent prompts.
 

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -541,7 +541,13 @@ A structured workflow for domain modeling using event storming. Guides you throu
 
 ## Advanced Skills -- Wave Pattern
 
-These enable parallel execution of work across multiple agents. The wave pattern decomposes a large feature into independent sub-issues, groups them into dependency-ordered waves, and executes each wave with isolated worktrees and flight-based conflict avoidance.
+The wave pattern decomposes work into dependency-ordered waves and executes each wave with lifecycle tracking, dashboard visibility, and an audit trail. It supports three topologies:
+
+- **Parallel** — multiple agents execute independent issues concurrently on isolated worktrees with flight-based conflict avoidance
+- **Serial** — single-issue flights execute sequentially with a streamlined fast-path (no worktree isolation, no conflict detection)
+- **Mixed** — some waves are parallel, some are serial
+
+The wave pattern is valuable for **tracking and visibility**, not just parallelism. Even fully sequential work benefits from the dashboard, lifecycle management, and git audit trail.
 
 The pipeline is: `/assesswaves` (decide) -> `/prepwaves` (plan) -> `/nextwave` (execute).
 
@@ -549,12 +555,12 @@ The pipeline is: `/assesswaves` (decide) -> `/prepwaves` (plan) -> `/nextwave` (
 
 ### `/assesswaves` -- Quick Wave Assessment
 
-Quickly assesses whether a set of work items can benefit from parallel agent execution via the wave pattern. This is a decision tool -- it recommends a verdict but does not create issues, plans, or execute anything.
+Quickly assesses whether a set of work items can benefit from wave-pattern execution (parallel, serial, or mixed). This is a decision tool -- it recommends a topology and verdict but does not create issues, plans, or execute anything.
 
 **When to use it:**
-- Before `/prepwaves`, to decide whether wave-pattern execution is worth the overhead
-- When evaluating a new feature or epic for parallelism potential
-- After issues are created, to check for file-level conflicts
+- Before `/prepwaves`, to decide whether wave-pattern execution is worth it
+- When evaluating a new feature or epic — even fully sequential work can benefit from wave tracking
+- After issues are created, to check for file-level conflicts and determine optimal topology
 
 **Examples:**
 
@@ -564,17 +570,17 @@ Quickly assesses whether a set of work items can benefit from parallel agent exe
 /assesswaves                  # Describe work items in conversation
 ```
 
-It gathers work items, launches sub-agents to analyze file impact, builds a conflict matrix, and presents a verdict card: wave-able (yes/no/maybe), suggested waves, risk level, and a recommendation for next steps.
+It gathers work items, launches sub-agents to analyze file impact, builds a conflict matrix, and presents a verdict card: wave-able (yes/no/maybe), topology (parallel/serial/mixed), suggested waves, risk level, and a recommendation for next steps.
 
 ---
 
 ### `/prepwaves` -- Plan Execution Waves
 
-Analyzes a master issue and its sub-issues, validates they are ready for spec-driven agent execution, computes dependency-ordered waves, and prepares everything for `/nextwave`.
+Analyzes a master issue and its sub-issues, validates they are ready for spec-driven agent execution, computes dependency-ordered waves (parallel, serial, or mixed), and prepares everything for `/nextwave`.
 
 **When to use it:**
-- After `/assesswaves` confirms the work is wave-able
-- When you have a master issue (epic) with well-specified sub-issues and want to plan parallel execution
+- After `/assesswaves` confirms the work is wave-able (any topology)
+- When you have a master issue (epic) with well-specified sub-issues
 - Before running `/nextwave` for the first time on a set of issues
 
 **Examples:**
@@ -592,10 +598,10 @@ It validates the master issue structure, reads each sub-issue and checks for req
 
 ### `/nextwave` -- Execute One Wave
 
-Executes the next pending wave from a plan created by `/prepwaves`. Uses a two-phase approach: planning agents identify file targets, then issues are partitioned into conflict-free flights for safe parallel execution on isolated worktrees.
+Executes the next pending wave from a plan created by `/prepwaves`. Automatically selects the right execution mode: for multi-issue flights, planning agents detect file conflicts and agents execute on isolated worktrees. For single-issue flights (serial topology), the fast-path skips conflict detection and worktree isolation.
 
 **When to use it:**
-- After `/prepwaves` has created a wave plan
+- After `/prepwaves` has created a wave plan (any topology)
 - To execute the next wave in the sequence (one wave per invocation)
 - When the previous wave has been merged and you are ready to continue
 
@@ -605,9 +611,11 @@ Executes the next pending wave from a plan created by `/prepwaves`. Uses a two-p
 /nextwave
 ```
 
-No arguments. It identifies the next pending wave from the task list, runs pre-flight checks, launches planning agents to detect file conflicts, partitions into flights, and executes each flight with isolated worktrees. Between flights, it runs re-validation to ensure merged changes have not invalidated the next flight's plans. After all flights, it runs a design review of the next wave's specs.
+No arguments. It identifies the next pending wave from the task list and auto-detects topology. For parallel flights: launches planning agents, detects file conflicts, partitions into flights, executes on isolated worktrees. For serial flights: skips planning and worktree isolation, executes directly. Between flights, it runs re-validation. After all flights, it runs a drift check on the next wave's specs.
 
-**Flow:** Pre-Flight Checks -> Planning Phase -> Flight 1 (execute + merge) -> Re-Validate -> Flight 2 (execute + merge) -> ... -> Design Review -> Wave Complete.
+**Flow (parallel):** Pre-Flight Checks -> Planning Phase -> Flight 1 (execute + merge) -> Re-Validate -> Flight 2 -> ... -> Drift Check -> Wave Complete.
+
+**Flow (serial):** Pre-Flight Checks -> Flight 1 (execute + merge) -> Flight 2 (execute + merge) -> ... -> Drift Check -> Wave Complete.
 
 **Key detail:** One wave per invocation. The user controls the pace. Run `/cryo` between waves if compaction is imminent.
 

--- a/skills/assesswaves/SKILL.md
+++ b/skills/assesswaves/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assesswaves
-description: Quick assessment of whether a piece of work is suitable for wave-pattern parallel execution. Lighter than /prepwaves — helps decide decomposition before (or after) issues are created.
+description: Quick assessment of whether a piece of work is suitable for wave-pattern execution (parallel or serial). Lighter than /prepwaves — helps decide decomposition before (or after) issues are created.
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -11,7 +11,7 @@ description: Quick assessment of whether a piece of work is suitable for wave-pa
 
 # AssessWaves: Is This Work Wave-Patternable?
 
-Quickly assess whether a set of work items can benefit from parallel agent execution via the wave pattern. This is a **decision tool**, not a planning tool — it recommends a decomposition and verdict, but does not create issues, flight plans, or execute anything.
+Quickly assess whether a set of work items can benefit from wave-pattern execution — parallel, serial, or mixed. The wave pattern provides lifecycle tracking, dashboard visibility, and audit trail regardless of whether work runs in parallel or sequentially. This is a **decision tool**, not a planning tool — it recommends a topology and verdict, but does not create issues, flight plans, or execute anything.
 
 Use this **before** `/prepwaves` to decide whether wave-pattern execution is worth it.
 
@@ -78,6 +78,7 @@ Present the assessment in this format:
 |-------|-------|
 | **Work items** | N items assessed |
 | **Wave-able** | yes / no / maybe |
+| **Topology** | parallel / serial / mixed |
 | **Suggested waves** | N waves (rough sketch) |
 | **Risk level** | low / medium / high |
 
@@ -93,8 +94,16 @@ Present the assessment in this format:
 
 ### Wave Sketch
 
+Examples by topology:
+
+**Parallel/mixed:**
 - **Wave 1** (parallel): Items 1, 3 — no file overlap, independent
-- **Wave 2** (sequential after wave 1): Item 2 — depends on Item 1's output
+- **Wave 2** (serial — depends on Wave 1): Item 2 — depends on Item 1's output
+
+**Serial (all sequential):**
+- **Wave 1** (serial): Item 1
+- **Wave 2** (serial): Item 2 — depends on Item 1
+- **Wave 3** (serial): Item 3 — depends on Item 2
 
 ### Risk Flags
 
@@ -104,10 +113,14 @@ Present the assessment in this format:
 ### Recommendation
 
 (one of:)
-- "Wave-able. Create issues for each item and run `/prepwaves` for full planning."
-- "Wave-able. Issues already exist — ready for `/prepwaves`."
-- "Not wave-able. These items have too much file overlap / are logically sequential. Execute them in series."
+- "Wave-able (parallel). Create issues for each item and run `/prepwaves` for full planning."
+- "Wave-able (parallel). Issues already exist — ready for `/prepwaves`."
+- "Wave-able (serial). Issues are sequential — use single-issue flights for lifecycle tracking and dashboard visibility."
+- "Wave-able (mixed). Some items can run in parallel, others are sequential. `/prepwaves` will compute the optimal topology."
 - "Maybe wave-able with restructuring. Consider splitting <item> into <X> and <Y> to reduce overlap."
+- "Not wave-able. Fewer than 3 items — overhead exceeds benefit. Execute directly."
+
+**Key insight:** Serial work is a valid wave topology. The wave pattern provides lifecycle tracking, a dashboard, and an audit trail regardless of parallelism. "Logically sequential" is NOT a reason to reject wave tracking — it determines topology (serial flights), not suitability.
 ```
 
 ## What This Skill Does NOT Do

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nextwave
-description: Execute the next pending wave of parallel spec-driven sub-agents on isolated worktrees, using flight-based conflict avoidance
+description: Execute the next pending wave of spec-driven sub-agents, using flight-based conflict avoidance for parallel flights and a streamlined fast-path for serial flights
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -11,16 +11,23 @@ description: Execute the next pending wave of parallel spec-driven sub-agents on
 
 # NextWave: Execute One Wave with Flight-Based Conflict Avoidance
 
-Execute the next pending wave from a plan created by `/prepwaves`. Uses a two-phase approach: **planning agents** identify file targets, then issues are partitioned into **flights** (conflict-free groups) for safe parallel execution. Merges via PR/MR — never directly to main.
+Execute the next pending wave from a plan created by `/prepwaves`. Supports two execution modes:
+
+- **Parallel flights** (2+ issues per flight): Planning agents identify file targets, issues are partitioned into conflict-free flights, executed on isolated worktrees.
+- **Serial flights** (1 issue per flight): Fast-path — skip planning agents, skip worktree isolation, execute directly. Same lifecycle tracking and dashboard updates.
+
+The mode is detected automatically based on flight size. Merges via PR/MR — never directly to main.
 
 ## Core Concepts
 
 - **Wave**: A group of issues whose dependencies are all satisfied by prior waves. Defined by `/prepwaves`.
-- **Flight**: A subset of a wave's issues that can execute in parallel without file-level conflicts. Determined at runtime by analyzing planning agent output.
-- **Planning Agent**: A lightweight, read-only agent that reads an issue and the codebase, then reports which files/functions it would modify — without writing any code.
-- **Execution Agent**: A full agent that implements the issue on an isolated worktree.
+- **Flight**: A subset of a wave's issues that can execute in parallel without file-level conflicts. Determined at runtime by analyzing planning agent output. A single-issue flight uses the serial fast-path.
+- **Planning Agent**: A lightweight, read-only agent that reads an issue and the codebase, then reports which files/functions it would modify — without writing any code. **Skipped for single-issue flights.**
+- **Execution Agent**: A full agent that implements the issue on an isolated worktree (parallel) or directly in the current session (serial).
 
-Flow: `Pre-Flight Checks → Planning Phase → Flight 1 (execute + merge) → Re-Validate → Flight 2 (execute + merge) → ... → Drift Check → Wave Complete`
+Flow (parallel): `Pre-Flight Checks → Planning Phase → Flight 1 (execute + merge) → Re-Validate → Flight 2 (execute + merge) → ... → Drift Check → Wave Complete`
+
+Flow (serial): `Pre-Flight Checks → Flight 1 (execute + merge) → Flight 2 (execute + merge) → ... → Drift Check → Wave Complete`
 
 ## Status Panel
 
@@ -74,6 +81,27 @@ If any check fails, **stop and report** — do not launch agents on a bad founda
 ---
 
 ## Step 2: Planning Phase — Target Analysis
+
+### Serial Fast-Path
+
+**If this wave contains only 1 issue, or the plan's topology is serial (each wave has 1 issue):** Skip this entire step. There are no file conflicts to detect when the wave has a single issue. Jump directly to Step 3 with a trivial flight plan — one flight per issue, sequential order. Still signal the transition:
+```bash
+wave-status planning
+```
+Then immediately build the flight plan (one issue per flight) and proceed:
+```bash
+# Build trivial serial flight plan
+cat > /tmp/flight-plan.json << 'FLIGHTS'
+[
+  {"issues": [<issue-1>], "status": "pending"},
+  {"issues": [<issue-2>], "status": "pending"},
+  ...
+]
+FLIGHTS
+wave-status flight-plan /tmp/flight-plan.json
+```
+
+### Parallel Path (2+ issues in at least one flight)
 
 Signal the transition to the planning phase:
 ```bash
@@ -193,6 +221,16 @@ Signal the flight is starting:
 ```bash
 wave-status flight <N>
 ```
+
+### Serial Flight (1 issue)
+
+If this flight has exactly 1 issue:
+1. **Skip worktree isolation** — execute directly on the feature branch (no parallel agents, no merge conflict risk)
+2. **Launch a single execution agent** (or execute directly in the current session if preferred)
+3. The agent works on the feature branch created in Step 1, implements the issue, and reports back
+4. Proceed to the pre-commit checklist and merge flow below (same as parallel)
+
+### Parallel Flight (2+ issues)
 
 For the current flight, launch **execution agents** — one per issue, all in parallel on isolated worktrees.
 
@@ -416,6 +454,8 @@ For each approved agent:
 
 **This step runs before each flight after Flight 1.** Its purpose is to ensure that the previous flight's merged changes haven't invalidated the next flight's plans.
 
+**Serial fast-path:** When both the previous and next flights are single-issue, re-validation is still valuable (the previous issue may have changed files the next issue needs) but the re-validation agent is optional — the execution agent in Step 3 reads the codebase fresh anyway. Use judgment: if the previous flight's changes were small and localized, skip re-validation. If they were structural, run it.
+
 ### 4a: Identify Changed Files
 
 Determine which files were modified by the previous flight:
@@ -626,8 +666,8 @@ Do NOT let deferred items disappear into the void. Every deferral must be tracke
 - Sub-agents are SPEC EXECUTORS — they implement what the issue says, nothing more
 - If an agent needs to deviate from the spec, it escalates — it does NOT improvise
 - **Default to safe** — latency is always preferable to broken code or merge conflicts
-- **Flights exist to prevent merge conflicts** — the planning phase is cheap, conflict resolution is expensive
-- Worktrees provide isolation — agents cannot interfere with each other or with `main`
+- **Flights exist to prevent merge conflicts** — the planning phase is cheap, conflict resolution is expensive. For single-issue flights, conflicts are impossible — use the serial fast-path.
+- Worktrees provide isolation for parallel flights — agents cannot interfere with each other or with `main`. Serial flights skip worktree isolation since there's only one agent.
 - **NEVER merge directly to main** — always go through a PR/MR for audit trail and CI
 - NEVER skip the pre-commit checklist — it exists because compaction has caused skipped reviews before
 - NEVER commit without user approval — even if the agent reports all green

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepwaves
-description: Analyze a master issue, validate sub-issue specs, compute dependency waves, and prepare for parallel agent execution
+description: Analyze a master issue, validate sub-issue specs, compute dependency waves, and prepare for wave-pattern execution (parallel, serial, or mixed)
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -9,9 +9,9 @@ description: Analyze a master issue, validate sub-issue specs, compute dependenc
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 
-# PrepWaves: Plan Parallel Execution Waves
+# PrepWaves: Plan Wave Execution
 
-Analyze epic issues and their sub-issues, validate they are ready for spec-driven parallel agent execution, compute dependency-ordered waves, and prepare everything for `/nextwave` to execute.
+Analyze epic issues and their sub-issues, validate they are ready for spec-driven agent execution, compute dependency-ordered waves, and prepare everything for `/nextwave` to execute. Supports parallel, serial, and mixed topologies — the wave pattern provides lifecycle tracking and dashboard visibility regardless of whether agents run concurrently.
 
 ## Prerequisites
 
@@ -81,9 +81,16 @@ Using the dependency graph from the sub-issues:
 1. **Topological sort** — Group issues into waves where all dependencies are satisfied by prior waves
 2. **Maximize parallelism** — Within each wave, all issues are independent and can run concurrently
 3. **Identify the critical path** — The longest chain of sequential waves
+4. **Detect topology** — Classify the plan:
+   - **Parallel**: at least one wave has 2+ independent issues
+   - **Serial**: every wave has exactly 1 issue (linear dependency chain)
+   - **Mixed**: some waves are parallel, some are single-issue
 
-Present the wave plan:
+All three topologies are valid. Serial waves get the same tracking, dashboard, and audit trail as parallel waves — `/nextwave` uses a streamlined fast-path for single-issue flights (no worktree isolation, no conflict detection).
 
+Present the wave plan. Examples by topology:
+
+**Parallel/mixed topology:**
 ```
 Wave 1 (parallel — no dependencies)
 ├── #N  Title  [branch: feature/N-description]
@@ -92,8 +99,18 @@ Wave 1 (parallel — no dependencies)
 Wave 2 (parallel — depends on Wave 1)
 ├── #P  Title  [needs #N]
 └── #Q  Title  [needs #N, #M]
+```
 
-...
+**Serial topology (1 issue per wave):**
+```
+Wave 1 (serial)
+└── #N  Title  [branch: feature/N-description]
+
+Wave 2 (serial — depends on Wave 1)
+└── #M  Title  [needs #N]
+
+Wave 3 (serial — depends on Wave 2)
+└── #P  Title  [needs #M]
 ```
 
 Include:
@@ -185,4 +202,5 @@ Tell the user:
 - If the user wants to change the wave plan, iterate here — not during `/nextwave`
 - The quality of the issue specs directly determines the quality of agent output
 - Pair with `/nextwave` for execution: `/prepwaves` plans, `/nextwave` executes one wave at a time
-- `/nextwave` uses a **flight model** within each wave — it launches planning agents first to detect file-level conflicts, then partitions the wave into conflict-free flights. You do NOT need to account for file-level conflicts during `/prepwaves` — only dependency-level ordering matters here. Flight partitioning happens at execution time.
+- `/nextwave` uses a **flight model** within each wave — for multi-issue flights, it launches planning agents to detect file-level conflicts, then partitions into conflict-free flights. For single-issue flights (serial topology), it skips conflict detection and worktree isolation entirely. You do NOT need to account for file-level conflicts during `/prepwaves` — only dependency-level ordering matters here. Flight partitioning happens at execution time.
+- **Serial is valid.** A fully sequential dependency chain (every issue depends on the previous one) still benefits from wave tracking. Don't reject serial work — classify it as serial topology and let `/nextwave` use its streamlined path.


### PR DESCRIPTION
## Summary

Update the wave pattern to treat serial execution (1 issue per flight) as a first-class topology. The wave pattern provides lifecycle tracking, dashboard visibility, and audit trail regardless of whether work runs in parallel or sequentially. "Logically sequential" is no longer a reason to reject wave tracking — it determines topology, not suitability.

## Changes

- **assesswaves**: Add topology field to verdict card, serial recommendation option, serial wave sketch example, consistent "serial" terminology
- **prepwaves**: Add topology detection to Step 3, serial wave plan example, updated Important section
- **nextwave**: Add serial fast-path to Step 2 (skip planning agents for single-issue waves) and Step 3 (skip worktree isolation for single-issue flights), updated Step 4 re-validation note
- **skill-reference.md**: Rewrite wave pattern intro to cover all topologies, update all three skill descriptions
- **concepts.md**: Update Advanced Skills section from parallel-only to all topologies
- **getting-started.md**: Rename section, update descriptions

## Linked Issues

Closes #250
Part of #242

## Test Plan

- Validated with `./scripts/ci/validate.sh` — 72/72 passed
- Code review by `feature-dev:code-reviewer` — 4 findings, all fixed
- Verified terminology consistency ("serial" not "sequential") across all 6 files
- No executable code changed — skill markdown definitions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)