### PR TITLE
feat(wave-status): add set-kahuna-branch subcommand for KAHUNA state writes

### DIFF
--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -38,6 +38,7 @@ from wave_status.state import (
     review,
     save_json,
     set_current_wave,
+    set_kahuna_branch,
     show,
     status_dir,
     store_flight_plan,
@@ -209,6 +210,14 @@ def _cmd_set_current(args: argparse.Namespace) -> None:
     _regenerate_dashboard(root)
 
 
+def _cmd_set_kahuna_branch(args: argparse.Namespace) -> None:
+    """Handle ``set-kahuna-branch [<branch>]`` — empty arg clears the field."""
+    root = get_project_root()
+    branch = args.branch.strip() if args.branch else ""
+    set_kahuna_branch(branch or None, root)
+    _regenerate_dashboard(root)
+
+
 def _cmd_wavemachine_start(args: argparse.Namespace) -> None:
     """Handle ``wavemachine-start [--launcher <tag>]``."""
     root = get_project_root()
@@ -361,6 +370,19 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_sc.add_argument("wave_id", help="Wave ID (e.g. 'wave-6a')")
     p_sc.set_defaults(func=_cmd_set_current)
+
+    # set-kahuna-branch
+    p_skb = sub.add_parser(
+        "set-kahuna-branch",
+        help="Set or clear the active KAHUNA integration branch (devspec §5.1.4)",
+    )
+    p_skb.add_argument(
+        "branch",
+        nargs="?",
+        default="",
+        help="Branch name (e.g. 'kahuna/42-foo'); pass empty to clear",
+    )
+    p_skb.set_defaults(func=_cmd_set_kahuna_branch)
 
     # wavemachine-start
     p_ws = sub.add_parser(

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -733,6 +733,26 @@ def set_current_wave(wave_id: str, root: Path) -> dict:
     return state_data
 
 
+def set_kahuna_branch(branch: str | None, root: Path) -> dict:
+    """Set or clear ``kahuna_branch`` in ``state.json``.
+
+    Used by the sdlc-server ``wave_init`` handler (mcp-server-sdlc#206) when
+    the optional ``kahuna`` argument is passed — the handler creates the
+    integration branch via the platform API and then calls this CLI to record
+    the branch name in wave state. See devspec §5.1.4 for the schema.
+
+    Pass an empty string or ``None`` to clear the field (sets ``kahuna_branch``
+    to ``None`` in the JSON, which serializes as ``null``). Idempotent:
+    re-setting the same value is a no-op aside from ``last_updated``.
+    """
+    d = status_dir(root)
+    state_data = load_state(d / "state.json")
+    state_data["kahuna_branch"] = branch if branch else None
+    state_data["last_updated"] = _now_iso()
+    save_json(d / "state.json", state_data)
+    return state_data
+
+
 def wavemachine_start(root: Path, launcher: str = "") -> dict:
     """Mark the plan as actively driven by wavemachine.
 

--- a/tests/test_wave_status.py
+++ b/tests/test_wave_status.py
@@ -534,6 +534,89 @@ class TestSetCurrent:
         assert html.stat().st_mtime_ns >= mtime_before
 
 
+class TestSetKahunaBranch:
+    """Verify ``set-kahuna-branch`` writes/clears the KAHUNA branch field."""
+
+    def test_set_kahuna_branch_writes_field(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """``set-kahuna-branch kahuna/42-foo`` writes kahuna_branch to state."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        rc, _, err = run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+        assert rc == 0, f"set-kahuna-branch failed: {err}"
+        assert _state(repo)["kahuna_branch"] == "kahuna/42-foo"
+
+    def test_set_kahuna_branch_empty_arg_clears(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Empty string arg clears the field (sets to null)."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+
+        rc, _, err = run_cli(["set-kahuna-branch", ""], repo)
+        assert rc == 0, f"clear failed: {err}"
+        assert _state(repo)["kahuna_branch"] is None
+
+    def test_set_kahuna_branch_no_arg_clears(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Missing positional arg defaults to empty → clear."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+
+        rc, _, err = run_cli(["set-kahuna-branch"], repo)
+        assert rc == 0, f"clear via no-arg failed: {err}"
+        assert _state(repo)["kahuna_branch"] is None
+
+    def test_set_kahuna_branch_idempotent(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Re-setting the same value does not error and leaves state unchanged."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+
+        rc, _, err = run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+        assert rc == 0, f"idempotent re-set failed: {err}"
+        assert _state(repo)["kahuna_branch"] == "kahuna/42-foo"
+
+    def test_set_kahuna_branch_regenerates_dashboard(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """``set-kahuna-branch`` triggers dashboard regeneration."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        html = repo / ".status-panel.html"
+        assert html.exists()
+        mtime_before = html.stat().st_mtime_ns
+
+        time.sleep(0.05)
+        rc, _, _ = run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+        assert rc == 0
+        assert html.stat().st_mtime_ns >= mtime_before
+
+    def test_set_kahuna_branch_replaces_previous(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Setting a new branch overwrites the previous value."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+        run_cli(["set-kahuna-branch", "kahuna/43-bar"], repo)
+
+        assert _state(repo)["kahuna_branch"] == "kahuna/43-bar"
+
+
 class TestWavemachineFlag:
     """Verify ``wavemachine-start`` / ``wavemachine-stop`` flip state flags."""
 


### PR DESCRIPTION
## Summary

Adds `wave-status set-kahuna-branch <branch>` to write the new `kahuna_branch` field in `.claude/status/state.json`. Empty/missing arg clears the field. Idempotent.

Required because the existing CLI had no path to mutate the `kahuna_branch` field (defined in mcp-server-sdlc#207), and the wave-state mandate forbids direct fs writes from external callers (incl. the sdlc-server). The handler in mcp-server-sdlc#206 will shell out to this subcommand after creating the integration branch via the platform API.

## Changes

- `src/wave_status/state.py` — `set_kahuna_branch(branch, root)` mutator following the `set_current_wave` pattern (load_state → set field → save → return). Accepts `str | None`; `""` or `None` clears.
- `src/wave_status/__main__.py` — imported, registered `_cmd_set_kahuna_branch` dispatcher and `set-kahuna-branch` subparser with `nargs="?"` so empty/missing arg clears.
- `tests/test_wave_status.py` — `TestSetKahunaBranch` class, 6 subprocess-based integration tests.

## Linked Issues

Closes #433

## Test Plan

- [x] `pytest tests/test_wave_status.py::TestSetKahunaBranch` — 6/6 pass
- [x] `pytest tests/test_wave_status.py tests/test_state.py tests/test_cli.py` — 191/191 pass
- [x] `./scripts/ci/validate.sh` — 105 passed, 0 failed
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — clean (0 critical, 0 important above threshold)

## Notes

Cross-repo dependency: this lands first, then mcp-server-sdlc#206 (the handler that calls the subcommand) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)