### PR TITLE
fix(wavemachine): route state writes through wave-status CLI

### DIFF
--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -37,7 +37,7 @@ On any refusal: explain the failure, suggest the remediation, **do not spawn**.
 
 Once pre-flight passes:
 
-1. **Set the active flag.** Write `wavemachine_active: true` to `.claude/status/state.json` (preserving all other keys). This is the signal the statusline 🌊 indicator reads.
+1. **Set the active flag.** Run `python3 -m wave_status wavemachine-start --launcher main` to stamp `wavemachine_active: true` into `state.json` (plus `wavemachine_started_at` and `wavemachine_launcher`). This is the signal the statusline 🌊 indicator reads, and the CLI guarantees atomic writes via `save_json`. Do **not** `Edit` `state.json` directly — the harness denies direct writes to `.claude/status/**` from background sub-agents, so all flag transitions must flow through this CLI for parity.
 2. **Regenerate and open the status panel.** Run `./scripts/generate-status-panel` then open `.status-panel.html` with `xdg-open` (Linux) or `open` (macOS). This happens here — not inside the background worker — so it costs zero sub-agent tokens and guarantees the panel is visible before work begins.
 3. **Detect CI trust.** Call `wave_ci_trust_level()` once and cache the result for the background worker. Drives whether `wave_health_check()` treats post-merge main CI as a separate gate.
 4. **Post to Discord.** `disc_send` to `#wave-status` (`1487386934094462986`): `"🌊 **Wavemachine started** — <project>, <N> waves pending. Agent: **<dev-name>** <dev-avatar>"`. Resolve identity from `/tmp/claude-agent-<md5>.json`. If `disc_send` fails, log and continue — Discord is informational, not a gate.
@@ -106,8 +106,11 @@ NOT on the abort list:
 
 1. Call `wave_waiting("wavemachine aborted: <one-line summary>")` to mark the plan
    as awaiting human attention.
-2. Write `wavemachine_active: false` to `.claude/status/state.json` (clears the 🌊
-   indicator).
+2. Run `python3 -m wave_status wavemachine-stop` to clear `wavemachine_active`,
+   `wavemachine_started_at`, and `wavemachine_launcher` (clears the 🌊 indicator).
+   Use the CLI — background sub-agents cannot write `.claude/status/state.json`
+   directly. `wavemachine-stop` is idempotent, so running it on an already-cleared
+   state is safe.
 3. Post to `#wave-status` (`1487386934094462986`): `"🛑 **Wavemachine aborted** —
    <project>, wave <id>: <one-line blocker summary>. Agent: **<dev-name>** <dev-avatar>"`.
 4. Report to the parent session with a structured summary:
@@ -118,7 +121,8 @@ NOT on the abort list:
 
 ## On Clean Completion
 
-1. Write `wavemachine_active: false` to `.claude/status/state.json`.
+1. Run `python3 -m wave_status wavemachine-stop` to clear `wavemachine_active`
+   (via CLI — background sub-agents cannot write state files directly).
 2. Post to `#wave-status` (`1487386934094462986`): `"✅ **Wavemachine complete** —
    <project>, all <N> waves merged. Run /dod to verify. Agent: **<dev-name>** <dev-avatar>"`.
 3. Report to the parent session:

--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -37,11 +37,14 @@ from wave_status.state import (
     record_mr,
     review,
     save_json,
+    set_current_wave,
     show,
     status_dir,
     store_flight_plan,
     waiting,
     waiting_ci,
+    wavemachine_start,
+    wavemachine_stop,
 )
 
 
@@ -194,6 +197,27 @@ def _cmd_defer_accept(args: argparse.Namespace) -> None:
     _regenerate_dashboard(root)
 
 
+def _cmd_set_current(args: argparse.Namespace) -> None:
+    """Handle ``set-current <wave-id>``."""
+    root = get_project_root()
+    set_current_wave(args.wave_id, root)
+    _regenerate_dashboard(root)
+
+
+def _cmd_wavemachine_start(args: argparse.Namespace) -> None:
+    """Handle ``wavemachine-start [--launcher <tag>]``."""
+    root = get_project_root()
+    wavemachine_start(root, launcher=args.launcher or "")
+    _regenerate_dashboard(root)
+
+
+def _cmd_wavemachine_stop(args: argparse.Namespace) -> None:
+    """Handle ``wavemachine-stop``."""
+    root = get_project_root()
+    wavemachine_stop(root)
+    _regenerate_dashboard(root)
+
+
 def _cmd_show(args: argparse.Namespace) -> None:
     """Handle ``show`` — print summary, NO dashboard regen."""
     root = get_project_root()
