### PR TITLE
chore(vox): change default TTS voice to ono_anna

### DIFF
--- a/scripts/vox-tts
+++ b/scripts/vox-tts
@@ -22,7 +22,7 @@
 # Environment:
 #   VOX_COMMAND    Shell expression evaluated by bash -c (text on stdin, audio on stdout)
 #   VOX_ENDPOINT   HTTP TTS endpoint (default: http://archer:8004/v1/audio/speech)
-#   VOX_VOICE      Default voice name (default: aiden)
+#   VOX_VOICE      Default voice name (default: ono_anna)
 #   VOX_MODEL      TTS model name (default: qwen3-tts)
 #
 # Exit codes:
@@ -34,7 +34,7 @@ set -euo pipefail
 # --- Defaults -----------------------------------------------------------------
 
 DEFAULT_ENDPOINT="http://archer:8004/v1/audio/speech"
-DEFAULT_VOICE="aiden"
+DEFAULT_VOICE="ono_anna"
 DEFAULT_MODEL="qwen3-tts"
 
 # --- Parse args ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Change the default TTS voice from `aiden` to `ono_anna`.

## Changes

- `scripts/vox-tts`: `DEFAULT_VOICE` and comment updated

## Linked Issues

Closes #362

## Test Plan

- `validate.sh` — 81/81 pass
- Voice tested live via `vox` command