### PR TITLE
docs(mcp): document disabledMcpServers per-project exclusion knob

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,54 @@ Closes #NNN
 
 ---
 
+## MCP Server Scoping
+
+Claude Code's MCP scopes are **additive, not exclusive**. Servers from `~/.claude/mcp.json`, `~/.claude/settings.json` (`mcpServers`, `enabledPlugins`), `~/.claude.json` (`mcpServers`), project `.mcp.json`, and claude.ai account-connected plugins all merge into a single deferred tool list at session start. Creating a project `.mcp.json` does NOT replace inherited servers; it adds to them.
+
+### The per-project exclusion knob
+
+`~/.claude.json` → `projects["<project-path>"].disabledMcpServers` is an array of server names to suppress for a specific project. Tools from disabled servers do not appear in the deferred tool list when running in that project. This mechanism works but is undocumented in the official Claude Code docs — it was discovered via direct inspection of `~/.claude.json` (see #266).
+
+**Server name format** — use the exact string reported by `claude mcp list`:
+- `claude.ai <Name>` for claude.ai-hosted plugins (spaces, not underscores)
+- `plugin:<marketplace>:<name>` for marketplace plugins from `enabledPlugins`
+- The raw name for stdio servers (`kapture`, `nerf-server`, etc.)
+
+### Updating the disable list
+
+```bash
+# 1. Inventory all currently-resolved servers
+claude mcp list
+
+# 2. Edit ~/.claude.json via jq + write-temp-then-mv (not an interactive
+#    editor — the file is large and contains session state written back by
+#    Claude Code, so mid-session interactive edits race with CC's own writes)
+#
+# CRITICAL: write to a .new file, NEVER `jq '...' ~/.claude.json > ~/.claude.json`
+# directly. The shell truncates the output file to zero bytes before jq reads
+# the input, silently destroying your 150KB config. Always use the temp-file
+# pattern below.
+jq '.projects["/abs/path/to/project"].disabledMcpServers = [
+      "plugin:github:github",
+      "claude.ai Canva"
+    ]' ~/.claude.json > ~/.claude.json.new && mv ~/.claude.json.new ~/.claude.json
+
+# 3. Verify
+jq '.projects["/abs/path/to/project"].disabledMcpServers' ~/.claude.json
+
+# 4. Restart Claude Code — changes take effect at the next session start,
+#    not mid-session. Verify by checking that the deferred tool list in the
+#    new session no longer contains tools from the disabled servers.
+```
+
+**Project policy for this repo:** Only servers directly used in this repo's work are kept active. `discord-watcher` (session messaging via `--channels`), `wtf-server` (flight recorder hook), and `plugin:context7:context7` (library docs) are kept. Everything else is disabled for context hygiene. See `~/.claude.json` for the authoritative current list.
+
+What this does NOT solve:
+- `.mcp.json` scope merging — there is no "exclusive mode" for project config
+- Discoverability — the `disabledMcpServers` field is not surfaced in `claude mcp --help` or the official docs; this section IS the documentation
+
+---
+
 ## Session Onboarding
 
 On session start, run `/engage` to detect platform, resolve identity, load context, and confirm rules.


### PR DESCRIPTION
## Summary

- Documents the undocumented \`~/.claude.json\` → \`projects[\"<path>\"].disabledMcpServers\` mechanism for per-project MCP server exclusion
- Explains why project \`.mcp.json\` does NOT replace inherited servers (scopes are additive, not exclusive) — a key misconception that leads users to file bugs like #266
- Captures the safe jq rewrite pattern for editing the 150KB \`~/.claude.json\` in place, with an explicit CRITICAL warning against the \`jq '...' file > file\` footgun that truncates the output before jq reads the input

## Changes

- **\`CLAUDE.md\`** — New \`## MCP Server Scoping\` section inserted immediately before \`## Session Onboarding\`. Covers the additive merge rule, the \`disabledMcpServers\` knob location and syntax, server name format per category (\`claude.ai <Name>\`, \`plugin:<marketplace>:<name>\`, raw stdio name), safe update pattern, restart requirement, this project's keep-active policy (discord-watcher, wtf-server, plugin:context7:context7), and the limitations that are NOT solved by this mechanism.

## Linked Issues

Closes #266

## Context

During investigation of #266 (\"deferred tool list includes MCP servers not enabled for the current project\"), I found that the deferred tool list delivered to each session was polluted with ~100+ tools from servers irrelevant to this project: \`mcp__claude_ai_Canva__*\` (~30), \`mcp__kapture__*\` (~35), \`mcp__nerf-server__*\`, and the full \`claude.ai *\` auth surface.

The issue's escalation clause said: \"This may require an upstream Claude Code CLI change if there's no local knob. If that turns out to be the case, close this issue and file the request against \`anthropics/claude-code\` instead.\" A local knob exists — it's just undocumented. A \`claude-code-guide\` subagent search of the official docs could not find the \`disabledMcpServers\` field; it was discovered via direct inspection of \`~/.claude.json\`. This PR adds the documentation to CLAUDE.md so future agents can find it without the investigation I just did.

**Verification that the mechanism works:** This project already had \`plugin:github:github\` in its \`disabledMcpServers\` list, and the current session's deferred tool list contains zero \`mcp__plugin_github_github__*\` entries — confirming that disabled servers drop out cleanly. The actual list expansion for this project is an operator step performed outside this PR (editing \`~/.claude.json\`), since that file is in the user's home directory and contains session state written back by Claude Code — outside the repo's scope.

The code-reviewer flagged the \`jq '...' file > file\` clobber pattern as an important footgun worth documenting; fixed before precheck by adding an explicit CRITICAL warning block in the code example comment.

**What this PR does NOT do:**
- Apply the actual disable list to \`~/.claude.json\` (operator step, happens after merge)
- Fix the upstream Claude Code documentation gap — that's a separate discoverability issue that could be filed against \`anthropics/claude-code\` as a follow-up

## Test Plan

- \`./scripts/ci/validate.sh\` → 81/81 passed
- \`python3 -m pytest tests/\` → 1020/1020 passed (docs-only change, no test impact expected; full suite run as a regression sanity check)
- Code-reviewer agent run on the diff — one important finding (clobber warning) fixed, two medium findings deferred with documented rationale
- The \`disabledMcpServers\` mechanism was verified functional before writing the docs (see Context above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)