### PR TITLE
feat(prd): /prd skill with Deliverables Manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Key features:
 | nextwave | `/nextwave` | Execute parallel spec-driven sub-agents |
 | ping | `/ping` | Post to #ai-dev Slack channel |
 | pong | `/pong` | Read #ai-dev Slack channel |
+| prd | `/prd` | Interactive PRD creation with Deliverables Manifest and finalization checklist |
 | precheck | `/precheck` | Pre-commit gate — verify compliance, run code review, present checklist |
 | prepwaves | `/prepwaves` | Analyze issues and compute dependency waves |
 | review | `/review` | Code review on staged/branch changes |

--- a/docs/DDD-to-PRD-protocol.md
+++ b/docs/DDD-to-PRD-protocol.md
@@ -1,5 +1,7 @@
 # DDD → PRD Translation Protocol
 
+> **Recommended:** Use `/prd create` with a DDD domain model as input to automate this translation interactively. The `/prd create` skill walks each PRD section with you, applies the mapping rules below, and manages the Deliverables Manifest. This protocol document remains as reference for understanding the mapping, but the primary workflow is now: `/ddd accept` (produces concept handoff) → `/prd create` (produces PRD).
+
 This guide documents the process for converting a Domain Model (Event Storming output) into a Product Requirements Document following the PRD template (`docs/PRD-template.md`).
 
 ## Purpose

