### PR TITLE
feat(install): auto-create discord.json from template if missing

### DIFF
--- a/config/discord.template.json
+++ b/config/discord.template.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Discord server configuration for disc-server channel name resolution. Deployed by install to ~/.claude/discord.json only if the file does not exist. Never overwritten.",
+  "guild_id": "1486516321385578576",
+  "default_channel_id": "1487288523638837268",
+  "roll_call_channel_id": "1487382005036617851",
+  "channels": {
+    "general": "1486516322249478166",
+    "agent-ops": "1487288523638837268",
+    "roll-call": "1487382005036617851",
+    "wave-status": "1487386934094462986",
+    "remote-sessions": "1487462945972682763",
+    "pops-notify": "1490117544466452704",
+    "self-messages": "1490561225338388631",
+    "precheck": "1491195025198157834"
+  }
+}

--- a/deps.json
+++ b/deps.json
@@ -20,8 +20,8 @@
       "files": [
         "~/.claude/discord.json"
       ],
-      "install": "Copy from docs/discord.example.json or ask BJ for the current channel map",
-      "optional": true
+      "install": "Run ./install or ./install --config to create from config/discord.template.json. Safe to customize; install never overwrites.",
+      "optional": false
     }
   },
   "commands": [

--- a/install
+++ b/install
@@ -454,6 +454,22 @@ if [[ "$INSTALL_CONFIG" == true ]]; then
 			fi
 		fi
 	fi
+
+	# discord.json — create from template only if missing, never overwrite
+	if [[ -f "$REPO_DIR/config/discord.template.json" ]]; then
+		if [[ -f "$CLAUDE_DIR/discord.json" ]]; then
+			skip "discord.json (already exists — not overwriting)"
+		else
+			if [[ "$DRY_RUN" == true ]]; then
+				info "(dry-run) $REPO_DIR/config/discord.template.json → $CLAUDE_DIR/discord.json"
+			else
+				mkdir -p "$(dirname "$CLAUDE_DIR/discord.json")"
+				jq 'walk(if type == "object" then del(._comment) else . end)' \
+					"$REPO_DIR/config/discord.template.json" >"$CLAUDE_DIR/discord.json"
+				info "Installed discord.json (stripped _comment keys)"
+			fi
+		fi
+	fi
 fi
 
 # --- Build and install packages -----------------------------------------------


### PR DESCRIPTION
## Summary

Ships `config/discord.template.json` with the Oak and Wave channel map. `install` deploys it to `~/.claude/discord.json` when missing — never overwrites if the file exists, preserving user customizations.

## Changes

- `config/discord.template.json` — new template with guild_id + 8-channel name-to-ID map, annotated with `_comment`
- `install` — creates `~/.claude/discord.json` from template if missing, skips if present. Strips `_comment` recursively via `jq walk()` so future nested comments are handled
- `deps.json` — `discord-config` entry is now required (not optional); install hint clarifies that `./install --config` is needed for partial installs that skip the config section

## Linked Issues

Closes #380

## Test Plan

- Fresh install path: removed `~/.claude/discord.json`, ran `./install --config`, verified file created with `_comment` stripped
- Preservation path: wrote custom content to `~/.claude/discord.json`, ran `./install --config`, verified file unchanged
- Dry-run: verified both paths show correct "(dry-run)" output
- `./scripts/ci/validate.sh` — 87 passed, 0 failed
- `trivy fs` — 0 HIGH/CRITICAL