### PR TITLE
docs: add tool-skill-map + fix precheck agent behaviors

### DIFF
--- a/docs/tool-skill-map.md
+++ b/docs/tool-skill-map.md
@@ -1,0 +1,137 @@
+# Tool & Skill Map
+
+Everything surfaced to the user — skills invoked via `/command` and MCP tools called directly.
+
+```mermaid
+graph TB
+  root((Workflow))
+
+  root --> shipping
+  root --> wave
+  root --> stages
+  root --> tracking
+  root --> ops
+  root --> session
+
+  subgraph shipping ["Shipping"]
+    precheck([/precheck])
+    scp([/scp])
+    scpmr([/scpmr])
+    scpmmr([/scpmmr])
+    mmr([/mmr])
+    review([/review])
+    jfail([/jfail])
+  end
+
+  subgraph wave ["Wave Pattern"]
+    prepwaves([/prepwaves])
+    assesswaves([/assesswaves])
+    nextwave([/nextwave])
+    wavemachine([/wavemachine])
+  end
+
+  subgraph stages ["SDLC Stages"]
+    sdlc([/sdlc])
+    ddd([/ddd])
+    devspec([/devspec])
+    dod([/dod])
+  end
+
+  subgraph tracking ["Work Tracking"]
+    issue([/issue])
+    ibm([/ibm])
+    ccwork([/ccwork])
+  end
+
+  subgraph ops ["Ops & Context"]
+    nerf([/nerf])
+    wtf([/wtf])
+    wtf_now([/wtf-now])
+    wtf_happened([/wtf-happened])
+    wtf_imout([/wtf-imout])
+    disc([/disc])
+  end
+
+  subgraph session ["Session & UI"]
+    engage([/engage])
+    name([/name])
+    ccfold([/ccfold])
+    cryo([/cryo])
+    man([/man])
+    vox([/vox])
+    view([/view])
+    edit([/edit])
+    ping([/ping])
+    pong([/pong])
+  end
+
+  root --> direct
+
+  subgraph direct ["Direct MCP Tools"]
+    direction TB
+    subgraph direct_sdlc ["sdlc-server"]
+      pr_comment
+      ci_runs_for_branch
+      spec_acceptance_criteria
+      wave_dependency_graph
+    end
+    subgraph direct_campaign ["sdlc-server / campaign"]
+      campaign_init
+      campaign_show
+      campaign_dashboard_url
+      campaign_stage_start
+      campaign_stage_review
+      campaign_stage_complete
+      campaign_defer
+    end
+  end
+```
+
+---
+
+## Reverse Index: Skill -> MCP Tools
+
+What each skill calls under the hood.
+
+| Skill | MCP Tools |
+|-------|-----------|
+| `/assesswaves` | `spec_validate_structure`, `spec_dependencies`, `wave_topology` |
+| `/ccwork` | `spec_get`, `work_item` |
+| `/ddd` | `ddd_locate_domain_model`, `ddd_locate_sketchbook`, `ddd_summary`, `ddd_verify_committed` |
+| `/devspec` | `devspec_locate`, `devspec_summary`, `devspec_approve`, `devspec_finalize`, `devspec_parse_section_8`, `devspec_verify_approved` |
+| `/disc` | `disc_send`, `disc_read`, `disc_list`, `disc_resolve`, `disc_create_channel`, `disc_create_thread` |
+| `/dod` | `dod_load_manifest`, `dod_verify_deliverable`, `dod_run_test_suite`, `dod_check_coverage` |
+| `/ibm` | `ibm` |
+| `/issue` | `work_item` |
+| `/jfail` | `ci_run_status`, `ci_failed_jobs`, `ci_run_logs` |
+| `/mmr` | `pr_status`, `pr_diff`, `pr_wait_ci`, `pr_merge`, `ci_wait_run` |
+| `/nerf` | `nerf_status`, `nerf_mode`, `nerf_darts`, `nerf_budget`, `nerf_scope` |
+| `/nextwave` | `spec_validate_structure`, `wave_preflight`, `wave_planning`, `wave_flight`, `wave_flight_plan`, `wave_flight_done`, `wave_close_issue`, `wave_record_mr`, `wave_review`, `wave_complete`, `wave_waiting`, `wave_defer`, `wave_next_pending`, `wave_previous_merged`, `wave_show`, `flight_overlap`, `flight_partition`, `drift_files_changed`, `drift_check_path_exists`, `drift_check_symbol_exists` |
+| `/precheck` | `ibm`, `spec_validate_structure`, `disc_send` |
+| `/prepwaves` | `epic_sub_issues`, `spec_validate_structure`, `spec_dependencies`, `wave_compute`, `wave_topology`, `wave_init` |
+| `/review` | `pr_diff`, `pr_files` |
+| `/scp` | `ibm`, `pr_list`, `pr_create` |
+| `/scpmr` | *(delegates to /scp)* |
+| `/scpmmr` | *(delegates to /scp + /mmr)* |
+| `/sdlc` | `ibm`, `work_item` |
+| `/wavemachine` | `wave_show`, `wave_previous_merged`, `wave_next_pending`, `wave_health_check`, `wave_ci_trust_level`, `wave_waiting` |
+| `/wtf` | `wtf_freshell` |
+| `/wtf-happened` | `wtf_happened` |
+| `/wtf-imout` | `wtf_imout` |
+| `/wtf-now` | `wtf_now` |
+
+### No MCP tools (pure orchestration / UI)
+
+`/ccfold`, `/cryo`, `/edit`, `/engage`, `/man`, `/name`, `/ping`, `/pong`, `/view`, `/vox`
+
+---
+
+## Summary
+
+| Server | Total Tools | Skill-wrapped | Direct (no skill) |
+|--------|-------------|---------------|-------------------|
+| sdlc-server | 66 | 55 | 11 |
+| disc-server | 6 | 6 | 0 |
+| nerf-server | 5 | 5 | 0 |
+| wtf-server | 4 | 4 | 0 |
+| **Total** | **81** | **70** | **11** |

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -5,7 +5,9 @@ description: Pre-commit gate — verify branch/issue, run code-reviewer, present
 
 # Pre-Commit Gate
 
