### PR TITLE
chore(precheck): add trivy vulnerability scan to precheck gate

### DIFF
--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -15,12 +15,19 @@ Mandatory verification before any commit. Checks compliance, runs code review, p
 - `mcp__disc-server__disc_send` — post approval request to `#precheck` (channel `1491195025198157834`)
 
 ## Procedure
-`ibm()` (stop on fail) → `spec_validate_structure(N)` → run repo validation (`validate.sh`/`make test`/`pytest`/`npm test`); fix failures first → launch `feature-dev:code-reviewer` via Agent over all changed files, WAIT, fix high+ findings → present the checklist → **notify BJ** (see "The Notification" below): `disc_send` to `#precheck` **then** `vox` locally — **always do both**. → **STOP.** Wait for `/scp`/`/scpmr`/`/scpmmr`/affirmative. Negative/rework → return to work. If `disc_send` fails (MCP unavailable, network), still do `vox` — still STOP and wait for approval. Never bypass the STOP on notification failure.
+`ibm()` (stop on fail) → `spec_validate_structure(N)` → run repo validation (`validate.sh`/`make test`/`pytest`/`npm test`); fix failures first → **dependency vulnerability scan** (see below) → launch `feature-dev:code-reviewer` via Agent over all changed files, WAIT, fix high+ findings → present the checklist → **notify BJ** (see "The Notification" below): `disc_send` to `#precheck`, **then `vox`** — **ALWAYS do both** → **STOP.** Wait for `/scp`/`/scpmr`/`/scpmmr`/affirmative. Negative/rework → return to work. If `disc_send` fails (MCP unavailable, network), still do `vox` — still STOP and wait for approval. Never bypass the STOP on notification failure.
+
+## Dependency Vulnerability Scan
+Run `trivy fs --scanners vuln --severity HIGH,CRITICAL --format json --quiet .` on the project root. Parse the JSON output (each finding has a `FixedVersion` field — empty string means no fix available).
+- **Zero findings** → checklist item passes, move on.
+- **Findings exist** → report each finding (package, CVE, severity, fixed version if any) as a deferred checklist item. Do NOT auto-upgrade dependencies — the user approves the codebase state at the gate. Do NOT block the gate on vulnerabilities with no available fix.
+- **`trivy` not installed** → skip with a warning on the checklist: `[SKIPPED — trivy not installed]`. Do not fail the gate.
 
 ## The Checklist (full every time; a checkmark means VERIFIED by reading the codebase)
 **Context:** Project | Issue #N — title | Branch `feature/N-...` → `main`
 - [ ] Implementation (AC verified) — [ ] TODOs (searched+addressed) — [ ] Docs (reviewed+updated) — [ ] Validation (actually ran)
 - [ ] New tests (cover new code) — [ ] All tests pass (entire suite) — [ ] Scripts executed (linting is NOT testing) — [ ] Code review (high+ fixed)
+- [ ] Dependencies (trivy: 0 HIGH/CRITICAL, or exceptions documented, or [SKIPPED])
 
 **Summary:** `[codebase]` `[docs]` `[tests]` `[config]`. **Findings:** `[fixed]` / `[deferred]` / "(none)".
 
@@ -44,7 +51,7 @@ Ready for `/scp` / `/scpmr` / `/scpmmr` or rework.
 — **<dev-name>** <dev-avatar> (<dev-team>)
 ```
 
-**`vox` (ALWAYS — not a fallback):** same info, conversational, 1-2 sentences, ending with "Ready for your call." Vox runs regardless of whether `disc_send` succeeded. Discord is for async visibility; vox is for immediate attention. Both are required.
+**`vox`:** same info, conversational, 1-2 sentences, ending with "Ready for your call."
 
 ## Rules
 No diff. No commit. No skipping code-reviewer. Honesty over speed — no checking items you haven't verified. **Linting is not testing** — passing lint/typecheck does not mean code works. **`vox` is ALWAYS called** — it is NOT a fallback for disc_send failure. Both notifications happen every time.


### PR DESCRIPTION
## Summary

Adds a dependency vulnerability scan step to the precheck gate, using trivy to check for HIGH/CRITICAL CVEs before code review.

## Changes

- Insert vulnerability scan step in procedure between repo validation and code-reviewer
- New "Dependency Vulnerability Scan" section with trivy instructions and fail-open design
- New Dependencies checklist line with pass/defer/skip states
- Sync minor vox wording from live skill

## Linked Issues

Closes #374

## Test Plan

- Verified repo validation passes (81/81)
- Trivy scan ran clean (0 HIGH/CRITICAL)
- Code review: fixed naming ("currency"→"vulnerability") and removed auto-upgrade side effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)