### PR TITLE
chore(vox): add openai-qwen provider example + payload-extension pattern

### DIFF
--- a/scripts/vox
+++ b/scripts/vox
@@ -110,7 +110,7 @@ usage() {
 
 		Setup flags:
 		  --non-interactive  Don't prompt; use --pick to select
-		  --pick NAME        Provider name (silent|openai-endpoint|piper-local|espeak|macos-say)
+		  --pick NAME        Provider name (silent|openai-endpoint|openai-qwen|piper-local|espeak|macos-say)
 
 		Message can be passed as arguments or piped via stdin.
 
@@ -161,6 +161,7 @@ do_setup() {
 		echo "Available providers:"
 		echo "  silent           — no-op (writes 0.1s silence; safe default)"
 		echo "  openai-endpoint  — any OpenAI-compatible TTS API (VOX_ENDPOINT)"
+		echo "  openai-qwen      — OpenAI-extended TTS (qwen3-tts, Chatterbox) — adds VOX_EMOTION"
 		echo "  piper-local      — local piper binary (VOX_PIPER_MODEL)"
 		echo "  espeak           — espeak-ng fallback (no network)"
 		echo "  macos-say        — macOS say(1)"

--- a/scripts/vox-providers/README.md
+++ b/scripts/vox-providers/README.md
@@ -30,6 +30,7 @@ Each is a copy-and-adapt template. They ship executable so `vox --setup --pick=<
 |---|---|---|
 | `silent.sh` | no-op (valid WAV of 0.1s silence) | — |
 | `openai-endpoint.sh` | OpenAI-compatible TTS API (POST JSON, WAV response) | `VOX_ENDPOINT`, `VOX_VOICE`, `VOX_MODEL` |
+| `openai-qwen.sh` | OpenAI-extended TTS (qwen3-tts, Chatterbox-over-HTTP, any server that accepts extra payload fields) — adds optional `emotion` field | `VOX_ENDPOINT`, `VOX_VOICE`, `VOX_MODEL`, optional `VOX_EMOTION` |
 | `piper-local.sh` | local [piper](https://github.com/rhasspy/piper) binary | `VOX_PIPER_MODEL` (path to `.onnx`) |
 | `espeak.sh` | `espeak` / `espeak-ng` (zero-deps fallback) | — |
 | `macos-say.sh` | macOS `say(1)` + `afconvert` for WAV | — |
@@ -84,6 +85,30 @@ TEXT="${1:-$(cat)}"
 
 # ... synthesize $TEXT into $VOX_OUTPUT_FILE ...
 ```
+
+### Extending the JSON payload (HTTP backends)
+
+Many OpenAI-compatible servers accept additional fields beyond the canonical `{model, input, voice, response_format}` set — `emotion`, `speed`, `pitch`, `style`, custom `metadata`, etc. Handle these via **new `VOX_*` env vars**, not by baking flags into `VOX_COMMAND`. The pattern:
+
+```python
+# inside your provider's payload builder
+payload = {
+    "model": os.environ["MODEL"],
+    "input": os.environ["TEXT"],
+    "voice": os.environ["VOICE"],
+    "response_format": "wav",
+}
+emotion = os.environ.get("EMOTION", "")
+if emotion:
+    payload["emotion"] = emotion     # include only when set
+```
+
+**Two rules the contract enforces:**
+
+1. **MAY honor, MUST ignore.** Providers whose backend doesn't support a field MUST silently ignore it. `espeak.sh` doesn't use `VOX_EMOTION`; that's fine — it must not error when it sees one set.
+2. **Unset = field omitted.** When `VOX_EMOTION` is unset or empty, the provider MUST NOT send `"emotion": ""` or `"emotion": null`. Omit the key entirely. This keeps extended-field payloads compatible with strict endpoints.
+
+See `openai-qwen.sh` for a worked example: same wire protocol as `openai-endpoint.sh` but includes `emotion` in the payload when `VOX_EMOTION` is set. Prefer copying that one when your server accepts extended fields; copy `openai-endpoint.sh` when you need strict OpenAI-spec compliance.
 
 ## Troubleshooting
 

--- a/scripts/vox-providers/openai-qwen.sh
+++ b/scripts/vox-providers/openai-qwen.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# openai-qwen.sh — vox provider for OpenAI-extended TTS servers (e.g. qwen3-tts).
+#
+# Identical wire protocol to openai-endpoint.sh (POST JSON to
+# /v1/audio/speech, receive WAV body) but sends an optional VOX_EMOTION
+# field in the payload that qwen3-tts and Chatterbox-over-HTTP both
+# recognize. Strict OpenAI endpoints (api.openai.com) will reject or
+# ignore the extra field — use openai-endpoint.sh for those instead.
+#
+# Contract: VOX_PROVIDER_CONTRACT=1
+#   In:  $1 or stdin — text to speak
+#   Out: $VOX_OUTPUT_FILE — WAV audio from the endpoint
+#
+# Required env:
+#   VOX_ENDPOINT   — URL, e.g. http://myserver:8004/v1/audio/speech
+#
+# Optional env (canonical OpenAI spec):
+#   VOX_VOICE      — voice name (default: alloy)
+#   VOX_MODEL      — model name (default: tts-1)
+#   VOX_API_KEY    — bearer token (if your endpoint requires auth)
+#
+# Optional env (qwen/extended):
+#   VOX_EMOTION    — free-form emotion prompt. Unset or empty → field omitted.
+#                    Examples: "cheerful", "the speaker's voice is very young",
+#                    "angry and loud". Server-dependent semantics.
+
+set -euo pipefail
+
+: "${VOX_OUTPUT_FILE:?openai-qwen.sh: VOX_OUTPUT_FILE not set}"
+: "${VOX_ENDPOINT:?openai-qwen.sh: VOX_ENDPOINT not set}"
+
+TEXT="${1:-}"
+if [[ -z "$TEXT" ]]; then
+	TEXT="$(cat)"
+fi
+[[ -n "${TEXT//[$' \t\n\r']/}" ]] || {
+	echo "openai-qwen.sh: empty text" >&2
+	exit 1
+}
+
+voice="${VOX_VOICE:-alloy}"
+model="${VOX_MODEL:-tts-1}"
+emotion="${VOX_EMOTION:-}"
+
+command -v curl >/dev/null || {
+	echo "openai-qwen.sh: curl required" >&2
+	exit 1
+}
+command -v python3 >/dev/null || {
+	echo "openai-qwen.sh: python3 required (JSON encoding)" >&2
+	exit 1
+}
+
+# Extend the payload: VOX_EMOTION becomes payload["emotion"] iff set.
+# Unset or empty → field omitted entirely (MUST, per the contract — don't
+# send "emotion": "" or "emotion": null).
+payload=$(
+	TEXT="$TEXT" MODEL="$model" VOICE="$voice" EMOTION="$emotion" python3 -c '
+import json, os
+payload = {
+    "model": os.environ["MODEL"],
+    "input": os.environ["TEXT"],
+    "voice": os.environ["VOICE"],
+    "response_format": "wav",
+}
+emotion = os.environ.get("EMOTION", "")
+if emotion:
+    payload["emotion"] = emotion
+print(json.dumps(payload))
+'
+)
+
+auth_args=()
+if [[ -n "${VOX_API_KEY:-}" ]]; then
+	auth_args=(-H "Authorization: Bearer $VOX_API_KEY")
+fi
+
+http_code=$(curl -sS -w '%{http_code}' -o "$VOX_OUTPUT_FILE" \
+	-X POST \
+	-H "Content-Type: application/json" \
+	"${auth_args[@]}" \
+	-d "$payload" \
+	--connect-timeout 5 \
+	--max-time 30 \
+	"$VOX_ENDPOINT")
+
+if [[ "$http_code" -ge 400 ]]; then
+	echo "openai-qwen.sh: TTS endpoint returned HTTP $http_code" >&2
+	[[ -s "$VOX_OUTPUT_FILE" ]] && head -c 500 "$VOX_OUTPUT_FILE" >&2
+	exit 1
+fi
+
+[[ -s "$VOX_OUTPUT_FILE" ]] || {
+	echo "openai-qwen.sh: empty response from TTS endpoint" >&2
+	exit 1
+}

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -28,6 +28,7 @@ PROVIDERS_DIR = REPO_ROOT / "scripts" / "vox-providers"
 SILENT = PROVIDERS_DIR / "silent.sh"
 ESPEAK = PROVIDERS_DIR / "espeak.sh"
 OPENAI = PROVIDERS_DIR / "openai-endpoint.sh"
+OPENAI_QWEN = PROVIDERS_DIR / "openai-qwen.sh"
 PIPER = PROVIDERS_DIR / "piper-local.sh"
 MACOS_SAY = PROVIDERS_DIR / "macos-say.sh"
 
@@ -293,7 +294,7 @@ def test_silent_sh_without_output_file_errors(tmp_path):
 
 @pytest.mark.parametrize(
     "provider",
-    [SILENT, ESPEAK, OPENAI, PIPER, MACOS_SAY],
+    [SILENT, ESPEAK, OPENAI, OPENAI_QWEN, PIPER, MACOS_SAY],
     ids=lambda p: p.name,
 )
 def test_shipped_provider_shellcheck_clean(provider):
@@ -307,6 +308,167 @@ def test_shipped_provider_shellcheck_clean(provider):
     )
     if r.returncode != 0:
         pytest.fail(f"shellcheck failed on {provider.name}:\n{r.stdout}{r.stderr}")
+
+
+# ---------------------------------------------------------------------------
+# openai-qwen.sh payload construction
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_curl(tmp_path: Path) -> tuple[Path, Path]:
+    """Install a fake `curl` earlier on PATH that captures -d payload for assertions.
+
+    Returns (fake-bin-dir, payload-sentinel-file). The fake curl writes the
+    JSON payload it received via `-d <payload>` to FAKE_CURL_PAYLOAD_OUT,
+    writes a minimal dummy WAV to the `-o` file so the provider's post-curl
+    `[[ -s "$VOX_OUTPUT_FILE" ]]` check passes, and prints "200" on stdout
+    so the `%{http_code}` capture succeeds.
+
+    This means the provider's real code path runs end-to-end — argv parsing,
+    payload construction, curl invocation — with zero network activity and
+    no test-only hooks baked into the provider itself.
+    """
+    bin_dir = tmp_path / "fake-bin"
+    bin_dir.mkdir()
+    sentinel = tmp_path / "curl-payload.json"
+    fake = bin_dir / "curl"
+    fake.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+out_file=""
+payload=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o) out_file="$2"; shift 2;;
+        -d) payload="$2"; shift 2;;
+        -X|-H|--connect-timeout|--max-time|-w) shift 2;;
+        -sS) shift;;
+        *) shift;;
+    esac
+done
+[[ -n "${FAKE_CURL_PAYLOAD_OUT:-}" ]] && printf '%s' "$payload" > "$FAKE_CURL_PAYLOAD_OUT"
+[[ -n "$out_file" ]] && printf 'RIFFfakewavdata' > "$out_file"
+printf '200'
+"""
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir, sentinel
+
+
+def _run_qwen_payload_capture(
+    tmp_path: Path,
+    extra_env: dict[str, str],
+    text: str = "hello",
+) -> dict:
+    """Run openai-qwen.sh end-to-end with a fake curl on PATH; return the
+    parsed JSON payload the provider would have POSTed.
+
+    The provider's production code path runs unmodified — no `VOX_DEBUG_*`
+    hooks, no mocking of the script itself. Only `curl` is replaced, via the
+    PATH-interposition pattern.
+    """
+    import json as _json
+
+    fake_bin, sentinel = _install_fake_curl(tmp_path)
+    out_path = tmp_path / "out.wav"
+    env = {
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "VOX_OUTPUT_FILE": str(out_path),
+        "VOX_ENDPOINT": "http://example.invalid/v1/audio/speech",
+        "FAKE_CURL_PAYLOAD_OUT": str(sentinel),
+        **extra_env,
+    }
+    r = subprocess.run(
+        [str(OPENAI_QWEN), text],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert r.returncode == 0, f"provider exited {r.returncode}: {r.stderr}"
+    assert sentinel.exists(), "fake curl did not capture payload"
+    return _json.loads(sentinel.read_text())
+
+
+def test_openai_qwen_omits_emotion_when_unset(tmp_path):
+    payload = _run_qwen_payload_capture(tmp_path, extra_env={})
+    assert "emotion" not in payload, f"emotion field leaked: {payload}"
+    assert payload["model"] == "tts-1"
+    assert payload["voice"] == "alloy"
+    assert payload["input"] == "hello"
+    assert payload["response_format"] == "wav"
+
+
+def test_openai_qwen_omits_emotion_when_empty_string(tmp_path):
+    payload = _run_qwen_payload_capture(tmp_path, extra_env={"VOX_EMOTION": ""})
+    assert "emotion" not in payload, f"emotion='' should be omitted, got: {payload}"
+
+
+def test_openai_qwen_includes_emotion_when_set(tmp_path):
+    payload = _run_qwen_payload_capture(
+        tmp_path,
+        extra_env={"VOX_EMOTION": "cheerful"},
+    )
+    assert payload.get("emotion") == "cheerful"
+
+
+def test_openai_qwen_includes_free_form_emotion(tmp_path):
+    """qwen3-tts accepts natural-language emotion prompts, not just single tokens."""
+    phrase = "the speaker's voice is very young and warm"
+    payload = _run_qwen_payload_capture(
+        tmp_path,
+        extra_env={"VOX_EMOTION": phrase},
+    )
+    assert payload.get("emotion") == phrase
+
+
+def test_openai_qwen_honors_voice_and_model_overrides(tmp_path):
+    payload = _run_qwen_payload_capture(
+        tmp_path,
+        extra_env={"VOX_VOICE": "clone:Stephi", "VOX_MODEL": "qwen3-tts"},
+    )
+    assert payload["voice"] == "clone:Stephi"
+    assert payload["model"] == "qwen3-tts"
+
+
+def test_openai_qwen_errors_without_endpoint(tmp_path):
+    out = tmp_path / "out.wav"
+    r = subprocess.run(
+        [str(OPENAI_QWEN), "hi"],
+        env={"PATH": os.environ["PATH"], "VOX_OUTPUT_FILE": str(out)},
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode != 0
+    assert "VOX_ENDPOINT" in r.stderr
+
+
+def test_openai_qwen_errors_without_output_file(tmp_path):
+    r = subprocess.run(
+        [str(OPENAI_QWEN), "hi"],
+        env={
+            "PATH": os.environ["PATH"],
+            "VOX_ENDPOINT": "http://example.invalid/",
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode != 0
+    assert "VOX_OUTPUT_FILE" in r.stderr
+
+
+# --- vox --setup --pick=openai-qwen ---
+
+
+def test_setup_accepts_openai_qwen_pick(env, tmp_path):
+    r = _run(
+        [str(VOX), "--setup", "--non-interactive", "--pick", "openai-qwen"],
+        env=env,
+    )
+    assert r.returncode == 0, r.stderr
+    link = Path(env["XDG_CONFIG_HOME"]) / "vox" / "provider"
+    assert link.is_symlink()
+    assert link.resolve() == OPENAI_QWEN.resolve()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ships a second OpenAI-compatible TTS provider example (`scripts/vox-providers/openai-qwen.sh`) that demonstrates the payload-extension pattern — how to cleanly add backend-specific fields (e.g. `emotion` for qwen3-tts) without polluting the canonical `openai-endpoint.sh` example.

Follow-up to #398 (the vox provider-hook refactor), prompted by a real user bring-up against a krieger/qwen3-tts server.

Closes #401.

## Changes

- **Added** `scripts/vox-providers/openai-qwen.sh` — same wire protocol as `openai-endpoint.sh` but conditionally includes `emotion` in the JSON payload when `VOX_EMOTION` is set. If unset or empty, the `emotion` key is omitted entirely (never sends `"emotion": ""` or `"emotion": null`).
- **Extended** `scripts/vox-providers/README.md`:
  - New row in "Bundled examples" table
  - New "Extending the JSON payload" subsection under "Writing your own provider" — worked example + MAY-honor/MUST-ignore discipline
- **Extended** `scripts/vox`:
  - `--setup --pick=openai-qwen` now works
  - `--help` and interactive setup list `openai-qwen` in the provider menu
- **Extended** `tests/test_vox.py`:
  - Added `openai-qwen.sh` to the parametrized shellcheck test
  - +8 new cases for payload-construction behavior (emotion omit/include, free-form prompt, voice/model overrides, missing-env errors)
  - +1 case for `--setup --pick=openai-qwen` symlink creation

## Contract discipline

Two rules the README and provider enforce:

1. **MAY honor, MUST ignore.** Providers whose backend doesn't support a field ignore it silently. `espeak.sh`, `piper-local.sh`, `macos-say.sh`, `silent.sh`, and `openai-endpoint.sh` all continue to ignore `VOX_EMOTION` unchanged.
2. **Unset = field omitted.** When `VOX_EMOTION` is unset or empty string, the payload MUST NOT include an `emotion` key. Prevents extended-field payloads from leaking into strict endpoints.

## Test approach

Real code-path testing via **PATH-interposed fake `curl`** — a test fixture script placed earlier on PATH captures the `-d` argument to a sentinel file, writes a dummy WAV body to the `-o` file, and emits `"200"` for the `%{http_code}` capture. The provider runs unmodified; zero network calls; no test-only hatches baked into the shipped script.

This approach came out of code review (see "Code review findings" below) — the first draft shipped a `VOX_DEBUG_PAYLOAD` env var that let tests observe the payload before curl ran. That's a test-only surface in production code with arbitrary-write risk AND network fragility in restricted CI. PATH interposition eliminates both.

## Code review findings (pre-commit)

feature-dev:code-reviewer found 2 HIGH findings, both fixed in-branch:

- **HIGH** `openai-qwen.sh` — shipped `VOX_DEBUG_PAYLOAD` env var was a caller-controlled write target with no bounds. Test-only escape hatch in production code. **Removed entirely.**
- **HIGH** `tests/test_vox.py` — used `curl` against `127.0.0.1:1` to force a quick connection-refused and then read a pre-curl payload dump. Fragile on CI where firewall DROP rules turn refused-connection into a 5-second wait. **Replaced with PATH-interposed fake curl** — no network calls at all, and the test now exercises *more* of the real code path than before (including `%{http_code}` capture and the post-curl body-size check).

## Test Plan

- `./scripts/ci/validate.sh` — **103 passed, 0 failed**
- `pytest tests/test_vox.py` — **30/30 pass** (21 existing + 9 new)
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- Manual smoke: `VOX_EMOTION="the speakers voice is very young" VOX_VOICE="clone:Stephi" vox-providers/openai-qwen.sh "test"` against `http://krieger:8004/v1/audio/speech` → valid 24kHz mono WAV returned

## Linked Issues

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)