### PR TITLE
feat(dod): create /dod skill for DoD verification (#247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Key features:
 | cryo | `/cryo` | Preserve session state before context compaction |
 | ddd | `/ddd` | Domain-Driven Design facilitation — event storming, domain modeling, concept handoff |
 | disc | `/disc` | Discord integration — check-in, send, read, list, resolve channels |
+| dod | `/dod` | Project Definition of Done verification against the Deliverables Manifest |
 | edit | `/edit` | Open file/URL in GUI editor |
 | engage | `/engage` | Load CLAUDE.md, confirm rules of engagement |
 | ibm | `/ibm` | Issue-Branch-PR/MR workflow reminder |

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -593,6 +593,48 @@ Run the Section 7.2 Finalization Checklist mechanically against an existing PRD.
 
 ---
 
+### `/dod` -- Project Definition of Done Verification
+
+Reads the Deliverables Manifest from the project's PRD (Section 5.A) and mechanically verifies that every deliverable was produced, every test passed, and every artifact exists at its declared file path. Generates a pass/fail verification report and requires human sign-off to close the project. This is the final gate in the SDLC pipeline.
+
+**When to use it:**
+- After all implementation waves are complete and the project is ready for final verification
+- When you want to confirm that every deliverable in the PRD has been produced
+- Before closing the parent epic or transitioning the campaign to the DoD stage
+- When stakeholders ask for evidence that all requirements have been met
+
+**Examples:**
+
+```
+/dod            # Run the full DoD verification (default)
+/dod check      # Same as /dod
+```
+
+**Verification categories:**
+
+| Category | What is checked |
+|----------|----------------|
+| Docs | File exists at declared path, is non-empty |
+| Code (binary/package) | File exists, build command succeeds |
+| Code (CI/CD) | Pipeline config exists, last CI run passed |
+| Code (build system) | Makefile/task runner exists, `make test` succeeds |
+| Test (results) | File exists, parse for pass/fail summary |
+| Test (coverage) | File exists, parse coverage percentage |
+| Test (manual procedures) | File exists, has recorded execution results |
+| Trace (VRTM) | VRTM populated, no "Pending" status rows |
+
+**Report format:** Each deliverable is marked V (verified), X (failing), or O (N/A opted out). The report includes a summary count, Global DoD (Section 7) verification, and a final READY/NOT READY verdict.
+
+**Approval flow:**
+1. All pass -> "Approve to close the project?"
+2. Failures exist -> "Approve anyway, or fix first?"
+3. On "fix" -> lists each failure with specific remediation (file paths, commands, PRD sections)
+4. On approval -> updates campaign state (if active), suggests closing the epic
+
+**Key detail:** N/A rows with rationale are respected and do not count as failures. Bare "N/A" without explanation is flagged. VRTM completeness is mandatory -- every requirement must be traceable with no "Pending" rows.
+
+---
+
 ## Advanced Skills -- Wave Pattern
 
 The wave pattern decomposes work into dependency-ordered waves and executes each wave with lifecycle tracking, dashboard visibility, and an audit trail. It supports three topologies:

--- a/skills/dod/SKILL.md
+++ b/skills/dod/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: dod
+description: Project Definition of Done verification against the Deliverables Manifest — verify every deliverable, run tests, check VRTM, produce pass/fail report
+---
+
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-dod does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-dod
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
+# Project DoD Verification
+
+This skill reads the Deliverables Manifest from the project's PRD and mechanically verifies that every deliverable was produced, every test passed, and every artifact exists at its declared file path. It generates a pass/fail report and requires human sign-off to close the project.
+
+## Platform Detection
+
+Before proceeding, detect the platform:
+1. Check `.claude-project.md` for cached platform config
+2. If not cached, run `git remote -v` and inspect the origin URL
+3. GitHub -> `gh` CLI, GitLab -> `glab` CLI
+
+## Commands
+
+- **`/dod check`** -- Run the full verification. Read the Deliverables Manifest from the PRD, verify each row, report results.
+- **`/dod`** (no args) -- Same as `/dod check`.
+
+## Usage
+
+```bash
+# Run the full DoD verification
+/dod check
+
+# Same as /dod check
+/dod
+```
+
+---
+
+{{#if (eq args "check")}}
+  {{> dod-check}}
+{{else}}
+  {{> dod-check}}
+{{/if}}
+
+<!-- BEGIN TEMPLATE: dod-check -->
+## DoD Verification Workflow
+
+### Step 1: Locate the PRD
+
+Find the project's PRD:
+1. If the user provided a path, use it
+2. Otherwise, look for `docs/*-PRD.md` files
+3. If multiple PRDs exist, ask the user which one to verify
+4. If no PRD exists, tell the user: "No PRD found. Run `/prd create` first."
+
+### Step 2: Read the PRD
+
+Read the entire PRD file into context. Extract:
+1. **Deliverables Manifest (Section 5.A)** -- the table of all deliverables
+2. **Section 7 (Definition of Done)** -- the global DoD checklist
+3. **Section 9, Appendix V (VRTM)** -- the Verification Requirements Traceability Matrix
+
+### Step 3: Parse the Deliverables Manifest
+
+For each row in the Deliverables Manifest (Section 5.A), extract:
+- **ID** (e.g., DM-01)
+- **Deliverable** (e.g., README.md)
+- **Category** (Docs, Code, Test, Trace)
+- **File Path** (the declared file location)
+- **Status** (required, N/A, etc.)
+- **Notes**
+
+Separate rows into:
+- **Active rows** -- rows that need verification (not marked N/A)
+- **N/A rows** -- rows marked "N/A -- [reason]" (verify rationale exists, skip verification)
+
+### Step 4: Verify Each Deliverable
+
+For each **active** row, apply the verification logic based on its Category:
+
+#### Category: Docs
+
+1. Check that the file exists at the declared path
+2. Check that the file is non-empty (has content)
+3. **Pass** if file exists and is non-empty
+4. **Fail** if file is missing or empty
+5. Report: file path, line count
+
+#### Category: Code (binary/package)
+
+1. Check that the file exists at the declared path
+2. If a build command is discoverable (Makefile, package.json, etc.), run it
+3. **Pass** if file exists and build succeeds (or no build command found)
+4. **Fail** if file is missing or build fails
+5. Report: file path, build result
+
+#### Category: Code (CI/CD)
+
+1. Check that the pipeline config file exists (`.github/workflows/*.yml` or `.gitlab-ci.yml`)
+2. Check the last CI run status using the platform CLI:
+   - GitHub: `gh run list --limit 1 --json status,conclusion`
+   - GitLab: `glab ci list --per-page 1`
+3. **Pass** if config exists and last CI run passed
+4. **Fail** if config is missing or last CI run failed
+5. Report: config file path, last run status
+
+#### Category: Code (build system)
+
+1. Check that the Makefile or task runner exists at the declared path
+2. Run `make test` (or equivalent test target)
+3. **Pass** if file exists and tests pass
+4. **Fail** if file is missing or tests fail
+5. Report: file path, test result
+
+#### Category: Test (results)
+
+1. Check that the test results file exists at the declared path (e.g., `reports/junit.xml`)
+2. If the file exists, parse it for a pass/fail summary
+3. **Pass** if file exists and contains passing results
+4. **Fail** if file is missing or contains failures
+5. Report: file path, pass/fail counts
+
+#### Category: Test (coverage)
+
+1. Check that the coverage report file exists at the declared path (e.g., `reports/coverage.xml`)
+2. If the file exists, parse it for the coverage percentage
+3. **Pass** if file exists (coverage percentage is informational, not a gate)
+4. **Fail** if file is missing
+5. Report: file path, coverage percentage
+
+#### Category: Test (manual procedures)
+
+1. Check that the procedures document exists at the declared path
+2. Check for recorded results (evidence that the procedures were executed)
+3. **Pass** if document exists and has execution records
+4. **Fail** if document is missing or has no execution evidence
+5. Report: file path, execution status
+
+#### Category: Trace (VRTM)
+
+1. Find the VRTM section in the PRD (Section 9, Appendix V)
+2. Parse all rows in the VRTM table
+3. Check for any rows with status "Pending" or empty status
+4. **Pass** if VRTM is populated and no rows have "Pending" status
+5. **Fail** if VRTM has "Pending" rows or is empty
+6. Report: row count, pending count
+
+#### N/A Rows
+
+For each N/A row:
+1. Verify that a rationale exists after "N/A" (e.g., "N/A -- CLI-only tool, API ref covers usage")
+2. Report as "N/A (opted out)" with the rationale
+3. These do **not** count as failures
+
+### Step 5: Check Global DoD (Section 7)
+
+Verify each item in the Section 7 Definition of Done checklist:
+
+1. **All Phase DoD checklists satisfied** -- Check Section 8 for Phase DoD items; verify all are checked
+2. **All Test Plan items executed and passed** -- Cross-reference Section 6 test items with test results
+3. **All deliverables from Deliverables Manifest produced and verified** -- This is the result of Step 4 above
+4. **Cross-cutting conditions** -- Verify each additional DoD item by checking the codebase for evidence
+
+### Step 6: Check VRTM Completeness
+
+Verify the VRTM (Section 9, Appendix V) separately:
+1. Every requirement ID from Section 3 must appear in the VRTM
+2. Every VRTM row must have a non-empty "Verified By" column
+3. No VRTM row should have status "Pending"
+4. **Pass** if all requirements are traced and verified
+5. **Fail** if any requirement is untraced or any row is pending
+
+### Step 7: Present the Verification Report
+
+Format and present the report:
+
+```
+======================================================
+  Project DoD Verification Report
+  Project: <project-name>
+  PRD: docs/<project>-PRD.md
+  Date: <date>
+======================================================
+
+Deliverables Manifest: X/Y verified
+
+  V DM-01  README.md                    README.md exists (847 lines)
+  V DM-02  Unified build system         Makefile exists, make test passes
+  V DM-03  CI/CD pipeline               .github/workflows/ci.yml exists, last run passed
+  X DM-04  Automated test suite         reports/junit.xml missing
+  O DM-09  User manual                  N/A -- CLI-only tool, API ref covers usage
+  ...
+
+Global DoD (Section 7): X/Y verified
+  V All Phase DoD checklists satisfied
+  X VRTM has 2 rows with status "Pending"
+  ...
+
+RESULT: NOT READY -- 2 items failing
+
+Approve anyway? (yes / no / fix)
+```
+
+Use these status indicators:
+- **V** (checkmark equivalent) -- verified/passing
+- **X** -- failing
+- **O** (circle) -- N/A / opted out
+
+### Step 8: Approval Flow
+
+After presenting the report:
+
+1. **If all items pass:**
+   - "Project DoD verified. All deliverables confirmed, all tests passed, VRTM complete."
+   - "Approve to close the project? (yes / no)"
+
+2. **If failures exist:**
+   - "X items failing. Approve anyway, or fix first? (yes / no / fix)"
+
+3. **On approval (user says yes/approve/y):**
+   - If `campaign-status` is active (`.sdlc/` directory exists), update the campaign:
+     ```bash
+     campaign-status stage-review dod
+     ```
+   - Suggest closing the epic: "DoD approved. Consider closing the parent epic if all phases are complete."
+
+4. **On "fix" (user says fix):**
+   - List each failing item with a specific remediation suggestion:
+     - Missing file -> "Create [file] at [path]"
+     - Failed build -> "Fix build errors and re-run"
+     - Pending VRTM rows -> "Update VRTM status for requirements [IDs]"
+     - Missing test results -> "Run tests and generate [file]"
+
+5. **On rejection (user says no/reject/n):**
+   - "DoD verification deferred. Re-run `/dod` when ready."
+
+<!-- END TEMPLATE: dod-check -->
+
+---
+
+## Important Rules
+
+1. **Mechanical verification only.** Every check is deterministic -- file exists or it does not, tests pass or they do not. No subjective "looks good enough" judgments.
+2. **N/A is not a failure.** Rows explicitly marked N/A with a rationale are respected. The rationale must exist -- bare "N/A" without explanation is flagged.
+3. **VRTM completeness is mandatory.** Every requirement must be traceable. "Pending" status rows are failures.
+4. **Human approval is required.** Even if all items pass, the report must be presented and the user must explicitly approve before any campaign state change.
+5. **Remediation is actionable.** When suggesting fixes, provide specific file paths, commands, or PRD sections -- not vague advice.
+6. **The Deliverables Manifest is the source of truth.** Verify against Section 5.A, not against assumptions about what should exist.

--- a/skills/dod/introduction.md
+++ b/skills/dod/introduction.md
@@ -1,0 +1,57 @@
+# Welcome to Project DoD Verification
+
+This skill verifies that a project has met its **Definition of Done** by mechanically checking every deliverable in the PRD's Deliverables Manifest (Section 5.A).
+
+## What It Does
+
+`/dod` reads your PRD, finds the Deliverables Manifest, and checks each row:
+
+- **Docs** -- File exists and is non-empty
+- **Code** -- File exists, build succeeds, CI passes
+- **Test** -- Results exist, coverage report present, manual procedures executed
+- **Trace (VRTM)** -- Every requirement is traced, no "Pending" rows
+
+It also checks the Global Definition of Done (Section 7) and VRTM completeness (Section 9, Appendix V).
+
+## The Verification Report
+
+After checking everything, `/dod` presents a formatted report:
+
+```
+Deliverables Manifest: 7/9 verified
+
+  V DM-01  README.md                    README.md exists (847 lines)
+  V DM-02  Unified build system         Makefile exists, make test passes
+  X DM-04  Automated test suite         reports/junit.xml missing
+  O DM-09  User manual                  N/A -- CLI-only tool
+  ...
+
+RESULT: NOT READY -- 2 items failing
+```
+
+- **V** = verified (passing)
+- **X** = failing
+- **O** = N/A (opted out with rationale)
+
+## Approval Flow
+
+- If everything passes: "Approve to close the project?"
+- If failures exist: "Approve anyway, or fix first?"
+- On "fix": lists each failure with a specific remediation step
+
+## Where It Fits in the Pipeline
+
+`/dod` is the **final gate** in the SDLC pipeline:
+
+```
+/ddd --> /prd --> /prepwaves --> /nextwave --> /dod
+```
+
+After `/dod` approval, the project is done. If `campaign-status` is active, it transitions the campaign to the DoD review stage.
+
+## Commands
+
+- **`/dod`** -- Run the full DoD verification (same as `/dod check`)
+- **`/dod check`** -- Explicit check subcommand
+
+**Ready to verify?** Run `/dod` to check your project's Definition of Done.

--- a/tests/test_dod_skill.py
+++ b/tests/test_dod_skill.py
@@ -1,0 +1,362 @@
+"""Tests for skills/dod/SKILL.md — DoD verification skill.
+
+Validates:
+- SKILL.md frontmatter has correct name and description
+- Introduction gate is present
+- dod-check template exists with all 8 steps
+- Verification categories documented (Docs, Code, Test, Trace)
+- N/A opt-out handling documented
+- Report format with status indicators
+- Approval flow with yes/no/fix responses
+- Campaign integration (campaign-status stage-review dod)
+- VRTM completeness check
+- Remediation suggestions for failures
+- docs/skill-reference.md has /dod section
+- README.md has dod row in skills table
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = _ROOT / "skills" / "dod" / "SKILL.md"
+INTRO_PATH = _ROOT / "skills" / "dod" / "introduction.md"
+SKILL_REF_PATH = _ROOT / "docs" / "skill-reference.md"
+README_PATH = _ROOT / "README.md"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Read the DoD SKILL.md file."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def skill_ref_text() -> str:
+    """Read the skill-reference.md file."""
+    return SKILL_REF_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def readme_text() -> str:
+    """Read the README.md file."""
+    return README_PATH.read_text(encoding="utf-8")
+
+
+def _extract_template(text: str, template_name: str) -> str:
+    """Extract content between BEGIN TEMPLATE and END TEMPLATE markers."""
+    pattern = (
+        rf"<!-- BEGIN TEMPLATE: {re.escape(template_name)} -->\n"
+        rf"(.*?)"
+        rf"<!-- END TEMPLATE: {re.escape(template_name)} -->"
+    )
+    match = re.search(pattern, text, re.DOTALL)
+    return match.group(1) if match else ""
+
+
+# ---------------------------------------------------------------------------
+# 1. Frontmatter and structure
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatter:
+    """Verify SKILL.md frontmatter and basic structure."""
+
+    def test_frontmatter_name(self, skill_text: str) -> None:
+        """Frontmatter has name: dod."""
+        assert "name: dod" in skill_text
+
+    def test_frontmatter_description(self, skill_text: str) -> None:
+        """Frontmatter has a description mentioning DoD or verification."""
+        lines = skill_text.split("\n")
+        assert lines[0].strip() == "---"
+        end_idx = skill_text.index("---", 4)
+        frontmatter = skill_text[:end_idx + 3]
+        assert "verification" in frontmatter.lower() or "definition of done" in frontmatter.lower()
+
+    def test_introduction_gate_present(self, skill_text: str) -> None:
+        """Introduction gate comment is present."""
+        assert "introduction-gate" in skill_text
+        assert "/tmp/.skill-intro-dod" in skill_text
+
+    def test_introduction_file_exists(self) -> None:
+        """introduction.md exists in the dod skill directory."""
+        assert INTRO_PATH.exists()
+
+    def test_introduction_not_empty(self) -> None:
+        """introduction.md is not empty."""
+        assert len(INTRO_PATH.read_text(encoding="utf-8").strip()) > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Template structure
+# ---------------------------------------------------------------------------
+
+
+class TestTemplate:
+    """Verify the dod-check template exists with expected steps."""
+
+    def test_dod_check_template_exists(self, skill_text: str) -> None:
+        """The dod-check template exists."""
+        check = _extract_template(skill_text, "dod-check")
+        assert check, "dod-check template not found"
+
+    def test_has_locate_prd_step(self, skill_text: str) -> None:
+        """Template has a step to locate the PRD."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Locate the PRD" in check or "*-PRD.md" in check
+
+    def test_has_read_prd_step(self, skill_text: str) -> None:
+        """Template has a step to read and parse the PRD."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Deliverables Manifest" in check
+        assert "Section 5.A" in check
+
+    def test_has_verify_step(self, skill_text: str) -> None:
+        """Template has a step to verify each deliverable."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Verify Each Deliverable" in check or "verify each" in check.lower()
+
+    def test_has_global_dod_step(self, skill_text: str) -> None:
+        """Template has a step to check Global DoD (Section 7)."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Section 7" in check
+        assert "Global DoD" in check or "Definition of Done" in check
+
+    def test_has_vrtm_step(self, skill_text: str) -> None:
+        """Template has a step to check VRTM completeness."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "VRTM" in check
+
+    def test_has_report_step(self, skill_text: str) -> None:
+        """Template has a step to present the verification report."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Verification Report" in check
+
+    def test_has_approval_step(self, skill_text: str) -> None:
+        """Template has a step for the approval flow."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Approval Flow" in check or "approval" in check.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. Verification categories
+# ---------------------------------------------------------------------------
+
+
+class TestVerificationCategories:
+    """Verify all verification categories are documented."""
+
+    def test_docs_category(self, skill_text: str) -> None:
+        """Docs category checks file existence and non-empty."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Category: Docs" in check
+        assert "non-empty" in check
+
+    def test_code_binary_category(self, skill_text: str) -> None:
+        """Code binary/package category checks file and build."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Code (binary" in check or "Code (CI" in check
+        assert "build" in check.lower()
+
+    def test_code_cicd_category(self, skill_text: str) -> None:
+        """Code CI/CD category checks pipeline config and last run."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "CI/CD" in check
+        assert "pipeline" in check.lower() or "workflow" in check.lower()
+
+    def test_code_build_system_category(self, skill_text: str) -> None:
+        """Code build system category checks Makefile and tests."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "build system" in check.lower()
+        assert "Makefile" in check or "task runner" in check
+
+    def test_test_results_category(self, skill_text: str) -> None:
+        """Test results category checks JUnit XML or equivalent."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Test (results)" in check or "test results" in check.lower()
+
+    def test_test_coverage_category(self, skill_text: str) -> None:
+        """Test coverage category checks coverage report."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "coverage" in check.lower()
+
+    def test_test_manual_category(self, skill_text: str) -> None:
+        """Manual procedures category checks execution evidence."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "manual" in check.lower()
+        assert "execution" in check.lower() or "executed" in check.lower()
+
+    def test_trace_vrtm_category(self, skill_text: str) -> None:
+        """Trace VRTM category checks for Pending rows."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "Trace (VRTM)" in check or "VRTM" in check
+        assert "Pending" in check
+
+
+# ---------------------------------------------------------------------------
+# 4. N/A handling
+# ---------------------------------------------------------------------------
+
+
+class TestNAHandling:
+    """Verify N/A opt-out handling."""
+
+    def test_na_rows_documented(self, skill_text: str) -> None:
+        """N/A row handling is documented."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "N/A" in check
+
+    def test_na_not_failure(self, skill_text: str) -> None:
+        """N/A rows do not count as failures."""
+        check = _extract_template(skill_text, "dod-check")
+        # Strip markdown bold markers for matching
+        plain = check.replace("**", "").lower()
+        assert "not count as failure" in plain or "do not fail" in plain or "not a failure" in plain
+
+    def test_na_rationale_required(self, skill_text: str) -> None:
+        """N/A rows must have a rationale."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "rationale" in check.lower()
+
+
+# ---------------------------------------------------------------------------
+# 5. Report format
+# ---------------------------------------------------------------------------
+
+
+class TestReportFormat:
+    """Verify the report format."""
+
+    def test_report_has_project_name(self, skill_text: str) -> None:
+        """Report includes project name."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "project-name" in check.lower() or "Project:" in check
+
+    def test_report_has_prd_path(self, skill_text: str) -> None:
+        """Report includes PRD file path."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "PRD:" in check or "docs/" in check
+
+    def test_report_has_status_indicators(self, skill_text: str) -> None:
+        """Report uses V/X/O status indicators."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "V" in check  # checkmark
+        assert "X" in check  # failing
+        assert "O" in check  # N/A
+
+
+# ---------------------------------------------------------------------------
+# 6. Approval flow
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalFlow:
+    """Verify the approval flow."""
+
+    def test_all_pass_flow(self, skill_text: str) -> None:
+        """All-pass flow suggests closing the project."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "all" in check.lower() and "pass" in check.lower()
+
+    def test_failure_flow(self, skill_text: str) -> None:
+        """Failure flow offers yes/no/fix options."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "fix" in check.lower()
+
+    def test_campaign_integration(self, skill_text: str) -> None:
+        """Approval integrates with campaign-status."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "campaign-status" in check
+        assert "stage-review dod" in check
+
+    def test_remediation_on_fix(self, skill_text: str) -> None:
+        """Fix flow provides specific remediation suggestions."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "remediation" in check.lower() or "Create" in check or "Fix build" in check
+
+    def test_rejection_flow(self, skill_text: str) -> None:
+        """Rejection flow defers verification."""
+        check = _extract_template(skill_text, "dod-check")
+        assert "reject" in check.lower() or "deferred" in check.lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. Important rules
+# ---------------------------------------------------------------------------
+
+
+class TestImportantRules:
+    """Verify Important Rules section."""
+
+    def test_mechanical_verification_rule(self, skill_text: str) -> None:
+        """Rule: mechanical verification only."""
+        assert "Mechanical verification" in skill_text or "mechanical" in skill_text.lower()
+
+    def test_na_not_failure_rule(self, skill_text: str) -> None:
+        """Rule: N/A is not a failure."""
+        assert "N/A is not a failure" in skill_text
+
+    def test_vrtm_mandatory_rule(self, skill_text: str) -> None:
+        """Rule: VRTM completeness is mandatory."""
+        assert "VRTM completeness" in skill_text
+
+    def test_human_approval_rule(self, skill_text: str) -> None:
+        """Rule: human approval is required."""
+        assert "Human approval" in skill_text or "human approval" in skill_text
+
+    def test_manifest_source_of_truth_rule(self, skill_text: str) -> None:
+        """Rule: Deliverables Manifest is the source of truth."""
+        assert "source of truth" in skill_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# 8. docs/skill-reference.md
+# ---------------------------------------------------------------------------
+
+
+class TestSkillReference:
+    """Verify docs/skill-reference.md has /dod section."""
+
+    def test_dod_section_exists(self, skill_ref_text: str) -> None:
+        """The /dod section exists."""
+        assert "### `/dod`" in skill_ref_text or "### `/dod" in skill_ref_text
+
+    def test_dod_section_mentions_deliverables(self, skill_ref_text: str) -> None:
+        """The /dod section mentions Deliverables Manifest."""
+        dod_start = skill_ref_text.find("/dod")
+        assert dod_start != -1
+        after = skill_ref_text[dod_start:dod_start + 2000]
+        assert "Deliverables Manifest" in after or "deliverable" in after.lower()
+
+
+# ---------------------------------------------------------------------------
+# 9. README.md
+# ---------------------------------------------------------------------------
+
+
+class TestReadme:
+    """Verify README.md has dod row in skills table."""
+
+    def test_dod_row_exists(self, readme_text: str) -> None:
+        """The dod row exists in the skills table."""
+        assert "| dod |" in readme_text
+
+    def test_dod_row_has_command(self, readme_text: str) -> None:
+        """The dod row has the /dod command."""
+        for line in readme_text.split("\n"):
+            if "| dod |" in line:
+                assert "`/dod`" in line
+                break


### PR DESCRIPTION
## Summary

Create the `/dod` skill for project Definition of Done verification against the Deliverables Manifest. Mechanically verifies every deliverable by category, checks VRTM completeness, presents a formatted pass/fail report, and requires human approval.

## Changes

- **`skills/dod/SKILL.md`** (new): 8-step verification workflow — locate PRD, parse manifest, verify by category (Docs/Code/Test/Trace), check Global DoD, check VRTM, present report, approval flow with campaign-status integration
- **`skills/dod/introduction.md`** (new): First-run introduction
- **`docs/skill-reference.md`**: Added `/dod` section with examples, verification categories, report format, key details
- **`README.md`**: Added `dod` row to Skills table
- **Tests**: 41 tests across 9 classes validating all acceptance criteria

## Linked Issues

Closes #247

## Test Plan

- `python3 -m pytest tests/test_dod_skill.py -v` — 41/41 passed
- `./scripts/ci/validate.sh` — 79/79 passed