### PR TITLE
refactor(ddd): convert /ddd accept to concept handoff (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Key features:
 | ccfold | `/ccfold` | Merge upstream CLAUDE.md template updates into local project |
 | ccwork | `/ccwork` | Onboarding hub — tour the kit, run labs, configure integrations |
 | cryo | `/cryo` | Preserve session state before context compaction |
-| ddd | `/ddd` | Domain-Driven Design facilitation — event storming, domain modeling, PRD generation |
+| ddd | `/ddd` | Domain-Driven Design facilitation — event storming, domain modeling, concept handoff |
 | disc | `/disc` | Discord integration — check-in, send, read, list, resolve channels |
 | edit | `/edit` | Open file/URL in GUI editor |
 | engage | `/engage` | Load CLAUDE.md, confirm rules of engagement |

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -515,23 +515,23 @@ Checks `$VISUAL` and `$EDITOR` environment variables, then user preferences, the
 
 ### `/ddd` -- Domain-Driven Design Facilitation
 
-A structured workflow for domain modeling using event storming. Guides you through 8 stages of domain discovery, formalizes the results into a Domain Model document, and translates it into an implementation-ready PRD.
+A structured workflow for domain modeling using event storming. Guides you through 8 stages of domain discovery, formalizes the results into a Domain Model document, and hands off to `/prd create` for PRD generation.
 
 **When to use it:**
 - When starting a new project and need to discover the domain model
 - When translating business requirements into technical architecture
-- When you want a structured PRD generated from domain analysis
+- When you want a structured domain model to feed into PRD creation
 
 **Examples:**
 
 ```
 /ddd begin       # Start interactive event storming session
 /ddd draft       # Formalize sketchbook into Domain Model document
-/ddd accept      # Translate Domain Model to PRD
+/ddd accept      # Verify domain model and hand off to PRD creation
 /ddd resume      # Resume interrupted event storming session
 ```
 
-**The pipeline:** `/ddd begin` (8-stage event storming → `docs/SKETCHBOOK.md`) → `/ddd draft` (formalize → `docs/DOMAIN-MODEL.md`) → `/ddd accept` (translate → `docs/<project>-PRD.md`).
+**The pipeline:** `/ddd begin` (8-stage event storming → `docs/SKETCHBOOK.md`) → `/ddd draft` (formalize → `docs/DOMAIN-MODEL.md`) → `/ddd accept` (verify and hand off) → `/prd create` (generate PRD).
 
 **Event storming stages:** Domain Context → Events (brainstorm) → Events (organize) → Commands → Actors → Policies → Aggregates → Read Models. Progress is checkpointed to the sketchbook after each stage.
 

--- a/skills/ddd/SKILL.md
+++ b/skills/ddd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ddd
-description: Domain-Driven Design facilitation — event storming, domain modeling, and PRD generation
+description: Domain-Driven Design facilitation — event storming, domain modeling, and concept handoff
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -11,13 +11,13 @@ description: Domain-Driven Design facilitation — event storming, domain modeli
 
 # Domain-Driven Design Workflow
 
-This skill provides a structured workflow for Domain-Driven Design using event storming. It guides you through discovering your domain model and translating it into an implementation-ready PRD.
+This skill provides a structured workflow for Domain-Driven Design using event storming. It guides you through discovering your domain model and preparing it for PRD creation via `/prd create`.
 
 ## Commands
 
 - **`/ddd begin`** — Start interactive event storming session (creates SKETCHBOOK.md)
 - **`/ddd draft`** — Formalize sketchbook into Domain Model document (creates DOMAIN-MODEL.md)
-- **`/ddd accept`** — Translate Domain Model to PRD (creates docs/[project]-PRD.md)
+- **`/ddd accept`** — Verify domain model and hand off to PRD creation
 - **`/ddd resume`** — Resume interrupted event storming session
 
 ## Usage
@@ -29,7 +29,7 @@ This skill provides a structured workflow for Domain-Driven Design using event s
 # Formalize raw notes into domain model
 /ddd draft
 
-# Generate PRD from domain model
+# Verify domain model and hand off to /prd create
 /ddd accept
 
 # Resume interrupted session
@@ -71,8 +71,8 @@ Progress is saved to `docs/SKETCHBOOK.md` after each stage.
 ### `/ddd draft` — Formalize Domain Model
 Reads `docs/SKETCHBOOK.md` and produces a formal `docs/DOMAIN-MODEL.md` following the Domain Model template. Validates completeness and adds traceability.
 
-### `/ddd accept` — Generate PRD
-Reads `docs/DOMAIN-MODEL.md` and generates `docs/[project]-PRD.md` using the DDD→PRD translation protocol. The PRD is implementation-ready with full traceability back to the domain model.
+### `/ddd accept` — Verify Domain Model and Hand Off to PRD Creation
+Verifies `docs/DOMAIN-MODEL.md` exists and is committed, prints a summary of domain model contents (aggregate/command/policy counts), and suggests running `/prd create` to generate the PRD.
 
 ### `/ddd resume` — Resume Session
 If your event storming session was interrupted (context compaction, restart), this command reads `docs/SKETCHBOOK.md` and picks up where you left off.
@@ -448,39 +448,38 @@ If the sketchbook exists, proceed. Read it and generate the formal domain model 
 <!-- END TEMPLATE: ddd-draft -->
 
 <!-- BEGIN TEMPLATE: ddd-accept -->
-## Translating Domain Model → PRD
+## Domain Model Handoff
 
-I'll apply the DDD→PRD translation protocol to generate an implementation-ready Product Requirements Document.
+I'll verify the domain model is ready and hand off to PRD creation.
 
-**Process:**
-1. Read `docs/DOMAIN-MODEL.md` (source of truth)
-2. Read `docs/PRD-template.md` (target structure)
-3. Read `docs/DDD-to-PRD-protocol.md` (translation rules)
-4. Apply 8-step translation:
-   - **Step 1:** Actors → Section 1.4 Personas
-   - **Step 2:** Aggregates → Section 5.1 Data Model
-   - **Step 3:** Policies → Section 3 Requirements (EARS format)
-   - **Step 4:** Commands → Section 4 Concept of Operations (flows)
-   - **Step 5:** Read Models → Section 5 API/UI + Section 6 Test Plan
-   - **Step 6:** Create Test Plan from policies and read models
-   - **Step 7:** Decompose into Stories (Section 8) from aggregates + policies
-   - **Step 8:** Add traceability — Domain Model as appendix, event catalog, VRTM skeleton
-5. Write `docs/[project]-PRD.md`
+**Step 1 — Verify `docs/DOMAIN-MODEL.md` exists:**
 
-**Before proceeding:** Check that the required files exist.
+Check whether `docs/DOMAIN-MODEL.md` exists and is non-empty.
 
-- Check `docs/DOMAIN-MODEL.md` — **required.** If missing, tell the user: "Run `/ddd draft` first."
-- Check `docs/PRD-template.md` — optional. If missing, use the built-in PRD structure.
-- Check `docs/DDD-to-PRD-protocol.md` — optional. If missing, use the built-in translation rules.
+- **If missing or empty:** Tell the user: "No domain model found at `docs/DOMAIN-MODEL.md`. Run `/ddd draft` first to formalize your sketchbook into a domain model."
+- **If present:** Continue to Step 2.
 
-If the domain model exists, ask the user for the project name:
+**Step 2 — Verify the file is committed and pushed:**
 
-**What should the PRD be named?** (e.g., "remotion-studio" → `docs/remotion-studio-PRD.md`)
+Run `git status docs/DOMAIN-MODEL.md` and check for uncommitted changes.
 
-After the user provides the name:
-1. Translate the domain model
-2. Generate the PRD with full traceability
-3. Validate that every policy has a requirement, every requirement has verification
+- **If uncommitted changes exist:** Tell the user: "The domain model has uncommitted changes. Please commit and push `docs/DOMAIN-MODEL.md` before accepting."
+- **If clean:** Continue to Step 3.
 
-**Commitment moment:** Once this PRD is generated, the Domain Model becomes the canonical source. Future changes should update the Domain Model and re-run `/ddd accept` to regenerate the PRD.
+**Step 3 — Present a domain model summary:**
+
+Read `docs/DOMAIN-MODEL.md` and count:
+- Number of **Aggregates** (look for aggregate table rows or `| **` patterns in the Aggregates section)
+- Number of **Commands** (look for `C-NN` entries or command table rows)
+- Number of **Policies** (look for `P-NN` entries or policy table rows)
+
+Present:
+
+> **Domain model ready.** N aggregates, M commands, P policies.
+
+**Step 4 — Suggest next step:**
+
+> Run `/prd create` to generate the PRD from this domain model.
+
+**Stop here.** Do not generate a PRD. Do not read PRD templates. Do not apply DDD→PRD translation. The `/prd create` command handles PRD generation.
 <!-- END TEMPLATE: ddd-accept -->

--- a/tests/test_ddd_skill.py
+++ b/tests/test_ddd_skill.py
@@ -1,0 +1,374 @@
+"""Tests for skills/ddd/SKILL.md — ddd accept refactor into concept handoff.
+
+Validates:
+- /ddd accept no longer references PRD generation
+- /ddd accept includes domain model verification steps (exists, committed)
+- /ddd accept includes domain model summary (aggregate/command/policy counts)
+- /ddd accept suggests running /prd create
+- /ddd begin, /ddd draft, /ddd resume templates are unchanged in structure
+- docs/DDD-to-PRD-protocol.md is preserved (not deleted)
+- Help text reflects new /ddd accept behavior
+- Skill frontmatter description updated
+- docs/skill-reference.md updated with new /ddd accept description
+- README.md updated with new DDD row description
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = _ROOT / "skills" / "ddd" / "SKILL.md"
+PROTOCOL_PATH = _ROOT / "docs" / "DDD-to-PRD-protocol.md"
+SKILL_REF_PATH = _ROOT / "docs" / "skill-reference.md"
+README_PATH = _ROOT / "README.md"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Read the DDD SKILL.md file."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def skill_ref_text() -> str:
+    """Read the skill-reference.md file."""
+    return SKILL_REF_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def readme_text() -> str:
+    """Read the README.md file."""
+    return README_PATH.read_text(encoding="utf-8")
+
+
+def _extract_template(text: str, template_name: str) -> str:
+    """Extract content between BEGIN TEMPLATE and END TEMPLATE markers."""
+    pattern = (
+        rf"<!-- BEGIN TEMPLATE: {re.escape(template_name)} -->\n"
+        rf"(.*?)"
+        rf"<!-- END TEMPLATE: {re.escape(template_name)} -->"
+    )
+    match = re.search(pattern, text, re.DOTALL)
+    return match.group(1) if match else ""
+
+
+# ---------------------------------------------------------------------------
+# 1. /ddd accept no longer generates a PRD
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptNoPrdGeneration:
+    """Verify /ddd accept does not generate a PRD file."""
+
+    def test_no_prd_file_creation_in_accept(self, skill_text: str) -> None:
+        """The ddd-accept template must not reference writing a PRD file."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert accept, "ddd-accept template not found"
+        assert "Write `docs/" not in accept
+        assert "-PRD.md`" not in accept
+
+    def test_no_prd_template_reading(self, skill_text: str) -> None:
+        """The ddd-accept template must not read PRD templates."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "PRD-template.md" not in accept
+
+    def test_no_translation_steps(self, skill_text: str) -> None:
+        """The ddd-accept template must not contain DDD-to-PRD translation steps."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "8-step translation" not in accept
+        assert "Apply 8-step" not in accept
+        assert "Step 1:" not in accept or "Actors" not in accept
+
+    def test_no_ddd_to_prd_protocol_reading(self, skill_text: str) -> None:
+        """The ddd-accept template must not read DDD-to-PRD-protocol.md."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "DDD-to-PRD-protocol.md" not in accept
+
+    def test_stop_directive_present(self, skill_text: str) -> None:
+        """The ddd-accept template must include an explicit stop directive."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "Stop here" in accept or "Do not generate a PRD" in accept
+
+
+# ---------------------------------------------------------------------------
+# 2. /ddd accept verifies domain model exists and is committed
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptVerification:
+    """Verify /ddd accept includes domain model verification."""
+
+    def test_checks_domain_model_exists(self, skill_text: str) -> None:
+        """The ddd-accept template checks DOMAIN-MODEL.md exists."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "DOMAIN-MODEL.md" in accept
+        assert "exists" in accept.lower() or "missing" in accept.lower()
+
+    def test_checks_domain_model_committed(self, skill_text: str) -> None:
+        """The ddd-accept template checks DOMAIN-MODEL.md is committed."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "committed" in accept.lower() or "git status" in accept.lower()
+
+    def test_error_message_for_missing_model(self, skill_text: str) -> None:
+        """If DOMAIN-MODEL.md is missing, directs user to /ddd draft."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "/ddd draft" in accept
+
+    def test_error_message_for_uncommitted_changes(self, skill_text: str) -> None:
+        """If DOMAIN-MODEL.md has uncommitted changes, tells user to commit."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "uncommitted" in accept.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. /ddd accept prints summary with counts
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptSummary:
+    """Verify /ddd accept prints a domain model summary."""
+
+    def test_summary_mentions_aggregates(self, skill_text: str) -> None:
+        """Summary references aggregate counts."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "Aggregate" in accept or "aggregate" in accept
+
+    def test_summary_mentions_commands(self, skill_text: str) -> None:
+        """Summary references command counts."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "Command" in accept or "command" in accept
+
+    def test_summary_mentions_policies(self, skill_text: str) -> None:
+        """Summary references policy counts."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "Polic" in accept or "polic" in accept
+
+    def test_domain_model_ready_message(self, skill_text: str) -> None:
+        """Summary includes a 'Domain model ready' message."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "Domain model ready" in accept
+
+
+# ---------------------------------------------------------------------------
+# 4. /ddd accept suggests running /prd create
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptHandoff:
+    """Verify /ddd accept suggests /prd create."""
+
+    def test_suggests_prd_create(self, skill_text: str) -> None:
+        """The ddd-accept template suggests running /prd create."""
+        accept = _extract_template(skill_text, "ddd-accept")
+        assert "/prd create" in accept
+
+
+# ---------------------------------------------------------------------------
+# 5. /ddd begin, /ddd draft, /ddd resume are unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestOtherTemplatesPreserved:
+    """Verify begin, draft, and resume templates still exist and have expected content."""
+
+    def test_begin_template_exists(self, skill_text: str) -> None:
+        """The ddd-begin template still exists."""
+        begin = _extract_template(skill_text, "ddd-begin")
+        assert begin, "ddd-begin template not found"
+
+    def test_begin_has_event_storming(self, skill_text: str) -> None:
+        """The ddd-begin template still references event storming."""
+        begin = _extract_template(skill_text, "ddd-begin")
+        assert "Event Storming" in begin
+
+    def test_begin_has_8_stages(self, skill_text: str) -> None:
+        """The ddd-begin template still has all 8 stages."""
+        begin = _extract_template(skill_text, "ddd-begin")
+        assert "Stage 1" in begin
+        assert "Stage 8" in begin
+
+    def test_draft_template_exists(self, skill_text: str) -> None:
+        """The ddd-draft template still exists."""
+        draft = _extract_template(skill_text, "ddd-draft")
+        assert draft, "ddd-draft template not found"
+
+    def test_draft_reads_sketchbook(self, skill_text: str) -> None:
+        """The ddd-draft template still reads SKETCHBOOK.md."""
+        draft = _extract_template(skill_text, "ddd-draft")
+        assert "SKETCHBOOK.md" in draft
+
+    def test_resume_template_exists(self, skill_text: str) -> None:
+        """The ddd-resume template still exists."""
+        resume = _extract_template(skill_text, "ddd-resume")
+        assert resume, "ddd-resume template not found"
+
+    def test_resume_checks_sketchbook(self, skill_text: str) -> None:
+        """The ddd-resume template still checks for SKETCHBOOK.md."""
+        resume = _extract_template(skill_text, "ddd-resume")
+        assert "SKETCHBOOK.md" in resume
+
+
+# ---------------------------------------------------------------------------
+# 6. DDD-to-PRD protocol is preserved
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolPreserved:
+    """Verify docs/DDD-to-PRD-protocol.md is not deleted."""
+
+    def test_protocol_file_exists(self) -> None:
+        """The DDD-to-PRD-protocol.md file must still exist."""
+        assert PROTOCOL_PATH.exists(), (
+            f"DDD-to-PRD-protocol.md was deleted: {PROTOCOL_PATH}"
+        )
+
+    def test_protocol_file_not_empty(self) -> None:
+        """The DDD-to-PRD-protocol.md file must not be empty."""
+        content = PROTOCOL_PATH.read_text(encoding="utf-8")
+        assert len(content.strip()) > 0, "DDD-to-PRD-protocol.md is empty"
+
+
+# ---------------------------------------------------------------------------
+# 7. Help text reflects new /ddd accept behavior
+# ---------------------------------------------------------------------------
+
+
+class TestHelpText:
+    """Verify the ddd-help template reflects the new accept behavior."""
+
+    def test_help_accept_no_generate_prd(self, skill_text: str) -> None:
+        """Help text for /ddd accept does not say 'Generate PRD'."""
+        help_text = _extract_template(skill_text, "ddd-help")
+        # Find the accept section in help
+        accept_idx = help_text.find("/ddd accept")
+        assert accept_idx != -1, "/ddd accept not found in help text"
+        # Get the text from /ddd accept to the next ### heading
+        after_accept = help_text[accept_idx:]
+        next_heading = after_accept.find("\n###", 1)
+        accept_help = after_accept[:next_heading] if next_heading != -1 else after_accept
+        assert "Generate PRD" not in accept_help
+
+    def test_help_accept_mentions_verify(self, skill_text: str) -> None:
+        """Help text for /ddd accept mentions verification."""
+        help_text = _extract_template(skill_text, "ddd-help")
+        accept_idx = help_text.find("/ddd accept")
+        assert accept_idx != -1
+        after_accept = help_text[accept_idx:]
+        next_heading = after_accept.find("\n###", 1)
+        accept_help = after_accept[:next_heading] if next_heading != -1 else after_accept
+        assert "Verif" in accept_help or "verif" in accept_help
+
+    def test_help_accept_mentions_prd_create(self, skill_text: str) -> None:
+        """Help text for /ddd accept mentions /prd create."""
+        help_text = _extract_template(skill_text, "ddd-help")
+        accept_idx = help_text.find("/ddd accept")
+        assert accept_idx != -1
+        after_accept = help_text[accept_idx:]
+        next_heading = after_accept.find("\n###", 1)
+        accept_help = after_accept[:next_heading] if next_heading != -1 else after_accept
+        assert "/prd create" in accept_help
+
+
+# ---------------------------------------------------------------------------
+# 8. Frontmatter description updated
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatter:
+    """Verify SKILL.md frontmatter description reflects the change."""
+
+    def test_frontmatter_no_prd_generation(self, skill_text: str) -> None:
+        """Frontmatter description must not say 'PRD generation'."""
+        # Extract frontmatter (between --- markers)
+        lines = skill_text.split("\n")
+        assert lines[0].strip() == "---"
+        end_idx = skill_text.index("---", 4)
+        frontmatter = skill_text[: end_idx + 3]
+        assert "PRD generation" not in frontmatter
+
+    def test_frontmatter_mentions_handoff(self, skill_text: str) -> None:
+        """Frontmatter description mentions concept handoff or similar."""
+        lines = skill_text.split("\n")
+        assert lines[0].strip() == "---"
+        end_idx = skill_text.index("---", 4)
+        frontmatter = skill_text[: end_idx + 3]
+        assert "handoff" in frontmatter.lower() or "hand off" in frontmatter.lower()
+
+
+# ---------------------------------------------------------------------------
+# 9. skill-reference.md updated
+# ---------------------------------------------------------------------------
+
+
+class TestSkillReference:
+    """Verify docs/skill-reference.md has updated /ddd accept description."""
+
+    def test_ddd_section_exists(self, skill_ref_text: str) -> None:
+        """The /ddd section exists in skill-reference.md."""
+        assert "### `/ddd`" in skill_ref_text
+
+    def test_no_translate_domain_model_to_prd(self, skill_ref_text: str) -> None:
+        """The /ddd section does not say 'Translate Domain Model to PRD'."""
+        # Find the /ddd section
+        ddd_start = skill_ref_text.find("### `/ddd`")
+        assert ddd_start != -1
+        # Find the next ## heading
+        next_section = skill_ref_text.find("\n## ", ddd_start + 1)
+        ddd_section = skill_ref_text[ddd_start:next_section] if next_section != -1 else skill_ref_text[ddd_start:]
+        assert "Translate Domain Model to PRD" not in ddd_section
+
+    def test_accept_described_as_handoff(self, skill_ref_text: str) -> None:
+        """The /ddd accept example line reflects handoff behavior."""
+        ddd_start = skill_ref_text.find("### `/ddd`")
+        assert ddd_start != -1
+        next_section = skill_ref_text.find("\n## ", ddd_start + 1)
+        ddd_section = skill_ref_text[ddd_start:next_section] if next_section != -1 else skill_ref_text[ddd_start:]
+        # The accept line in the examples block should mention verify/handoff
+        assert "hand off" in ddd_section.lower() or "verify" in ddd_section.lower()
+
+    def test_pipeline_includes_prd_create(self, skill_ref_text: str) -> None:
+        """The pipeline description includes /prd create as the next step."""
+        ddd_start = skill_ref_text.find("### `/ddd`")
+        assert ddd_start != -1
+        next_section = skill_ref_text.find("\n## ", ddd_start + 1)
+        ddd_section = skill_ref_text[ddd_start:next_section] if next_section != -1 else skill_ref_text[ddd_start:]
+        assert "/prd create" in ddd_section
+
+
+# ---------------------------------------------------------------------------
+# 10. README.md updated
+# ---------------------------------------------------------------------------
+
+
+class TestReadme:
+    """Verify README.md has updated DDD row description."""
+
+    def test_ddd_row_exists(self, readme_text: str) -> None:
+        """The DDD row exists in the skills table."""
+        assert "| ddd |" in readme_text
+
+    def test_ddd_row_no_prd_generation(self, readme_text: str) -> None:
+        """The DDD row does not say 'PRD generation'."""
+        for line in readme_text.split("\n"):
+            if "| ddd |" in line:
+                assert "PRD generation" not in line
+                break
+
+    def test_ddd_row_mentions_handoff(self, readme_text: str) -> None:
+        """The DDD row mentions concept handoff."""
+        for line in readme_text.split("\n"):
+            if "| ddd |" in line:
+                assert "handoff" in line.lower() or "hand off" in line.lower()
+                break


### PR DESCRIPTION
## Summary

Refactor `/ddd accept` from a full PRD generator into a lightweight concept handoff command. It now verifies the domain model, prints a summary, and suggests `/prd create` — no PRD generation.

## Changes

- **`skills/ddd/SKILL.md`**: Replaced `ddd-accept` template with 4-step handoff gate; updated help text, frontmatter description, intro paragraph
- **`docs/skill-reference.md`**: Updated `/ddd` section — pipeline now shows `/ddd accept` → `/prd create`
- **`README.md`**: Updated DDD row description from "PRD generation" to "concept handoff"
- **Tests**: 35 tests across 10 classes validating all acceptance criteria

## Linked Issues

Closes #243

## Test Plan

- `python3 -m pytest tests/test_ddd_skill.py -v` — 35/35 passed
- `python3 -m pytest` (full suite) — 900/900 passed
- `./scripts/ci/validate.sh` — 78/78 passed