### PR TITLE
chore(skills): slim ibm, issue, review, ccwork — replace CLI with MCP tools

### DIFF
--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -174,9 +174,7 @@ Read each template's `name:` field to find the match. If the argument is `#N` (a
 
 If no existing issue was referenced, create one from the template. Extract the markdown content from the template's `body` section (the `value:` field under `type: markdown`):
 
-```bash
-gh issue create --title "<lab name from template>" --body "<extracted markdown body>" --label "lab"
-```
+Call `work_item({type: "issue", title: "<lab name from template>", body: "<extracted markdown body>", labels: "lab"})`. The tool handles platform detection and creation internally.
 
 Record the created issue number for later reference.
 
@@ -189,10 +187,7 @@ Read the issue body (either the newly created issue or the referenced `#N`) and 
 - **Session replay** — look for `` **Session replay:** `labs/NN/session.jsonl` `` and extract the file path
 - **Curated session** — look for `` **Curated session:** `lab-NN` `` and extract the Clawback session ID
 
-```bash
-# Read the issue body
-gh issue view <issue-number> --json body --jq '.body'
-```
+Call `spec_get({issue: <issue-number>})` to fetch the issue body as structured sections.
 
 Parse these values. Session replay and curated session are optional — if missing, the completion step will fall back gracefully.
 
@@ -278,10 +273,8 @@ Where `<solution-tag>` is the value parsed in Step 4 (e.g., `lab/01-solution`).
 
 Read the "You Learned" checklist from the issue body. For each item, check it off in the issue:
 
-```bash
-# Update the issue body with checked items
-gh issue edit <issue-number> --body "<updated body with [x] items>"
-```
+<!-- TODO: migrate to work_item_update MCP tool when available -->
+Update the issue body via CLI (`gh issue edit` / `glab issue edit`) — no MCP tool for issue updates exists yet.
 
 ### Step 10: Update LAB.md completion tracking
 

--- a/skills/ccwork/tours/orientation.md
+++ b/skills/ccwork/tours/orientation.md
@@ -69,7 +69,7 @@ Present this table:
 
 | Step | What you do | Skill |
 |------|------------|-------|
-| 1. Track | Create or pick an issue | `gh issue create` / `gh issue view` |
+| 1. Track | Create or pick an issue | `/issue` skill |
 | 2. Branch | Create a feature branch | `git checkout -b feature/42-description` |
 | 3. Code | Write the implementation | (you or Claude) |
 | 4. Gate | Run the pre-commit checklist | `/precheck` |

--- a/skills/ibm/SKILL.md
+++ b/skills/ibm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ibm
-description: Reminder to follow Issue → Branch → PR/MR workflow for the current work
+description: Verify Issue → Branch → PR/MR workflow compliance via MCP tool
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -9,109 +9,20 @@ description: Reminder to follow Issue → Branch → PR/MR workflow for the curr
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 
-# IBM: Issue → Branch → PR/MR Workflow Reminder
+# IBM: Issue → Branch → PR/MR Workflow Check
 
-**STOP.** Before writing any code, verify you have followed the proper workflow.
+## Tools Used
+- `mcp__sdlc-server__ibm` — checks branch/issue compliance, platform detection, target branch resolution. All logic is server-side.
 
-## Step 0a: Detect Platform (CRITICAL)
+## Procedure
 