@@ -226,7 +250,7 @@ def _read_json_source(source: str) -> str:
 # ---------------------------------------------------------------------------
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Construct the argparse parser with all 14 subcommands."""
+    """Construct the argparse parser with all subcommands."""
     parser = argparse.ArgumentParser(
         prog="wave-status",
         description="Wave execution lifecycle CLI",
@@ -310,6 +334,33 @@ def _build_parser() -> argparse.ArgumentParser:
     p_da = sub.add_parser("defer-accept", help="Accept a pending deferral")
     p_da.add_argument("index", type=int, help="1-based deferral index")
     p_da.set_defaults(func=_cmd_defer_accept)
+
+    # set-current
+    p_sc = sub.add_parser(
+        "set-current",
+        help="Set current_wave to <wave-id> (must exist in the plan)",
+    )
+    p_sc.add_argument("wave_id", help="Wave ID (e.g. 'wave-6a')")
+    p_sc.set_defaults(func=_cmd_set_current)
+
+    # wavemachine-start
+    p_ws = sub.add_parser(
+        "wavemachine-start",
+        help="Mark the plan as driven by wavemachine (sets wavemachine_active)",
+    )
+    p_ws.add_argument(
+        "--launcher",
+        default="",
+        help="Optional label identifying who started the run (e.g. agent task ID)",
+    )
+    p_ws.set_defaults(func=_cmd_wavemachine_start)
+
+    # wavemachine-stop
+    p_wst = sub.add_parser(
+        "wavemachine-stop",
+        help="Clear wavemachine_active (call from worker on abort or clean exit)",
+    )
+    p_wst.set_defaults(func=_cmd_wavemachine_stop)
 
     # show
     p_sh = sub.add_parser("show", help="Print status summary (read-only)")

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -427,6 +427,24 @@ def extend_state(plan_data: dict, root: Path) -> None:
                 if issue_key not in existing_state["issues"]:
                     existing_state["issues"][issue_key] = {"status": "open"}
 
+    # Auto-advance current_wave when the prior plan has been fully worked off
+    # and new pending waves now exist. Without this, running `init --extend`
+    # on top of a completed plan leaves `current_wave` stuck at None (or at
+    # the last-completed wave), and every subsequent subcommand that asserts
+    # "a current wave is set" (planning, flight, flight_plan, …) refuses
+    # because it can't tell the plan was extended.
+    waves_state = existing_state.get("waves", {})
+    current = existing_state.get("current_wave")
+    current_is_done = (
+        current is None
+        or waves_state.get(current, {}).get("status") == "completed"
+    )
+    if current_is_done:
+        for wid in _all_wave_ids(existing_plan):
+            if waves_state.get(wid, {}).get("status") == "pending":
+                existing_state["current_wave"] = wid
+                break
+
     existing_state["last_updated"] = _now_iso()
     save_json(state_path, existing_state)
 
@@ -507,6 +525,82 @@ def waiting(root: Path, msg: str = "") -> dict:
 def waiting_ci(root: Path, detail: str = "") -> dict:
     """Set current_action to ``waiting-ci`` — heartbeat during CI polling."""
     return _set_action(root, "waiting-ci", "waiting-ci", detail)
+
+
+def set_current_wave(wave_id: str, root: Path) -> dict:
+    """Set ``current_wave`` to *wave_id* in ``state.json``.
+
+    Validates *wave_id* exists in the plan and is not already ``completed``.
+    Intended as the CLI-accessible path to advance ``current_wave`` outside
+    of the normal ``complete`` flow (e.g. after ``init --extend`` on an
+    already-completed plan, or when a human needs to jump the pointer during
+    recovery).  Raises ``ValueError`` if the wave ID is unknown or already
+    completed — pointing at a completed wave would let ``planning`` flip its
+    status back to ``in_progress``, corrupting the completion record.
+    """
+    d = status_dir(root)
+    plan_data = load_json(d / "phases-waves.json")
+    valid_ids = _all_wave_ids(plan_data)
+    if wave_id not in valid_ids:
+        raise ValueError(
+            f"Error: wave '{wave_id}' does not exist in the plan. "
+            f"Valid wave IDs: {', '.join(valid_ids) if valid_ids else '(none)'}."
+        )
+
+    state_data = load_state(d / "state.json")
+    target_status = state_data.get("waves", {}).get(wave_id, {}).get("status")
+    if target_status == "completed":
+        raise ValueError(
+            f"Error: wave '{wave_id}' is already completed. "
+            "Pass a pending or in_progress wave ID instead."
+        )
+
+    state_data["current_wave"] = wave_id
+    state_data["last_updated"] = _now_iso()
+    save_json(d / "state.json", state_data)
+    return state_data
+
+
+def wavemachine_start(root: Path, launcher: str = "") -> dict:
+    """Mark the plan as actively driven by wavemachine.
+
+    Sets ``wavemachine_active: true`` in ``state.json`` along with
+    ``wavemachine_started_at`` and ``wavemachine_launcher`` metadata.
+    Raises ``ValueError`` if a wavemachine run is already active (one plan
+    at a time — matches the SKILL.md non-negotiable).
+    """
+    d = status_dir(root)
+    state_data = load_state(d / "state.json")
+    if state_data.get("wavemachine_active"):
+        raise ValueError(
+            "Error: wavemachine is already active for this plan. "
+            "Run 'wavemachine-stop' first, or wait for the current run to exit."
+        )
+
+    state_data["wavemachine_active"] = True
+    state_data["wavemachine_started_at"] = _now_iso()
+    if launcher:
+        state_data["wavemachine_launcher"] = launcher
+    state_data["last_updated"] = _now_iso()
+    save_json(d / "state.json", state_data)
+    return state_data
+
+
+def wavemachine_stop(root: Path) -> dict:
+    """Clear wavemachine ownership from ``state.json``.
+
+    Deletes ``wavemachine_active``, ``wavemachine_started_at``, and
+    ``wavemachine_launcher``.  Idempotent — succeeds even if no wavemachine
+    run is active (worker abort paths need this to be safe on re-entry).
+    """
+    d = status_dir(root)
+    state_data = load_state(d / "state.json")
+    state_data.pop("wavemachine_active", None)
+    state_data.pop("wavemachine_started_at", None)
+    state_data.pop("wavemachine_launcher", None)
+    state_data["last_updated"] = _now_iso()
+    save_json(d / "state.json", state_data)
+    return state_data
 
 
 def flight(n: int, root: Path) -> dict:

--- a/tests/test_wave_status.py
+++ b/tests/test_wave_status.py
@@ -457,6 +457,269 @@ class TestDashboardGeneration:
 
 
 # ---------------------------------------------------------------------------
+# set-current + wavemachine-start/stop tests (issue #382)
+# ---------------------------------------------------------------------------
+
+def _state(repo: Path) -> dict:
+    """Read state.json from *repo* into a dict."""
+    return json.loads(
+        (repo / ".claude" / "status" / "state.json").read_text(encoding="utf-8")
+    )
+
+
+class TestSetCurrent:
+    """Verify ``set-current <wave-id>`` updates current_wave."""
+
+    def test_set_current_moves_pointer(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """``set-current wave-3`` sets current_wave to wave-3."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        rc, _, err = run_cli(["set-current", "wave-3"], repo)
+        assert rc == 0, f"set-current failed: {err}"
+        assert _state(repo)["current_wave"] == "wave-3"
+
+    def test_set_current_rejects_unknown_wave(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Unknown wave ID -> exit 1 with a listing of valid IDs."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        rc, _, err = run_cli(["set-current", "wave-does-not-exist"], repo)
+        assert rc == 1
+        assert "Error:" in err
+        # Valid IDs should be listed to guide recovery.
+        assert "wave-1" in err
+
+    def test_set_current_rejects_completed_wave(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Target wave already completed -> exit 1 (no status corruption)."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        # Manually mark wave-1 as completed.
+        state_path = repo / ".claude" / "status" / "state.json"
+        st = json.loads(state_path.read_text(encoding="utf-8"))
+        st["waves"]["wave-1"]["status"] = "completed"
+        state_path.write_text(json.dumps(st), encoding="utf-8")
+
+        rc, _, err = run_cli(["set-current", "wave-1"], repo)
+        assert rc == 1
+        assert "Error:" in err
+        assert "already completed" in err
+        # Completed status must not have been flipped to anything else.
+        assert _state(repo)["waves"]["wave-1"]["status"] == "completed"
+
+    def test_set_current_regenerates_dashboard(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """``set-current`` regenerates the status panel (state mutation)."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        html = repo / ".status-panel.html"
+        assert html.exists()
+        mtime_before = html.stat().st_mtime_ns
+
+        time.sleep(0.05)
+        rc, _, _ = run_cli(["set-current", "wave-2"], repo)
+        assert rc == 0
+        assert html.stat().st_mtime_ns >= mtime_before
+
+
+class TestWavemachineFlag:
+    """Verify ``wavemachine-start`` / ``wavemachine-stop`` flip state flags."""
+
+    def test_start_sets_active_flag(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """``wavemachine-start`` writes wavemachine_active=true + metadata."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        rc, _, err = run_cli(
+            ["wavemachine-start", "--launcher", "task-abc"], repo
+        )
+        assert rc == 0, f"wavemachine-start failed: {err}"
+
+        st = _state(repo)
+        assert st["wavemachine_active"] is True
+        assert "wavemachine_started_at" in st
+        assert st["wavemachine_launcher"] == "task-abc"
+
+    def test_start_rejects_when_already_active(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Second ``wavemachine-start`` fails — one plan at a time."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["wavemachine-start"], repo)
+
+        rc, _, err = run_cli(["wavemachine-start"], repo)
+        assert rc == 1
+        assert "Error:" in err
+        assert "already active" in err
+
+    def test_stop_clears_all_wavemachine_keys(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """``wavemachine-stop`` removes all three wavemachine keys."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["wavemachine-start", "--launcher", "task-xyz"], repo)
+
+        rc, _, err = run_cli(["wavemachine-stop"], repo)
+        assert rc == 0, f"wavemachine-stop failed: {err}"
+
+        st = _state(repo)
+        assert "wavemachine_active" not in st
+        assert "wavemachine_started_at" not in st
+        assert "wavemachine_launcher" not in st
+
+    def test_stop_is_idempotent(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Calling ``wavemachine-stop`` on a clean state succeeds (exit 0)."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        # No wavemachine-start first — should still succeed.
+        rc, _, err = run_cli(["wavemachine-stop"], repo)
+        assert rc == 0, f"idempotent stop failed: {err}"
+
+    def test_start_preserves_other_state_keys(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """``wavemachine-start`` leaves current_wave, waves, issues untouched."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        before = _state(repo)
+
+        run_cli(["wavemachine-start"], repo)
+        after = _state(repo)
+
+        assert after["current_wave"] == before["current_wave"]
+        assert after["waves"] == before["waves"]
+        assert after["issues"] == before["issues"]
+
+
+# ---------------------------------------------------------------------------
+# init --extend auto-advance current_wave (issue #382)
+# ---------------------------------------------------------------------------
+
+class TestExtendAutoAdvance:
+    """Verify ``init --extend`` auto-advances current_wave when prior done."""
+
+    # Phase 2 extension data — wave-6a, wave-6b with unique issue numbers.
+    _EXTEND_PLAN: dict = {
+        "phases": [
+            {
+                "name": "Extended",
+                "waves": [
+                    {
+                        "id": "wave-6a",
+                        "name": "Wave 6a",
+                        "issues": [
+                            {"number": 600, "title": "New 600", "deps": []},
+                        ],
+                    },
+                    {
+                        "id": "wave-6b",
+                        "name": "Wave 6b",
+                        "issues": [
+                            {"number": 601, "title": "New 601", "deps": [600]},
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    def _complete_all_waves(self, repo: Path) -> None:
+        """Manually mark every wave and issue in the state as completed/closed."""
+        state_path = repo / ".claude" / "status" / "state.json"
+        st = json.loads(state_path.read_text(encoding="utf-8"))
+        for wid in st["waves"]:
+            st["waves"][wid]["status"] = "completed"
+        for iid in st["issues"]:
+            st["issues"][iid]["status"] = "closed"
+        st["current_wave"] = None
+        state_path.write_text(json.dumps(st), encoding="utf-8")
+
+    def test_extend_advances_from_none_to_first_new_wave(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Prior plan fully done (current_wave=None) — extend sets it to the new wave."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        self._complete_all_waves(repo)
+
+        extend_path = repo / "extend.json"
+        extend_path.write_text(json.dumps(self._EXTEND_PLAN), encoding="utf-8")
+
+        rc, _, err = run_cli(["init", "--extend", "extend.json"], repo)
+        assert rc == 0, f"extend failed: {err}"
+        assert _state(repo)["current_wave"] == "wave-6a"
+
+    def test_extend_preserves_current_wave_when_prior_active(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Prior plan still in progress — extend leaves current_wave alone."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        # current_wave is wave-1 after init, all pending — do NOT complete.
+
+        extend_path = repo / "extend.json"
+        extend_path.write_text(json.dumps(self._EXTEND_PLAN), encoding="utf-8")
+
+        rc, _, err = run_cli(["init", "--extend", "extend.json"], repo)
+        assert rc == 0, f"extend failed: {err}"
+        # Prior phase still has pending waves, so current_wave should not jump.
+        assert _state(repo)["current_wave"] == "wave-1"
+
+    def test_extend_advances_from_completed_pointer(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """current_wave stuck on last completed wave (not None) — extend advances."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        # Simulate a plan that ended with the pointer still on the last
+        # completed wave rather than being advanced to None (possible via
+        # manual state edit or a migration path that bypassed `complete`).
+        state_path = repo / ".claude" / "status" / "state.json"
+        st = json.loads(state_path.read_text(encoding="utf-8"))
+        for wid in st["waves"]:
+            st["waves"][wid]["status"] = "completed"
+        for iid in st["issues"]:
+            st["issues"][iid]["status"] = "closed"
+        st["current_wave"] = "wave-3"
+        state_path.write_text(json.dumps(st), encoding="utf-8")
+
+        extend_path = repo / "extend.json"
+        extend_path.write_text(json.dumps(self._EXTEND_PLAN), encoding="utf-8")
+
+        rc, _, err = run_cli(["init", "--extend", "extend.json"], repo)
+        assert rc == 0, f"extend failed: {err}"
+        assert _state(repo)["current_wave"] == "wave-6a"
+
+
+# ---------------------------------------------------------------------------
 # No external dependencies test [CT-01]
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`/wavemachine` background sub-agents couldn't complete their job. Two interacting defects made the common `/devspec upshift` → `wave_init --extend` → `/wavemachine` path unusable on any plan with a completed prior phase: (1) `current_wave` stayed `null` (or stuck at the last completed wave) after `init --extend` because `_find_next_pending_wave` was only reachable via `wave-status complete`, and (2) the wavemachine skill directed background sub-agents to `Edit` `.claude/status/state.json` directly, which the Claude Code harness denies for background sub-agents.

Fixed via pure-CLI routing (option b from the bug spec) — no harness perm relaxation requested, no Edit-on-state-files in the skill. The `wave-status` CLI is the contract; every wavemachine state transition now runs via `Bash` against the CLI, which the harness allows.

## Changes

- `src/wave_status/state.py` — new `set_current_wave(wave_id, root)` that validates the target wave exists in the plan and is not already `completed` (prevents `planning` from silently flipping a completed wave back to `in_progress`). New `wavemachine_start(root, launcher="")` and `wavemachine_stop(root)` that set/clear `wavemachine_active` + `wavemachine_started_at` + `wavemachine_launcher` atomically via `save_json`. `extend_state()` now auto-advances `current_wave` to the first pending wave when the prior plan is fully completed — covers both `current_wave=None` and `current_wave` stuck on a completed wave.
- `src/wave_status/__main__.py` — three new subcommands: `set-current <wave-id>`, `wavemachine-start [--launcher <tag>]`, `wavemachine-stop`. All three route through the standard `_regenerate_dashboard` hook so the status panel reflects the flag change.
- `skills/wavemachine/SKILL.md` — the three direct-Edit state writes (launch step 1, abort step 2, clean-completion step 1) are now `python3 -m wave_status wavemachine-start/-stop` invocations. Docs spell out the reason (harness denies direct `.claude/status/**` writes from background sub-agents) so future edits don't regress.
- `tests/test_wave_status.py` — 12 new subprocess-based tests: 4 for `set-current` (happy path, unknown wave, completed-wave guard, dashboard regen), 5 for the wavemachine flag subcommands (start+launcher, double-start rejection, stop clears all keys, stop idempotency, start preserves other state), 3 for extend auto-advance (from `None`, no-advance when prior in-progress, from completed-pointer edge case).

## Linked Issues

Closes #382

## Test Plan

- [x] `pytest tests/test_wave_status.py` — 29/29 pass (27 pre-existing + 12 new; 2 of the 12 were added during code-reviewer rework for the completed-wave guard and the completed-pointer extend edge case)
- [x] `pytest tests/` (full suite, excluding pre-existing `test_discord_status` collection error) — 947 pass, 99 fail; the 99 failures baselined identical against `main` on a stashed-clean checkout (all in `test_install*` / `test_install_merge*` / `test_dod_skill` — unrelated env/config issues, not introduced by this PR)
- [x] `./scripts/ci/validate.sh` — 87 passed, 0 failed
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- [x] `python3 -m wave_status --help` — confirms `set-current`, `wavemachine-start`, `wavemachine-stop` registered
- [x] `feature-dev:code-reviewer` pass — 2 confidence-85+ findings (missing completed-wave guard + missing extend auto-advance test from completed pointer) both fixed inline
- [ ] Post-merge live verification: re-run the bug repro (`wave_init --extend` on a fully-completed prior plan, then `/wavemachine`) and confirm the background worker advances through the new waves without main-session intervention — only verifiable in a real CC session since the harness permission gate doesn't exist in `pytest`