### PR TITLE
chore(ci): add merge_group event trigger to enable merge queue

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
 
+  merge_group:
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `merge_group:` to the workflow trigger so that the merge queue's required check can fire.

Without this trigger, PRs entering the merge queue sit forever waiting for checks that never run. This is a bootstrap fix — admin-merged once to break the chicken-and-egg deadlock; future PRs in this repo will use the normal queue flow.

Generated with [Claude Code](https://claude.com/claude-code)