-**Before anything else, determine whether this is a GitHub or GitLab project.**
-
-```bash
-git remote -v | head -1
-```
-
-- If the URL contains `github` → **GitHub** — use `gh` CLI, PRs, GitHub terminology
-- If the URL contains `gitlab` → **GitLab** — use `glab` CLI, MRs, GitLab terminology
-
-Store the result for use in all subsequent steps:
-```bash
-REMOTE_URL=$(git remote get-url origin 2>/dev/null)
-if echo "$REMOTE_URL" | grep -qi github; then
-  PLATFORM="github"; CLI="gh"
-elif echo "$REMOTE_URL" | grep -qi gitlab; then
-  PLATFORM="gitlab"; CLI="glab"
-else
-  echo "Unknown platform — ask the user"; exit 1
-fi
-```
-
-## Step 0b: Resolve Target Branch (CRITICAL)
-
-**Determine the correct branch to branch from and target PRs/MRs to.**
-
-1. **Delete any existing cache** — `rm -f .claude/target-branch-cache.json` (new issue = fresh lookup)
-2. **Query the platform for the project's default branch:**
-   - **GitLab:** `glab api projects/:id | jq -r '.default_branch'`
-   - **GitHub:** `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'`
-3. **Verify the default branch is not locked down (GitLab only):**
-   ```bash
-   # Check protected branch rules — if merges are fully blocked, it's locked
-   glab api "projects/:id/protected_branches/<default-branch>"
-   ```
-   On GitHub, branch protection rules rarely block PRs from targeting the default branch — skip this check unless issues arise.
-4. **Decision tree:**
-   - Default branch is an unlocked `release/*` → **use it** as target
-   - Default branch is locked → look for other unlocked `release/*` branches
-   - Zero unlocked release branches → **STOP and warn the user**: "No active release target. The project needs an unlocked release branch before work can begin."
-   - Multiple unlocked release branches → check repo's CLAUDE.md, or ask the user
-   - **GitHub with standard `main` default** → use `main` as target (this is the normal GitHub Flow)
-5. **Cache the result** — Write `.claude/target-branch-cache.json`:
-   ```json
-   { "target_branch": "release/X.Y.Z", "platform": "gitlab", "project_id": "12345", "fetched_at": "2026-02-27T..." }
-   ```
-
-**NEVER use the system-injected `gitStatus` "Main branch" value.** It is auto-detected and frequently wrong for projects using release branches.
-
-## Step 1: Issue
-
-Does an issue exist for this work?
-- If NO: Create one with `$CLI issue create` (`gh issue create` / `glab issue create`)
-- If YES: Note the issue number
-
-## Step 2: Branch
-
-Are you on a feature branch linked to the issue?
-- Branch from the **resolved target branch** (from Step 0b), not `main` (unless `main` IS the resolved target)
-- Name format: `feature/<issue-number>-description` or `fix/<issue-number>-description`
-- Example: `git checkout -b feature/42-add-coppermind-homepage`
-
-## Step 3: PR/MR
-
-After committing, create a PR or MR targeting the **resolved target branch**:
-- **GitLab:** `glab mr create --target-branch <resolved-target> --remove-source-branch`
-- **GitHub:** `gh pr create --base <resolved-target>`
-- Include `Closes #<issue-number>` in the description
-
-## Quick Reference
-
-```bash
-# Detect platform (do this FIRST)
-REMOTE_URL=$(git remote get-url origin 2>/dev/null)
-if echo "$REMOTE_URL" | grep -qi github; then CLI="gh"; else CLI="glab"; fi
-
-# Resolve target branch
-TARGET=$(jq -r '.target_branch' .claude/target-branch-cache.json)
-
-# Create issue
-$CLI issue create --title "Description" --description "Details"
-
-# Create branch from resolved target
-git checkout "$TARGET" && git pull
-git checkout -b feature/<issue>-description
-
-# After commit, create PR/MR
-# GitLab:
-glab mr create --target-branch "$TARGET" --remove-source-branch
-# GitHub:
-gh pr create --base "$TARGET"
-```
+1. Call `ibm()` with no arguments. The tool detects platform, validates branch naming, verifies issue linkage, and resolves the target branch — all internally.
+2. If it returns errors or remediation steps, present them and **STOP**.
+3. If it passes, report the result (platform, issue number, branch, target) and continue.
 
 ## Remember
 
 - **No commits without an issue**
 - **No pushes without a branch**
 - **No merges without a PR/MR**
-- **Always target the resolved release branch (or `main` on GitHub if that is the resolved target)**
-- **Always resolve the target branch fresh at the start of new work**
-- **Always detect the platform before running CLI commands**
+- **Always target the branch the tool resolves** — never override with a guess

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -33,20 +33,10 @@ Create properly templated and labeled issues from a natural language prompt.
 /issue                         Infer from recent conversation context
 ```
 
-## Step 1: Detect Platform
+## Tools Used
+- `mcp__sdlc-server__work_item` — create issues cross-platform (handles GitHub/GitLab detection internally)
 
-```bash
-REMOTE_URL=$(git remote get-url origin 2>/dev/null)
-if echo "$REMOTE_URL" | grep -qi github; then
-  PLATFORM="github"; CLI="gh"
-elif echo "$REMOTE_URL" | grep -qi gitlab; then
-  PLATFORM="gitlab"; CLI="glab"
-fi
-```
-
-Or read from `.claude-project.md` if it exists.
-
-## Step 2: Parse Arguments
+## Step 1: Parse Arguments
 
 {{#if args}}
 Parse: `{{args}}`
@@ -66,7 +56,7 @@ Extract two things:
 - Mentions epic, phase, milestone, multi-part → `epic`
 - Ambiguous → ask the user
 
-## Step 3: Draft the Issue
+## Step 2: Draft the Issue
 
 Use the prompt (or conversation context) to fill in the appropriate template below. The agent should flesh out the template sections intelligently — don't just echo the prompt back. Think about what a spec-driven implementing agent would need.
 
@@ -242,7 +232,7 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 [Quantitative or qualitative measures of success]
 ```
 
