### PR TITLE
feat(precheck): post approval request to #precheck Discord channel

### DIFF
--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -10,9 +10,10 @@ Mandatory verification before any commit. Checks compliance, runs code review, p
 ## Tools Used
 - `mcp__sdlc-server__ibm` — branch/issue workflow (no protected branch; branch linked to an open issue)
 - `mcp__sdlc-server__spec_validate_structure` — linked issue has Changes / Tests / AC
+- `mcp__disc-server__disc_send` — post approval request to `#precheck` (channel `1491195025198157834`)
 
 ## Procedure
-`ibm()` (stop on fail) → `spec_validate_structure(N)` → run repo validation (`validate.sh`/`make test`/`pytest`/`npm test`); fix failures first → launch `feature-dev:code-reviewer` via Agent over all changed files, WAIT, fix high+ findings → present the checklist → `vox` (identity from `/tmp/claude-agent-<md5>.json`; conversational: name/team/project/issue/summary/"Ready for your call") → **STOP.** Wait for `/scp`/`/scpmr`/`/scpmmr`/affirmative. Negative/rework → return to work.
+`ibm()` (stop on fail) → `spec_validate_structure(N)` → run repo validation (`validate.sh`/`make test`/`pytest`/`npm test`); fix failures first → launch `feature-dev:code-reviewer` via Agent over all changed files, WAIT, fix high+ findings → present the checklist → **notify BJ** (see "The Notification" below): `disc_send` to `#precheck` AND `vox` locally → **STOP.** Wait for `/scp`/`/scpmr`/`/scpmmr`/affirmative. Negative/rework → return to work. If `disc_send` fails (MCP unavailable, network), fall back to `vox` only — still STOP and wait for approval. Never bypass the STOP on notification failure.
 
 ## The Checklist (full every time; a checkmark means VERIFIED by reading the codebase)
 **Context:** Project | Issue #N — title | Branch `feature/N-...` → `main`
@@ -20,6 +21,28 @@ Mandatory verification before any commit. Checks compliance, runs code review, p
 - [ ] New tests (cover new code) — [ ] All tests pass (entire suite) — [ ] Scripts executed (linting is NOT testing) — [ ] Code review (high+ fixed)
 
 **Summary:** `[codebase]` `[docs]` `[tests]` `[config]`. **Findings:** `[fixed]` / `[deferred]` / "(none)".
+
+## The Notification (Discord + vox)
+Resolve identity from `/tmp/claude-agent-<md5>.json` (md5 of project root path). Use it for both the Discord post and the vox announcement.
+
+**Important:** Do NOT prefix the Discord post with `@all`, `@<Dev-Team>`, or any `@`-mention. This post is for BJ only (human-facing). The discord-watcher filters by `@`-addressing, so an `@`-prefix would fan the precheck gate notice out to every listening agent in the fleet. Unaddressed is intentional.
+
+**`disc_send` to `#precheck` (`1491195025198157834`) — exact body shape:**
+```
+⚠️ **Precheck gate — awaiting approval**
+
+**Project:** <project-name>
+**Issue:** #<N> — <title>
+**Branch:** `<type>/<N>-<slug>` → `main`
+**Checklist:** `[codebase]` `[docs]` `[tests]` `[config]`
+**Findings:** <fixed> / <deferred> / (none)
+
+Ready for `/scp` / `/scpmr` / `/scpmmr` or rework.
+
+— **<dev-name>** <dev-avatar> (<dev-team>)
+```
+
+**`vox`:** same info, conversational, 1-2 sentences, ending with "Ready for your call."
 
 ## Rules
 No diff. No commit. No skipping code-reviewer. Honesty over speed — no checking items you haven't verified. **Linting is not testing** — passing lint/typecheck does not mean code works.


### PR DESCRIPTION
## Summary

Extends the `/precheck` skill so the approval gate posts to a new fleet-wide `#precheck` Discord channel alongside the existing local `vox` TTS announcement. Motivation: BJ runs 5+ concurrent sessions and needs a centralized view of pending precheck approvals across agents.

## Changes

- `skills/precheck/SKILL.md`
  - Adds `mcp__disc-server__disc_send` to **Tools Used**
  - Updates **Procedure** line to call `disc_send` to `#precheck` (`1491195025198157834`) alongside `vox`; graceful-degradation clause: disc_send failure falls back to vox only — STOP behavior preserved regardless
  - Adds new **"The Notification"** section with the exact Discord message template, identity resolution, and an explicit anti-`@`-prefix guard (prevents discord-watcher from fanning the notice to all listening agents)
- Memory (outside repo, not in this PR): `ref_discord_server.md` updated with the new channel row

## Linked Issues

Closes #309

## Test Plan

- [x] Ran `./scripts/ci/validate.sh` — **81 passed, 0 failed** (frontmatter validator confirms `skills/precheck/SKILL.md` is well-formed)
- [x] Ran `feature-dev:code-reviewer` agent on the diff — 2 findings (multi-agent fanout risk, STOP-skip ambiguity), both fixed before this PR
- [x] Verified `#precheck` channel exists via `mcp__disc-server__disc_list` (ID `1491195025198157834`, guild `1486516321385578576`)
- [x] Verified `disc_send` MCP tool is operational in this session (used it during investigation of the disc_send envelope bug earlier)
- [ ] **Deferred: end-to-end precheck run with the new skill** — the installed copy at `~/.claude/skills/precheck/SKILL.md` does not hot-reload from project source. Full self-referential verification requires merge + install + restart + next real precheck cycle. Will confirm on the next precheck run after install and update issue #309's AC checklist.

## Design decisions

- **No `@` mention of BJ.** Channel-level notification settings handle pinging. Avoids every skill update embedding a Discord user ID.
- **Both `disc_send` and `vox` fire.** Different observation modes (at-workstation vs. fleet-dashboard from phone) — redundancy is intentional.
- **Graceful degradation on disc_send failure.** Notification is convenience, the mandatory STOP gate is not. Explicit "never bypass STOP on notification failure" wording prevents misinterpretation.
- **Anti-`@`-prefix guard.** Without it, the discord-watcher would fan out every precheck gate notice to every listening agent in the fleet. Post is human-facing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)