### PR TITLE
feat(install): smart external dependency checking for install/sync

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -1,0 +1,42 @@
+{
+  "deps": {
+    "context-crystallizer": {
+      "type": "repo",
+      "description": "Hook scripts for context crystallization (PostToolUse, SessionStart, SubagentStop)",
+      "required_by": "settings.json hooks",
+      "files": [
+        "~/.claude/context-crystallizer/hooks/post-tool-use.sh",
+        "~/.claude/context-crystallizer/hooks/session-start.sh",
+        "~/.claude/context-crystallizer/hooks/subagent-stop.sh"
+      ],
+      "clone_url": "git@github.com:Wave-Engineering/context-crystallizer.git",
+      "clone_dest": "~/.claude/context-crystallizer",
+      "optional": false
+    },
+    "discord-config": {
+      "type": "config",
+      "description": "Channel name-to-ID map for disc-server resolution (avoids API calls)",
+      "required_by": "disc-server channel name resolution",
+      "files": [
+        "~/.claude/discord.json"
+      ],
+      "install": "Copy from docs/discord.example.json or ask BJ for the current channel map",
+      "optional": true
+    }
+  },
+  "commands": [
+    { "name": "curl",       "required_by": "MCP install scripts" },
+    { "name": "jq",         "required_by": "settings.json merge, MCP install" },
+    { "name": "bun",        "required_by": "MCP server builds" },
+    { "name": "gh",         "required_by": "GitHub CLI (issues, PRs, releases)" },
+    { "name": "glab",       "required_by": "GitLab CLI (issues, MRs)" },
+    { "name": "python3",    "required_by": "Package builds (zipapp)" },
+    { "name": "shellcheck", "required_by": "Script validation" },
+    { "name": "shfmt",      "required_by": "Script formatting" },
+    { "name": "trivy",      "required_by": "Dependency vulnerability scan (precheck)", "optional": true }
+  ],
+  "secrets": [
+    { "path": "~/secrets/slack-bot-token",   "required_by": "/ping skill" },
+    { "path": "~/secrets/discord-bot-token", "required_by": "disc-server and discord-watcher MCPs" }
+  ]
+}

--- a/install
+++ b/install
@@ -348,6 +348,14 @@ if [[ "$CHECK_MODE" == true ]]; then
 		fi
 	fi
 
+	# External dependencies
+	# shellcheck source=scripts/ci/check-deps.sh
+	source "$REPO_DIR/scripts/ci/check-deps.sh"
+	# shellcheck disable=SC2119  # intentionally no --install arg in check mode
+	if ! check_deps; then
+		drifted=$((drifted + 1))
+	fi
+
 	echo ""
 	echo "══════════════════════════════════════════"
 	if [[ $drifted -eq 0 ]]; then
@@ -519,33 +527,12 @@ else
 	echo "Installation complete."
 fi
 
-# --- Dependency check ---------------------------------------------------------
-echo ""
-echo "Dependency check:"
-missing=()
-for cmd in curl jq bun glab gh python3 shellcheck shfmt; do
-	if command -v "$cmd" &>/dev/null; then
-		info "$cmd $(command -v "$cmd")"
-	else
-		warn "$cmd — NOT FOUND"
-		missing+=("$cmd")
-	fi
-done
-
-if [[ -f "$HOME/secrets/slack-bot-token" ]]; then
-	info "slack-bot-token found"
+# --- Dependency check (via check-deps.sh) ------------------------------------
+# shellcheck source=scripts/ci/check-deps.sh
+source "$REPO_DIR/scripts/ci/check-deps.sh"
+if [[ "$DRY_RUN" == true ]]; then
+	# shellcheck disable=SC2119  # intentionally no --install arg in dry-run
+	check_deps
 else
