### PR TITLE
chore(sdlc-mcp): scaffold mcp-server-sdlc with glob-based handler registry

### DIFF
--- a/mcps.json
+++ b/mcps.json
@@ -19,6 +19,11 @@
       "repo": "Wave-Engineering/mcp-server-discord",
       "install_url": "https://raw.githubusercontent.com/Wave-Engineering/mcp-server-discord/main/scripts/install-remote.sh",
       "description": "Discord send/read/manage for Claude Code agents"
+    },
+    "sdlc-server": {
+      "repo": "Wave-Engineering/mcp-server-sdlc",
+      "install_url": "https://raw.githubusercontent.com/Wave-Engineering/mcp-server-sdlc/main/scripts/install-remote.sh",
+      "description": "SDLC workflow tools for Claude Code agents"
     }
   }
 }

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: sdlc
+description: SDLC workflow tools — work item creation, branch/PR compliance
+---
+
+# SDLC Workflow Tools
+
+Route all /sdlc intents to `sdlc_*` MCP tool calls. Do NOT use bash or shell commands.
+
+## Available Tools
+
+- `work_item` — Create any work item (epic, story, bug, chore, docs, PR, MR) on GitHub or GitLab
+- `ibm` — Check issue/branch/PR workflow compliance for the current branch
+
+## Usage
+
+Invoke the appropriate MCP tool directly. The tool handles platform detection (GitHub vs GitLab) internally.


### PR DESCRIPTION
## Summary

Registers `mcp-server-sdlc` in the cc-workflow kit. Creates the new repo at `Wave-Engineering/mcp-server-sdlc` with a glob-based handler registry architecture — `index.ts` is frozen after scaffold, adding a tool requires dropping one file in `handlers/`.

## Changes

- `mcps.json` — adds `sdlc-server` entry
- `skills/sdlc/SKILL.md` — 17-line routing stub directing `/sdlc` intents to `sdlc_*` MCP tools

## New Repo

`Wave-Engineering/mcp-server-sdlc` — Bun/TypeScript, `import.meta.glob('./handlers/*.ts', { eager: true })` registry, CI green, 3-platform release workflow ready.

Handler registry pattern: each tool is a self-contained file exporting a `HandlerDef` default. Zero `index.ts` changes required when adding tools — enables true parallel wave execution.

## Test Results

- `bun test` — 3 pass, 0 fail (registry filtering unit tests)
- `./scripts/ci/validate.sh` — 3/3 pass
- New repo CI — green on first push

Closes #284

Generated with [Claude Code](https://claude.com/claude-code)