### PR TITLE
chore(skills): move wtf skills from mcp-server-wtf into this repo

### DIFF
--- a/skills/wtf-happened/SKILL.md
+++ b/skills/wtf-happened/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: wtf-happened
+description: Retrieve the WTF incident timeline and generate a runbook
+---
+
+# /wtf happened — Get the Incident Timeline
+
+Retrieve a distilled timeline of the current troubleshooting incident and
+generate a runbook skeleton. Returns a concise summary by default, or the
+full untruncated timeline on request.
+
+## Resolve Intent
+
+Parse the invocation arguments:
+
+- **No arguments** — return the summary timeline (default, max 50 lines).
+- **`full`** — return the full timeline with no truncation.
+
+## Steps
+
+### 1. Call wtf_happened
+
+Call the `wtf_happened` MCP tool with the appropriate detail level:
+
+**Default (no args):**
+```json
+{}
+```
+
+**Full mode (`/wtf happened full`):**
+```json
+{
+  "detail": "full"
+}
+```
+
+### 2. Present the result
+
+Display the returned Markdown timeline directly to the user. The tool
+response includes a header with duration, entry counts, and status,
+followed by a numbered timeline of classified events.
+
+If a runbook was generated, note the file path:
+
+> Runbook written to `.wtf/runbook.md`
+
+### 3. Offer next steps
+
+After presenting the timeline, briefly suggest:
+
+- `/wtf now "<observation>"` to keep recording
+- `wtf_freshell` to archive and start a new incident
+- `/view .wtf/runbook.md` to review the generated runbook

--- a/skills/wtf-imout/SKILL.md
+++ b/skills/wtf-imout/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: wtf-imout
+description: Suspend the WTF troubleshooting session (preserves data)
+---
+
+# /wtf imout — Suspend Troubleshooting Session
+
+Stop recording tool calls but preserve all captured data for later analysis.
+
+## Steps
+
+1. **Call the `wtf_imout` MCP tool** with no arguments.
+
+2. **Parse the response** and report to the user:
+   - If `ok: true` → "Recording suspended. Incident {incident_id} preserved for triage via `wtf_happened`."
+   - If `ok: false` → "{message}" (e.g., "No active incident to suspend.")
+
+## Important
+
+- This does NOT delete captured data — it only stops future captures
+- The suspended incident can still be viewed with `wtf_happened`
+- Starting a new `/wtf` session will create a new incident (the suspended one remains archived)

--- a/skills/wtf-now/SKILL.md
+++ b/skills/wtf-now/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: wtf-now
+description: Record a manual journal entry in the WTF flight recorder
+---
+
+# /wtf now — Record a Manual Journal Entry
+
+Add a manual observation to the WTF flight recorder journal. The entry is
+stored as a crafted (intentional) record. Classification of the entry's
+action type is handled by the background classifier — do not attempt to
+infer it here.
+
+## Resolve Intent
+
+The entire argument string after `/wtf now` is the freeform text to record.
+There are no subcommands or flags.
+
+Examples:
+- `/wtf now the DNS resolver is returning stale records`
+- `/wtf now "checked nginx logs — 502s started at 14:32"`
+- `/wtf now theory: might be a connection pool exhaustion issue`
+
+## Steps
+
+### 1. Record the entry
+
+Call the `wtf_now` MCP tool with:
+
+```json
+{
+  "gen_type": "crafted",
+  "text": "<user's text>"
+}
+```
+
+Do **not** set `action_type`. Leave classification to the background
+classifier.
+
+### 2. Confirm to the user
+
+Respond with:
+
+> Recorded: <user's text>
+
+Nothing else is needed. Keep it brief so the user can continue
+troubleshooting without interruption.

--- a/skills/wtf/SKILL.md
+++ b/skills/wtf/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: wtf
+description: Start a WTF flight recorder troubleshooting session
+---
+
+# /wtf — Start a Troubleshooting Session
+
+Launch the WTF flight recorder for a new troubleshooting incident. Archives
+any prior incident, prompts for an optional title, then puts Claude into
+flight recorder mode where significant observations, theories, and corrective
+actions are journaled automatically.
+
+## Resolve Intent
+
+Parse the invocation arguments:
+
+- **No arguments** — start a new troubleshooting session (default behavior).
+- **`record <text>`** — shorthand for `/wtf now <text>`. Route directly to
+  the `/wtf now` skill with the provided text, then stop.
+
+## Steps
+
+### 1. Archive prior incident
+
+Call the `wtf_freshell` MCP tool with no arguments. This archives any
+currently active incident and creates a fresh one.
+
+### 2. Prompt for incident title
+
+Ask the user:
+
+> What are you troubleshooting? (optional — press Enter to skip)
+
+If the user provides a title, call `wtf_freshell` again with `{ "title": "<user's title>" }` to set the title on the newly created incident.
+
+Wait for the user's response before proceeding.
+
+### 3. Confirm and activate flight recorder mode
+
+Tell the user the session is active, then follow these behavioral
+instructions for the remainder of the conversation:
+
+---
+
+You are now in **WTF flight recorder mode**. A background journal is
+capturing every tool call automatically. In addition to that automatic
+capture, you should:
+
+- Call `wtf_now` with `gen_type: "crafted"` and `action_type: "breadcrumb"`
+  when you observe something diagnostically significant
+- Call `wtf_now` with `gen_type: "crafted"` and `action_type: "theory"` when
+  you form a hypothesis about the root cause
+- Call `wtf_now` with `gen_type: "crafted"` and `action_type: "action"` when
+  you take a corrective action (not exploratory commands)
+
+**Bias toward recording.** When in doubt, record it. A noisy journal can be
+distilled; a silent journal cannot be recovered.
+
+At any time, the user may call `wtf_happened` to see the current timeline,
+or `/wtf now` to add their own observations.
+
+---
+
+After injecting these instructions, confirm to the user:
+
+> Flight recorder is active. I'll journal significant findings as we go.
+> Use `/wtf now <text>` to add your own notes, or `wtf_happened` when you
+> want to see the timeline.


### PR DESCRIPTION
## Summary

Moves the 4 WTF flight recorder skills into claudecode-workflow, establishing the pattern that MCP servers deliver tools and this repo delivers skills.

## Changes

- Added `skills/wtf/SKILL.md`, `skills/wtf-now/SKILL.md`, `skills/wtf-happened/SKILL.md`, `skills/wtf-imout/SKILL.md` with frontmatter
- Normalized `wtf-imout` to use direct tool call instead of stale `ToolSearch` pattern

## Linked Issues

Closes #378

## Test Plan

- `./scripts/ci/validate.sh` — 87 passed, 0 failed (4 new frontmatter checks)
- `./sync.sh --check` no longer reports wtf skills as "exists locally but NOT in repo"
- Companion PR in mcp-server-wtf removes skill delivery from installer