### PR TITLE
chore(wave-mcp): register /wavemachine in install script (regression guard)

### DIFF
--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -219,6 +219,27 @@ for skill_file in "$REPO_DIR"/skills/*/SKILL.md; do
 	fi
 done
 
+# --- Install script skill registration ---------------------------------------
+# Ensures every skills/*/ directory is reachable by the install script's
+# skill-discovery loop. This guards against regressions where a new skill
+# (e.g. wavemachine) gets filed but the install path is accidentally narrowed
+# to a hardcoded list. Both install and scripts/install-remote.sh must loop
+# over skills/*/ unconditionally.
+echo ""
+echo "Install script skill registration"
+echo "──────────────────────────────────────────"
+for install_script in "$REPO_DIR/install" "$REPO_DIR/scripts/install-remote.sh"; do
+	[[ -f "$install_script" ]] || continue
+	rel="${install_script#"$REPO_DIR/"}"
+	if grep -q 'for skill_dir in .*skills/\*/' "$install_script"; then
+		info "$rel — discovers skills/*/ unconditionally"
+		PASS=$((PASS + 1))
+	else
+		err "$rel — does not appear to discover skills/*/ (possible hardcoded list)"
+		FAIL=$((FAIL + 1))
+	fi
+done
+
 # --- Summary ------------------------------------------------------------------
 echo ""
 echo "──────────────────────────────────────────"


### PR DESCRIPTION
## Summary

Verified that both `install` and `scripts/install-remote.sh` already auto-discover `skills/wavemachine/` via their `for skill_dir in ... skills/*/` loops — the AC's "should be automatic via skill directory loop" is already met out-of-the-box, no core logic change needed.

Added a regression guard to `scripts/ci/validate.sh` that asserts both install scripts continue to loop over `skills/*/` unconditionally, so a future refactor can't accidentally narrow the discovery to a hardcoded list and orphan `wavemachine` (or any new skill).

## Changes

- `scripts/ci/validate.sh` — new "Install script skill registration" test block (2 new passing tests)
- No change to `install` or `scripts/install-remote.sh`

## Verification

- `./install --dry-run --skills` → lists `skills/wavemachine/SKILL.md → ~/.claude/skills/wavemachine/SKILL.md`
- `./install --check` → reports `wavemachine — NOT INSTALLED` (tracked correctly)
- `./scripts/ci/validate.sh` → 81/81 passing (including the 2 new regression checks and wavemachine frontmatter)
- `shellcheck` on all three scripts → clean

## Linked Issues

Closes #297

## Test Plan

- `./scripts/ci/validate.sh` — PASS locally (81/81)
- Manual `./install --dry-run --skills` + `./install --check` verifications
- `shellcheck install scripts/install-remote.sh scripts/ci/validate.sh`