--- a/docs/PRD-template.md
+++ b/docs/PRD-template.md
@@ -14,11 +14,11 @@
 3. [Requirements (EARS Format)](#3-requirements-ears-format)
 4. [Concept of Operations](#4-concept-of-operations)
 5. [Detailed Design](#5-detailed-design)
-   - [5.A Artifact Manifest](#5a-artifact-manifest)
+   - [5.A Deliverables Manifest](#5a-deliverables-manifest)
    - [5.B Installation & Deployment](#5b-installation--deployment)
 6. [Test Plan](#6-test-plan)
 7. [Definition of Done](#7-definition-of-done)
-   - [7.1 Documentation Kit](#71-documentation-kit)
+   - [7.2 PRD Finalization Checklist](#72-prd-finalization-checklist)
 8. [Phased Implementation Plan](#8-phased-implementation-plan)
 9. [Appendices](#9-appendices)
 
@@ -136,7 +136,7 @@ Not every project needs all of these. Include the flows that are necessary to gi
 - **Technology Choices** — table of components with chosen technology and rationale
 - **Deployment Architecture** — how the system is deployed and operated (if applicable)
 - **Security Model** — authentication, authorization, secrets handling (if applicable)
-- **Artifact Manifest** — every artifact the project produces, including test outputs (see 5.A below)
+- **Deliverables Manifest** — everything the project must produce: code artifacts, test outputs, documentation, and verification records (see 5.A below)
 - **Installation & Deployment** — how artifacts get from "built" to "running/available" (see 5.B below)
 
 Include diagrams where they add clarity. Prefer ASCII art or Mermaid for version-control-friendly diagrams.]]
@@ -147,18 +147,37 @@ _Sections 5.1–5.N are project-specific design topics — add as many as needed
 
 [[detailed design content]]
 
-### 5.A Artifact Manifest
+### 5.A Deliverables Manifest
 
-[[Every artifact this project produces — not just the primary deliverable, but test outputs, documentation, packages, and anything that leaves the build. This manifest is the single source of truth for "what does this project emit?" and directly informs CI/CD pipeline design and story acceptance criteria.
+[[The single source of truth for everything this project must produce — code artifacts, test outputs, documentation, and verification records. Every row needs a file path and a wave assignment before the PRD is finalized.
 
-Include test artifacts (JUnit XML, coverage reports, lint summaries) — these are first-class outputs that CI consumes.]]
+**Tier system:**
+- **Tier 1 (required):** Opt-OUT with rationale — must provide "N/A — because [reason]" to skip
+- **Tier 2 (conditional):** Added when triggers fire (documented in the trigger column)
+- **Tier 3 (opt-in):** Only added when explicitly requested — silent-skip is fine
 
-| ID | Artifact | Type | Build Command | Destination |
-|----|----------|------|---------------|-------------|
-| A-01 | [[e.g., `dist/my-tool`]] | [[binary / package / report / doc]] | [[e.g., `./scripts/ci/build.sh`]] | [[e.g., `~/.local/bin/`, PyPI, S3, GitLab Package Registry]] |
-| A-02 | [[e.g., `reports/junit.xml`]] | test report | [[e.g., `pytest --junitxml=reports/junit.xml`]] | [[e.g., CI artifact upload, GitLab test report parser]] |
-| A-03 | [[e.g., `reports/coverage.xml`]] | coverage report | [[e.g., `pytest --cov --cov-report=xml`]] | [[e.g., CI artifact upload, Codecov]] |
-| A-04 | [[e.g., `docs/api-reference.md`]] | documentation | [[e.g., `./scripts/ci/gen-docs.sh`]] | [[e.g., GitLab/GitHub Pages, S3 static site]] |
+The table below starts with Tier 1 defaults. The `/prd create` skill walks these with you during PRD generation. Tier 2 rows are added when their triggers fire. Tier 3 rows are added only on request.]]
+
+| ID | Deliverable | Category | Tier | File Path | Produced In | Status | Notes |
+|----|-------------|----------|------|-----------|-------------|--------|-------|
+| DM-01 | README.md | Docs | 1 | `README.md` | | required | Project overview, quickstart, contributing guide |
+| DM-02 | Unified build system | Code | 1 | `Makefile` | | required | CI and terminal use identical commands |
+| DM-03 | CI/CD pipeline | Code | 1 | | | required | Automated lint + test on every PR/MR |
+| DM-04 | Automated test suite | Test | 1 | | | required | Unit + integration tests |
+| DM-05 | Test results (JUnit XML) | Test | 1 | `reports/junit.xml` | | required | CI artifact upload |
+| DM-06 | Coverage report | Test | 1 | `reports/coverage.xml` | | required | CI artifact upload |
+| DM-07 | CHANGELOG | Docs | 1 | `CHANGELOG.md` | | required | Release-by-release summary |
+| DM-08 | VRTM | Trace | 1 | PRD Appendix V | | required | Requirement traceability matrix |
+| DM-09 | Audience-facing doc (ops runbook, user manual, API/CLI ref) | Docs | 1 | | | required | At least one must have a file path |
+
+[[**Tier 2 triggers** (add rows when conditions are met):
+- **Manual test procedures** → when MV-XX items exist in Section 6.4
+- **Architecture doc** → when >2 interacting components
+- **Deployment verification procedures** → when project deploys infrastructure
+- **Environment prerequisites doc** → when project has host/platform requirements]]
+
+[[**Tier 3 examples** (add only when requested):
+- Sequence diagrams, data flow diagrams, threat model, performance benchmarks]]
 
 ### 5.B Installation & Deployment
 
@@ -255,30 +274,21 @@ After all phases are complete, the VRTM in Section 9 provides the formal proof t
 
 - [ ] All Phase DoD checklists are satisfied
 - [ ] All Test Plan items (Section 6) executed and passed
-- [ ] All Documentation Kit items delivered (Section 7.1)
-- [ ] All artifacts from the Artifact Manifest (Section 5.A) build and install successfully
+- [ ] All deliverables from the Deliverables Manifest (Section 5.A) produced and verified
 - [ ] [[cross-cutting condition — annotate with requirement IDs, e.g., [R-01, R-05] ]]
 - [ ] [[cross-cutting condition [R-XX] ]]
 
-### 7.1 Documentation Kit
+### 7.2 PRD Finalization Checklist
 
-[[Define the complete set of documentation artifacts the project must deliver. This is not "nice to have" — these are tracked deliverables with owners and deadlines (by phase). Each document should have a story in the implementation plan that produces it.
+[[Go/no-go gate before wave planning. Run `/prd finalize` to verify mechanically.]]
 
-Common documentation artifacts to consider:
-- **README** — project overview, quickstart, how to contribute
-- **API Reference** — auto-generated or hand-written endpoint/function docs
-- **Architecture / Design Doc** — high-level system design for maintainers
-- **Runbook / Operations Guide** — how to deploy, monitor, troubleshoot (if applicable)
-- **User Guide** — how end users interact with the system (if applicable)
-- **CHANGELOG** — release-by-release summary of changes
-
-Not every project needs all of these. But every project needs to explicitly decide which ones it needs and plan stories to produce them.]]
-
-| Document | Audience | Format | Produced In | Notes |
-|----------|----------|--------|-------------|-------|
-| [[e.g., README.md]] | [[e.g., developers, contributors]] | [[e.g., Markdown in repo root]] | [[e.g., Phase 1]] | [[e.g., must include quickstart and install instructions]] |
-| [[e.g., API Reference]] | [[e.g., integrators]] | [[e.g., auto-generated from docstrings]] | [[e.g., Phase 2]] | [[e.g., published to GitHub Pages]] |
-| [[e.g., Runbook]] | [[e.g., operators]] | [[e.g., Markdown in docs/]] | [[e.g., Phase 3]] | [[e.g., covers deploy, rollback, alerting]] |
+- [ ] Every Tier 1 row in the Deliverables Manifest (5.A) has a file path or "N/A — because [reason]"
+- [ ] Every Tier 2 trigger that fires has a corresponding row in the Deliverables Manifest
+- [ ] Every Deliverables Manifest row has a "Produced In" wave assignment
+- [ ] Every MV-XX in Section 6.4 has a procedure document in the Deliverables Manifest
+- [ ] No deliverable is referenced only as a verb without a corresponding noun (file path)
+- [ ] At least one audience-facing doc (DM-09) has a file path assigned
+- [ ] Section 7 Definition of Done references the Deliverables Manifest (not separate Artifact Manifest + Documentation Kit)
 
 ---
 
@@ -302,11 +312,11 @@ Every project needs certain infrastructure before feature work begins. Wave 1 sh
 
 - [ ] **Project scaffold** — dependency manifest (`pyproject.toml`, `package.json`, `pom.xml`, etc.), package/module structure, empty test directory
 - [ ] **CI/CD pipeline** — implement the pipeline defined in Section 5.B. Automated lint + test on every PR/MR. Keep workflow definitions thin (orchestration only) with logic in scripts.
-- [ ] **Artifact build & install** — implement the build commands and installation procedures from the Artifact Manifest (Section 5.A) and Installation & Deployment (Section 5.B)
+- [ ] **Artifact build & install** — implement the build commands and installation procedures from the Deliverables Manifest (Section 5.A) and Installation & Deployment (Section 5.B)
 - [ ] **Linting and formatting** — configured and enforced in CI from the first commit
-- [ ] **Test runner** — configured and passing (even if the only test is a smoke/import test). Test artifact outputs (JUnit XML, coverage) wired to CI as defined in the Artifact Manifest (Section 5.A).
+- [ ] **Test runner** — configured and passing (even if the only test is a smoke/import test). Test artifact outputs (JUnit XML, coverage) wired to CI as defined in the Deliverables Manifest (Section 5.A).
 - [ ] **Makefile or task runner** — standard targets (`lint`, `test`, `ci`) so humans and agents use the same commands
-- [ ] **Initial documentation** — README and any Phase 1 items from the Documentation Kit (Section 7.1)
+- [ ] **Initial documentation** — README and any Phase 1 items from the Deliverables Manifest (Section 5.A)
 
 If any of these are missing from Wave 1, add a story. CI/CD in particular is easy to forget and painful to retrofit — every PR from Wave 2 onward should be validated automatically.
 

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -539,6 +539,40 @@ A structured workflow for domain modeling using event storming. Guides you throu
 
 ---
 
+### `/prd` -- Interactive PRD Creation
+
+Creates Product Requirements Documents through an interactive, section-by-section workflow. Instead of generating a PRD in one shot, it walks each section collaboratively -- drafting, presenting, and waiting for feedback before moving on. Manages a unified Deliverables Manifest (Tier 1 required defaults, Tier 2 conditional triggers, Tier 3 opt-in) and runs a mechanical finalization checklist.
+
+**When to use it:**
+- After `/ddd accept` produces a domain model and you need to create a PRD from it
+- When starting a new project and need a structured PRD from a concept doc or verbal description
+- When you have an existing PRD and want to verify it meets completeness requirements
+
+**Examples:**
+
+```
+/prd create       # Start interactive PRD generation
+/prd finalize     # Run the finalization checklist on an existing PRD
+/prd              # Show help
+```
+
+**The pipeline:** `/ddd accept` (domain model) or concept doc or verbal description → `/prd create` (interactive PRD generation → `docs/<project>-PRD.md`) → `/prd finalize` (verify completeness) → `/prepwaves` (plan execution waves).
+
+**`/prd create` flow:**
+1. Determine input source (DDD domain model, external doc, or verbal description)
+2. Walk each PRD section (1-9) interactively -- draft, present, get feedback, iterate
+3. After Section 5: walk Tier 1 Deliverables Manifest defaults, confirm or N/A each row
+4. Scan for Tier 2 triggers, add conditional rows
+5. After Section 8: verify every manifest row has a wave assignment
+6. Write the PRD file
+
+**`/prd finalize` flow:**
+Run the Section 7.2 Finalization Checklist mechanically against an existing PRD. Reports pass/fail per item (Tier 1 file paths, Tier 2 triggers, wave assignments, MV-XX coverage, verb-only deliverables, audience-facing docs, DoD references). Summary: "X/7 checks passed. PRD is ready / not ready for approval."
+
+**Key detail:** Tier 1 deliverables are opt-OUT (must provide "N/A -- because [reason]" to skip). The Deliverables Manifest (Section 5.A) is the single source of truth for all project outputs -- there is no separate Artifact Manifest or Documentation Kit.
+
+---
+
 ## Advanced Skills -- Wave Pattern
 
 The wave pattern decomposes work into dependency-ordered waves and executes each wave with lifecycle tracking, dashboard visibility, and an audit trail. It supports three topologies:

--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: prd
+description: Interactive PRD creation with Deliverables Manifest and finalization checklist
+---
+
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-prd does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-prd
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
+# PRD Creation Workflow
+
+This skill provides a structured, interactive workflow for creating Product Requirements Documents. It walks each PRD section collaboratively, manages the Deliverables Manifest, and runs a mechanical finalization checklist.
+
+## Platform Detection
+
+Before proceeding, detect the platform:
+1. Check `.claude-project.md` for cached platform config
+2. If not cached, run `git remote -v` and inspect the origin URL
+3. GitHub → `gh` CLI, GitLab → `glab` CLI
+
+## Commands
+
+- **`/prd create`** — Interactive PRD generation (walk each section, build Deliverables Manifest)
+- **`/prd finalize`** — Mechanical finalization checklist (verify PRD completeness)
+
+## Usage
+
+```bash
+# Create a new PRD interactively
+/prd create
+
+# Run the finalization checklist on an existing PRD
+/prd finalize
+
+# Show help
+/prd
+```
+
+---
+
+{{#if (eq args "create")}}
+  {{> prd-create}}
+{{else if (eq args "finalize")}}
+  {{> prd-finalize}}
+{{else}}
+  {{> prd-help}}
+{{/if}}
+
+<!-- BEGIN TEMPLATE: prd-help -->
+## /prd Command Reference
+
+You've invoked `/prd` without a command. Use one of:
+
+### `/prd create` — Interactive PRD Generation
+Walk each PRD section collaboratively. I'll generate a draft for each section, present it for review, and wait for your feedback before moving to the next. After Section 5 (Detailed Design), we'll walk the Deliverables Manifest defaults together.
+
+**Input sources:** DDD domain model, external document, or verbal description.
+
+### `/prd finalize` — Finalization Checklist
+Run the Section 7.2 finalization checklist mechanically against an existing PRD. Reports pass/fail per item with explanation.
+
+**Which command would you like to run?**
+<!-- END TEMPLATE: prd-help -->
+
+<!-- BEGIN TEMPLATE: prd-create -->
+## Interactive PRD Generation
+
+I'll guide you through creating a complete PRD, section by section. For each section, I'll generate a draft, present it for review, and wait for your feedback before proceeding.
+
+### Step 1: Determine Input Source
+
+**How would you like to provide the concept for this PRD?**
+
+Check the arguments and conversation context for input mode:
+
+1. **DDD Domain Model** — If the user provides a path to a domain model (e.g., `docs/DOMAIN-MODEL.md`), or says "from the domain model", read it and use the DDD-to-PRD translation protocol (`docs/DDD-to-PRD-protocol.md`) as the mapping guide.
+2. **External Document** — If the user provides a path to any other document (concept doc, brief, notes), read it and extract the concept.
+3. **Verbal Description** — If no document is provided, ask the user to describe the project concept verbally.
+
+**If input is a DDD domain model:**
+- Read `docs/DDD-to-PRD-protocol.md` for the translation rules
+- Apply the 8-step translation as the backbone, but still walk each section interactively
+- The protocol provides structure; the user provides judgment
+
+**If input is an external document or verbal:**
+- Read the document or capture the verbal description
+- Use it as the foundation for drafting each section
+
+### Step 2: Ask for Project Name
+
+**What should the PRD be named?** (e.g., "my-project" → `docs/my-project-PRD.md`)
+
+Read `docs/PRD-template.md` to load the template structure.
+
+### Step 3: Walk Each Section
+
+For **each** PRD section (1 through 9), follow this pattern:
+
+1. **Generate a draft** for the section based on the input source
+2. **Present the draft** to the user
+3. **Ask for feedback:** "Does this look right? Any changes before we move on?"
+4. **Wait for the user to approve or request changes**
+5. **Incorporate feedback** — iterate until the user is satisfied
+6. **Record the final version** and move to the next section
+
+#### Section Walk Order
+
+**Section 1: Problem Domain**
+- 1.1 Background
+- 1.2 Problem Statement
+- 1.3 Proposed Solution
+- 1.4 Target Users (if DDD input: translate from Actors responsibility matrix)
+- 1.5 Non-Goals
+
+**Section 2: Constraints**
+- 2.1 Technical Constraints
+- 2.2 Product Constraints
+
+**Section 3: Requirements (EARS Format)**
+- If DDD input: translate policies to EARS requirements using the heuristic table
+- Group requirements by theme
+- Number sequentially: R-01, R-02, ...
+
+**Section 4: Concept of Operations**
+- 4.1 System Context
+- 4.X Operational flows (if DDD input: derive from commands and serial chains)
+
+**Section 5: Detailed Design**
+- 5.1+ Design topics (project-specific)
+- 5.A Deliverables Manifest → **see Step 4 below**
+- 5.B Installation & Deployment
+- 5.N Open Questions
+
+**Section 6: Test Plan**
+- 6.1 Test Strategy
+- 6.2 Integration Tests
+- 6.3 End-to-End Tests
+- 6.4 Manual Verification Procedures
+
+**Section 7: Definition of Done**
+- Global DoD checklist
+- 7.2 PRD Finalization Checklist (pre-populated from template)
+
+**Section 8: Phased Implementation Plan**
+- Phase structure, stories, waves
+- After this section: verify manifest wave assignments (see Step 6)
+
+**Section 9: Appendices**
+- Appendix V: VRTM skeleton
+- Additional appendices as needed
+
+### Step 4: Walk the Deliverables Manifest (After Section 5)
+
+After completing the design topics in Section 5, walk the **Tier 1 Deliverables Manifest defaults** with the user.
+
+For **each** Tier 1 row (DM-01 through DM-09):
+1. **Present the row:** ID, deliverable, category, default file path
+2. **Ask:** "Confirm this deliverable? If not applicable, provide a rationale (N/A — because [reason])."
+3. **Record the response:** confirmed (with any file path adjustments) or N/A with rationale
+4. **If confirmed:** ask which wave/phase will produce it (fill "Produced In" column)
+
+**Tier 1 defaults to walk:**
+
+| ID | Deliverable | Category |
+|----|-------------|----------|
+| DM-01 | README.md | Docs |
+| DM-02 | Unified build system (Makefile) | Code |
+| DM-03 | CI/CD pipeline | Code |
+| DM-04 | Automated test suite | Test |
+| DM-05 | Test results (JUnit XML) | Test |
+| DM-06 | Coverage report | Test |
+| DM-07 | CHANGELOG | Docs |
+| DM-08 | VRTM | Trace |
+| DM-09 | Audience-facing doc (ops runbook, user manual, API/CLI ref) | Docs |
+
+### Step 5: Scan for Tier 2 Triggers
+
+After walking Tier 1, scan the PRD content for Tier 2 trigger conditions:
+
+| Trigger Condition | Deliverable to Add |
+|-------------------|--------------------|
+| MV-XX items exist in Section 6.4 | Manual test procedures document |
+| >2 interacting components in design | Architecture document |
+| Project deploys infrastructure | Deployment verification procedures |
+| Project has host/platform requirements | Environment prerequisites document |
+
+For each trigger that fires:
+1. **Tell the user:** "Tier 2 trigger fired: [condition]. Adding [deliverable] to the manifest."
+2. **Ask for file path and wave assignment**
+3. **Add the row** to the Deliverables Manifest
+
+### Step 6: Verify Manifest Wave Assignments (After Section 8)
+
+After completing Section 8 (Implementation Plan), verify that **every** Deliverables Manifest row has a "Produced In" wave/phase assignment.
+
+For any row missing an assignment:
+1. **Flag it:** "DM-XX ([deliverable]) has no wave assignment yet."
+2. **Ask the user** which wave/phase should produce it
+3. **Update the row**
+
+This is a hard gate — the PRD cannot be finalized without complete wave assignments.
+
+### Step 7: Write the PRD
+
+After all sections are walked and the manifest is complete:
+
+1. **Assemble the PRD** from all approved sections
+2. **Write to** `docs/<project-name>-PRD.md`
+3. **Report:** "PRD written to `docs/<project-name>-PRD.md`. Run `/prd finalize` to verify completeness."
+
+---
+
+## Facilitation Rules
+
+- **Never skip a section.** Every section in the template must be walked, even if minimal.
+- **Never auto-approve.** Present each draft and wait for explicit user feedback.
+- **Iterate on feedback.** If the user requests changes, regenerate and re-present.
+- **Preserve traceability.** If the input is a DDD domain model, annotate requirements with policy IDs (`[P-XX]`), flows with command/event IDs, and AC items with requirement IDs.
+- **Use EARS format** for all requirements in Section 3.
+- **Fill in template placeholders.** Replace `[[...]]` guidance blocks with actual content — do not leave template instructions in the output.
+
+<!-- END TEMPLATE: prd-create -->
+
+<!-- BEGIN TEMPLATE: prd-finalize -->
+## PRD Finalization Checklist
+
+I'll run the Section 7.2 finalization checklist mechanically against an existing PRD and report pass/fail for each item.
+
+### Step 1: Locate the PRD
+
+Check for the PRD file:
+1. If the user provided a path, use it
+2. Otherwise, look for `docs/*-PRD.md` files
+3. If multiple PRDs exist, ask the user which one to finalize
+4. If no PRD exists, tell the user: "No PRD found. Run `/prd create` first."
+
+### Step 2: Read the PRD
+
+Read the entire PRD file into context. Also read `docs/PRD-template.md` for reference on expected structure.
+
+### Step 3: Run Each Check
+
+Execute each item from the Section 7.2 PRD Finalization Checklist. For each item, report:
+- **Pass** or **Fail**
+- **Evidence** — what was found (or not found) that determined the result
+- **Location** — where in the PRD the relevant content lives
+
+#### Check 1: Tier 1 Deliverables Manifest — File Paths
+
+> Every Tier 1 row in the Deliverables Manifest (5.A) has a file path or "N/A — because [reason]"
+
+**How to verify:**
+1. Find Section 5.A in the PRD
+2. Identify all rows with Tier = 1
+3. For each Tier 1 row, check the "File Path" column
+4. Pass if every Tier 1 row has a non-empty file path OR contains "N/A" with a rationale
+5. Fail if any Tier 1 row has an empty file path without N/A rationale
+
+#### Check 2: Tier 2 Triggers
+
+> Every Tier 2 trigger that fires has a corresponding row in the Deliverables Manifest
+
+**How to verify:**
+1. Check Section 6.4 for MV-XX items → if present, manifest must have a "Manual test procedures" row
+2. Count interacting components in Section 5 → if >2, manifest must have an "Architecture doc" row
+3. Check for infrastructure deployment references → if present, manifest must have "Deployment verification" row
+4. Check for host/platform requirements → if present, manifest must have "Environment prerequisites" row
+5. Pass if all fired triggers have corresponding rows
+6. Fail if any fired trigger is missing
+
+#### Check 3: Wave Assignments
+
+> Every Deliverables Manifest row has a "Produced In" wave assignment
+
+**How to verify:**
+1. Read every row in the Deliverables Manifest (5.A)
+2. Check the "Produced In" column for each non-N/A row
+3. Pass if every active row has a wave/phase assignment
+4. Fail if any active row has an empty "Produced In"
+
+#### Check 4: Manual Verification Coverage
+
+> Every MV-XX in Section 6.4 has a procedure document in the Deliverables Manifest
+
+**How to verify:**
+1. List all MV-XX items from Section 6.4
+2. For each MV-XX, check that the Deliverables Manifest has a corresponding procedure document
+3. Pass if all MV-XX items are covered
+4. Fail if any MV-XX lacks a manifest entry
+
+#### Check 5: Verbs Without Nouns
+
+> No deliverable is referenced only as a verb without a corresponding noun (file path)
+
+**How to verify:**
+1. Scan the Deliverables Manifest for active (non-N/A) rows
+2. For each row, verify the "File Path" column contains an actual path (starts with a directory, has an extension, or is a recognizable file reference)
+3. Flag any row where the deliverable is described as an action ("run tests", "deploy") but has no file artifact
+4. Pass if all active deliverables have concrete file references
+5. Fail if any deliverable is verb-only
+
+#### Check 6: Audience-Facing Documentation
+
+> At least one audience-facing doc (DM-09) has a file path assigned
+
+**How to verify:**
+1. Find DM-09 (or equivalent audience-facing doc rows) in the Deliverables Manifest
+2. Check that at least one has a concrete file path (not N/A)
+3. Pass if at least one audience-facing doc has a path
+4. Fail if all are N/A or empty
+
+#### Check 7: Definition of Done References
+
+> Section 7 Definition of Done references the Deliverables Manifest (not separate Artifact Manifest + Documentation Kit)
+
+**How to verify:**
+1. Read Section 7 (Definition of Done)
+2. Check that it references "Deliverables Manifest (Section 5.A)" or equivalent
+3. Check that it does NOT reference "Artifact Manifest" and "Documentation Kit" as separate concepts
+4. Pass if references are unified
+5. Fail if references are split or outdated
+
+### Step 4: Report Summary
+
+After all checks complete, present:
+
+```
+## PRD Finalization Report
+
+| # | Check | Result | Evidence |
+|---|-------|--------|----------|
+| 1 | Tier 1 file paths | PASS/FAIL | [details] |
+| 2 | Tier 2 triggers | PASS/FAIL | [details] |
+| 3 | Wave assignments | PASS/FAIL | [details] |
+| 4 | MV-XX coverage | PASS/FAIL | [details] |
+| 5 | Verbs without nouns | PASS/FAIL | [details] |
+| 6 | Audience-facing docs | PASS/FAIL | [details] |
+| 7 | DoD references | PASS/FAIL | [details] |
+
+**Result: X/7 checks passed. PRD is [ready / not ready] for approval.**
+```
+
+If not all checks pass:
+- List the specific failures with remediation steps
+- Suggest running `/prd create` to fix the issues interactively
+
+If all checks pass:
+- "PRD is ready for approval. Next step: get stakeholder sign-off, then run `/prepwaves` to plan execution."
+
+<!-- END TEMPLATE: prd-finalize -->
+
+---
+
+## Important Rules
+
+1. **Never skip the interactive walk.** Every section must be presented and approved by the user. Do not generate the entire PRD in one shot.
+2. **Tier 1 is opt-OUT.** Every Tier 1 deliverable must be explicitly confirmed or given an "N/A — because [reason]" rationale. Silence is not consent to skip.
+3. **Tier 2 triggers are mechanical.** Scan the PRD content for trigger conditions — do not rely on the user to remember them.
+4. **Wave assignment is a hard gate.** Every active manifest row must have a "Produced In" wave before the PRD is written.
+5. **The Deliverables Manifest is the single source of truth.** Do not create separate artifact manifests or documentation kits — everything goes in 5.A.
+6. **Finalization is mechanical.** `/prd finalize` checks are deterministic — no judgment calls, no "looks good enough."
+7. **Traceability is non-negotiable.** If the input is a DDD domain model, every requirement must trace back to a policy, every flow to commands/events, every story AC to requirements.

--- a/skills/prd/introduction.md
+++ b/skills/prd/introduction.md
@@ -1,0 +1,14 @@
+# Welcome to PRD Creation
+
+This skill provides an interactive, section-by-section workflow for creating Product Requirements Documents. Instead of generating a PRD in one shot, it walks each section collaboratively — drafting, presenting, and waiting for your feedback before moving on.
+
+The centerpiece is the **Deliverables Manifest** (Section 5.A) — a unified table of everything the project must produce: code artifacts, test outputs, documentation, and verification records. Tier 1 items are required by default (opt-out with rationale), Tier 2 items are added when trigger conditions fire, and Tier 3 items are added only on request.
+
+This skill pairs with `/ddd` and `/prepwaves` in the project pipeline. If you have a DDD domain model from `/ddd accept`, use it as input to `/prd create` for structured translation. Once the PRD is finalized, feed it into `/prepwaves` to plan execution waves.
+
+## Commands
+
+- **`/prd create`** — Walk each PRD section interactively, build the Deliverables Manifest, write the PRD
+- **`/prd finalize`** — Run the mechanical finalization checklist against an existing PRD
+
+**Ready to begin?** Run `/prd create` to start building your PRD.


### PR DESCRIPTION
## Summary

Create `/prd` skill for interactive PRD creation and restructure the PRD template with a unified Deliverables Manifest. Part of the Campaign Pipeline epic (#242).

## Changes

- **New `skills/prd/SKILL.md`** — Two subcommands: `/prd create` (interactive section-by-section PRD generation with Tier 1/2/3 Deliverables Manifest management) and `/prd finalize` (mechanical 7-check finalization checklist)
- **New `skills/prd/introduction.md`** — First-use intro
- **`docs/PRD-template.md`** — Merged Section 5.A Artifact Manifest + Section 7.1 Documentation Kit into unified Deliverables Manifest (5.A) with three-tier taxonomy. Replaced 7.1 with 7.2 PRD Finalization Checklist. Updated ToC, DoD, and all internal references.
- **`docs/DDD-to-PRD-protocol.md`** — Added `/prd create` recommendation
- **`docs/skill-reference.md`** — Added `/prd` section between DDD and Wave Pattern
- **`README.md`** — Added `/prd` to skills table

## Linked Issues

Closes #244

## Test Plan

- `./scripts/ci/validate.sh` — 73 passed, 0 failed
- Verified skill structure matches existing patterns (`/ddd`, `/precheck`)
- Verified all old 5.A/7.1 references updated to new Deliverables Manifest/Finalization Checklist
- No executable code — skill markdown only

Generated with [Claude Code](https://claude.com/claude-code)