### PR TITLE
feat(sdlc): org-wide SDLC dashboard viewer (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Key features:
 | `cc-inspector` | `python3`, `mitmproxy` | Context window inspector — proxy + Flask UI for API payload capture |
 | `discord-lock` | `flock`, `jq` | Advisory lock for serializing Discord channel writes across agents |
 | `campaign-status` | `python3` | SDLC campaign lifecycle CLI — stage tracking, gates, deferrals, and dashboard |
+| `sdlc-dashboard` | browser | Org-wide SDLC dashboard viewer — static Pages site with live state polling |
 | `generate-status-panel` | `python3` | Generate HTML status panel for wave progress |
 | `worktree-manager` | `git` | Manage isolated worktrees for parallel agent execution |
 

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -671,6 +671,7 @@ A standalone CLI tool (Python zipapp) for tracking project progress through SDLC
 | `stage-complete <stage>` | Mark stage as complete (gate passed) |
 | `defer <item> --reason <text>` | Defer a deliverable or work item with rationale |
 | `show` | Print current campaign state to terminal (read-only) |
+| `dashboard-url [--branch <branch>]` | Print the SDLC dashboard viewer URL for this repo |
 
 **Stage progression:** concept -> prd -> backlog -> implementation -> dod. Each stage must be completed before the next can start. Concept, PRD, and DoD have review gates; backlog and implementation go directly from active to complete.
 
@@ -690,6 +691,38 @@ campaign-status show
 ### `wave-status` -- Wave Execution Lifecycle CLI
 
 A standalone CLI tool (Python zipapp) for tracking wave-pattern execution. See the wave pattern skills above for context on how waves work.
+
+---
+
+### `sdlc-dashboard-viewer` -- Org-Wide SDLC Dashboard
+
+A self-contained HTML+JS dashboard viewer deployed once per GitHub org via Pages. Opens in a browser and fetches campaign and wave state JSON from the repo's raw URL, renders the dashboard client-side, and polls for updates every 3-5 seconds. Zero per-project setup -- any project with a `.sdlc/` directory is immediately visible.
+
+**Usage:**
+
+Open in a browser with URL parameters:
+
+```
+https://<org>.github.io/sdlc-dashboard/?repo=<org>/<repo>&branch=<branch>
+```
+
+Or generate the URL from the CLI:
+
+```bash
+campaign-status dashboard-url
+campaign-status dashboard-url --branch feature/42-work
+```
+
+**Features:**
+
+- Campaign progress rail (5-stage pipeline visualization)
+- Wave/flight detail view during implementation
+- Auto-refresh: polls raw URLs every 3-5 seconds
+- Offline indicator: shows "stale" badge if fetch fails for >30 seconds
+- Private repo support: one-time PAT paste stored in localStorage
+- Responsive: works on mobile for quick status checks
+- Cyberpunk theme: consistent with wave-status panel aesthetic
+- Self-contained: no external dependencies, no build step
 
 ---
 

--- a/sdlc-dashboard/index.html
+++ b/sdlc-dashboard/index.html
@@ -1,0 +1,862 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SDLC Dashboard</title>
+  <style>
+    /* ---------------------------------------------------------------
+       Cyberpunk theme — consistent with wave-status panel aesthetic
+       --------------------------------------------------------------- */
+    :root {
+      --bg-primary: #0a0a1a;
+      --bg-secondary: #12122a;
+      --bg-card: #1a1a3e;
+      --bg-card-hover: #222255;
+      --border: #2a2a5a;
+      --text-primary: #e0e0ff;
+      --text-secondary: #8888bb;
+      --text-muted: #5555aa;
+      --accent-cyan: #00e5ff;
+      --accent-magenta: #ff00ff;
+      --accent-green: #39ff14;
+      --accent-yellow: #ffe600;
+      --accent-orange: #ff8c00;
+      --accent-red: #ff1744;
+      --stage-not-started: #333366;
+      --stage-active: #003388;
+      --stage-review: #664400;
+      --stage-complete: #005500;
+      --glow-cyan: 0 0 8px rgba(0, 229, 255, 0.3);
+      --glow-magenta: 0 0 8px rgba(255, 0, 255, 0.3);
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'Courier New', 'Fira Code', monospace;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      min-height: 100vh;
+    }
+
+    /* Header */
+    .header {
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 1.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .header h1 {
+      font-size: 1.1rem;
+      color: var(--accent-cyan);
+      text-shadow: var(--glow-cyan);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      flex-shrink: 0;
+    }
+
+    .header .repo-info {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .header .repo-info strong {
+      color: var(--accent-magenta);
+    }
+
+    .header .status-badge {
+      margin-left: auto;
+      font-size: 0.75rem;
+      padding: 0.25rem 0.6rem;
+      border-radius: 3px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .status-badge.live {
+      background: rgba(57, 255, 20, 0.15);
+      color: var(--accent-green);
+      border: 1px solid rgba(57, 255, 20, 0.3);
+    }
+
+    .status-badge.stale {
+      background: rgba(255, 23, 68, 0.15);
+      color: var(--accent-red);
+      border: 1px solid rgba(255, 23, 68, 0.3);
+      animation: pulse-stale 2s ease-in-out infinite;
+    }
+
+    .status-badge.loading {
+      background: rgba(255, 230, 0, 0.15);
+      color: var(--accent-yellow);
+      border: 1px solid rgba(255, 230, 0, 0.3);
+    }
+
+    @keyframes pulse-stale {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    /* Auth form */
+    .auth-form {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 1.5rem;
+      margin: 1.5rem;
+      max-width: 600px;
+    }
+
+    .auth-form h2 {
+      font-size: 0.9rem;
+      color: var(--accent-yellow);
+      margin-bottom: 0.75rem;
+    }
+
+    .auth-form p {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      margin-bottom: 1rem;
+    }
+
+    .auth-form input {
+      width: 100%;
+      padding: 0.5rem;
+      background: var(--bg-primary);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--text-primary);
+      font-family: inherit;
+      font-size: 0.85rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .auth-form input:focus {
+      outline: none;
+      border-color: var(--accent-cyan);
+      box-shadow: var(--glow-cyan);
+    }
+
+    .auth-form button {
+      padding: 0.4rem 1rem;
+      background: var(--accent-cyan);
+      color: var(--bg-primary);
+      border: none;
+      border-radius: 3px;
+      font-family: inherit;
+      font-size: 0.8rem;
+      cursor: pointer;
+      font-weight: bold;
+    }
+
+    .auth-form button:hover { opacity: 0.85; }
+
+    .auth-form .clear-btn {
+      background: transparent;
+      color: var(--accent-red);
+      border: 1px solid var(--accent-red);
+      margin-left: 0.5rem;
+    }
+
+    /* Container */
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 1.5rem;
+    }
+
+    /* Campaign progress rail */
+    .progress-rail {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      margin-bottom: 2rem;
+      overflow-x: auto;
+      padding: 0.5rem 0;
+    }
+
+    .rail-stage {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      flex-shrink: 0;
+    }
+
+    .rail-node {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 6px;
+      min-width: 90px;
+      text-align: center;
+      transition: background 0.3s;
+    }
+
+    .rail-node .icon { font-size: 1.3rem; }
+    .rail-node .label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .rail-node.not_started { background: var(--stage-not-started); color: var(--text-muted); }
+    .rail-node.active {
+      background: var(--stage-active);
+      color: var(--accent-cyan);
+      border: 1px solid rgba(0, 229, 255, 0.3);
+      box-shadow: var(--glow-cyan);
+    }
+    .rail-node.review {
+      background: var(--stage-review);
+      color: var(--accent-orange);
+      border: 1px solid rgba(255, 140, 0, 0.3);
+    }
+    .rail-node.complete {
+      background: var(--stage-complete);
+      color: var(--accent-green);
+    }
+
+    .rail-connector {
+      width: 30px;
+      height: 2px;
+      background: var(--border);
+      flex-shrink: 0;
+    }
+
+    .rail-connector.complete { background: var(--accent-green); }
+
+    /* Section headings */
+    .section-title {
+      font-size: 0.85rem;
+      color: var(--accent-cyan);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* Wave detail */
+    .wave-detail {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .wave-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.75rem;
+    }
+
+    .wave-header h3 {
+      font-size: 0.9rem;
+      color: var(--text-primary);
+    }
+
+    .wave-header .wave-meta {
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    .flight-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.8rem;
+    }
+
+    .flight-table th {
+      text-align: left;
+      padding: 0.4rem 0.6rem;
+      color: var(--text-muted);
+      font-weight: normal;
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.05em;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .flight-table td {
+      padding: 0.4rem 0.6rem;
+      border-bottom: 1px solid rgba(42, 42, 90, 0.5);
+    }
+
+    .flight-table tr:last-child td { border-bottom: none; }
+
+    .issue-status {
+      display: inline-block;
+      padding: 0.15rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.7rem;
+      text-transform: uppercase;
+    }
+
+    .issue-status.merged {
+      background: rgba(57, 255, 20, 0.15);
+      color: var(--accent-green);
+    }
+
+    .issue-status.flying {
+      background: rgba(0, 229, 255, 0.15);
+      color: var(--accent-cyan);
+    }
+
+    .issue-status.queued {
+      background: rgba(85, 85, 170, 0.15);
+      color: var(--text-muted);
+    }
+
+    .issue-status.failed {
+      background: rgba(255, 23, 68, 0.15);
+      color: var(--accent-red);
+    }
+
+    /* Deliverables summary */
+    .summary-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .summary-stat {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+
+    .summary-stat strong {
+      color: var(--text-primary);
+    }
+
+    /* Footer */
+    .footer {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      padding-top: 1rem;
+      border-top: 1px solid var(--border);
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    /* Empty state */
+    .empty-state {
+      text-align: center;
+      padding: 3rem 1rem;
+      color: var(--text-muted);
+    }
+
+    .empty-state h2 {
+      font-size: 1rem;
+      color: var(--text-secondary);
+      margin-bottom: 0.75rem;
+    }
+
+    .empty-state p {
+      font-size: 0.85rem;
+      line-height: 1.6;
+    }
+
+    .empty-state code {
+      background: var(--bg-card);
+      padding: 0.15rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.8rem;
+    }
+
+    /* No wave data state */
+    .no-wave-data {
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      font-style: italic;
+      padding: 0.5rem 0;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .header { flex-direction: column; align-items: flex-start; }
+      .header .status-badge { margin-left: 0; }
+      .container { padding: 1rem; }
+      .progress-rail { gap: 0; }
+      .rail-node { min-width: 65px; padding: 0.4rem 0.5rem; }
+      .rail-node .label { font-size: 0.6rem; }
+      .rail-connector { width: 15px; }
+      .summary-bar { flex-direction: column; gap: 0.5rem; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <h1>SDLC Dashboard</h1>
+  <div class="repo-info" id="repo-info">
+    Loading...
+  </div>
+  <div class="status-badge loading" id="status-badge">Connecting</div>
+</div>
+
+<div class="container" id="main-container">
+  <div class="empty-state" id="empty-state">
+    <h2>No repository selected</h2>
+    <p>
+      Add URL parameters to select a repo:<br>
+      <code>?repo=org/repo-name&amp;branch=main</code>
+    </p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // -------------------------------------------------------------------
+  // Configuration
+  // -------------------------------------------------------------------
+
+  var POLL_INTERVAL_MS = 4000;
+  var STALE_THRESHOLD_MS = 30000;
+  var RAW_BASE = "https://raw.githubusercontent.com";
+  var LS_TOKEN_KEY = "sdlc-dashboard-pat";
+
+  // -------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------
+
+  var state = {
+    repo: null,          // "org/repo"
+    branch: "main",
+    campaignState: null,
+    campaignItems: null,
+    waveState: null,
+    waveFlights: null,
+    lastSuccessfulFetch: 0,
+    pollTimer: null,
+    fetchInProgress: false,
+    authRequired: false,
+    errorCount: 0
+  };
+
+  // -------------------------------------------------------------------
+  // URL parameter parsing
+  // -------------------------------------------------------------------
+
+  function getParams() {
+    var params = new URLSearchParams(window.location.search);
+    return {
+      repo: params.get("repo"),
+      branch: params.get("branch") || "main"
+    };
+  }
+
+  // -------------------------------------------------------------------
+  // Auth helpers
+  // -------------------------------------------------------------------
+
+  function getToken() {
+    try { return localStorage.getItem(LS_TOKEN_KEY) || ""; }
+    catch (e) { return ""; }
+  }
+
+  function setToken(token) {
+    try { localStorage.setItem(LS_TOKEN_KEY, token); }
+    catch (e) { /* localStorage unavailable */ }
+  }
+
+  function clearToken() {
+    try { localStorage.removeItem(LS_TOKEN_KEY); }
+    catch (e) { /* localStorage unavailable */ }
+  }
+
+  // -------------------------------------------------------------------
+  // Fetch helpers
+  // -------------------------------------------------------------------
+
+  function rawUrl(filePath) {
+    return RAW_BASE + "/" + state.repo + "/" + state.branch + "/" + filePath;
+  }
+
+  function fetchJson(filePath) {
+    var url = rawUrl(filePath);
+    var headers = {};
+    var token = getToken();
+    if (token) {
+      headers["Authorization"] = "token " + token;
+    }
+    return fetch(url, { headers: headers })
+      .then(function (res) {
+        if (res.status === 404) return null;
+        if (res.status === 401 || res.status === 403) {
+          state.authRequired = true;
+          return null;
+        }
+        if (!res.ok) return null;
+        state.authRequired = false;
+        return res.json();
+      })
+      .catch(function () { return null; });
+  }
+
+  // -------------------------------------------------------------------
+  // Data fetching
+  // -------------------------------------------------------------------
+
+  function fetchAllData() {
+    if (state.fetchInProgress || !state.repo) return;
+    state.fetchInProgress = true;
+
+    Promise.all([
+      fetchJson(".sdlc/campaign-state.json"),
+      fetchJson(".sdlc/campaign-items.json"),
+      fetchJson(".sdlc/waves/state.json"),
+      fetchJson(".sdlc/waves/flights.json")
+    ]).then(function (results) {
+      state.fetchInProgress = false;
+
+      var campaignState = results[0];
+      var campaignItems = results[1];
+      var waveState = results[2];
+      var waveFlights = results[3];
+
+      if (state.authRequired) {
+        renderAuthForm();
+        return;
+      }
+
+      if (campaignState !== null) {
+        state.campaignState = campaignState;
+        state.lastSuccessfulFetch = Date.now();
+        state.errorCount = 0;
+      } else {
+        state.errorCount++;
+      }
+
+      if (campaignItems !== null) {
+        state.campaignItems = campaignItems;
+      }
+
+      state.waveState = waveState;
+      state.waveFlights = waveFlights;
+
+      render();
+    }).catch(function () {
+      state.fetchInProgress = false;
+      state.errorCount++;
+      render();
+    });
+  }
+
+  // -------------------------------------------------------------------
+  // Rendering: status badge
+  // -------------------------------------------------------------------
+
+  function renderStatusBadge() {
+    var badge = document.getElementById("status-badge");
+    if (!badge) return;
+
+    var now = Date.now();
+    var timeSinceLast = now - state.lastSuccessfulFetch;
+
+    if (state.lastSuccessfulFetch === 0) {
+      badge.className = "status-badge loading";
+      badge.textContent = "Connecting";
+    } else if (timeSinceLast > STALE_THRESHOLD_MS) {
+      badge.className = "status-badge stale";
+      badge.textContent = "Stale (" + Math.round(timeSinceLast / 1000) + "s)";
+    } else {
+      badge.className = "status-badge live";
+      badge.textContent = "Live";
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // Rendering: repo info
+  // -------------------------------------------------------------------
+
+  function renderRepoInfo() {
+    var el = document.getElementById("repo-info");
+    if (!el) return;
+    el.innerHTML = "<strong>" + escapeHtml(state.repo) + "</strong> &middot; branch: <strong>" + escapeHtml(state.branch) + "</strong>";
+  }
+
+  // -------------------------------------------------------------------
+  // Rendering: auth form
+  // -------------------------------------------------------------------
+
+  function renderAuthForm() {
+    var container = document.getElementById("main-container");
+    var existingToken = getToken();
+
+    container.innerHTML =
+      '<div class="auth-form">' +
+      '<h2>Authentication Required</h2>' +
+      '<p>This appears to be a private repository. Enter a GitHub Personal Access Token with <code>contents:read</code> scope. The token is stored in localStorage and never leaves your browser.</p>' +
+      '<input type="password" id="pat-input" placeholder="ghp_xxxxxxxxxxxx" value="' + escapeHtml(existingToken) + '">' +
+      '<button onclick="window.__sdlcSaveToken()">Save &amp; Retry</button>' +
+      '<button class="clear-btn" onclick="window.__sdlcClearToken()">Clear Token</button>' +
+      '</div>';
+  }
+
+  window.__sdlcSaveToken = function () {
+    var input = document.getElementById("pat-input");
+    if (input && input.value.trim()) {
+      setToken(input.value.trim());
+      state.authRequired = false;
+      state.errorCount = 0;
+      fetchAllData();
+    }
+  };
+
+  window.__sdlcClearToken = function () {
+    clearToken();
+    state.authRequired = false;
+    state.errorCount = 0;
+    fetchAllData();
+  };
+
+  // -------------------------------------------------------------------
+  // Rendering: progress rail
+  // -------------------------------------------------------------------
+
+  var STAGES = ["concept", "prd", "backlog", "implementation", "dod"];
+  var STAGE_LABELS = {
+    concept: "Concept",
+    prd: "PRD",
+    backlog: "Backlog",
+    implementation: "Impl",
+    dod: "DoD"
+  };
+
+  var STATUS_ICONS = {
+    not_started: "\u25CB",  // empty circle
+    active: "\u25CF",       // filled circle
+    review: "\u25D4",       // half circle
+    complete: "\u2714"      // checkmark
+  };
+
+  function renderProgressRail(stagesData) {
+    if (!stagesData) return "";
+
+    var html = '<div class="progress-rail">';
+    for (var i = 0; i < STAGES.length; i++) {
+      var stage = STAGES[i];
+      var status = stagesData[stage] || "not_started";
+      var icon = STATUS_ICONS[status] || STATUS_ICONS.not_started;
+      var label = STAGE_LABELS[stage] || stage;
+
+      html += '<div class="rail-stage">';
+      html += '<div class="rail-node ' + escapeHtml(status) + '">';
+      html += '<span class="icon">' + icon + '</span>';
+      html += '<span class="label">' + escapeHtml(label) + '</span>';
+      html += '</div>';
+
+      if (i < STAGES.length - 1) {
+        var connClass = status === "complete" ? "rail-connector complete" : "rail-connector";
+        html += '<div class="' + connClass + '"></div>';
+      }
+
+      html += '</div>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  // -------------------------------------------------------------------
+  // Rendering: wave/flight detail
+  // -------------------------------------------------------------------
+
+  function renderWaveDetail() {
+    var ws = state.waveState;
+    var wf = state.waveFlights;
+
+    if (!ws && !wf) {
+      return "";
+    }
+
+    var html = '<div class="section-title">Wave / Flight Detail</div>';
+
+    if (ws) {
+      var currentWave = ws.current_wave || ws.wave || "?";
+      var totalWaves = ws.total_waves || "?";
+      var currentFlight = ws.current_flight || ws.flight || "?";
+      var totalFlights = ws.total_flights || "?";
+
+      html += '<div class="wave-detail">';
+      html += '<div class="wave-header">';
+      html += '<h3>Wave ' + escapeHtml(String(currentWave)) + ' of ' + escapeHtml(String(totalWaves)) + '</h3>';
+      html += '<span class="wave-meta">Flight ' + escapeHtml(String(currentFlight)) + ' of ' + escapeHtml(String(totalFlights)) + '</span>';
+      html += '</div>';
+    } else {
+      html += '<div class="wave-detail">';
+      html += '<div class="wave-header"><h3>Waves</h3></div>';
+    }
+
+    if (wf && wf.length > 0) {
+      html += '<table class="flight-table">';
+      html += '<thead><tr><th>Issue</th><th>Flight</th><th>Status</th><th>PR/MR</th></tr></thead>';
+      html += '<tbody>';
+
+      for (var i = 0; i < wf.length; i++) {
+        var item = wf[i];
+        var issueNum = item.issue || item.number || "?";
+        var flight = item.flight || "?";
+        var itemStatus = item.status || "queued";
+        var pr = item.pr || item.mr || "\u2014";
+
+        html += '<tr>';
+        html += '<td>#' + escapeHtml(String(issueNum)) + '</td>';
+        html += '<td>' + escapeHtml(String(flight)) + '</td>';
+        html += '<td><span class="issue-status ' + escapeHtml(itemStatus) + '">' + escapeHtml(itemStatus) + '</span></td>';
+        html += '<td>' + escapeHtml(String(pr)) + '</td>';
+        html += '</tr>';
+      }
+
+      html += '</tbody></table>';
+    } else {
+      html += '<div class="no-wave-data">No flight data available.</div>';
+    }
+
+    html += '</div>';
+    return html;
+  }
+
+  // -------------------------------------------------------------------
+  // Rendering: deliverables summary
+  // -------------------------------------------------------------------
+
+  function renderSummaryBar() {
+    var items = state.campaignItems;
+    var cs = state.campaignState;
+    var html = '<div class="summary-bar">';
+
+    if (items) {
+      var deferrals = items.deferrals || [];
+      html += '<div class="summary-stat">Deferrals: <strong>' + deferrals.length + '</strong></div>';
+    }
+
+    if (cs && cs.stages) {
+      var completedCount = 0;
+      for (var i = 0; i < STAGES.length; i++) {
+        if (cs.stages[STAGES[i]] === "complete") completedCount++;
+      }
+      html += '<div class="summary-stat">Stages complete: <strong>' + completedCount + '/' + STAGES.length + '</strong></div>';
+    }
+
+    if (cs && cs.last_updated) {
+      html += '<div class="summary-stat">State updated: <strong>' + escapeHtml(cs.last_updated) + '</strong></div>';
+    }
+
+    html += '</div>';
+    return html;
+  }
+
+  // -------------------------------------------------------------------
+  // Rendering: main
+  // -------------------------------------------------------------------
+
+  function render() {
+    renderStatusBadge();
+
+    if (!state.repo) return;
+
+    renderRepoInfo();
+
+    var container = document.getElementById("main-container");
+    if (!container) return;
+
+    if (!state.campaignState) {
+      if (state.errorCount > 0 && state.lastSuccessfulFetch === 0) {
+        container.innerHTML =
+          '<div class="empty-state">' +
+          '<h2>No campaign data found</h2>' +
+          '<p>Could not fetch <code>.sdlc/campaign-state.json</code> from<br>' +
+          '<code>' + escapeHtml(state.repo) + '</code> on branch <code>' + escapeHtml(state.branch) + '</code>.</p>' +
+          '<p>Make sure the repository has been initialized with <code>campaign-status init</code>.</p>' +
+          '</div>';
+      }
+      return;
+    }
+
+    var html = "";
+
+    // Campaign progress rail
+    html += '<div class="section-title">Campaign Progress</div>';
+    html += renderProgressRail(state.campaignState.stages);
+
+    // Summary bar
+    html += renderSummaryBar();
+
+    // Wave/flight detail (only when implementation is active/review)
+    var implStatus = state.campaignState.stages ? state.campaignState.stages.implementation : null;
+    if (implStatus === "active" || implStatus === "review" || state.waveState || state.waveFlights) {
+      html += renderWaveDetail();
+    }
+
+    // Footer
+    var ago = state.lastSuccessfulFetch > 0
+      ? Math.round((Date.now() - state.lastSuccessfulFetch) / 1000) + "s ago"
+      : "never";
+
+    html += '<div class="footer">';
+    html += '<span>Last fetched: ' + ago + '</span>';
+    html += '<span>Polling every ' + (POLL_INTERVAL_MS / 1000) + 's</span>';
+    html += '</div>';
+
+    container.innerHTML = html;
+  }
+
+  // -------------------------------------------------------------------
+  // Utility
+  // -------------------------------------------------------------------
+
+  function escapeHtml(str) {
+    if (typeof str !== "string") str = String(str || "");
+    return str
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  // -------------------------------------------------------------------
+  // Init
+  // -------------------------------------------------------------------
+
+  function init() {
+    var params = getParams();
+    if (!params.repo) {
+      document.title = "SDLC Dashboard";
+      return;
+    }
+
+    state.repo = params.repo;
+    state.branch = params.branch;
+
+    document.title = "SDLC — " + state.repo;
+
+    renderRepoInfo();
+    fetchAllData();
+
+    state.pollTimer = setInterval(function () {
+      fetchAllData();
+      renderStatusBadge();
+    }, POLL_INTERVAL_MS);
+  }
+
+  init();
+})();
+</script>
+
+</body>
+</html>

--- a/src/campaign_status/__main__.py
+++ b/src/campaign_status/__main__.py
@@ -34,6 +34,64 @@ from campaign_status.state import (
 
 
 # ---------------------------------------------------------------------------
+# Git detection helpers
+# ---------------------------------------------------------------------------
+
+def _detect_org_repo(root: Path) -> str | None:
+    """Parse ``org/repo`` from the git remote origin URL.
+
+    Supports both SSH (``git@github.com:Org/Repo.git``) and HTTPS
+    (``https://github.com/Org/Repo.git``) formats.
+
+    Returns ``None`` if detection fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        url = result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    # SSH: git@github.com:Org/Repo.git
+    if url.startswith("git@"):
+        # "git@github.com:Org/Repo.git" -> "Org/Repo.git"
+        _, _, path_part = url.partition(":")
+        return path_part.removesuffix(".git") if path_part else None
+
+    # HTTPS: https://github.com/Org/Repo.git
+    if "://" in url:
+        # "https://github.com/Org/Repo.git" -> ["", "github.com", "Org", "Repo.git"]
+        parts = url.split("/")
+        if len(parts) >= 5:
+            org = parts[3]
+            repo = parts[4].removesuffix(".git")
+            return f"{org}/{repo}"
+
+    return None
+
+
+def _detect_branch(root: Path) -> str:
+    """Return the current git branch name, defaulting to ``main``."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        branch = result.stdout.strip()
+        return branch if branch else "main"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "main"
+
+
+# ---------------------------------------------------------------------------
 # Dashboard regeneration helper
 # ---------------------------------------------------------------------------
 
@@ -142,12 +200,38 @@ def _cmd_show(args: argparse.Namespace) -> None:
     print("\n".join(lines))
 
 
+def _cmd_dashboard_url(args: argparse.Namespace) -> None:
+    """Handle ``dashboard-url`` -- print the SDLC dashboard viewer URL."""
+    root = get_project_root()
+
+    # Detect org/repo from git remote
+    org_repo = _detect_org_repo(root)
+    if org_repo is None:
+        print(
+            "Error: could not detect org/repo from git remote. "
+            "Ensure a remote named 'origin' is configured.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    org = org_repo.split("/")[0]
+
+    # Detect current branch
+    branch = args.branch
+    if branch is None:
+        branch = _detect_branch(root)
+
+    base_url = f"https://{org}.github.io/sdlc-dashboard/"
+    full_url = f"{base_url}?repo={org_repo}&branch={branch}"
+    print(full_url)
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Construct the argparse parser with all 6 subcommands."""
+    """Construct the argparse parser with all 7 subcommands."""
     parser = argparse.ArgumentParser(
         prog="campaign-status",
         description="SDLC campaign lifecycle CLI -- stage tracking, gates, deferrals",
@@ -183,6 +267,18 @@ def _build_parser() -> argparse.ArgumentParser:
     # show
     p_sh = sub.add_parser("show", help="Print current campaign state (read-only)")
     p_sh.set_defaults(func=_cmd_show)
+
+    # dashboard-url
+    p_du = sub.add_parser(
+        "dashboard-url",
+        help="Print the SDLC dashboard viewer URL for this repo",
+    )
+    p_du.add_argument(
+        "--branch",
+        default=None,
+        help="Branch to view (default: current branch)",
+    )
+    p_du.set_defaults(func=_cmd_dashboard_url)
 
     return parser
 

--- a/tests/test_sdlc_dashboard.py
+++ b/tests/test_sdlc_dashboard.py
@@ -1,0 +1,361 @@
+"""Tests for the SDLC dashboard viewer and dashboard-url subcommand.
+
+Tests cover:
+- ``sdlc-dashboard/index.html`` — existence, self-contained, key content
+- ``_detect_org_repo()`` — SSH and HTTPS git remote parsing
+- ``_detect_branch()`` — current branch detection
+- ``dashboard-url`` subcommand via subprocess (integration tests)
+
+Mocks are ONLY used for ``subprocess.run`` (external git process).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src/ is importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from campaign_status.__main__ import _detect_branch, _detect_org_repo
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SRC_DIR = str(_PROJECT_ROOT / "src")
+_DASHBOARD_HTML = _PROJECT_ROOT / "sdlc-dashboard" / "index.html"
+
+
+# ---------------------------------------------------------------------------
+# Helper: run campaign-status CLI
+# ---------------------------------------------------------------------------
+
+def _run_campaign_cli(
+    args: list[str],
+    cwd: str | Path,
+) -> tuple[int, str, str]:
+    """Run ``python3 -m campaign_status <args>`` as a subprocess."""
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = _SRC_DIR + (os.pathsep + existing if existing else "")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "campaign_status"] + args,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return (result.returncode, result.stdout, result.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Tests: sdlc-dashboard/index.html
+# ---------------------------------------------------------------------------
+
+class TestDashboardHtmlFile:
+    """Verify the dashboard HTML file exists and is self-contained."""
+
+    def test_index_html_exists(self) -> None:
+        """sdlc-dashboard/index.html must exist in the project."""
+        assert _DASHBOARD_HTML.exists(), (
+            f"Expected {_DASHBOARD_HTML} to exist"
+        )
+
+    def test_is_valid_html(self) -> None:
+        """Must start with DOCTYPE and contain html/head/body."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert content.startswith("<!DOCTYPE html>")
+        assert "<html" in content
+        assert "<head>" in content
+        assert "<body>" in content
+        assert "</html>" in content
+
+    def test_no_external_dependencies(self) -> None:
+        """Must not reference external CSS/JS files (self-contained)."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        # No external stylesheet links
+        assert 'rel="stylesheet"' not in content or "href=" not in content.split('rel="stylesheet"')[0]
+        # No script src (all JS is inline)
+        assert '<script src=' not in content
+
+    def test_has_inline_css(self) -> None:
+        """Must have inline <style> block."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert "<style>" in content
+        assert "</style>" in content
+
+    def test_has_inline_js(self) -> None:
+        """Must have inline <script> block."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert "<script>" in content
+        assert "</script>" in content
+
+    def test_contains_campaign_stages(self) -> None:
+        """JS must reference the 5 SDLC stages."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        for stage in ("concept", "prd", "backlog", "implementation", "dod"):
+            assert stage in content, f"Stage '{stage}' not found in index.html"
+
+    def test_contains_poll_logic(self) -> None:
+        """Must contain polling logic (setInterval or similar)."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert "setInterval" in content or "setTimeout" in content
+
+    def test_contains_raw_githubusercontent_url(self) -> None:
+        """Must fetch from raw.githubusercontent.com."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert "raw.githubusercontent.com" in content
+
+    def test_contains_stale_indicator(self) -> None:
+        """Must show stale indicator when fetch fails."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        # Check for stale-related CSS class or text
+        assert "stale" in content.lower()
+
+    def test_contains_auth_support(self) -> None:
+        """Must support PAT in localStorage."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert "localStorage" in content
+
+    def test_contains_repo_url_param(self) -> None:
+        """Must read repo from URL parameters."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert "URLSearchParams" in content or "getParams" in content
+
+    def test_responsive_meta_tag(self) -> None:
+        """Must have viewport meta tag for mobile."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert 'name="viewport"' in content
+
+    def test_responsive_css(self) -> None:
+        """Must have media query for responsive layout."""
+        content = _DASHBOARD_HTML.read_text(encoding="utf-8")
+        assert "@media" in content
+
+
+# ---------------------------------------------------------------------------
+# Tests: _detect_org_repo
+# ---------------------------------------------------------------------------
+
+class TestDetectOrgRepo:
+    """Tests for _detect_org_repo() — git remote URL parsing."""
+
+    def test_ssh_url(self, tmp_path: Path) -> None:
+        """Parse org/repo from SSH remote URL."""
+        with patch("campaign_status.__main__.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="git@github.com:Wave-Engineering/my-repo.git\n",
+                returncode=0,
+            )
+            result = _detect_org_repo(tmp_path)
+            assert result == "Wave-Engineering/my-repo"
+
+    def test_https_url(self, tmp_path: Path) -> None:
+        """Parse org/repo from HTTPS remote URL."""
+        with patch("campaign_status.__main__.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="https://github.com/Wave-Engineering/my-repo.git\n",
+                returncode=0,
+            )
+            result = _detect_org_repo(tmp_path)
+            assert result == "Wave-Engineering/my-repo"
+
+    def test_https_no_git_suffix(self, tmp_path: Path) -> None:
+        """Parse org/repo from HTTPS URL without .git suffix."""
+        with patch("campaign_status.__main__.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="https://github.com/MyOrg/MyRepo\n",
+                returncode=0,
+            )
+            result = _detect_org_repo(tmp_path)
+            assert result == "MyOrg/MyRepo"
+
+    def test_ssh_no_git_suffix(self, tmp_path: Path) -> None:
+        """Parse org/repo from SSH URL without .git suffix."""
+        with patch("campaign_status.__main__.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="git@github.com:MyOrg/MyRepo\n",
+                returncode=0,
+            )
+            result = _detect_org_repo(tmp_path)
+            assert result == "MyOrg/MyRepo"
+
+    def test_no_remote_returns_none(self, tmp_path: Path) -> None:
+        """Return None when no remote is configured."""
+        with patch(
+            "campaign_status.__main__.subprocess.run",
+            side_effect=subprocess.CalledProcessError(128, "git"),
+        ):
+            result = _detect_org_repo(tmp_path)
+            assert result is None
+
+    def test_passes_root_as_cwd(self, tmp_path: Path) -> None:
+        """Verify subprocess is called with root as cwd."""
+        with patch("campaign_status.__main__.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="git@github.com:Org/Repo.git\n",
+                returncode=0,
+            )
+            _detect_org_repo(tmp_path)
+            call_kwargs = mock_run.call_args
+            assert call_kwargs.kwargs.get("cwd") == str(tmp_path) or \
+                (len(call_kwargs.args) > 0 and str(tmp_path) in str(call_kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Tests: _detect_branch
+# ---------------------------------------------------------------------------
+
+class TestDetectBranch:
+    """Tests for _detect_branch() — current branch detection."""
+
+    def test_returns_current_branch(self, tmp_path: Path) -> None:
+        """Return the branch name from git."""
+        with patch("campaign_status.__main__.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="feature/42-my-work\n",
+                returncode=0,
+            )
+            result = _detect_branch(tmp_path)
+            assert result == "feature/42-my-work"
+
+    def test_defaults_to_main_on_failure(self, tmp_path: Path) -> None:
+        """Default to 'main' when git fails."""
+        with patch(
+            "campaign_status.__main__.subprocess.run",
+            side_effect=subprocess.CalledProcessError(128, "git"),
+        ):
+            result = _detect_branch(tmp_path)
+            assert result == "main"
+
+    def test_defaults_to_main_on_empty(self, tmp_path: Path) -> None:
+        """Default to 'main' when git returns empty string."""
+        with patch("campaign_status.__main__.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="\n",
+                returncode=0,
+            )
+            result = _detect_branch(tmp_path)
+            assert result == "main"
+
+
+# ---------------------------------------------------------------------------
+# Tests: dashboard-url subcommand (subprocess integration)
+# ---------------------------------------------------------------------------
+
+class TestDashboardUrlSubcommand:
+    """Integration tests for ``campaign-status dashboard-url`` via subprocess."""
+
+    def test_dashboard_url_outputs_url(self, temp_git_repo: Path) -> None:
+        """dashboard-url should output a valid SDLC dashboard URL."""
+        # Set up a remote so _detect_org_repo works
+        subprocess.run(
+            ["git", "remote", "add", "origin",
+             "git@github.com:TestOrg/test-repo.git"],
+            cwd=str(temp_git_repo),
+            capture_output=True,
+            check=True,
+        )
+
+        rc, out, err = _run_campaign_cli(["dashboard-url"], temp_git_repo)
+        assert rc == 0, f"dashboard-url failed: {err}"
+        url = out.strip()
+        assert url.startswith("https://TestOrg.github.io/sdlc-dashboard/")
+        assert "repo=TestOrg/test-repo" in url
+        # Should include current branch
+        assert "branch=" in url
+
+    def test_dashboard_url_with_explicit_branch(
+        self, temp_git_repo: Path
+    ) -> None:
+        """dashboard-url --branch <name> should use the specified branch."""
+        subprocess.run(
+            ["git", "remote", "add", "origin",
+             "https://github.com/MyOrg/MyRepo.git"],
+            cwd=str(temp_git_repo),
+            capture_output=True,
+            check=True,
+        )
+
+        rc, out, err = _run_campaign_cli(
+            ["dashboard-url", "--branch", "feature/42-work"],
+            temp_git_repo,
+        )
+        assert rc == 0, f"dashboard-url failed: {err}"
+        url = out.strip()
+        assert "branch=feature/42-work" in url
+        assert "repo=MyOrg/MyRepo" in url
+
+    def test_dashboard_url_no_remote_fails(
+        self, temp_git_repo: Path
+    ) -> None:
+        """dashboard-url with no remote should fail gracefully."""
+        rc, out, err = _run_campaign_cli(
+            ["dashboard-url"], temp_git_repo
+        )
+        assert rc != 0
+        assert "Error:" in err or "error" in err.lower()
+
+    def test_dashboard_url_is_read_only(
+        self, temp_git_repo: Path
+    ) -> None:
+        """dashboard-url should not create git commits or modify files."""
+        subprocess.run(
+            ["git", "remote", "add", "origin",
+             "git@github.com:Org/Repo.git"],
+            cwd=str(temp_git_repo),
+            capture_output=True,
+            check=True,
+        )
+
+        # Count commits before
+        result_before = subprocess.run(
+            ["git", "rev-list", "--all", "--count"],
+            cwd=str(temp_git_repo),
+            capture_output=True,
+            text=True,
+        )
+        count_before = result_before.stdout.strip()
+
+        _run_campaign_cli(["dashboard-url"], temp_git_repo)
+
+        # Count commits after
+        result_after = subprocess.run(
+            ["git", "rev-list", "--all", "--count"],
+            cwd=str(temp_git_repo),
+            capture_output=True,
+            text=True,
+        )
+        count_after = result_after.stdout.strip()
+
+        assert count_after == count_before, "dashboard-url created a git commit"
+
+    def test_dashboard_url_does_not_require_sdlc_dir(
+        self, temp_git_repo: Path
+    ) -> None:
+        """dashboard-url should work without .sdlc/ directory
+        (it only needs git remote, not campaign state).
+        """
+        subprocess.run(
+            ["git", "remote", "add", "origin",
+             "git@github.com:Org/Repo.git"],
+            cwd=str(temp_git_repo),
+            capture_output=True,
+            check=True,
+        )
+
+        # Ensure no .sdlc exists
+        sdlc_dir = temp_git_repo / ".sdlc"
+        assert not sdlc_dir.exists()
+
+        rc, out, err = _run_campaign_cli(["dashboard-url"], temp_git_repo)
+        assert rc == 0, f"dashboard-url failed without .sdlc: {err}"
+        assert "github.io/sdlc-dashboard/" in out


### PR DESCRIPTION
## Summary

Create a self-contained SDLC dashboard viewer for org-wide project visibility and add a `dashboard-url` subcommand to the `campaign-status` CLI.

## Changes

- **`sdlc-dashboard/index.html`**: Self-contained HTML+CSS+JS dashboard with cyberpunk theme, 4s polling via raw.githubusercontent.com, PAT auth via localStorage, stale indicator, responsive layout
- **`src/campaign_status/__main__.py`**: Added `_detect_org_repo()`, `_detect_branch()` helpers and `dashboard-url` subcommand
- **`docs/skill-reference.md`**: Added `dashboard-url` to campaign-status table, added `sdlc-dashboard-viewer` entry in Tools/CLI section
- **`README.md`**: Added `sdlc-dashboard` row to Scripts table
- **Tests**: 27 tests — HTML structure (13), git helpers (9), CLI integration (5)

## Linked Issues

Closes #249

## Test Plan

- `python3 -m pytest tests/test_sdlc_dashboard.py -v` — 27/27 passed
- `python3 -m pytest tests/test_campaign_status.py -v` — 78/78 existing tests pass (no regressions)
- `./scripts/ci/validate.sh` — 78/78 passed