-	warn "$HOME/secrets/slack-bot-token — NOT FOUND (needed for /ping)"
-fi
-
-if [[ -f "$HOME/secrets/discord-bot-token" ]]; then
-	info "discord-bot-token found"
-else
-	warn "$HOME/secrets/discord-bot-token — NOT FOUND (needed for /disc and discord-watcher)"
-fi
-
-if [[ ${#missing[@]} -gt 0 ]]; then
-	echo ""
-	warn "Missing dependencies: ${missing[*]}"
-	echo "  Install them before using the skills that require them."
+	check_deps --install
 fi

--- a/scripts/ci/check-deps.sh
+++ b/scripts/ci/check-deps.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# check-deps.sh — Verify external dependencies for the Claude Code workflow
+#
+# Sourceable library exporting check_deps(). Designed to be sourced by
+# install and sync.sh — not executed directly.
+#
+# Three verification layers:
+#   1. Auto-scan settings.template.json hooks for referenced file paths
+#   2. Read deps.json manifest for declared file/repo/config dependencies
+#   3. Check CLI commands and secrets from deps.json
+#
+# Expects REPO_DIR to be set by the sourcing script. Uses info/warn/ok/skip
+# helpers if defined, otherwise defines minimal versions.
+
+# Guard: define output helpers if the sourcing script hasn't already
+type info &>/dev/null || info() { echo "  [+] $*"; }
+type warn &>/dev/null || warn() { echo "  [!] $*"; }
+type ok &>/dev/null || ok() { echo "  [✓] $*"; }
+type skip &>/dev/null || skip() { echo "  [-] $*"; }
+type drift &>/dev/null || drift() { echo "  [~] $*"; }
+
+# Expand ~ to $HOME in a path string
+_expand_home() {
+	local p="$1"
+	echo "${p/#\~/$HOME}"
+}
+
+# ---------------------------------------------------------------------------
+# Layer 1: Auto-scan settings.template.json hook commands
+# ---------------------------------------------------------------------------
+_check_hook_scripts() {
+	local template="$REPO_DIR/config/settings.template.json"
+	if [[ ! -f "$template" ]]; then
+		skip "settings.template.json not found — skipping hook scan"
+		return 0
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		warn "jq not found — cannot scan settings.template.json hooks"
+		return 1
+	fi
+
+	local missing=0
+	# Extract all command strings from hooks (ignoring _comment keys)
+	local commands
+	commands=$(jq -r '
+		.hooks // {} | to_entries[]
+		| select(.key != "_comment")
+		| .value[]
+		| .hooks[]
+		| select(.type == "command")
+		| .command
+	' "$template" 2>/dev/null)
+
+	while IFS= read -r cmd; do
+		[[ -z "$cmd" ]] && continue
+		# Extract the executable path — first token (e.g. "bash script.sh" → "bash",
+		# but bare paths like "~/.claude/hook.sh" → the path itself).
+		# For "interpreter script" patterns, check the second token if the first
+		# is a known interpreter.
+		local script_path first_token
+		first_token=$(echo "$cmd" | awk '{print $1}')
+		case "$first_token" in
+		bash | sh | zsh | env)
+			# Interpreter prefix — the actual script is the last non-flag token
+			script_path=$(echo "$cmd" | awk '{for(i=NF;i>=1;i--) if($i !~ /^-/) {print $i; exit}}')
+			;;
+		*)
+			script_path="$first_token"
+			;;
+		esac
+		script_path=$(_expand_home "$script_path")
+
+		if [[ -f "$script_path" ]]; then
+			ok "hook: $script_path"
+		else
+			warn "hook: $script_path — NOT FOUND"
+			warn "  Referenced in settings.template.json hooks"
+			missing=$((missing + 1))
+		fi
+	done <<<"$commands"
+
+	return $missing
+}
+
+# ---------------------------------------------------------------------------
+# Layer 2: deps.json manifest — file/repo/config dependencies
+# ---------------------------------------------------------------------------
+_check_manifest_deps() {
+	local manifest="$REPO_DIR/deps.json"
+	if [[ ! -f "$manifest" ]]; then
+		skip "deps.json not found — skipping manifest check"
+		return 0
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		warn "jq not found — cannot read deps.json"
+		return 1
+	fi
+
+	local missing=0
+
+	while IFS= read -r dep_name; do
+		[[ -z "$dep_name" ]] && continue
+		local dep_type dep_optional dep_required_by
+		dep_type=$(jq -r ".deps[\"$dep_name\"].type" "$manifest")
+		dep_optional=$(jq -r ".deps[\"$dep_name\"].optional // false" "$manifest")
+		dep_required_by=$(jq -r ".deps[\"$dep_name\"].required_by // empty" "$manifest")
+
+		local all_present=true
+		while IFS= read -r file_path; do
+			[[ -z "$file_path" ]] && continue
+			local expanded
+			expanded=$(_expand_home "$file_path")
+			if [[ ! -e "$expanded" ]]; then
+				all_present=false
+				break
+			fi
+		done < <(jq -r ".deps[\"$dep_name\"].files[]" "$manifest")
+
+		if [[ "$all_present" == true ]]; then
+			ok "$dep_name ($dep_type)"
+		else
+			if [[ "$dep_optional" == "true" ]]; then
+				skip "$dep_name ($dep_type) — not installed (optional)"
+			else
+				warn "$dep_name ($dep_type) — NOT FOUND"
+				missing=$((missing + 1))
+			fi
+			[[ -n "$dep_required_by" ]] && warn "  Required by: $dep_required_by"
+			# Show install hint: structured clone for repos, freeform hint for others
+			local clone_url clone_dest install_hint
+			clone_url=$(jq -r ".deps[\"$dep_name\"].clone_url // empty" "$manifest")
+			clone_dest=$(jq -r ".deps[\"$dep_name\"].clone_dest // empty" "$manifest")
+			install_hint=$(jq -r ".deps[\"$dep_name\"].install // empty" "$manifest")
+			if [[ -n "$clone_url" && -n "$clone_dest" ]]; then
+				warn "  Install: git clone $clone_url $clone_dest"
+			elif [[ -n "$install_hint" ]]; then
+				warn "  Install: $install_hint"
+			fi
+		fi
+	done < <(jq -r '.deps | keys[]' "$manifest")
+
+	return $missing
+}
+
+# ---------------------------------------------------------------------------
+# Layer 3: CLI commands from deps.json
+# ---------------------------------------------------------------------------
+_check_commands() {
+	local manifest="$REPO_DIR/deps.json"
+	if [[ ! -f "$manifest" ]] || ! command -v jq &>/dev/null; then
+		return 0
+	fi
+
+	local missing=0
+	local count
+	count=$(jq '.commands | length' "$manifest")
+
+	for ((i = 0; i < count; i++)); do
+		local cmd_name cmd_required_by cmd_optional
+		cmd_name=$(jq -r ".commands[$i].name" "$manifest")
+		cmd_required_by=$(jq -r ".commands[$i].required_by // empty" "$manifest")
+		cmd_optional=$(jq -r ".commands[$i].optional // false" "$manifest")
+
+		if command -v "$cmd_name" &>/dev/null; then
+			ok "$cmd_name ($(command -v "$cmd_name"))"
+		elif [[ "$cmd_optional" == "true" ]]; then
+			skip "$cmd_name — not installed (optional, needed for: $cmd_required_by)"
+		else
+			warn "$cmd_name — NOT FOUND (needed for: $cmd_required_by)"
+			missing=$((missing + 1))
+		fi
+	done
+
+	return $missing
+}
+
+# ---------------------------------------------------------------------------
+# Layer 4: Secrets from deps.json
+# ---------------------------------------------------------------------------
+_check_secrets() {
+	local manifest="$REPO_DIR/deps.json"
+	if [[ ! -f "$manifest" ]] || ! command -v jq &>/dev/null; then
+		return 0
+	fi
+
+	local missing=0
+	local count
+	count=$(jq '.secrets | length' "$manifest")
+
+	for ((i = 0; i < count; i++)); do
+		local secret_path secret_required_by
+		secret_path=$(jq -r ".secrets[$i].path" "$manifest")
+		secret_required_by=$(jq -r ".secrets[$i].required_by // empty" "$manifest")
+		secret_path=$(_expand_home "$secret_path")
+
+		if [[ -f "$secret_path" ]]; then
+			ok "$(basename "$secret_path")"
+		else
+			warn "$(basename "$secret_path") — NOT FOUND ($secret_path)"
+			[[ -n "$secret_required_by" ]] && warn "  Needed for: $secret_required_by"
+			missing=$((missing + 1))
+		fi
+	done
+
+	return $missing
+}
+
+# ---------------------------------------------------------------------------
+# Public API: check_deps [--install]
+#
+#   --install  Attempt to install missing repo-type deps (used by install.sh)
+#
+# Returns: number of missing required dependencies
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC2120  # $1 is optional --install flag
+check_deps() {
+	local do_install=false
+	[[ "${1:-}" == "--install" ]] && do_install=true
+
+	local total_missing=0
+
+	echo ""
+	echo "External Dependencies"
+	echo "══════════════════════════════════════════"
+
+	echo ""
+	echo "Hook Scripts (auto-scanned from settings.template.json)"
+	echo "──────────────────────────────────────────"
+	_check_hook_scripts || total_missing=$((total_missing + $?))
+
+	echo ""
+	echo "Declared Dependencies (deps.json)"
+	echo "──────────────────────────────────────────"
+	_check_manifest_deps || total_missing=$((total_missing + $?))
+
+	# Attempt install for repo-type deps if requested
+	if [[ "$do_install" == true ]] && command -v jq &>/dev/null && [[ -f "$REPO_DIR/deps.json" ]]; then
+		while IFS= read -r dep_name; do
+			[[ -z "$dep_name" ]] && continue
+			local dep_type dep_optional clone_url clone_dest
+			dep_type=$(jq -r ".deps[\"$dep_name\"].type" "$REPO_DIR/deps.json")
+			dep_optional=$(jq -r ".deps[\"$dep_name\"].optional // false" "$REPO_DIR/deps.json")
+
+			[[ "$dep_type" != "repo" ]] && continue
+			[[ "$dep_optional" == "true" ]] && continue
+
+			clone_url=$(jq -r ".deps[\"$dep_name\"].clone_url // empty" "$REPO_DIR/deps.json")
+			clone_dest=$(jq -r ".deps[\"$dep_name\"].clone_dest // empty" "$REPO_DIR/deps.json")
+			[[ -z "$clone_url" || -z "$clone_dest" ]] && continue
+
+			clone_dest=$(_expand_home "$clone_dest")
+
+			# Check if already installed
+			local all_present=true
+			while IFS= read -r file_path; do
+				[[ -z "$file_path" ]] && continue
+				local expanded
+				expanded=$(_expand_home "$file_path")
+				if [[ ! -e "$expanded" ]]; then
+					all_present=false
+					break
+				fi
+			done < <(jq -r ".deps[\"$dep_name\"].files[]" "$REPO_DIR/deps.json")
+
+			if [[ "$all_present" == false ]]; then
+				echo ""
+				info "Installing $dep_name..."
+				if git clone "$clone_url" "$clone_dest"; then
+					ok "$dep_name installed"
+				else
+					warn "$dep_name install failed — run manually:"
+					warn "  git clone $clone_url $clone_dest"
+				fi
+			fi
+		done < <(jq -r '.deps | keys[]' "$REPO_DIR/deps.json")
+	fi
+
+	echo ""
+	echo "CLI Tools"
+	echo "──────────────────────────────────────────"
+	_check_commands || total_missing=$((total_missing + $?))
+
+	echo ""
+	echo "Secrets"
+	echo "──────────────────────────────────────────"
+	_check_secrets || total_missing=$((total_missing + $?))
+
+	echo ""
+	echo "══════════════════════════════════════════"
+	if [[ $total_missing -eq 0 ]]; then
+		echo "All external dependencies satisfied."
+	else
+		echo "$total_missing required dependency/dependencies missing."
+	fi
+
+	return $total_missing
+}

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -78,7 +78,7 @@ else
 				info "$rel (not a shell script — skipped)"
 				continue
 			fi
-			if shellcheck "$script" 2>&1; then
+			if shellcheck -x "$script" 2>&1; then
 				info "$rel"
 				PASS=$((PASS + 1))
 			else

--- a/sync.sh
+++ b/sync.sh
@@ -220,11 +220,22 @@ echo ""
 echo "══════════════════════════════════════════"
 
 if [[ ${#changed_installed[@]} -eq 0 ]]; then
-	echo "Everything in sync. Nothing to pull."
-	exit 0
+	echo "All files in sync."
+else
+	echo "${#changed_installed[@]} file(s) differ."
 fi
 
-echo "${#changed_installed[@]} file(s) differ."
+# External dependency check (always runs in --check mode)
+if [[ "$CHECK_ONLY" == true ]]; then
+	# shellcheck source=scripts/ci/check-deps.sh
+	source "$REPO_DIR/scripts/ci/check-deps.sh"
+	# shellcheck disable=SC2119  # intentionally no --install arg
+	check_deps || true
+fi
+
+if [[ ${#changed_installed[@]} -eq 0 ]]; then
+	exit 0
+fi
 
 if [[ "$CHECK_ONLY" == true ]]; then
 	echo "Run ./sync.sh to pull changes into the repo."


### PR DESCRIPTION
## Summary

Adds external dependency verification to `install` and `sync.sh` so gaps between what config references and what's actually installed are surfaced immediately — not discovered at runtime via cryptic hook errors.

## Changes

- **`deps.json`** — New manifest declaring external deps: repos (context-crystallizer), configs (discord.json), CLI tools (curl, jq, bun, etc.), and secrets
- **`scripts/ci/check-deps.sh`** — Shared library exporting `check_deps()`. Two verification layers: auto-scans `settings.template.json` hooks for referenced file paths, reads `deps.json` for declared deps
- **`install`** — Replaced hardcoded dep check with `check_deps()`. Wired into `--check` mode and post-install. Repo-type deps auto-installed via structured `git clone` (no eval)
- **`sync.sh`** — Wired `check_deps()` into `--check` mode
- **`scripts/ci/validate.sh`** — Added `-x` flag to shellcheck so it follows source directives

## Linked Issues

Closes #376

## Test Plan

- Ran `./install --check` — all deps reported correctly
- Temporarily removed context-crystallizer hook → correctly reported as MISSING by both auto-scan and manifest layers
- `./sync.sh --check` — dep status appended to drift report
- `./scripts/ci/validate.sh` — 83 passed, 0 failed
- `shellcheck -x` passes on all modified scripts
- `trivy fs` — 0 HIGH/CRITICAL findings