-## Step 4: Determine Labels
+## Step 3: Determine Labels
 
 Labels use the `group::value` convention. Within each group, labels are mutually exclusive.
 
@@ -274,40 +264,15 @@ Assess and apply values for these groups using judgment. Do not pause to confirm
 
 Assess labels based on the content — do not ask the user to confirm each one. Use your judgment.
 
-## Step 5: Create the Issue
+## Step 4: Create the Issue
 
 Create immediately — do not ask for approval. Issues are cheap to edit and close. The user gave intent when they invoked `/issue`; the real review happens in the project board where the editing tools are better.
 
-Write the issue body to a temp file first, then create:
+Call `work_item` with the drafted title, body, and labels. The tool handles platform detection and issue creation internally — no `gh` or `glab` CLI calls.
 
-**GitHub:**
-```bash
-# Write body to temp file (avoids shell escaping issues with multi-line markdown)
-cat > /tmp/issue-body.md << 'BODY'
-<the filled-in template>
-BODY
+If a label doesn't exist on the repo, the tool or platform will report it. Offer to create missing labels via CLI as a one-time setup step (label CRUD MCP tool is planned but not yet available).
 
-gh issue create --title "<title>" --label "<comma-separated-labels>" --body-file /tmp/issue-body.md
-```
-
-**GitLab:**
-```bash
-glab issue create --title "<title>" --label "<comma-separated-labels>" --description "$(cat /tmp/issue-body.md)"
-```
-
-If a label doesn't exist on the repo, offer to create it:
-
-**GitHub:**
-```bash
-gh label create "type::feature" --description "Feature request" --color "0E8A16"
-```
-
-**GitLab:**
-```bash
-glab label create "type::feature" --description "Feature request" --color "#0E8A16"
-```
-
-## Step 6: Report
+## Step 5: Report
 
 Confirm creation with the issue number, URL, and a nudge to review:
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -16,6 +16,7 @@ Targeted code review via the `feature-dev:code-reviewer` subagent.
 ## Tools Used
 - `pr_diff` — unified diff for a PR/MR by number (platform-agnostic)
 - `pr_files` — changed-file list for a PR/MR by number
+- `spec_get` — fetch issue body as structured sections (platform-agnostic)
 
 ## Scope
 Parse `{{args}}` (default `branch`): `staged` (`git diff --cached`), `branch` (full diff vs base), `<filepath>` (single file), `mr <number>` / `pr <number>` (PR/MR by number).
@@ -26,7 +27,7 @@ Parse `{{args}}` (default `branch`): `staged` (`git diff --cached`), `branch` (f
    - `branch`: determine base (`release/*` or `main`), run `git diff <base>...HEAD`
    - `<filepath>`: `git diff HEAD -- <filepath>` plus read the full file
    - `mr <number>` / `pr <number>`: `pr_files({number})` for the path-level overview, then `pr_diff({number})` for the unified diff. Tools handle platform translation — no `gh`/`glab` calls.
-2. **Issue** — if branch name contains an issue number (e.g., `fix/76-description`), fetch via `gh issue view <N>` / `glab issue view <N>`.
+2. **Issue** — if branch name contains an issue number (e.g., `fix/76-description`), fetch via `spec_get({issue: N})`. The tool handles platform detection internally.
 3. **Intent** — `git log --oneline <base>...HEAD`.
 
 If the diff is empty, stop and tell the user there's nothing to review.


### PR DESCRIPTION
## Summary

Remove procedural bash logic (platform detection, raw gh/glab CLI calls) from skill files and route through MCP tools instead. Skills orchestrate, MCP tools enforce. Net -130 lines of procedural bloat.

## Changes

- **ibm**: Rewrote from 118 lines of bash to ~25 lines calling `ibm()` MCP tool
- **issue**: Removed platform detection block, replaced `gh/glab issue create` with `work_item` MCP tool
- **review**: Replaced `gh/glab issue view` with `spec_get` MCP tool
- **ccwork**: Replaced `gh issue create` with `work_item`, `gh issue view` with `spec_get`, updated orientation tour

## Linked Issues

Closes #351, Closes #352, Closes #353, Closes #354

## Test Plan

- `validate.sh` — 81/81 passed
- Code review — 2 findings (stale CLI refs in ccwork), both fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)