### PR TITLE
fix(wave-status): add schema_version and migration to state.json

### DIFF
--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -31,6 +31,7 @@ from wave_status.state import (
     get_project_root,
     init_state,
     load_json,
+    load_state,
     planning,
     preflight,
     record_mr,
@@ -175,7 +176,7 @@ def _cmd_defer(args: argparse.Namespace) -> None:
     """Handle ``defer <desc> <risk>``."""
     root = get_project_root()
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     if state_data.get("current_wave") is None:
         raise ValueError("no active wave — all waves are complete")
     deferrals.defer(state_data, args.desc, args.risk, state_data["current_wave"])
@@ -187,7 +188,7 @@ def _cmd_defer_accept(args: argparse.Namespace) -> None:
     """Handle ``defer-accept <index>``."""
     root = get_project_root()
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     deferrals.accept(state_data, args.index)
     save_json(d / "state.json", state_data)
     _regenerate_dashboard(root)

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -127,6 +127,72 @@ def save_json(path: Path, data: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Schema versioning and migration
+# ---------------------------------------------------------------------------
+
+CURRENT_SCHEMA_VERSION = 2
+
+
+def migrate_state(data: dict) -> dict:
+    """Migrate *data* to the current schema version in place and return it.
+
+    Detects the schema version:
+    - **v0**: has ``completed_waves`` (Phase 1 list-based layout).
+      Structural migration: lists to dicts, attach ``mr_urls`` to the
+      last completed wave.
+    - **v1**: has ``waves`` but no ``schema_version`` (Phase 2 dict-based).
+      Stamp only — no structural changes.
+    - **v2**: has ``schema_version: 2``.  No-op.
+
+    Unknown keys (e.g. ``wavemachine_active``) are always preserved.
+    """
+    version = data.get("schema_version", 0)
+
+    # Already current — no-op.
+    if version >= CURRENT_SCHEMA_VERSION:
+        return data
+
+    # v0 → v2: structural migration from Phase 1 list-based layout.
+    if "completed_waves" in data and "waves" not in data:
+        completed_waves = data.pop("completed_waves", [])
+        completed_issues = data.pop("completed_issues", [])
+        merge_requests = data.pop("merge_requests", {})
+
+        waves: dict[str, dict] = {}
+        for wid in completed_waves:
+            waves[wid] = {"status": "completed", "mr_urls": {}}
+        # Attach merge_requests to the last completed wave.
+        if completed_waves and merge_requests:
+            waves[completed_waves[-1]]["mr_urls"] = merge_requests
+
+        issues: dict[str, dict] = {}
+        for n in completed_issues:
+            issues[str(n)] = {"status": "closed"}
+
+        data["waves"] = waves
+        data["issues"] = issues
+
+    # Stamp the version (covers both v0→v2 and v1→v2).
+    data["schema_version"] = CURRENT_SCHEMA_VERSION
+    return data
+
+
+def load_state(path: Path, *, write_back: bool = True) -> dict:
+    """Load ``state.json``, auto-migrate, and optionally write back.
+
+    This is the canonical way to read ``state.json``.  Every call site
+    that previously used ``load_json(d / "state.json")`` should use this
+    instead.
+    """
+    data = load_json(path)
+    before_version = data.get("schema_version", 0)
+    data = migrate_state(data)
+    if write_back and data.get("schema_version", 0) != before_version:
+        save_json(path, data)
+    return data
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
@@ -372,7 +438,7 @@ def store_flight_plan(flights_data: list, root: Path) -> None:
     (e.g. ``[{"issues": [13, 1], "status": "pending"}, ...]``).
     """
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     current_wave = state_data.get("current_wave")
     if current_wave is None:
         raise ValueError(
@@ -388,7 +454,7 @@ def store_flight_plan(flights_data: list, root: Path) -> None:
 def _set_action(root: Path, action: str, label: str, detail: str = "") -> dict:
     """Update ``current_action`` in state.json and return the state dict."""
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     state_data["current_action"] = {
         "action": action,
         "label": label,
@@ -407,7 +473,7 @@ def preflight(root: Path) -> dict:
 def planning(root: Path) -> dict:
     """Set current_action to ``planning`` and current wave to ``in_progress`` [R-05]."""
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     current_wave = state_data.get("current_wave")
 
     state_data["current_action"] = {
@@ -428,7 +494,7 @@ def planning(root: Path) -> dict:
 def review(root: Path) -> dict:
     """Set current_action to ``post-wave-review`` [R-05]."""
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     current_wave = state_data.get("current_wave")
     return _set_action(root, "post-wave-review", "post-wave-review", current_wave or "")
 
@@ -450,7 +516,7 @@ def flight(n: int, root: Path) -> dict:
     Also sets ``current_action`` to ``in-flight``.
     """
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     current_wave = state_data.get("current_wave")
     if current_wave is None:
         raise ValueError(
@@ -504,7 +570,7 @@ def flight_done(n: int, root: Path) -> dict:
     Also sets ``current_action`` to ``merging``.
     """
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     current_wave = state_data.get("current_wave")
     if current_wave is None:
         raise ValueError(
@@ -550,7 +616,7 @@ def complete(root: Path) -> dict:
     Also sets ``current_action`` to ``idle``.
     """
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     plan_data = load_json(d / "phases-waves.json")
     current_wave = state_data.get("current_wave")
 
@@ -585,7 +651,7 @@ def close_issue(n: int, root: Path) -> dict:
     Raises ``ValueError`` if the issue does not exist in the plan.
     """
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     plan_data = load_json(d / "phases-waves.json")
 
     valid_issues = _all_issue_numbers(plan_data)
@@ -610,7 +676,7 @@ def record_mr(issue: int, mr: str, root: Path) -> dict:
     ``mr_urls`` [R-08].
     """
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json")
     current_wave = state_data.get("current_wave")
     if current_wave is None:
         raise ValueError(
@@ -637,7 +703,7 @@ def show(root: Path) -> dict:
     **Read-only** — no files are modified, no dashboard is regenerated.
     """
     d = status_dir(root)
-    state_data = load_json(d / "state.json")
+    state_data = load_state(d / "state.json", write_back=False)
     plan_data = load_json(d / "phases-waves.json")
     flights_data = load_json(d / "flights.json")
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -22,6 +22,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from wave_status.state import (
+    CURRENT_SCHEMA_VERSION,
     close_issue,
     complete,
     ensure_status_dir,
@@ -31,6 +32,8 @@ from wave_status.state import (
     html_path,
     init_state,
     load_json,
+    load_state,
+    migrate_state,
     planning,
     preflight,
     record_mr,
@@ -208,6 +211,115 @@ class TestAtomicJsonIO:
         with open(path) as f:
             data = json.load(f)
         assert data == {"hello": "world"}
+
+
+# ---------------------------------------------------------------------------
+# migrate_state / load_state — schema versioning (#174)
+# ---------------------------------------------------------------------------
+
+class TestMigrateState:
+    """Tests for ``migrate_state()`` and ``load_state()`` — schema versioning."""
+
+    def test_v0_to_v2_structural(self) -> None:
+        """v0 (Phase 1 list-based) → v2: lists converted to dicts."""
+        v0 = {
+            "completed_waves": ["w1", "w2"],
+            "completed_issues": [1, 2, 3],
+            "merge_requests": {
+                "1": "https://github.com/org/repo/pull/10",
+                "2": "https://github.com/org/repo/pull/11",
+            },
+            "current_wave": "w3",
+            "current_action": {"action": "idle", "label": "idle", "detail": ""},
+            "wavemachine_active": True,
+        }
+        result = migrate_state(v0)
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        # Lists converted to dicts.
+        assert "completed_waves" not in result
+        assert "completed_issues" not in result
+        assert "merge_requests" not in result
+        assert result["waves"]["w1"]["status"] == "completed"
+        assert result["waves"]["w2"]["status"] == "completed"
+        # mr_urls attached to last completed wave.
+        assert result["waves"]["w2"]["mr_urls"]["1"] == "https://github.com/org/repo/pull/10"
+        assert result["issues"]["1"]["status"] == "closed"
+        assert result["issues"]["3"]["status"] == "closed"
+        # Unknown key preserved.
+        assert result["wavemachine_active"] is True
+
+    def test_v1_to_v2_stamp(self) -> None:
+        """v1 (has ``waves`` but no schema_version) → v2: stamp only."""
+        v1 = {
+            "current_wave": "w1",
+            "waves": {"w1": {"status": "in_progress", "mr_urls": {}}},
+            "issues": {"10": {"status": "open"}},
+            "current_action": {"action": "idle", "label": "idle", "detail": ""},
+        }
+        result = migrate_state(v1)
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        # Structure unchanged.
+        assert result["waves"]["w1"]["status"] == "in_progress"
+        assert result["issues"]["10"]["status"] == "open"
+
+    def test_v2_to_v2_noop(self) -> None:
+        """v2 → v2: no changes."""
+        v2 = {
+            "schema_version": 2,
+            "current_wave": "w1",
+            "waves": {"w1": {"status": "pending", "mr_urls": {}}},
+            "issues": {},
+            "current_action": {"action": "idle", "label": "idle", "detail": ""},
+        }
+        import copy
+        original = copy.deepcopy(v2)
+        result = migrate_state(v2)
+        assert result == original
+
+    def test_write_back(self, project_root: Path) -> None:
+        """load_state with write_back=True persists the migration."""
+        d = status_dir(project_root)
+        # Manually write a v1 state (no schema_version).
+        state_path = d / "state.json"
+        v1 = load_json(state_path)
+        v1.pop("schema_version", None)
+        save_json(state_path, v1)
+        # Confirm no schema_version on disk.
+        assert "schema_version" not in load_json(state_path)
+        # load_state should migrate and write back.
+        data = load_state(state_path, write_back=True)
+        assert data["schema_version"] == CURRENT_SCHEMA_VERSION
+        # Verify it was persisted.
+        on_disk = load_json(state_path)
+        assert on_disk["schema_version"] == CURRENT_SCHEMA_VERSION
+
+    def test_unknown_keys_preserved(self) -> None:
+        """Migration preserves keys it does not recognize."""
+        v1 = {
+            "current_wave": "w1",
+            "waves": {"w1": {"status": "pending", "mr_urls": {}}},
+            "issues": {},
+            "current_action": {"action": "idle", "label": "idle", "detail": ""},
+            "wavemachine_active": True,
+            "custom_field": [1, 2, 3],
+        }
+        result = migrate_state(v1)
+        assert result["wavemachine_active"] is True
+        assert result["custom_field"] == [1, 2, 3]
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+
+    def test_idempotent(self) -> None:
+        """Calling migrate_state twice produces the same result."""
+        v1 = {
+            "current_wave": "w1",
+            "waves": {"w1": {"status": "pending", "mr_urls": {}}},
+            "issues": {},
+            "current_action": {"action": "idle", "label": "idle", "detail": ""},
+        }
+        first = migrate_state(v1)
+        import copy
+        second = migrate_state(copy.deepcopy(first))
+        assert first == second
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds schema versioning to state.json with automatic migration. Detects v0 (Phase 1 list-based), v1 (dict-based without version), and v2 (versioned), migrating transparently on load.

## Changes

- `src/wave_status/state.py`: Added `CURRENT_SCHEMA_VERSION = 2`, `migrate_state()`, `load_state()` wrapper. Replaced all 10 `load_json(d / "state.json")` call sites. `show()` uses `write_back=False`.
- `src/wave_status/__main__.py`: Added `load_state` import. Replaced 2 call sites.
- `tests/test_state.py`: New `TestMigrateState` class with 6 tests.

## Test Results

- 93 state tests, 48 CLI tests pass

## Linked Issues

Closes Wave-Engineering/mcp-server-sdlc#174