### PR TITLE
feat(disc): auto-split discord-bot send messages over 2000 char limit

### DIFF
--- a/skills/disc/discord-bot
+++ b/skills/disc/discord-bot
@@ -3,6 +3,8 @@
 #
 # Usage:
 #   discord-bot send <channel-id> <message> [--embed title:text] [--attach FILE]
+#     Messages over 2000 chars are automatically split into numbered multi-part
+#     messages. Embeds and attachments are applied to the final chunk only.
 #   discord-bot read <channel-id> [--limit N] [--after ID]
 #   discord-bot create-channel <guild-id> <name> [--topic TOPIC] [--category ID] [--type text|category]
 #   discord-bot create-thread <channel-id> <name> [--auto-archive 60|1440|4320|10080]
@@ -351,6 +353,72 @@ api_post() {
 	echo "$body"
 }
 
+# --- Message splitting --------------------------------------------------------
+# Discord's hard limit on the `content` field is 2000 characters (codepoints).
+# Anything larger returns HTTP 400. The splitter below slices oversize messages
+# into chunks at natural boundaries so callers don't have to truncate by hand.
+#
+# Budget is 1900 not 2000: each chunk gets a trailing "\n(N/M)" footer, and 100
+# chars of headroom handles totals up to (99/99) comfortably.
+#
+# Character math: ${#var} counts codepoints when the locale is UTF-8, which is
+# what Discord's limit actually measures. On non-UTF-8 locales it degrades to
+# byte counting — conservative, so splits will still be under the wire limit.
+_DISCORD_MSG_LIMIT=2000
+_DISCORD_CHUNK_BUDGET=1900
+
+# Split $1 into chunks of at most $_DISCORD_CHUNK_BUDGET characters.
+# Preference order at each split point: last newline in budget → last space in
+# budget → hard cut at budget. Writes chunks to stdout separated by NUL bytes
+# so embedded newlines remain unambiguous.
+#
+# Space-fallback note: when splitting at a space, the space itself is dropped
+# so the next chunk doesn't start with a leading space. Newline-fallback keeps
+# the newline with the preceding chunk (trailing) so line structure is visible.
+_split_for_discord() {
+	local text="$1"
+	local budget="$_DISCORD_CHUNK_BUDGET"
+	local -a chunks=()
+
+	while ((${#text} > budget)); do
+		local chunk="${text:0:$budget}"
+		local split_at=$budget
+
+		# Prefer the last newline in the budget window
+		local before_last_nl="${chunk%$'\n'*}"
+		if [[ "$before_last_nl" != "$chunk" ]]; then
+			# include the newline in the chunk we're about to emit
+			split_at=$((${#before_last_nl} + 1))
+			chunks+=("${text:0:$split_at}")
+			text="${text:$split_at}"
+			continue
+		fi
+
+		# Fall back to the last space in the budget window
+		local before_last_sp="${chunk% *}"
+		if [[ "$before_last_sp" != "$chunk" ]]; then
+			# emit through the character before the space, skip the space itself
+			local keep_len=${#before_last_sp}
+			chunks+=("${text:0:$keep_len}")
+			text="${text:$((keep_len + 1))}"
+			continue
+		fi
+
+		# Hard cut at the budget boundary
+		chunks+=("$chunk")
+		text="${text:$budget}"
+	done
+
+	chunks+=("$text")
+	printf '%s\0' "${chunks[@]}"
+}
+
+# Append "(idx/total)" as a new line on $3 and print to stdout.
+_apply_chunk_footer() {
+	local idx="$1" total="$2" chunk="$3"
+	printf '%s\n(%d/%d)' "$chunk" "$idx" "$total"
+}
+
 # --- Subcommand: send ---------------------------------------------------------
 send_help() {
 	cat <<'HELPTEXT'
@@ -367,12 +435,100 @@ Options:
   --attach FILE        Upload a file attachment alongside the message
   -h, --help           Show this help message
 
+Behavior:
+  Messages over 2000 characters (Discord's hard limit on content) are split
+  automatically into multiple messages. Each chunk is appended with a
+  "(N/M)" footer on its own line. Splits prefer newline boundaries, then
+  whitespace, then hard-cut as a last resort. Embeds and attachments are
+  attached to the FINAL chunk only so they render at the bottom of the
+  full message.
+
+  Return value: a single message ID on stdout. For split sends this is the
+  ID of the last chunk — preserving backward compat with callers that
+  capture the output.
+
 Examples:
   discord-bot send 123456789 "Hello, world!"
   discord-bot send 123456789 "Deploy report" --embed "Status:All green"
   discord-bot send 123456789 "See attached" --attach ./report.txt
+  discord-bot send 123456789 "$(cat long-report.md)"   # auto-splits
 HELPTEXT
 	exit 0
+}
+
+# Internal: send one Discord message (no splitting). Handles text-only via
+# api_post (which already has 429 handling) and the multipart attachment path
+# inline because multipart doesn't flow through api_post.
+#
+# Args: channel_id content [embed_title] [embed_text] [attach_file]
+# Writes the created message ID to stdout, or returns nonzero on failure.
+_send_single_chunk() {
+	local channel_id="$1" content="$2"
+	local embed_title="${3:-}" embed_text="${4:-}" attach_file="${5:-}"
+	local payload
+
+	if [[ -n "$embed_title" ]]; then
+		payload=$(jq -c -n \
+			--arg content "$content" \
+			--arg title "$embed_title" \
+			--arg desc "$embed_text" \
+			'{content: $content, embeds: [{title: $title, description: $desc}]}')
+	else
+		payload=$(jq -c -n --arg content "$content" '{content: $content}')
+	fi
+
+	if [[ -z "$attach_file" ]]; then
+		local response
+		response=$(api_post "/channels/$channel_id/messages" "$payload") || return 1
+		jq -r '.id' <<<"$response"
+		return 0
+	fi
+
+	# Multipart attachment path — duplicates 429 handling because the multipart
+	# POST doesn't route through api_post.
+	check_kill_switch
+	local http_code body endpoint="/channels/$channel_id/messages"
+	body=$(curl -sS -D "$_DISCORD_HEADERS_FILE" -w '\n%{http_code}' -X POST \
+		--config <(echo "$_curl_auth_cfg") \
+		-F "payload_json=$payload" \
+		-F "files[0]=@${attach_file}" \
+		"$API_BASE$endpoint")
+	http_code=$(tail -1 <<<"$body")
+	body=$(sed '$d' <<<"$body")
+	log_api_call "POST(multipart)" "$endpoint" "$http_code"
+
+	if [[ "$http_code" == "429" ]]; then
+		local is_global header_retry body_retry wait_time
+		is_global=$(echo "$body" | jq -r '.global // false' 2>/dev/null)
+		header_retry=$(_get_retry_after_header)
+		body_retry=$(echo "$body" | jq -r '.retry_after // empty' 2>/dev/null)
+		wait_time="${header_retry:-${body_retry:-1}}"
+
+		if [[ "$is_global" == "true" ]]; then
+			_engage_global_kill "${wait_time%.*}"
+			log_api_call "POST(multipart)" "$endpoint" "429" "global=true, retry_after=${wait_time}s, kill_engaged=true"
+			return 1
+		fi
+
+		echo "Rate limited (scope: channel). Waiting ${wait_time}s..." >&2
+		sleep "$wait_time"
+		check_kill_switch
+		body=$(curl -sS -D "$_DISCORD_HEADERS_FILE" -w '\n%{http_code}' -X POST \
+			--config <(echo "$_curl_auth_cfg") \
+			-F "payload_json=$payload" \
+			-F "files[0]=@${attach_file}" \
+			"$API_BASE$endpoint")
+		http_code=$(tail -1 <<<"$body")
+		body=$(sed '$d' <<<"$body")
+		log_api_call "POST(multipart)" "$endpoint" "$http_code" "retry=1 after ${wait_time}s"
+	fi
+
+	if [[ "$http_code" -ge 400 ]]; then
+		echo "Error: Discord API returned HTTP $http_code on multipart POST $endpoint" >&2
+		[[ -n "$body" ]] && echo "$body" | jq -r '.message // empty' 2>/dev/null >&2
+		return 1
+	fi
+	jq -r '.id' <<<"$body"
 }
 
 cmd_send() {
@@ -421,67 +577,32 @@ cmd_send() {
 		exit 1
 	}
 
-	local payload
-	if [[ -n "$embed_title" ]]; then
-		payload=$(jq -c -n \
-			--arg content "$message" \
-			--arg title "$embed_title" \
-			--arg desc "$embed_text" \
-			'{content: $content, embeds: [{title: $title, description: $desc}]}')
-	else
-		payload=$(jq -c -n --arg content "$message" '{content: $content}')
+	# Fast path: message fits in a single Discord message.
+	if ((${#message} <= _DISCORD_MSG_LIMIT)); then
+		_send_single_chunk "$channel_id" "$message" "$embed_title" "$embed_text" "$attach_file"
+		return
 	fi
 
-	if [[ -n "$attach_file" ]]; then
-		check_kill_switch
-		local http_code body endpoint="/channels/$channel_id/messages"
-		body=$(curl -sS -D "$_DISCORD_HEADERS_FILE" -w '\n%{http_code}' -X POST \
-			--config <(echo "$_curl_auth_cfg") \
-			-F "payload_json=$payload" \
-			-F "files[0]=@${attach_file}" \
-			"$API_BASE$endpoint")
-		http_code=$(tail -1 <<<"$body")
-		body=$(sed '$d' <<<"$body")
-		log_api_call "POST(multipart)" "$endpoint" "$http_code"
+	# Split path: slice into chunks, number them, send in order. The final
+	# chunk carries any embed/attachment so those render at the bottom of the
+	# full message thread.
+	local -a chunks=()
+	mapfile -d '' chunks < <(_split_for_discord "$message")
+	local total=${#chunks[@]}
 
-		# 429 handling — global vs channel
-		if [[ "$http_code" == "429" ]]; then
-			local is_global header_retry body_retry wait_time
-			is_global=$(echo "$body" | jq -r '.global // false' 2>/dev/null)
-			header_retry=$(_get_retry_after_header)
-			body_retry=$(echo "$body" | jq -r '.retry_after // empty' 2>/dev/null)
-			wait_time="${header_retry:-${body_retry:-1}}"
+	local last_id="" i idx footer_text
+	for ((i = 0; i < total; i++)); do
+		idx=$((i + 1))
+		footer_text=$(_apply_chunk_footer "$idx" "$total" "${chunks[$i]}")
 
-			if [[ "$is_global" == "true" ]]; then
-				_engage_global_kill "${wait_time%.*}"
-				log_api_call "POST(multipart)" "$endpoint" "429" "global=true, retry_after=${wait_time}s, kill_engaged=true"
-				return 1
-			fi
-
-			echo "Rate limited (scope: channel). Waiting ${wait_time}s..." >&2
-			sleep "$wait_time"
-			check_kill_switch
-			body=$(curl -sS -D "$_DISCORD_HEADERS_FILE" -w '\n%{http_code}' -X POST \
-				--config <(echo "$_curl_auth_cfg") \
-				-F "payload_json=$payload" \
-				-F "files[0]=@${attach_file}" \
-				"$API_BASE$endpoint")
-			http_code=$(tail -1 <<<"$body")
-			body=$(sed '$d' <<<"$body")
-			log_api_call "POST(multipart)" "$endpoint" "$http_code" "retry=1 after ${wait_time}s"
+		if ((idx == total)); then
+			last_id=$(_send_single_chunk "$channel_id" "$footer_text" "$embed_title" "$embed_text" "$attach_file") || return 1
+		else
+			_send_single_chunk "$channel_id" "$footer_text" "" "" "" >/dev/null || return 1
 		fi
+	done
 
-		if [[ "$http_code" -ge 400 ]]; then
-			echo "Error: Discord API returned HTTP $http_code on multipart POST $endpoint" >&2
-			[[ -n "$body" ]] && echo "$body" | jq -r '.message // empty' 2>/dev/null >&2
-			return 1
-		fi
-		jq -r '.id' <<<"$body"
-	else
-		local response
-		response=$(api_post "/channels/$channel_id/messages" "$payload")
-		jq -r '.id' <<<"$response"
-	fi
+	echo "$last_id"
 }
 
 # --- Subcommand: read ---------------------------------------------------------
@@ -856,6 +977,10 @@ cmd_resolve() {
 }
 
 # --- Dispatch -----------------------------------------------------------------
+# Skip dispatch when the script is sourced (e.g. from tests) so the helpers
+# above can be exercised without executing a subcommand.
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] || return 0
+
 [[ $# -lt 1 ]] && usage
 
 case "$1" in

--- a/tests/test_discord_bot_split.py
+++ b/tests/test_discord_bot_split.py
@@ -1,0 +1,255 @@
+"""Tests for discord-bot message auto-splitting (Wave-Engineering/claudecode-workflow#274).
+
+Exercises the `_split_for_discord` and `_apply_chunk_footer` shell helpers by
+sourcing the discord-bot script (which honors a sourcing guard and skips its
+subcommand dispatch when sourced) and running bash assertions via subprocess.
+
+No network calls — the splitter is pure string manipulation. A dummy
+DISCORD_BOT_TOKEN is provided so the script's auth gate is satisfied.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_REPO_DIR = Path(__file__).resolve().parent.parent
+_DISCORD_BOT = str(_REPO_DIR / "skills" / "disc" / "discord-bot")
+
+_HAS_BASH = shutil.which("bash") is not None
+_HAS_JQ = shutil.which("jq") is not None
+
+_SKIP_NO_BASH = pytest.mark.skipif(not _HAS_BASH, reason="bash not available")
+_SKIP_NO_JQ = pytest.mark.skipif(not _HAS_JQ, reason="jq not available")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_in_sourced_bot(snippet: str) -> subprocess.CompletedProcess[str]:
+    """Run ``snippet`` in a bash subshell with discord-bot sourced.
+
+    The snippet has access to ``_split_for_discord``, ``_apply_chunk_footer``,
+    ``_DISCORD_MSG_LIMIT``, and ``_DISCORD_CHUNK_BUDGET``.
+    """
+    wrapper = f'set -euo pipefail\nsource "{_DISCORD_BOT}"\n{snippet}\n'
+    env = {**os.environ, "DISCORD_BOT_TOKEN": "test-token-for-split"}
+    return subprocess.run(
+        ["bash", "-c", wrapper],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _count_chunks(input_text: str) -> int:
+    """Count NUL-separated chunks emitted by _split_for_discord for input_text."""
+    snippet = f"""
+input={_bash_quote(input_text)}
+_split_for_discord "$input" | tr -cd '\\0' | wc -c
+"""
+    result = _run_in_sourced_bot(snippet)
+    assert result.returncode == 0, f"bash failed: {result.stderr}"
+    return int(result.stdout.strip())
+
+
+def _max_chunk_len(input_text: str) -> int:
+    """Return the length (in codepoints) of the longest chunk."""
+    snippet = f"""
+input={_bash_quote(input_text)}
+mapfile -d '' chunks < <(_split_for_discord "$input")
+max=0
+for c in "${{chunks[@]}}"; do
+    (( ${{#c}} > max )) && max=${{#c}}
+done
+echo "$max"
+"""
+    result = _run_in_sourced_bot(snippet)
+    assert result.returncode == 0, f"bash failed: {result.stderr}"
+    return int(result.stdout.strip())
+
+
+def _first_chunk_len(input_text: str) -> int:
+    """Return the length (in codepoints) of the first emitted chunk."""
+    snippet = f"""
+input={_bash_quote(input_text)}
+mapfile -d '' chunks < <(_split_for_discord "$input")
+echo "${{#chunks[0]}}"
+"""
+    result = _run_in_sourced_bot(snippet)
+    assert result.returncode == 0, f"bash failed: {result.stderr}"
+    return int(result.stdout.strip())
+
+
+def _rejoin_equals_input(input_text: str) -> bool:
+    """Check that concatenating all chunks reproduces the original input exactly."""
+    # Write input to a temp file to avoid shell-quoting pitfalls on arbitrary
+    # text with shell metacharacters and multi-line content.
+    snippet = f"""
+input=$(cat <<'DISCORD_TEST_INPUT_EOF'
+{input_text}
+DISCORD_TEST_INPUT_EOF
+)
+# The heredoc adds exactly one trailing newline; strip it so the input
+# matches what the caller passed.
+input="${{input%$'\\n'}}"
+
+mapfile -d '' chunks < <(_split_for_discord "$input")
+joined=""
+for c in "${{chunks[@]}}"; do joined+="$c"; done
+[[ "$joined" == "$input" ]] && echo "MATCH" || echo "DIFFER len_orig=${{#input}} len_joined=${{#joined}}"
+"""
+    result = _run_in_sourced_bot(snippet)
+    assert result.returncode == 0, f"bash failed: {result.stderr}"
+    return result.stdout.strip() == "MATCH"
+
+
+def _bash_quote(text: str) -> str:
+    """Wrap a string in single-quotes suitable for bash variable assignment."""
+    return "'" + text.replace("'", "'\"'\"'") + "'"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _split_for_discord — size boundaries
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestSplitSizeBoundaries:
+    """AC: the splitter respects the 1900-char budget at boundary lengths."""
+
+    def test_empty_string_produces_one_chunk(self) -> None:
+        assert _count_chunks("") == 1
+
+    def test_1899_chars_produces_one_chunk(self) -> None:
+        assert _count_chunks("a" * 1899) == 1
+
+    def test_1900_chars_produces_one_chunk(self) -> None:
+        assert _count_chunks("a" * 1900) == 1
+
+    def test_1901_chars_splits_into_two_chunks(self) -> None:
+        assert _count_chunks("a" * 1901) == 2
+
+    def test_all_chunks_at_or_below_budget(self) -> None:
+        assert _max_chunk_len("a" * 5000) <= 1900
+
+
+# ---------------------------------------------------------------------------
+# Tests: _split_for_discord — fallback order (newline > space > hard cut)
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestSplitFallbacks:
+    """AC: splits prefer newline, then space, then hard cut."""
+
+    def test_hard_cut_at_exact_budget_when_no_whitespace(self) -> None:
+        # 5000 'a's with no whitespace → first chunk is exactly 1900 chars
+        assert _first_chunk_len("a" * 5000) == 1900
+
+    def test_newline_split_is_lossless(self) -> None:
+        # 60 lines of 79 chars + newline = 4800 chars
+        lines = "\n".join("x" * 79 for _ in range(60)) + "\n"
+        assert _rejoin_equals_input(lines)
+
+    def test_space_fallback_drops_the_space(self) -> None:
+        # 1950 'a's, then a space, then 100 'a's → split at the space,
+        # neither chunk retains the space
+        text = ("a" * 1950) + " " + ("a" * 100)
+        snippet = f"""
+input={_bash_quote(text)}
+mapfile -d '' chunks < <(_split_for_discord "$input")
+first="${{chunks[0]}}"
+second="${{chunks[1]}}"
+# First chunk must not end with a space
+[[ "${{first: -1}}" != " " ]] || {{ echo "FIRST_ENDS_WITH_SPACE"; exit 1; }}
+# Second chunk must not start with a space
+[[ "${{second:0:1}}" != " " ]] || {{ echo "SECOND_STARTS_WITH_SPACE"; exit 1; }}
+echo "OK"
+"""
+        result = _run_in_sourced_bot(snippet)
+        assert result.returncode == 0, f"bash failed: {result.stderr}"
+        assert result.stdout.strip() == "OK"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _split_for_discord — unicode
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestSplitUnicode:
+    """AC: unicode content is split by codepoint count, no corruption."""
+
+    def test_emoji_content_over_budget_splits(self) -> None:
+        # "🎉 " = 2 codepoints each. 1000 copies = 2000 codepoints → must split.
+        text = "🎉 " * 1000
+        assert _count_chunks(text) >= 2
+
+    def test_emoji_chunks_respect_budget(self) -> None:
+        text = "🎉 " * 1000
+        assert _max_chunk_len(text) <= 1900
+
+
+# ---------------------------------------------------------------------------
+# Tests: _apply_chunk_footer
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestChunkFooter:
+    """AC: _apply_chunk_footer appends '\\n(N/M)' to chunk text."""
+
+    def test_footer_format(self) -> None:
+        snippet = r"""
+out=$(_apply_chunk_footer 2 5 "hello")
+expected=$'hello\n(2/5)'
+[[ "$out" == "$expected" ]] && echo "OK" || { echo "GOT=$out"; exit 1; }
+"""
+        result = _run_in_sourced_bot(snippet)
+        assert result.returncode == 0, f"bash failed: {result.stderr}"
+        assert result.stdout.strip() == "OK"
+
+    def test_footer_preserves_chunk_trailing_newline(self) -> None:
+        snippet = r"""
+chunk=$'line1\nline2\n'
+out=$(_apply_chunk_footer 1 3 "$chunk")
+expected=$'line1\nline2\n\n(1/3)'
+[[ "$out" == "$expected" ]] && echo "OK" || { printf 'GOT=%q\n' "$out"; exit 1; }
+"""
+        result = _run_in_sourced_bot(snippet)
+        assert result.returncode == 0, f"bash failed: {result.stderr}"
+        assert result.stdout.strip() == "OK"
+
+
+# ---------------------------------------------------------------------------
+# Tests: sourcing guard — script can be sourced without running dispatch
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+class TestSourcingGuard:
+    """AC: sourcing discord-bot returns cleanly without executing a subcommand."""
+
+    def test_sourcing_does_not_invoke_usage(self) -> None:
+        # If the dispatch were active, sourcing would fall through to `usage`
+        # and exit 1 because there are no positional args.
+        snippet = 'echo "sourced fine"'
+        result = _run_in_sourced_bot(snippet)
+        assert result.returncode == 0
+        assert "sourced fine" in result.stdout


### PR DESCRIPTION
## Summary

Discord's REST API caps the `content` field at 2000 characters. `discord-bot send` previously forwarded oversize messages as-is and got HTTP 400, silently dropping long agent output. This adds transparent multi-part splitting so agents can `send` arbitrarily long text without truncating or buffering.

## Changes

**New splitting primitives in `skills/disc/discord-bot`:**

- `_split_for_discord <text>` — slices text into chunks of ≤1900 chars (the budget leaves 100-char headroom for a `(N/M)` footer). Split preference: last newline in the budget window → last space (dropped) → hard cut at the budget boundary. Chunks are emitted NUL-separated on stdout so callers can use `mapfile -d ''` without newline ambiguity.
- `_apply_chunk_footer <idx> <total> <chunk>` — appends `\n(N/M)` so each message is clearly numbered.
- `_send_single_chunk <channel_id> <content> [embed_title] [embed_text] [attach_file]` — factored out from the old inline `cmd_send` body. Handles text-only sends via `api_post` (which has 429 retry) and the multipart attachment path inline.
- `cmd_send` now branches on `${#message}`: ≤2000 → single-POST fast path (unchanged behavior); >2000 → split loop where the **final** chunk carries any embed/attachment so they render at the bottom of the rendered thread. Return value remains a single message ID (the final chunk's) for backward compat with any caller capturing `$(discord-bot send ...)`.
- **Sourcing guard** — `[[ "${BASH_SOURCE[0]}" == "${0}" ]] || return 0` before the dispatch lets tests source the script without triggering subcommand execution. Without this, pytest couldn't exercise the helpers directly.
- Header comment (lines 5-7) and `send_help` "Behavior" section both document the auto-split.

**New test suite: `tests/test_discord_bot_split.py`** — 13 pytest cases following the existing `test_discord_bot_help.py` pattern (sources the bash script via subprocess with a dummy token):

- **Size boundaries**: empty, 1899, 1900, 1901, 5000 chars — verifies the fast/slow path cutover and that all chunks stay ≤1900.
- **Fallback order**: hard-cut at exact budget, lossless rejoin when splits happen on newlines only, space-fallback drops the space on both sides.
- **Unicode**: 2000 codepoints of `"🎉 "` splits and respects the budget (proves `${#var}` codepoint math).
- **Footer format**: `_apply_chunk_footer` emits `\n(N/M)` and preserves a chunk's trailing newline.
- **Sourcing guard**: sourcing the script with no args returns cleanly instead of running `usage`.

## Linked Issues

Closes #274

## Test Plan

- [x] `bash -n skills/disc/discord-bot` — syntax clean
- [x] `shellcheck skills/disc/discord-bot` — no findings
- [x] `./scripts/ci/validate.sh` — 81 passed, 0 failed
- [x] `pytest tests/test_discord_bot_split.py -v` — 13 new cases all pass in 0.46s
- [x] `pytest tests/` — full main suite 1038/1038 passed (`tools/cc-inspector/tests/` collection errors are pre-existing, unrelated module-name collision and pass in isolation)
- [x] **End-to-end smoke test**: 4673-char payload sent to `#agent-ops`, delivered as 3 numbered Discord messages `(1/3)`, `(2/3)`, `(3/3)` in ~535ms, splits landed at natural line boundaries (Line 14/15, Line 33/34), no 429s
- [x] `feature-dev:code-reviewer` agent: no high-confidence findings; two deferred informational items (footer comment math wording, pre-existing multipart 429 single-retry)

## Out of Scope (documented in #274)

- Code-block (` ``` `) awareness across splits — defer; rare and adds real complexity (state machine over fences)
- Inter-chunk `sleep` pacing — the existing `api_post` 429 retry is the safety net; the 3-chunk smoke test ran well under rate limits
- `--no-split` opt-out flag — the current behavior is "fail with HTTP 400"; nobody wants to opt back into that
- Embed `description` field splitting (separate 4096-char limit)