### PR TITLE
fix(wave-status): add waiting-ci heartbeat command

### DIFF
--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -40,6 +40,7 @@ from wave_status.state import (
     status_dir,
     store_flight_plan,
     waiting,
+    waiting_ci,
 )
 
 
@@ -145,6 +146,14 @@ def _cmd_waiting(args: argparse.Namespace) -> None:
     root = get_project_root()
     msg = args.msg if args.msg else ""
     waiting(root, msg=msg)
+    _regenerate_dashboard(root)
+
+
+def _cmd_waiting_ci(args: argparse.Namespace) -> None:
+    """Handle ``waiting-ci [detail]``."""
+    root = get_project_root()
+    detail = args.detail if args.detail else ""
+    waiting_ci(root, detail=detail)
     _regenerate_dashboard(root)
 
 
@@ -272,6 +281,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_wt = sub.add_parser("waiting", help="Set action to waiting-on-meatbag")
     p_wt.add_argument("msg", nargs="?", default="", help="Optional message")
     p_wt.set_defaults(func=_cmd_waiting)
+
+    # waiting-ci
+    p_wci = sub.add_parser("waiting-ci", help="Heartbeat during CI polling")
+    p_wci.add_argument("detail", nargs="?", default="", help="Optional detail string")
+    p_wci.set_defaults(func=_cmd_waiting_ci)
 
     # close-issue
     p_ci = sub.add_parser("close-issue", help="Close an issue by number")

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -438,6 +438,11 @@ def waiting(root: Path, msg: str = "") -> dict:
     return _set_action(root, "waiting-on-meatbag", "waiting-on-meatbag", msg)
 
 
+def waiting_ci(root: Path, detail: str = "") -> dict:
+    """Set current_action to ``waiting-ci`` — heartbeat during CI polling."""
+    return _set_action(root, "waiting-ci", "waiting-ci", detail)
+
+
 def flight(n: int, root: Path) -> dict:
     """Set flight *n* to ``running`` in ``flights.json`` [R-11].
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -40,6 +40,7 @@ from wave_status.state import (
     status_dir,
     store_flight_plan,
     waiting,
+    waiting_ci,
 )
 
 
@@ -366,6 +367,29 @@ class TestWaiting:
     def test_includes_message(self, project_root: Path) -> None:
         result = waiting(project_root, msg="Wave 1 complete.")
         assert result["current_action"]["detail"] == "Wave 1 complete."
+
+
+class TestWaitingCi:
+    """Tests for ``waiting_ci()`` — heartbeat during CI polling (#172)."""
+
+    def test_sets_action_to_waiting_ci(self, project_root: Path) -> None:
+        result = waiting_ci(project_root)
+        assert result["current_action"]["action"] == "waiting-ci"
+        assert result["current_action"]["label"] == "waiting-ci"
+
+    def test_includes_detail(self, project_root: Path) -> None:
+        result = waiting_ci(project_root, detail="PR #42 attempt 3: 2/5 passed")
+        assert result["current_action"]["detail"] == "PR #42 attempt 3: 2/5 passed"
+
+    def test_updates_last_updated(self, project_root: Path) -> None:
+        state_before = load_json(status_dir(project_root) / "state.json")
+        ts_before = state_before.get("last_updated", "")
+        waiting_ci(project_root, detail="poll")
+        state_after = load_json(status_dir(project_root) / "state.json")
+        ts_after = state_after.get("last_updated", "")
+        # Timestamp should be refreshed (or at minimum present)
+        assert ts_after >= ts_before
+        assert len(ts_after) > 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

New waiting_ci() function and waiting-ci CLI subcommand for heartbeat updates during CI polling. Called by mcp-server-sdlc pr_wait_ci handler to keep state.json timestamps fresh.

## Changes

- `src/wave_status/state.py`: New `waiting_ci()` function (4 lines).
- `src/wave_status/__main__.py`: New `_cmd_waiting_ci()` handler, `waiting-ci` subcommand.
- `tests/test_state.py`: New `TestWaitingCi` class with 3 tests.

## Test Results

- 87 Python tests pass
- 48 CLI tests pass

## Linked Issues

Closes Wave-Engineering/mcp-server-sdlc#172