### PR TITLE
feat(prd): add /prd approve and /prd upshift (#245)

### DIFF
--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -541,22 +541,26 @@ A structured workflow for domain modeling using event storming. Guides you throu
 
 ### `/prd` -- Interactive PRD Creation
 
-Creates Product Requirements Documents through an interactive, section-by-section workflow. Instead of generating a PRD in one shot, it walks each section collaboratively -- drafting, presenting, and waiting for feedback before moving on. Manages a unified Deliverables Manifest (Tier 1 required defaults, Tier 2 conditional triggers, Tier 3 opt-in) and runs a mechanical finalization checklist.
+Creates Product Requirements Documents through an interactive, section-by-section workflow. Instead of generating a PRD in one shot, it walks each section collaboratively -- drafting, presenting, and waiting for feedback before moving on. Manages a unified Deliverables Manifest (Tier 1 required defaults, Tier 2 conditional triggers, Tier 3 opt-in) and runs a mechanical finalization checklist. Includes an approval gate and backlog population (upshift) for the full concept-to-execution pipeline.
 
 **When to use it:**
 - After `/ddd accept` produces a domain model and you need to create a PRD from it
 - When starting a new project and need a structured PRD from a concept doc or verbal description
 - When you have an existing PRD and want to verify it meets completeness requirements
+- When a finalized PRD needs stakeholder approval before execution
+- When an approved PRD needs to be broken into trackable backlog issues
 
 **Examples:**
 
 ```
 /prd create       # Start interactive PRD generation
 /prd finalize     # Run the finalization checklist on an existing PRD
+/prd approve      # Approval gate — finalize, summarize, and record approval
+/prd upshift      # Backlog population — create issues from approved PRD
 /prd              # Show help
 ```
 
-**The pipeline:** `/ddd accept` (domain model) or concept doc or verbal description → `/prd create` (interactive PRD generation → `docs/<project>-PRD.md`) → `/prd finalize` (verify completeness) → `/prepwaves` (plan execution waves).
+**The pipeline:** `/ddd accept` (domain model) or concept doc or verbal description → `/prd create` (interactive PRD generation → `docs/<project>-PRD.md`) → `/prd finalize` (verify completeness) → `/prd approve` (human approval gate) → `/prd upshift` (backlog population) → `/prepwaves` (plan execution waves).
 
 **`/prd create` flow:**
 1. Determine input source (DDD domain model, external doc, or verbal description)
@@ -568,6 +572,22 @@ Creates Product Requirements Documents through an interactive, section-by-sectio
 
 **`/prd finalize` flow:**
 Run the Section 7.2 Finalization Checklist mechanically against an existing PRD. Reports pass/fail per item (Tier 1 file paths, Tier 2 triggers, wave assignments, MV-XX coverage, verb-only deliverables, audience-facing docs, DoD references). Summary: "X/7 checks passed. PRD is ready / not ready for approval."
+
+**`/prd approve` flow:**
+1. Run the finalization checklist automatically (rejects if any checks fail)
+2. Present a PRD summary: section count, story count, wave count, deliverable count
+3. Hard stop: "Approve this PRD? (yes/no)" -- waits for human response
+4. On approval: records approval timestamp, approver, and finalization score in PRD metadata
+5. On rejection: lists failing items, suggests fixes, stops
+
+**`/prd upshift` flow:**
+1. Verify PRD has approval metadata (`approved: true`)
+2. Parse Section 8 (Phased Implementation Plan) for phases, waves, and stories
+3. Create one epic issue per phase with Phase DoD as acceptance criteria
+4. Create one story issue per story with implementation steps, test procedures, and AC from PRD
+5. Create wave master issues linking constituent story issues
+6. Report summary: "Created N epics, M stories, P wave master issues"
+7. Backfill issue numbers into the PRD (e.g., `### Phase 1: Foundation (#NNN)`)
 
 **Key detail:** Tier 1 deliverables are opt-OUT (must provide "N/A -- because [reason]" to skip). The Deliverables Manifest (Section 5.A) is the single source of truth for all project outputs -- there is no separate Artifact Manifest or Documentation Kit.
 

--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd
-description: Interactive PRD creation with Deliverables Manifest and finalization checklist
+description: Interactive PRD creation with Deliverables Manifest, finalization checklist, approval gate, and backlog population
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -24,6 +24,8 @@ Before proceeding, detect the platform:
 
 - **`/prd create`** — Interactive PRD generation (walk each section, build Deliverables Manifest)
 - **`/prd finalize`** — Mechanical finalization checklist (verify PRD completeness)
+- **`/prd approve`** — Approval gate (run finalization, present summary, record approval)
+- **`/prd upshift`** — Backlog population (create epics, stories, and wave master issues from approved PRD)
 
 ## Usage
 
@@ -33,6 +35,12 @@ Before proceeding, detect the platform:
 
 # Run the finalization checklist on an existing PRD
 /prd finalize
+
+# Approve a finalized PRD (human gate)
+/prd approve
+
+# Create backlog issues from an approved PRD
+/prd upshift
 
 # Show help
 /prd
@@ -44,6 +52,10 @@ Before proceeding, detect the platform:
   {{> prd-create}}
 {{else if (eq args "finalize")}}
   {{> prd-finalize}}
+{{else if (eq args "approve")}}
+  {{> prd-approve}}
+{{else if (eq args "upshift")}}
+  {{> prd-upshift}}
 {{else}}
   {{> prd-help}}
 {{/if}}
@@ -60,6 +72,16 @@ Walk each PRD section collaboratively. I'll generate a draft for each section, p
 
 ### `/prd finalize` — Finalization Checklist
 Run the Section 7.2 finalization checklist mechanically against an existing PRD. Reports pass/fail per item with explanation.
+
+### `/prd approve` — Approval Gate
+Run the finalization checklist, present a PRD summary (section count, story count, wave count, deliverable count), and hard-stop for human approval. On approval, records approval metadata in the PRD. On rejection, lists failing items with suggested fixes.
+
+**Prerequisite:** A finalized PRD that passes all checklist items.
+
+### `/prd upshift` — Backlog Population
+Create backlog issues from an approved PRD's Section 8 (Phased Implementation Plan). Creates epic issues per phase, story issues with full acceptance criteria, and wave master issues linking constituent stories. Backfills issue numbers into the PRD.
+
+**Prerequisite:** An approved PRD (must have approval metadata from `/prd approve`).
 
 **Which command would you like to run?**
 <!-- END TEMPLATE: prd-help -->
@@ -350,6 +372,228 @@ If all checks pass:
 - "PRD is ready for approval. Next step: get stakeholder sign-off, then run `/prepwaves` to plan execution."
 
 <!-- END TEMPLATE: prd-finalize -->
+
+<!-- BEGIN TEMPLATE: prd-approve -->
+## PRD Approval Gate
+
+This is the gate between PRD creation and backlog population. No issues get created until the PRD is explicitly approved by a human.
+
+### Step 1: Locate the PRD
+
+Check for the PRD file:
+1. If the user provided a path, use it
+2. Otherwise, look for `docs/*-PRD.md` files
+3. If multiple PRDs exist, ask the user which one to approve
+4. If no PRD exists, tell the user: "No PRD found. Run `/prd create` first."
+
+### Step 2: Run Finalization Checklist
+
+Run the `/prd finalize` checklist automatically against the PRD. This is the same mechanical checklist from the finalize subcommand.
+
+1. Execute all 7 finalization checks
+2. Collect the results
+
+**If any checks fail:**
+- Present the finalization report with failures highlighted
+- List each failing item with a specific remediation suggestion
+- Tell the user: "PRD has N failing checks. Fix these issues and run `/prd approve` again."
+- **Stop here.** Do not proceed to approval.
+
+### Step 3: Present PRD Summary
+
+If all finalization checks pass, present a PRD summary to the user:
+
+```
+## PRD Approval Summary
+
+| Metric | Count |
+|--------|-------|
+| Sections | N |
+| Stories | N |
+| Waves | N |
+| Deliverables | N |
+| Finalization checks | 7/7 passed |
+```
+
+Count these by scanning the PRD:
+- **Sections**: Count top-level `## N.` headings
+- **Stories**: Count story entries in Section 8 (look for `#### Story` headings or numbered story items)
+- **Waves**: Count wave entries in Section 8 (look for `### Wave` headings or wave references)
+- **Deliverables**: Count active (non-N/A) rows in the Deliverables Manifest (Section 5.A)
+
+### Step 4: Hard Stop for Approval
+
+Present the approval prompt and **stop**. Do not proceed until the user responds.
+
+**Tell the user:**
+
+> PRD is ready for approval. All 7 finalization checks passed.
+>
+> **Approve this PRD? (yes/no)**
+
+**Wait for the user's response.** Do not take any further action until they respond.
+
+### Step 5: Process Response
+
+**On approval (user says yes/approve/confirmed/y):**
+
+1. Add an approval metadata section to the PRD. Insert it after the frontmatter (if any) or at the top of the document, before Section 1:
+
+```markdown
+<!-- PRD-APPROVAL
+approved: true
+approved_by: [user name or "stakeholder"]
+approved_at: [ISO 8601 timestamp, e.g. 2026-04-04T12:00:00Z]
+finalization_score: 7/7
+-->
+```
+
+2. Confirm to the user: "PRD approved. Approval metadata recorded. Next step: run `/prd upshift` to create backlog issues."
+
+**On rejection (user says no/reject/n):**
+
+1. Ask the user what needs to change
+2. List the finalization results as a starting point for discussion
+3. Tell the user: "Make the requested changes to the PRD, then run `/prd approve` again."
+4. **Stop here.**
+
+<!-- END TEMPLATE: prd-approve -->
+
+<!-- BEGIN TEMPLATE: prd-upshift -->
+## PRD Backlog Population (Upshift)
+
+Creates backlog issues from an approved PRD's Section 8 (Phased Implementation Plan). This is the bridge from PRD to execution.
+
+### Step 1: Locate and Verify the PRD
+
+Check for the PRD file:
+1. If the user provided a path, use it
+2. Otherwise, look for `docs/*-PRD.md` files
+3. If multiple PRDs exist, ask the user which one to upshift
+4. If no PRD exists, tell the user: "No PRD found. Run `/prd create` first."
+
+**Verify approval:**
+1. Search the PRD for the approval metadata comment block (`<!-- PRD-APPROVAL`)
+2. Check that `approved: true` is present in the metadata
+3. If no approval metadata is found or `approved` is not `true`:
+   - Tell the user: "This PRD has not been approved. Run `/prd approve` first."
+   - **Stop here.** Do not create any issues.
+
+### Step 2: Parse Section 8
+
+Read Section 8 (Phased Implementation Plan) and extract the structure:
+
+1. **Phases** — Each `### Phase N:` heading defines a phase (epic)
+2. **Waves** — Each `#### Wave N` or wave reference within a phase
+3. **Stories** — Each story entry within a wave (look for `##### Story:` headings, numbered story items, or bullet-pointed stories)
+
+For each story, extract:
+- **Title** — The story name/description
+- **Implementation steps** — Numbered steps or bullet points under the story
+- **Test procedures** — Any test-related items
+- **Acceptance criteria** — Checkboxes or criteria items
+- **Wave assignment** — Which wave the story belongs to
+
+### Step 3: Create Epic Issues (One per Phase)
+
+For each Phase in Section 8:
+
+1. Create an epic issue using the platform CLI:
+   ```
+   Title: Epic: Phase N — [Phase Name]
+   Body:
+   ## Phase Definition of Done
+   [Copy the Phase DoD from the PRD]
+
+   ## Stories
+   [List story titles that will be linked after creation]
+
+   Labels: type::epic
+   ```
+
+2. Record the created issue number
+
+### Step 4: Create Story Issues (One per Story)
+
+For each Story in Section 8:
+
+1. Create an issue using the platform CLI:
+   ```
+   Title: [Story title from PRD]
+   Body:
+   ## Summary
+   [Story description from PRD]
+
+   ## Implementation Steps
+   [Copy implementation steps from PRD]
+
+   ## Test Procedures
+   [Copy test procedures from PRD]
+
+   ## Acceptance Criteria
+   [Copy acceptance criteria from PRD as checkboxes]
+
+   ## Metadata
+   - **Wave:** [wave assignment]
+   - **Phase:** [parent phase]
+   - **Parent Epic:** #[epic issue number]
+
+   Labels: type::feature
+   ```
+
+2. Record the created issue number
+3. Link to the parent epic by editing the epic issue body to include `#NNN`
+
+### Step 5: Create Wave Master Issues
+
+For each Wave in Section 8:
+
+1. Collect all story issue numbers created for this wave
+2. Create a wave master issue:
+   ```
+   Title: Wave N Master — [brief description]
+   Body:
+   ## Constituent Stories
+   - [ ] #[story-1-number] — [story-1-title]
+   - [ ] #[story-2-number] — [story-2-title]
+   ...
+
+   ## Wave Metadata
+   - **Phase:** [parent phase]
+   - **Story count:** N
+
+   Labels: type::chore
+   ```
+
+3. Record the created issue number
+
+### Step 6: Report Summary
+
+Present a creation summary:
+
+```
+## Backlog Population Summary
+
+| Type | Count | Issue Numbers |
+|------|-------|---------------|
+| Epics (Phases) | N | #X, #Y |
+| Stories | N | #A, #B, #C, ... |
+| Wave Masters | N | #P, #Q |
+| **Total issues created** | **N** | |
+```
+
+### Step 7: Backfill Issue Numbers into PRD
+
+Update the PRD file to include the created issue numbers:
+
+1. For each Phase heading, append the epic issue number: `### Phase 1: Foundation (#NNN)`
+2. For each Story, append the story issue number
+3. For each Wave reference, append the wave master issue number
+4. Write the updated PRD back to disk
+
+Confirm to the user: "Backlog populated. N issues created. PRD updated with issue references. Run `/prepwaves` to plan execution."
+
+<!-- END TEMPLATE: prd-upshift -->
 
 ---
 

--- a/tests/test_prd_skill.py
+++ b/tests/test_prd_skill.py
@@ -1,0 +1,462 @@
+"""Tests for skills/prd/SKILL.md — approve and upshift subcommands.
+
+Validates:
+- Frontmatter description updated to include approval and backlog population
+- Commands section lists all four subcommands
+- Routing block dispatches approve and upshift
+- Help template documents approve and upshift subcommands
+- prd-approve template: runs finalization, presents summary, hard-stops, records metadata, handles rejection
+- prd-upshift template: verifies approval, parses Section 8, creates epics/stories/wave masters, backfills
+- docs/skill-reference.md updated with approve and upshift
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = _ROOT / "skills" / "prd" / "SKILL.md"
+SKILL_REF_PATH = _ROOT / "docs" / "skill-reference.md"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Read the PRD SKILL.md file."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def skill_ref_text() -> str:
+    """Read the skill-reference.md file."""
+    return SKILL_REF_PATH.read_text(encoding="utf-8")
+
+
+def _extract_template(text: str, template_name: str) -> str:
+    """Extract content between BEGIN TEMPLATE and END TEMPLATE markers."""
+    pattern = (
+        rf"<!-- BEGIN TEMPLATE: {re.escape(template_name)} -->\n"
+        rf"(.*?)"
+        rf"<!-- END TEMPLATE: {re.escape(template_name)} -->"
+    )
+    match = re.search(pattern, text, re.DOTALL)
+    return match.group(1) if match else ""
+
+
+def _extract_prd_section(text: str) -> str:
+    """Extract the /prd section from skill-reference.md."""
+    start = text.find("### `/prd`")
+    if start == -1:
+        return ""
+    # Find next ### heading or ## heading
+    next_heading = text.find("\n---", start + 1)
+    return text[start:next_heading] if next_heading != -1 else text[start:]
+
+
+# ---------------------------------------------------------------------------
+# 1. Frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatter:
+    """Verify SKILL.md frontmatter description includes approval and backlog."""
+
+    def test_frontmatter_mentions_approval(self, skill_text: str) -> None:
+        """Frontmatter description mentions approval gate."""
+        lines = skill_text.split("\n")
+        assert lines[0].strip() == "---"
+        end_idx = skill_text.index("---", 4)
+        frontmatter = skill_text[:end_idx + 3]
+        assert "approval" in frontmatter.lower()
+
+    def test_frontmatter_mentions_backlog(self, skill_text: str) -> None:
+        """Frontmatter description mentions backlog population."""
+        lines = skill_text.split("\n")
+        assert lines[0].strip() == "---"
+        end_idx = skill_text.index("---", 4)
+        frontmatter = skill_text[:end_idx + 3]
+        assert "backlog" in frontmatter.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. Commands section
+# ---------------------------------------------------------------------------
+
+
+class TestCommandsSection:
+    """Verify the Commands section lists all four subcommands."""
+
+    def test_commands_lists_create(self, skill_text: str) -> None:
+        """Commands section lists /prd create."""
+        assert "`/prd create`" in skill_text
+
+    def test_commands_lists_finalize(self, skill_text: str) -> None:
+        """Commands section lists /prd finalize."""
+        assert "`/prd finalize`" in skill_text
+
+    def test_commands_lists_approve(self, skill_text: str) -> None:
+        """Commands section lists /prd approve."""
+        assert "`/prd approve`" in skill_text
+
+    def test_commands_lists_upshift(self, skill_text: str) -> None:
+        """Commands section lists /prd upshift."""
+        assert "`/prd upshift`" in skill_text
+
+
+# ---------------------------------------------------------------------------
+# 3. Routing block
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingBlock:
+    """Verify the routing conditional dispatches all four subcommands."""
+
+    def test_routing_create(self, skill_text: str) -> None:
+        """Routing block handles create."""
+        assert 'eq args "create"' in skill_text
+
+    def test_routing_finalize(self, skill_text: str) -> None:
+        """Routing block handles finalize."""
+        assert 'eq args "finalize"' in skill_text
+
+    def test_routing_approve(self, skill_text: str) -> None:
+        """Routing block handles approve."""
+        assert 'eq args "approve"' in skill_text
+
+    def test_routing_upshift(self, skill_text: str) -> None:
+        """Routing block handles upshift."""
+        assert 'eq args "upshift"' in skill_text
+
+    def test_routing_approve_dispatches_to_template(self, skill_text: str) -> None:
+        """Routing block dispatches approve to prd-approve template."""
+        assert "prd-approve" in skill_text
+
+    def test_routing_upshift_dispatches_to_template(self, skill_text: str) -> None:
+        """Routing block dispatches upshift to prd-upshift template."""
+        assert "prd-upshift" in skill_text
+
+
+# ---------------------------------------------------------------------------
+# 4. Help template
+# ---------------------------------------------------------------------------
+
+
+class TestHelpTemplate:
+    """Verify the help template documents approve and upshift."""
+
+    def test_help_template_exists(self, skill_text: str) -> None:
+        """The prd-help template exists."""
+        help_text = _extract_template(skill_text, "prd-help")
+        assert help_text, "prd-help template not found"
+
+    def test_help_lists_approve(self, skill_text: str) -> None:
+        """Help template lists /prd approve."""
+        help_text = _extract_template(skill_text, "prd-help")
+        assert "/prd approve" in help_text
+
+    def test_help_lists_upshift(self, skill_text: str) -> None:
+        """Help template lists /prd upshift."""
+        help_text = _extract_template(skill_text, "prd-help")
+        assert "/prd upshift" in help_text
+
+    def test_help_approve_describes_approval_gate(self, skill_text: str) -> None:
+        """Help text for /prd approve mentions approval gate behavior."""
+        help_text = _extract_template(skill_text, "prd-help")
+        approve_idx = help_text.find("/prd approve")
+        assert approve_idx != -1
+        after_approve = help_text[approve_idx:]
+        next_heading = after_approve.find("\n###", 1)
+        approve_help = after_approve[:next_heading] if next_heading != -1 else after_approve
+        assert "approval" in approve_help.lower()
+
+    def test_help_upshift_describes_backlog(self, skill_text: str) -> None:
+        """Help text for /prd upshift mentions backlog population."""
+        help_text = _extract_template(skill_text, "prd-help")
+        upshift_idx = help_text.find("/prd upshift")
+        assert upshift_idx != -1
+        after_upshift = help_text[upshift_idx:]
+        next_heading = after_upshift.find("\n###", 1)
+        upshift_help = after_upshift[:next_heading] if next_heading != -1 else after_upshift
+        assert "backlog" in upshift_help.lower() or "issue" in upshift_help.lower()
+
+    def test_help_approve_prerequisite(self, skill_text: str) -> None:
+        """Help text for /prd approve mentions prerequisite."""
+        help_text = _extract_template(skill_text, "prd-help")
+        approve_idx = help_text.find("/prd approve")
+        assert approve_idx != -1
+        after_approve = help_text[approve_idx:]
+        next_heading = after_approve.find("\n###", 1)
+        approve_help = after_approve[:next_heading] if next_heading != -1 else after_approve
+        assert "prerequisite" in approve_help.lower() or "finalize" in approve_help.lower()
+
+    def test_help_upshift_prerequisite(self, skill_text: str) -> None:
+        """Help text for /prd upshift mentions approved PRD prerequisite."""
+        help_text = _extract_template(skill_text, "prd-help")
+        upshift_idx = help_text.find("/prd upshift")
+        assert upshift_idx != -1
+        after_upshift = help_text[upshift_idx:]
+        next_heading = after_upshift.find("\n###", 1)
+        upshift_help = after_upshift[:next_heading] if next_heading != -1 else after_upshift
+        assert "approved" in upshift_help.lower()
+
+
+# ---------------------------------------------------------------------------
+# 5. prd-approve template
+# ---------------------------------------------------------------------------
+
+
+class TestApproveTemplate:
+    """Verify the prd-approve template implements the approval gate."""
+
+    def test_approve_template_exists(self, skill_text: str) -> None:
+        """The prd-approve template exists."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert approve, "prd-approve template not found"
+
+    def test_approve_runs_finalization(self, skill_text: str) -> None:
+        """The approve template runs the finalization checklist."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "finalization" in approve.lower() or "finalize" in approve.lower()
+        assert "checklist" in approve.lower() or "check" in approve.lower()
+
+    def test_approve_presents_summary(self, skill_text: str) -> None:
+        """The approve template presents a PRD summary with counts."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "summary" in approve.lower()
+        assert "section" in approve.lower()
+        assert "stor" in approve.lower()  # story/stories
+        assert "wave" in approve.lower()
+        assert "deliverable" in approve.lower()
+
+    def test_approve_hard_stop(self, skill_text: str) -> None:
+        """The approve template includes a hard stop for human approval."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "approve" in approve.lower() and "yes/no" in approve.lower()
+
+    def test_approve_waits_for_response(self, skill_text: str) -> None:
+        """The approve template explicitly waits for the user's response."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "wait" in approve.lower()
+
+    def test_approve_records_metadata(self, skill_text: str) -> None:
+        """The approve template records approval metadata in the PRD."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "PRD-APPROVAL" in approve
+        assert "approved: true" in approve
+        assert "approved_by" in approve
+        assert "approved_at" in approve
+
+    def test_approve_records_timestamp(self, skill_text: str) -> None:
+        """The approve template records an ISO 8601 timestamp."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "ISO 8601" in approve or "timestamp" in approve.lower()
+
+    def test_approve_records_finalization_score(self, skill_text: str) -> None:
+        """The approve template records the finalization score."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "finalization_score" in approve
+
+    def test_approve_handles_rejection(self, skill_text: str) -> None:
+        """The approve template handles rejection (user says no)."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "rejection" in approve.lower() or "reject" in approve.lower()
+
+    def test_approve_rejects_on_finalization_failure(self, skill_text: str) -> None:
+        """The approve template rejects if finalization checks fail."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "fail" in approve.lower()
+        # Must stop if checks fail
+        assert "stop" in approve.lower()
+
+    def test_approve_suggests_next_step(self, skill_text: str) -> None:
+        """The approve template suggests /prd upshift as the next step."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "/prd upshift" in approve
+
+    def test_approve_locates_prd(self, skill_text: str) -> None:
+        """The approve template includes PRD file location logic."""
+        approve = _extract_template(skill_text, "prd-approve")
+        assert "docs/*-PRD.md" in approve or "*-PRD.md" in approve
+
+
+# ---------------------------------------------------------------------------
+# 6. prd-upshift template
+# ---------------------------------------------------------------------------
+
+
+class TestUpshiftTemplate:
+    """Verify the prd-upshift template implements backlog population."""
+
+    def test_upshift_template_exists(self, skill_text: str) -> None:
+        """The prd-upshift template exists."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert upshift, "prd-upshift template not found"
+
+    def test_upshift_verifies_approval(self, skill_text: str) -> None:
+        """The upshift template verifies the PRD is approved."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "PRD-APPROVAL" in upshift or "approved" in upshift.lower()
+        assert "approved: true" in upshift
+
+    def test_upshift_refuses_unapproved(self, skill_text: str) -> None:
+        """The upshift template refuses to run on an unapproved PRD."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "/prd approve" in upshift
+        assert "stop" in upshift.lower() or "do not" in upshift.lower()
+
+    def test_upshift_parses_section_8(self, skill_text: str) -> None:
+        """The upshift template parses Section 8 (Phased Implementation Plan)."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "Section 8" in upshift
+        assert "Phased Implementation Plan" in upshift
+
+    def test_upshift_creates_epic_per_phase(self, skill_text: str) -> None:
+        """The upshift template creates one epic issue per Phase."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "epic" in upshift.lower()
+        assert "phase" in upshift.lower()
+
+    def test_upshift_epic_includes_dod(self, skill_text: str) -> None:
+        """The upshift template includes Phase DoD in epic acceptance criteria."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "DoD" in upshift or "Definition of Done" in upshift
+
+    def test_upshift_creates_story_issues(self, skill_text: str) -> None:
+        """The upshift template creates one issue per Story."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "story" in upshift.lower()
+        assert "issue" in upshift.lower()
+
+    def test_upshift_story_has_implementation_steps(self, skill_text: str) -> None:
+        """The upshift template includes implementation steps in story issues."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "Implementation Steps" in upshift or "implementation steps" in upshift.lower()
+
+    def test_upshift_story_has_test_procedures(self, skill_text: str) -> None:
+        """The upshift template includes test procedures in story issues."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "Test Procedures" in upshift or "test procedures" in upshift.lower()
+
+    def test_upshift_story_has_acceptance_criteria(self, skill_text: str) -> None:
+        """The upshift template includes acceptance criteria in story issues."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "Acceptance Criteria" in upshift or "acceptance criteria" in upshift.lower()
+
+    def test_upshift_story_has_wave_assignment(self, skill_text: str) -> None:
+        """The upshift template includes wave assignment in story issues."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "wave" in upshift.lower()
+
+    def test_upshift_creates_wave_masters(self, skill_text: str) -> None:
+        """The upshift template creates wave master issues."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "Wave" in upshift and "Master" in upshift
+
+    def test_upshift_wave_master_links_stories(self, skill_text: str) -> None:
+        """The upshift template links constituent stories in wave master issues."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "Constituent Stories" in upshift or "constituent" in upshift.lower()
+
+    def test_upshift_reports_summary(self, skill_text: str) -> None:
+        """The upshift template reports a creation summary."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "summary" in upshift.lower()
+        assert "epic" in upshift.lower()
+        assert "stor" in upshift.lower()
+
+    def test_upshift_backfills_issue_numbers(self, skill_text: str) -> None:
+        """The upshift template backfills issue numbers into the PRD."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "backfill" in upshift.lower() or "Backfill" in upshift
+
+    def test_upshift_suggests_prepwaves(self, skill_text: str) -> None:
+        """The upshift template suggests /prepwaves as the next step."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "/prepwaves" in upshift
+
+    def test_upshift_locates_prd(self, skill_text: str) -> None:
+        """The upshift template includes PRD file location logic."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "docs/*-PRD.md" in upshift or "*-PRD.md" in upshift
+
+    def test_upshift_links_stories_to_epics(self, skill_text: str) -> None:
+        """The upshift template links story issues to parent epic."""
+        upshift = _extract_template(skill_text, "prd-upshift")
+        assert "parent epic" in upshift.lower() or "Parent Epic" in upshift
+
+
+# ---------------------------------------------------------------------------
+# 7. docs/skill-reference.md
+# ---------------------------------------------------------------------------
+
+
+class TestSkillReference:
+    """Verify docs/skill-reference.md has updated /prd section."""
+
+    def test_prd_section_exists(self, skill_ref_text: str) -> None:
+        """The /prd section exists in skill-reference.md."""
+        assert "### `/prd`" in skill_ref_text
+
+    def test_prd_examples_include_approve(self, skill_ref_text: str) -> None:
+        """The /prd examples include /prd approve."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "/prd approve" in prd_section
+
+    def test_prd_examples_include_upshift(self, skill_ref_text: str) -> None:
+        """The /prd examples include /prd upshift."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "/prd upshift" in prd_section
+
+    def test_prd_pipeline_includes_approve(self, skill_ref_text: str) -> None:
+        """The pipeline description includes /prd approve."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "/prd approve" in prd_section
+
+    def test_prd_pipeline_includes_upshift(self, skill_ref_text: str) -> None:
+        """The pipeline description includes /prd upshift."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "/prd upshift" in prd_section
+
+    def test_prd_approve_flow_documented(self, skill_ref_text: str) -> None:
+        """The /prd approve flow is documented."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "/prd approve" in prd_section
+        assert "approval" in prd_section.lower()
+        assert "finalization" in prd_section.lower()
+
+    def test_prd_upshift_flow_documented(self, skill_ref_text: str) -> None:
+        """The /prd upshift flow is documented."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "/prd upshift" in prd_section
+        assert "epic" in prd_section.lower()
+        assert "story" in prd_section.lower() or "stories" in prd_section.lower()
+
+    def test_prd_description_mentions_approval(self, skill_ref_text: str) -> None:
+        """The /prd description mentions approval gate."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "approval" in prd_section.lower()
+
+    def test_prd_description_mentions_backlog(self, skill_ref_text: str) -> None:
+        """The /prd description mentions backlog population."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "backlog" in prd_section.lower()
+
+    def test_prd_when_to_use_includes_approval(self, skill_ref_text: str) -> None:
+        """The 'When to use it' section includes approval use case."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "approval" in prd_section.lower()
+
+    def test_prd_when_to_use_includes_backlog(self, skill_ref_text: str) -> None:
+        """The 'When to use it' section includes backlog use case."""
+        prd_section = _extract_prd_section(skill_ref_text)
+        assert "backlog" in prd_section.lower()


### PR DESCRIPTION
## Summary

Add two new subcommands to the `/prd` skill: `/prd approve` (approval gate with finalization check and metadata recording) and `/prd upshift` (backlog population from PRD Section 8 — creates epics, stories, and wave masters).

## Changes

- **`skills/prd/SKILL.md`**: Added `prd-approve` template (5-step approval gate with finalization, summary, hard-stop, metadata recording), `prd-upshift` template (7-step backlog population with epic/story/wave master creation and issue number backfill). Updated routing, help, frontmatter.
- **`docs/skill-reference.md`**: Expanded `/prd` section with approve/upshift flows, examples, pipeline, and use cases
- **Tests**: 60 tests across 7 classes validating all acceptance criteria

## Linked Issues

Closes #245

## Test Plan

- `python3 -m pytest tests/test_prd_skill.py -v` — 60/60 passed
- `python3 -m pytest` (full suite) — 960/960 passed
- `./scripts/ci/validate.sh` — 78/78 passed