### PR TITLE
fix(crystallizer): filter user instructions to plain strings and fix windowing

### DIFF
--- a/context-crystallizer/lib/crystallizer.sh
+++ b/context-crystallizer/lib/crystallizer.sh
@@ -35,14 +35,33 @@ crystallize() {
     local USER_MESSAGES ASSISTANT_MESSAGES TOOL_USES FILES_MODIFIED
     
     # Recent user prompts (last 10)
+    #
+    # In Claude Code's transcript format, "user"-type entries carry three
+    # different content shapes:
+    #   1. A plain string       — an actual user prompt (or slash-command
+    #                              invocation, Discord watcher notification,
+    #                              compaction continuation header)
+    #   2. An array of text blocks — a skill invocation body (e.g., /precheck
+    #                              loads the SKILL.md body into a "user" turn)
+    #   3. An array of tool_result blocks — a tool response
+    #
+    # Only shape (1) is an actual user instruction. Filtering on
+    # `.type == "text"` inside the array incorrectly captures skill bodies as
+    # "user messages", polluting the Recent User Instructions section with
+    # kilobytes of skill documentation. Restrict to plain strings.
+    #
+    # Windowing is done with jq slurp mode (`-s`) + array slicing rather than
+    # `tail -N | head -N` on jq's text output. Line-based windowing produces
+    # garbage when a single user message spans multiple lines (either empty
+    # output, or a mid-message fragment), because it has no record-boundary
+    # semantics. Slurp + slice operates on whole records.
     USER_MESSAGES=$(tail -500 "$TRANSCRIPT" | \
-        jq -r 'select(.type == "user" and .message.content) | 
-               .message.content | 
-               if type == "array" then 
-                   map(select(.type == "text") | .text) | join("\n") 
-               elif type == "string" then . 
-               else empty end' 2>/dev/null | \
-        tail -20 | head -10)
+        jq -rs 'map(select(.type == "user" and .message.content) |
+                    select((.message.content | type) == "string") |
+                    .message.content) |
+                .[-10:] |
+                map("- " + (gsub("\n"; "\n  "))) |
+                join("\n\n")' 2>/dev/null)
     
     # Recent assistant responses (summaries)
     ASSISTANT_MESSAGES=$(tail -500 "$TRANSCRIPT" | \

--- a/tests/test_crystallizer.py
+++ b/tests/test_crystallizer.py
@@ -1,0 +1,238 @@
+"""Tests for context-crystallizer/lib/crystallizer.sh.
+
+Exercises the real shell script via subprocess, writing synthetic transcripts
+into tmp_path and parsing the resulting context-state markdown file.
+
+Covers the #264 bug class: the `Recent User Instructions` section leaked
+skill invocation bodies and tool_result content because the jq filter
+accepted any text block inside user-type entries. Real user prompts are
+delivered as plain strings; skill invocations and tool results are arrays.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CRYSTALLIZER = REPO_ROOT / "context-crystallizer" / "lib" / "crystallizer.sh"
+
+
+def _write_transcript(path: Path, entries: list[dict]) -> None:
+    """Write a list of transcript entries as JSONL."""
+    with path.open("w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+def _run_crystallizer(transcript: Path, tmp_path: Path) -> Path:
+    """Run crystallizer.sh and return the path to the generated state file."""
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    result = subprocess.run(
+        ["bash", str(CRYSTALLIZER), str(transcript), str(outdir), str(tmp_path), "testsess"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"crystallizer failed: {result.stderr}"
+    # Script prints the output file path on stdout
+    output_file = Path(result.stdout.strip())
+    assert output_file.exists(), f"crystallizer did not create {output_file}"
+    return output_file
+
+
+def _extract_section(state_file: Path, header: str, next_header: str) -> str:
+    """Extract the body of a markdown section between two headers."""
+    text = state_file.read_text()
+    start = text.index(f"## {header}")
+    end = text.index(f"## {next_header}", start)
+    # Drop the header line itself
+    body_start = text.index("\n", start) + 1
+    return text[body_start:end].strip()
+
+
+# ---------------------------------------------------------------------------
+# Transcript entry builders
+# ---------------------------------------------------------------------------
+
+def _user_string(text: str) -> dict:
+    """A real user prompt — content is a plain string."""
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _user_skill_invocation(skill_body: str) -> dict:
+    """A skill invocation — content is an array with a single text block.
+
+    This shape is emitted when the user types a slash command like /precheck;
+    Claude Code loads the SKILL.md body into a "user"-type turn.
+    """
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": skill_body}],
+        },
+    }
+
+
+def _user_tool_result(tool_use_id: str, result_text: str) -> dict:
+    """A tool response — content is an array with a tool_result block."""
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": result_text,
+                }
+            ],
+        },
+    }
+
+
+def _assistant_text(text: str) -> dict:
+    """An assistant text response."""
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestRecentUserInstructions:
+    """Tests for the `Recent User Instructions` section of crystallized state."""
+
+    def test_plain_user_prompts_captured(self, tmp_path):
+        """Real user prompts (string content) appear in the output."""
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(transcript, [
+            _user_string("first question"),
+            _assistant_text("first answer"),
+            _user_string("second question"),
+            _assistant_text("second answer"),
+        ])
+
+        state_file = _run_crystallizer(transcript, tmp_path)
+        section = _extract_section(
+            state_file, "Recent User Instructions", "Recent Assistant Context"
+        )
+
+        assert "first question" in section
+        assert "second question" in section
+
+    def test_skill_invocation_body_excluded(self, tmp_path):
+        """Skill bodies (text arrays) must NOT leak into user instructions.
+
+        Regression test for #264: the original filter used
+        `map(select(.type == "text") | .text)` which incorrectly captured
+        skill-invocation text blocks as user messages.
+        """
+        skill_body = "LEAKED_SKILL_BODY_MARKER do not include this in user instructions"
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(transcript, [
+            _user_string("real prompt"),
+            _user_skill_invocation(skill_body),
+            _assistant_text("did something"),
+        ])
+
+        state_file = _run_crystallizer(transcript, tmp_path)
+        section = _extract_section(
+            state_file, "Recent User Instructions", "Recent Assistant Context"
+        )
+
+        assert "real prompt" in section
+        assert "LEAKED_SKILL_BODY_MARKER" not in section
+
+    def test_tool_result_content_excluded(self, tmp_path):
+        """Tool results must NOT leak into user instructions."""
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(transcript, [
+            _user_string("run a command please"),
+            _assistant_text("sure"),
+            _user_tool_result("tool_abc", "LEAKED_TOOL_OUTPUT_MARKER stdout line 1"),
+        ])
+
+        state_file = _run_crystallizer(transcript, tmp_path)
+        section = _extract_section(
+            state_file, "Recent User Instructions", "Recent Assistant Context"
+        )
+
+        assert "run a command please" in section
+        assert "LEAKED_TOOL_OUTPUT_MARKER" not in section
+
+    def test_chronological_order_most_recent_last(self, tmp_path):
+        """User messages appear in transcript order, most recent last."""
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(transcript, [
+            _user_string("alpha"),
+            _user_string("bravo"),
+            _user_string("charlie"),
+        ])
+
+        state_file = _run_crystallizer(transcript, tmp_path)
+        section = _extract_section(
+            state_file, "Recent User Instructions", "Recent Assistant Context"
+        )
+
+        alpha_pos = section.index("alpha")
+        bravo_pos = section.index("bravo")
+        charlie_pos = section.index("charlie")
+        assert alpha_pos < bravo_pos < charlie_pos
+
+    def test_window_limited_to_last_ten(self, tmp_path):
+        """Only the last 10 user prompts are captured."""
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(transcript, [
+            _user_string(f"msg_{i:02d}") for i in range(15)
+        ])
+
+        state_file = _run_crystallizer(transcript, tmp_path)
+        section = _extract_section(
+            state_file, "Recent User Instructions", "Recent Assistant Context"
+        )
+
+        # Last 10 are msg_05 .. msg_14
+        assert "msg_05" in section
+        assert "msg_14" in section
+        # First 5 are dropped
+        assert "msg_00" not in section
+        assert "msg_04" not in section
+
+    def test_multiline_user_prompt_preserved(self, tmp_path):
+        """A single multi-line user prompt appears intact.
+
+        Regression test for the pre-existing line-based windowing bug that
+        #264 also fixed: `tail -20 | head -10` on jq's text output truncated
+        multi-line messages mid-content. Slurp + array slicing handles
+        records atomically.
+        """
+        multiline = "line one\nline two\nline three"
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(transcript, [
+            _user_string("before"),
+            _user_string(multiline),
+            _user_string("after"),
+        ])
+
+        state_file = _run_crystallizer(transcript, tmp_path)
+        section = _extract_section(
+            state_file, "Recent User Instructions", "Recent Assistant Context"
+        )
+
+        assert "line one" in section
+        assert "line two" in section
+        assert "line three" in section
+        assert "before" in section
+        assert "after" in section


### PR DESCRIPTION
## Summary

Fixes the `Recent User Instructions` section of the context-crystallizer, which was leaking skill invocation bodies and tool_result content instead of showing BJ's actual recent prompts. While verifying the fix, discovered a secondary pre-existing windowing bug that caused the section to return the *oldest* messages in the window, not the newest — so crystallizations rarely showed any actually-recent activity.

## Changes

- **`context-crystallizer/lib/crystallizer.sh`** — Three-part fix to the user-prompt extraction pipeline:
  1. **Leak fix**: restrict to plain-string content via `select((.message.content | type) == "string")`. In Claude Code's transcript format, `user`-type entries carry three shapes — plain strings (real prompts), text arrays (skill invocation bodies), and tool_result arrays (tool responses). Only the first is a user instruction; the old filter incorrectly captured the second as text.
  2. **Windowing fix**: switch from line-based `tail -20 | head -10` to record-boundary jq slurp mode (`-rs`) with `.[-10:]` array slicing. The old approach had no record-boundary semantics and returned either empty output (when lines were sparse) or the oldest-10 instead of the newest-10 (regression test confirms: original code returned `msg_00..msg_09` when input was `msg_00..msg_14`).
  3. **Formatting**: bullet-prefix each message with `- ` and indent continuation lines so multi-line prompts remain visually grouped.
- **`tests/test_crystallizer.py`** — New file with 6 subprocess-based integration tests covering every #264 acceptance criterion. Helper builders construct synthetic transcripts matching Claude Code's JSONL format. Tests exercise the real `crystallizer.sh` via subprocess — no mocks.

## Linked Issues

Closes #264

## Test Plan

- [x] `./scripts/ci/validate.sh` — 81 passed, 0 failed
- [x] `python3 -m pytest tests/` — 1001 passed (no regressions across the suite)
- [x] `python3 -m pytest tests/test_crystallizer.py -v` — 6 new tests, all pass
- [x] **Bug reproduction verified**: stashed the fix, re-ran tests — `test_skill_invocation_body_excluded` and `test_window_limited_to_last_ten` correctly fail on the buggy code, other 4 still pass (smoke coverage). Fix restored, all 6 pass.
- [x] **Real-transcript test**: ran fixed crystallizer against `~/.claude/projects/-home-bakerb-sandbox-github-claudecode-workflow/eb6aa82a-32fa-4441-b28f-29cd3441bb07.jsonl` (the session whose crystallization exhibited the original bug). Output now shows the last 10 real user messages in chronological order with zero skill/tool pollution.
- [x] `feature-dev:code-reviewer` agent review — zero high-confidence findings. jq edge cases (missing `.message`, empty arrays, gsub scoping), shell safety, back-compat (no downstream consumer parses the section structurally — `session-start.sh` blindly cats the file), and test robustness all verified.

## Out of Scope

The assistant-side extraction (lines 67-74 of `crystallizer.sh`) has the **same** line-based windowing bug but no leak. Intentionally not touched — follow-up issue will be filed after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)