### PR TITLE
fix(install): restore context-crystallizer deploy block

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The `context-crystallizer/` directory contains the hooks and libraries that powe
 - **Libraries** — `context-analyzer.sh` (parse API payloads for token counts), `crystallizer.sh` (write crystal files)
 - **CLI** — `cc-context` (watch token usage in a terminal), `cc-cleanup` (prune old crystal files)
 
-Install standalone with `./install.sh --crystallizer`.
+Install standalone with `./install --crystallizer`.
 
 ### Settings Template
 
@@ -174,7 +174,7 @@ This will:
 ./install.sh --scripts     # Install scripts only
 ./install.sh --config      # Install config files only
 ./install.sh --mcps         # Install MCP servers only (via mcps.json manifest)
-./install.sh --crystallizer # Install context-crystallizer only
+./install --crystallizer   # Install context-crystallizer only
 ./install.sh --no-mcps      # Install everything except MCP servers
 ```
 

--- a/install
+++ b/install
@@ -12,16 +12,18 @@
 #   ./install.sh --scripts    Install scripts only (also builds packages from src/)
 #   ./install.sh --config     Install config files only (smart-merges settings.json)
 #   ./install.sh --mcps       Install MCP servers only (via mcps.json manifest)
+#   ./install.sh --crystallizer Install context-crystallizer only
 #   ./install.sh --no-mcps    Install everything except MCP servers
 #
 # Targets:
-#   Skills     → ~/.claude/skills/<name>/SKILL.md
-#   Scripts    → ~/.local/bin/<name>
-#   Packages   → ~/.local/bin/<name> (built from src/ via scripts/ci/build.sh)
-#   Statusline → ~/.claude/statusline-command.sh
-#   Settings   → ~/.claude/settings.json (smart-merged: missing keys added, your
-#                 customizations preserved — see merge_settings() for rules)
-#   MCPs       → user-scope MCP servers (installed via each MCP's install-remote.sh)
+#   Skills       → ~/.claude/skills/<name>/SKILL.md
+#   Scripts      → ~/.local/bin/<name>
+#   Packages     → ~/.local/bin/<name> (built from src/ via scripts/ci/build.sh)
+#   Statusline   → ~/.claude/statusline-command.sh
+#   Settings     → ~/.claude/settings.json (smart-merged: missing keys added, your
+#                   customizations preserved — see merge_settings() for rules)
+#   MCPs         → user-scope MCP servers (installed via each MCP's install-remote.sh)
+#   Crystallizer → ~/.claude/context-crystallizer/ (hooks, lib, bin)
 #
 # Existing files are backed up to <file>.bak before overwriting.
 
@@ -37,6 +39,7 @@ INSTALL_SKILLS=true
 INSTALL_SCRIPTS=true
 INSTALL_CONFIG=true
 INSTALL_MCPS=true
+INSTALL_CRYSTALLIZER=true
 
 # --- Parse args ---------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
@@ -53,24 +56,35 @@ while [[ $# -gt 0 ]]; do
 		INSTALL_SCRIPTS=false
 		INSTALL_CONFIG=false
 		INSTALL_MCPS=false
+		INSTALL_CRYSTALLIZER=false
 		shift
 		;;
 	--scripts)
 		INSTALL_SKILLS=false
 		INSTALL_CONFIG=false
 		INSTALL_MCPS=false
+		INSTALL_CRYSTALLIZER=false
 		shift
 		;;
 	--config)
 		INSTALL_SKILLS=false
 		INSTALL_SCRIPTS=false
 		INSTALL_MCPS=false
+		INSTALL_CRYSTALLIZER=false
 		shift
 		;;
 	--mcps)
 		INSTALL_SKILLS=false
 		INSTALL_SCRIPTS=false
 		INSTALL_CONFIG=false
+		INSTALL_CRYSTALLIZER=false
+		shift
+		;;
+	--crystallizer)
+		INSTALL_SKILLS=false
+		INSTALL_SCRIPTS=false
+		INSTALL_CONFIG=false
+		INSTALL_MCPS=false
 		shift
 		;;
 	--no-mcps)
@@ -310,6 +324,20 @@ if [[ "$CHECK_MODE" == true ]]; then
 		done
 	fi
 
+	# Crystallizer: compare repo files vs ~/.claude/context-crystallizer/
+	if [[ -d "$REPO_DIR/context-crystallizer" ]]; then
+		echo ""
+		echo "Crystallizer"
+		echo "──────────────────────────────────────────"
+		CRYST_DEST="$CLAUDE_DIR/context-crystallizer"
+		while IFS= read -r src_file; do
+			rel="${src_file#"$REPO_DIR"/context-crystallizer/}"
+			dest="$CRYST_DEST/$rel"
+			total=$((total + 1))
+			do_check "$src_file" "$dest" "crystallizer/$rel" || drifted=$((drifted + 1))
+		done < <(find "$REPO_DIR/context-crystallizer" -type f | sort)
+	fi
+
 	# MCPs: check each MCP's install-remote.sh --check
 	if [[ -f "$REPO_DIR/mcps.json" ]] && command -v claude &>/dev/null; then
 		echo ""
@@ -362,7 +390,7 @@ if [[ "$CHECK_MODE" == true ]]; then
 		echo "All $total items in sync."
 	else
 		echo "$drifted of $total items out of sync."
-		echo "Run ./install.sh to update."
+		echo "Run ./install to update."
 	fi
 	exit 0
 fi
@@ -470,6 +498,24 @@ if [[ "$INSTALL_CONFIG" == true ]]; then
 			fi
 		fi
 	fi
+fi
+
+# --- Install context-crystallizer ---------------------------------------------
+if [[ "$INSTALL_CRYSTALLIZER" == true && -d "$REPO_DIR/context-crystallizer" ]]; then
+	echo ""
+	echo "Crystallizer → $CLAUDE_DIR/context-crystallizer"
+	echo "──────────────────────────────────────────"
+	CRYST_DEST="$CLAUDE_DIR/context-crystallizer"
+	while IFS= read -r src_file; do
+		rel="${src_file#"$REPO_DIR"/context-crystallizer/}"
+		dest="$CRYST_DEST/$rel"
+		do_copy "$src_file" "$dest"
+		if [[ "$DRY_RUN" != true ]]; then
+			case "$dest" in
+			*.sh | */bin/*) chmod +x "$dest" ;;
+			esac
+		fi
+	done < <(find "$REPO_DIR/context-crystallizer" -type f | sort)
 fi
 
 # --- Build and install packages -----------------------------------------------


### PR DESCRIPTION
## Summary

PR #281 (the `install.sh` → `install` rename + `ok()` helper fix) silently dropped 45 lines of context-crystallizer install logic that PR #231 had added. Existing users are unaffected because their `~/.claude/context-crystallizer/` directory was populated by the pre-regression install script. **Fresh installs have been broken since 2026-04-06**: `config/settings.template.json` deploys three hooks pointing at `~/.claude/context-crystallizer/hooks/*.sh`, but those files were never copied there, so every tool call, session start, and subagent stop fires a missing-file hook error.

## Changes

- **`install`** (+52/-10):
  - Add `INSTALL_CRYSTALLIZER=true` flag and `--crystallizer` exclusive arg
  - Propagate `INSTALL_CRYSTALLIZER=false` through the four existing exclusive flags (`--skills`, `--scripts`, `--config`, `--mcps`)
  - Add crystallizer drift block to `--check` mode, placed between settings and MCP sections
  - Add main install block after Config section: deploys `context-crystallizer/{hooks,lib,bin}/*` to `~/.claude/context-crystallizer/` with `chmod +x` for `*.sh` and `*/bin/*`
  - Update "Run ./install.sh to update" → "Run ./install to update" in check-mode footer
  - Use `while IFS= read -r` with process substitution instead of `for x in $(find ...)` for whitespace-safety
- **`README.md`** (+2/-2): `./install.sh --crystallizer` → `./install --crystallizer` on the two crystallizer-flag references

## Linked Issues

Closes #404

## Test Plan

- [x] `./scripts/ci/validate.sh` → 103 passed, 0 failed
- [x] `./install --dry-run` → crystallizer block shows all 12 files would be deployed
- [x] `./install --check` → reports all 12 crystallizer files in sync (BJ's machine already has them)
- [x] `./install --crystallizer --dry-run` → exclusive flag skips skills/scripts/config/mcps, runs crystallizer only
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` → 0 findings
- [x] `feature-dev:code-reviewer` agent — no critical or important defects; flag propagation symmetric
- [ ] Fresh-install repro on a machine without `~/.claude/context-crystallizer/` — not run (no clean machine available); logically implied by the above

## Follow-ups (deferred, out of scope)

- Broader `install.sh` → `install` rename cleanup across README (lines 30, 111, 151, 156, 171-178, 186, 203), CHANGELOG, and `docs/` — 17+ remaining references, same root regression.
- Consider extracting crystallizer to its own repo with `install-remote.sh`, following the MCP server pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)