-Mandatory verification before any commit. Checks compliance, runs code review, presents the checklist, and **stops**. Does NOT commit/push/PR. Run when implementation is done — do not ask permission. The checklist is the approval gate.
+Mandatory verification before any commit. Checks compliance, runs code review, presents the checklist, and **stops**. Does NOT commit/push/PR.
+
+**IMPORTANT: When implementation is done, run this skill IMMEDIATELY. Do NOT ask "shall I run precheck?" or "ready for precheck?" — just start it. The checklist at the end is the approval gate; asking permission to START is a redundant pause.**
 
 ## Tools Used
 - `mcp__sdlc-server__ibm` — branch/issue workflow (no protected branch; branch linked to an open issue)
@@ -45,4 +47,4 @@ Ready for `/scp` / `/scpmr` / `/scpmmr` or rework.
 **`vox` (ALWAYS — not a fallback):** same info, conversational, 1-2 sentences, ending with "Ready for your call." Vox runs regardless of whether `disc_send` succeeded. Discord is for async visibility; vox is for immediate attention. Both are required.
 
 ## Rules
-No diff. No commit. No skipping code-reviewer. Honesty over speed — no checking items you haven't verified. **Linting is not testing** — passing lint/typecheck does not mean code works.
+No diff. No commit. No skipping code-reviewer. Honesty over speed — no checking items you haven't verified. **Linting is not testing** — passing lint/typecheck does not mean code works. **`vox` is ALWAYS called** — it is NOT a fallback for disc_send failure. Both notifications happen every time.


### PR DESCRIPTION
## Summary

Adds a Mermaid workflow diagram mapping all user-facing skills and direct MCP tools. Also fixes two precheck behavioral issues observed across the agent fleet.

## Changes

- New `docs/tool-skill-map.md` — vertical Mermaid `graph TB` with skills grouped into families (Shipping, Wave Pattern, SDLC Stages, Work Tracking, Ops & Context, Session & UI) plus direct MCP tools. Includes reverse index table and coverage stats.
- `skills/precheck/SKILL.md` — added bold IMPORTANT block telling agents to run precheck immediately without asking; added "vox is ALWAYS called" to Rules section.

## Linked Issues

Closes #360

## Test Plan

- `validate.sh` — 81/81 pass
- Mermaid syntax verified (removed orphan `comms` node caught in code review)