### PR TITLE
feat(wave-status): render kahuna_branch, kahuna_branches, gate actions

### DIFF
--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -233,7 +233,15 @@ def _cmd_wavemachine_stop(args: argparse.Namespace) -> None:
 
 
 def _cmd_show(args: argparse.Namespace) -> None:
-    """Handle ``show`` — print summary, NO dashboard regen."""
+    """Handle ``show`` — print summary, NO dashboard regen.
+
+    When the state carries KAHUNA context (``kahuna_branch`` set, or
+    ``kahuna_branches`` history non-empty, or ``action`` is a gate state),
+    the summary is followed by a "Kahuna" section with branch + merged/
+    pending flight counts, a trust-signal summary for ``gate_evaluating``,
+    a failure detail block for ``gate_blocked``, and a collapsed history
+    table (last 10 entries) per devspec §5.2.5.
+    """
     root = get_project_root()
     summary = show(root)
     lines = [
@@ -245,7 +253,100 @@ def _cmd_show(args: argparse.Namespace) -> None:
         f"Progress:  {summary['progress']}",
         f"Deferrals: {summary['deferrals']}",
     ]
+    lines.extend(_render_kahuna_cli(summary))
     print("\n".join(lines))
+
+
+def _render_kahuna_cli(summary: dict) -> list[str]:
+    """Format the Kahuna CLI block from a ``state.show`` summary.
+
+    Returns an empty list when there is no Kahuna context to report so
+    legacy, non-KAHUNA output remains byte-identical.
+    """
+    branch = summary.get("kahuna_branch")
+    history = summary.get("kahuna_branches") or []
+    action_key = summary.get("action_key") or ""
+    detail = summary.get("action_detail")
+
+    has_context = bool(branch) or bool(history) or action_key in (
+        "gate_evaluating",
+        "gate_blocked",
+    )
+    if not has_context:
+        return []
+
+    out: list[str] = ["", "Kahuna:"]
+
+    if branch:
+        merged = summary.get("kahuna_flights_merged", 0)
+        pending = summary.get("kahuna_flights_pending", 0)
+        out.append(f"  Branch:   {branch}")
+        out.append(f"  Flights:  {merged} merged, {pending} pending")
+    else:
+        out.append("  Branch:   (none active)")
+
+    if action_key == "gate_evaluating":
+        signals: list[str] = []
+        if isinstance(detail, dict):
+            raw = detail.get("signals")
+            if isinstance(raw, list):
+                signals = [str(s) for s in raw]
+        if not signals:
+            signals = [
+                "commutativity_verify",
+                "ci_wait_run",
+                "code-reviewer",
+                "trivy vuln scan",
+            ]
+        out.append("  Trust signals evaluating:")
+        for s in signals:
+            out.append(f"    - {s}")
+
+    elif action_key == "gate_blocked":
+        failures: list[str] = []
+        if isinstance(detail, dict):
+            raw = detail.get("failures")
+            if isinstance(raw, list):
+                for entry in raw:
+                    if isinstance(entry, dict):
+                        sig = str(entry.get("signal", ""))
+                        reason = str(entry.get("reason", ""))
+                        failures.append(
+                            f"{sig}: {reason}" if reason else sig
+                        )
+                    else:
+                        failures.append(str(entry))
+        elif isinstance(detail, str) and detail:
+            failures.append(detail)
+        if not failures:
+            failures.append("Gate blocked — see wave state for details.")
+        out.append("  Gate blocked — failing signals:")
+        for f in failures:
+            out.append(f"    - {f}")
+
+    if history:
+        # Collapsible table — print a header and up to the last 10 rows.
+        shown = history[-10:]
+        out.append(f"  History (last {len(shown)} of {len(history)}):")
+        out.append(
+            "    BRANCH | EPIC | CREATED | RESOLVED | DISPOSITION | "
+            "MERGE_SHA | ABORT_REASON"
+        )
+        for entry in shown:
+            if not isinstance(entry, dict):
+                continue
+            b = str(entry.get("branch", ""))
+            epic = str(entry.get("epic_id", ""))
+            created = str(entry.get("created_at", ""))
+            resolved = str(entry.get("resolved_at", ""))
+            disp = str(entry.get("disposition", ""))
+            sha = str(entry.get("main_merge_sha", "-") or "-")
+            reason = str(entry.get("abort_reason", "-") or "-")
+            out.append(
+                f"    {b} | {epic} | {created} | {resolved} | {disp} | "
+                f"{sha} | {reason}"
+            )
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/wave_status/dashboard/generator.py
+++ b/src/wave_status/dashboard/generator.py
@@ -21,6 +21,7 @@ from wave_status.dashboard.deferral_sections import (
 )
 from wave_status.dashboard.execution_grid import render_execution_grid
 from wave_status.dashboard.gauge_cards import render_gauge_cards
+from wave_status.dashboard.kahuna_section import render_kahuna_section
 from wave_status.dashboard.polling import render_polling_script
 from wave_status.dashboard.progress_rail import render_progress_rail
 from wave_status.dashboard.theme import ACTION_BANNER_STATES, render_base_css
@@ -132,6 +133,7 @@ def generate_dashboard(
     css = render_base_css()
     header = _render_header(phases_data, state_data)
     banner = _render_action_banner(state_data)
+    kahuna = render_kahuna_section(state_data, flights_data)
     rail = render_progress_rail(phases_data, state_data)
     gauges = render_gauge_cards(phases_data, state_data, flights_data)
     pending_deferrals = render_pending_deferrals(state_data)
@@ -139,6 +141,11 @@ def generate_dashboard(
     accepted_deferrals = render_accepted_deferrals(state_data)
     footer = _render_footer(state_data)
     script = render_polling_script()
+
+    # Kahuna section sits between the action banner and the progress rail
+    # when present.  Legacy state files (no kahuna_branch / kahuna_branches)
+    # produce an empty string — we drop an empty line to keep output tidy.
+    kahuna_block = f"{kahuna}\n" if kahuna else ""
 
     html_content = (
         "<!DOCTYPE html>\n"
@@ -155,6 +162,7 @@ def generate_dashboard(
         '<div class="container">\n'
         f"{header}\n"
         f"{banner}\n"
+        f"{kahuna_block}"
         f"{rail}\n"
         f"{gauges}\n"
         f"{pending_deferrals}\n"

--- a/src/wave_status/dashboard/kahuna_section.py
+++ b/src/wave_status/dashboard/kahuna_section.py
@@ -1,0 +1,259 @@
+"""Dashboard Kahuna section component.
+
+Renders the "Kahuna" block for the wave-status dashboard:
+- active ``kahuna_branch`` display with merged/pending flight counts
+- trust-signal summary block when ``action == gate_evaluating``
+- signal-failure detail block when ``action == gate_blocked``
+- ``kahuna_branches`` history table (collapsible, last 10 entries)
+
+Devspec references: §5.1.4 (schema), §5.2.5 (CLI/dashboard render), R-17/R-18,
+MV-02/MV-03.
+
+Pure presentation — takes parsed state/flights dicts and returns an HTML
+string. Returns an empty string when no Kahuna context is present so the
+legacy (non-KAHUNA) dashboard stays visually identical.
+
+No imports outside Python 3.10+ stdlib and wave_status internals [CT-01].
+"""
+
+from __future__ import annotations
+
+import html as _html
+
+
+# Maximum number of history rows rendered before the table collapses.  The
+# spec calls for "last 10 entries" (devspec §5.2.5).
+_HISTORY_LIMIT = 10
+
+
+def _flight_counts(flights_data: dict, current_wave: str | None) -> tuple[int, int]:
+    """Return ``(merged, pending)`` flight counts for *current_wave*.
+
+    "merged" here means a flight whose status is ``completed`` — the CLI's
+    existing vocabulary for a flight whose PRs have been merged (see
+    ``state.flight_done``).  Anything else that isn't ``completed`` counts as
+    "pending" (pending, running, or any future intermediate status).
+    """
+    if current_wave is None:
+        return (0, 0)
+    wave_flights = flights_data.get("flights", {}).get(current_wave, [])
+    merged = 0
+    pending = 0
+    for fl in wave_flights:
+        if fl.get("status") == "completed":
+            merged += 1
+        else:
+            pending += 1
+    return (merged, pending)
+
+
+def _render_trust_signals(state_data: dict) -> str:
+    """Render the trust-signal summary block for ``action == gate_evaluating``.
+
+    The summary lists which signals are currently being evaluated.  The list
+    comes from ``current_action.detail.signals`` when present (a list of
+    strings); otherwise falls back to the four canonical signals from
+    devspec §5.2.2 step 4.
+    """
+    current_action = state_data.get("current_action") or {}
+    detail = current_action.get("detail")
+
+    signals: list[str] = []
+    if isinstance(detail, dict):
+        raw = detail.get("signals")
+        if isinstance(raw, list):
+            signals = [str(s) for s in raw]
+    if not signals:
+        # Canonical four signals per devspec §5.2.2 step 4 / §4.4.4 detection.
+        signals = [
+            "commutativity_verify",
+            "ci_wait_run",
+            "code-reviewer",
+            "trivy vuln scan",
+        ]
+
+    items = "\n".join(
+        f"    <li>{_html.escape(s)}</li>" for s in signals
+    )
+    return (
+        '  <div class="kahuna-trust-signals">\n'
+        '    <h3>Trust signals evaluating</h3>\n'
+        '    <ul class="kahuna-signal-list">\n'
+        f"{items}\n"
+        "    </ul>\n"
+        "  </div>"
+    )
+
+
+def _render_signal_failures(state_data: dict) -> str:
+    """Render the signal-failure detail block for ``action == gate_blocked``.
+
+    Reads ``current_action.detail.failures`` — a list of either plain strings
+    or dicts shaped ``{"signal": "...", "reason": "..."}``.  Falls back to
+    rendering the raw detail string when that structure isn't present, so
+    older callers that stuff a free-form message into ``detail`` still get
+    something visible.
+    """
+    current_action = state_data.get("current_action") or {}
+    detail = current_action.get("detail")
+
+    failure_items: list[str] = []
+    if isinstance(detail, dict):
+        raw = detail.get("failures")
+        if isinstance(raw, list):
+            for entry in raw:
+                if isinstance(entry, dict):
+                    signal = _html.escape(str(entry.get("signal", "")))
+                    reason = _html.escape(str(entry.get("reason", "")))
+                    text = f"<strong>{signal}</strong>"
+                    if reason:
+                        text = f"{text}: {reason}"
+                    failure_items.append(text)
+                else:
+                    failure_items.append(_html.escape(str(entry)))
+    elif isinstance(detail, str) and detail:
+        failure_items.append(_html.escape(detail))
+
+    if not failure_items:
+        failure_items.append("Gate blocked — see wave state for details.")
+
+    items_html = "\n".join(
+        f"    <li>{item}</li>" for item in failure_items
+    )
+    return (
+        '  <div class="kahuna-signal-failures">\n'
+        '    <h3>Gate blocked — failing signals</h3>\n'
+        '    <ul class="kahuna-signal-list">\n'
+        f"{items_html}\n"
+        "    </ul>\n"
+        "  </div>"
+    )
+
+
+def _render_history_table(state_data: dict) -> str:
+    """Render the ``kahuna_branches`` history table (collapsible, last 10).
+
+    Missing optional fields (``main_merge_sha``, ``abort_reason``) are
+    tolerated — their columns render as an em-dash placeholder.
+    """
+    history = state_data.get("kahuna_branches")
+    if not isinstance(history, list) or not history:
+        return ""
+
+    # Take the most recent N entries; order preserved as written (the
+    # orchestrator appends chronologically per devspec §5.1.4 schema).
+    rows_src = history[-_HISTORY_LIMIT:]
+
+    rows: list[str] = []
+    for entry in rows_src:
+        if not isinstance(entry, dict):
+            continue
+        branch = _html.escape(str(entry.get("branch", "")))
+        epic_id = _html.escape(str(entry.get("epic_id", "")))
+        created_at = _html.escape(str(entry.get("created_at", "")))
+        resolved_at = _html.escape(str(entry.get("resolved_at", "")))
+        disposition = str(entry.get("disposition", ""))
+        disposition_html = _html.escape(disposition) if disposition else "—"
+        disposition_class = (
+            f"disposition-{_html.escape(disposition)}" if disposition else ""
+        )
+        # Optional fields — render an em-dash when missing.
+        merge_sha = entry.get("main_merge_sha")
+        merge_sha_html = _html.escape(str(merge_sha)) if merge_sha else "—"
+        abort_reason = entry.get("abort_reason")
+        abort_reason_html = (
+            _html.escape(str(abort_reason)) if abort_reason else "—"
+        )
+        rows.append(
+            "      <tr>\n"
+            f"        <td>{branch}</td>\n"
+            f"        <td>{epic_id}</td>\n"
+            f"        <td>{created_at}</td>\n"
+            f"        <td>{resolved_at}</td>\n"
+            f'        <td class="{disposition_class}">{disposition_html}</td>\n'
+            f"        <td>{merge_sha_html}</td>\n"
+            f"        <td>{abort_reason_html}</td>\n"
+            "      </tr>"
+        )
+
+    if not rows:
+        return ""
+
+    header = (
+        "<thead><tr>"
+        "<th>Branch</th>"
+        "<th>Epic</th>"
+        "<th>Created</th>"
+        "<th>Resolved</th>"
+        "<th>Disposition</th>"
+        "<th>Merge SHA</th>"
+        "<th>Abort reason</th>"
+        "</tr></thead>"
+    )
+    return (
+        '  <details class="kahuna-history">\n'
+        f"    <summary>Kahuna history ({len(rows)} / {len(history)} entries)</summary>\n"
+        '    <table class="kahuna-history-table">\n'
+        f"      {header}\n"
+        "      <tbody>\n"
+        + "\n".join(rows)
+        + "\n      </tbody>\n"
+        "    </table>\n"
+        "  </details>"
+    )
+
+
+def render_kahuna_section(state_data: dict, flights_data: dict) -> str:
+    """Render the full Kahuna section.
+
+    Returns an empty string when the state has no Kahuna context at all
+    (no active ``kahuna_branch`` AND no ``kahuna_branches`` history).
+    Legacy non-KAHUNA state files produce no output so the existing
+    dashboard layout is unaffected.
+    """
+    kahuna_branch = state_data.get("kahuna_branch")
+    history = state_data.get("kahuna_branches")
+    has_history = isinstance(history, list) and len(history) > 0
+
+    if not kahuna_branch and not has_history:
+        return ""
+
+    action_obj = state_data.get("current_action") or {}
+    action_key = action_obj.get("action", "")
+
+    parts: list[str] = ['<div class="kahuna-section">']
+    parts.append("  <h2>Kahuna</h2>")
+
+    if kahuna_branch:
+        branch_html = _html.escape(str(kahuna_branch))
+        parts.append(
+            f'  <div class="kahuna-branch">Active branch: '
+            f"<code>{branch_html}</code></div>"
+        )
+        current_wave = state_data.get("current_wave")
+        merged, pending = _flight_counts(flights_data, current_wave)
+        parts.append(
+            f'  <div class="kahuna-counts">'
+            f"Flights: {merged} merged, {pending} pending"
+            "</div>"
+        )
+    else:
+        # Only history is present (epic completed, cleaned up) — still show
+        # the header so the history table has context.
+        parts.append(
+            '  <div class="kahuna-counts">No active Kahuna branch.</div>'
+        )
+
+    # Action-conditional blocks (MV-03).
+    if action_key == "gate_evaluating":
+        parts.append(_render_trust_signals(state_data))
+    elif action_key == "gate_blocked":
+        parts.append(_render_signal_failures(state_data))
+
+    if has_history:
+        history_html = _render_history_table(state_data)
+        if history_html:
+            parts.append(history_html)
+
+    parts.append("</div>")
+    return "\n".join(parts)

--- a/src/wave_status/dashboard/theme.py
+++ b/src/wave_status/dashboard/theme.py
@@ -115,6 +115,23 @@ ACTION_BANNER_STATES: dict[str, dict[str, str]] = {
         "border_color": "var(--border)",
         "animation": "none",
     },
+    # Kahuna trust-score gate evaluating — pulsing yellow to signal active
+    # concurrent scoring (devspec §5.1.4, §5.2.5; R-23, MV-03).
+    "gate_evaluating": {
+        "icon": "&#x1F6A6;",  # vertical traffic light
+        "css_class": "action-gate-evaluating",
+        "border_color": "var(--yellow)",
+        "animation": "pulse 1.5s ease-in-out infinite",
+    },
+    # Kahuna trust-score gate blocked — red emphasis, one or more signals
+    # failed (devspec §5.1.4, §5.2.5; R-23, MV-03). Also gets an outer throb
+    # so the blocked state reads clearly against the other red failure cues.
+    "gate_blocked": {
+        "icon": "&#x1F6D1;",  # stop sign
+        "css_class": "action-gate-blocked",
+        "border_color": "var(--red)",
+        "animation": "throb 2.5s ease-in-out infinite",
+    },
 }
 
 
@@ -243,6 +260,25 @@ body {{
 @keyframes glow {{
     0%, 100% {{ box-shadow: 0 0 5px var(--fuchsia-dim); }}
     50% {{ box-shadow: 0 0 20px var(--fuchsia), 0 0 40px var(--fuchsia-dim); }}
+}}
+
+@keyframes pulse {{
+    0%, 100% {{ box-shadow: 0 0 4px var(--yellow), inset 0 0 0 rgba(255, 204, 0, 0); }}
+    50%      {{ box-shadow: 0 0 16px var(--yellow), inset 0 0 0 rgba(255, 204, 0, 0.15); }}
+}}
+
+/* === Kahuna gate emphasis (devspec §5.2.5) === */
+
+.action-banner.action-gate-blocked {{
+    background: rgba(255, 68, 68, 0.08);
+}}
+
+.action-banner.action-gate-blocked .label {{
+    color: var(--red);
+}}
+
+.action-banner.action-gate-evaluating .label {{
+    color: var(--yellow);
 }}
 
 /* === Progress Rail === */
@@ -509,6 +545,120 @@ body {{
     color: var(--orange);
     margin-top: 8px;
     display: none;
+}}
+
+/* === Kahuna section (devspec §5.2.5) === */
+
+.kahuna-section {{
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--cyan);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 20px;
+}}
+
+.kahuna-section h2 {{
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--cyan);
+    margin-bottom: 10px;
+}}
+
+.kahuna-section .kahuna-branch {{
+    font-family: var(--font-stack);
+    color: var(--text);
+    font-size: 0.95rem;
+    margin-bottom: 6px;
+    word-break: break-all;
+}}
+
+.kahuna-section .kahuna-counts {{
+    color: var(--text-dim);
+    font-size: 0.85rem;
+}}
+
+.kahuna-trust-signals,
+.kahuna-signal-failures {{
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px dashed var(--border);
+}}
+
+.kahuna-trust-signals h3,
+.kahuna-signal-failures h3 {{
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-dim);
+    margin-bottom: 6px;
+}}
+
+.kahuna-signal-failures {{
+    color: var(--red);
+}}
+
+.kahuna-signal-list {{
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}}
+
+.kahuna-signal-list li {{
+    padding: 3px 0;
+    font-size: 0.85rem;
+}}
+
+.kahuna-history {{
+    margin-top: 12px;
+}}
+
+.kahuna-history summary {{
+    cursor: pointer;
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 6px 0;
+}}
+
+.kahuna-history-table {{
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 6px;
+}}
+
+.kahuna-history-table th,
+.kahuna-history-table td {{
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.8rem;
+}}
+
+.kahuna-history-table th {{
+    color: var(--text-dim);
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 1px;
+}}
+
+.kahuna-history-table tr:last-child td {{
+    border-bottom: none;
+}}
+
+.kahuna-history-table .disposition-merged {{
+    color: var(--green);
+}}
+
+.kahuna-history-table .disposition-aborted {{
+    color: var(--red);
+}}
+
+.kahuna-history-table .disposition-abandoned {{
+    color: var(--orange);
 }}
 
 /* === Responsive === */

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -1137,10 +1137,18 @@ def show(root: Path) -> dict:
     accepted_count = sum(1 for d in deferrals if d.get("status") == "accepted")
 
     # Action.
-    action_obj = state_data.get("current_action", {})
+    action_obj = state_data.get("current_action", {}) or {}
     action_str = action_obj.get("action", "idle")
+    label_str = action_obj.get("label", "")
     detail = action_obj.get("detail", "")
-    action_display = f"{action_str} — {detail}" if detail else action_str
+    # The action display used to be a bare "action - detail" string, but
+    # the KAHUNA gate actions carry structured detail payloads (dict with
+    # "failures" / "signals") that render as gibberish when stringified.
+    # Fall back to the plain action when detail isn't a scalar.
+    if isinstance(detail, str) and detail:
+        action_display = f"{action_str} — {detail}"
+    else:
+        action_display = action_str
 
     flight_display: str
     if total_flights == 0:
@@ -1150,6 +1158,15 @@ def show(root: Path) -> dict:
     else:
         flight_display = f"\u2014/{total_flights}"
 
+    # Flight counts restricted to the current wave - used by the Kahuna
+    # section to report "merged / pending" per devspec 5.2.5.
+    kahuna_merged = sum(
+        1 for fl in wave_flights if fl.get("status") == "completed"
+    )
+    kahuna_pending = sum(
+        1 for fl in wave_flights if fl.get("status") != "completed"
+    )
+
     return {
         "project": plan_data.get("project", "unknown"),
         "phase": f"{current_phase_idx}/{total_phases}",
@@ -1157,6 +1174,14 @@ def show(root: Path) -> dict:
         "wave": f"{wave_in_phase}/{waves_in_current_phase} in phase {current_phase_idx}",
         "flight": flight_display,
         "action": action_display,
+        "action_key": action_str,
+        "action_label": label_str or action_str,
+        "action_detail": detail,
         "progress": f"{closed_issues}/{total_issues} issues ({pct}%)",
         "deferrals": f"{pending_count} pending, {accepted_count} accepted",
+        # Optional Kahuna fields - tolerate absence for legacy state files.
+        "kahuna_branch": state_data.get("kahuna_branch"),
+        "kahuna_branches": state_data.get("kahuna_branches", []) or [],
+        "kahuna_flights_merged": kahuna_merged,
+        "kahuna_flights_pending": kahuna_pending,
     }

--- a/tests/test_kahuna_section.py
+++ b/tests/test_kahuna_section.py
@@ -1,0 +1,530 @@
+"""Tests for wave_status.dashboard.kahuna_section and KAHUNA state rendering.
+
+Exercises REAL code paths — no mocking of the module under test.
+Covers AC-1 through AC-6 from issue #415 (KAHUNA devspec §5.1.4, §5.2.5).
+
+AC-7 (zipapp build succeeds) is covered by tests/test_zipapp.py and the
+``./scripts/ci/build.sh`` invocation in /precheck.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Ensure src/ is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wave_status.dashboard.generator import generate_dashboard
+from wave_status.dashboard.kahuna_section import (
+    render_kahuna_section,
+    _flight_counts,
+)
+from wave_status.dashboard.theme import ACTION_BANNER_STATES, render_base_css
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture data
+# ---------------------------------------------------------------------------
+
+def _legacy_state() -> dict:
+    """State with NO kahuna_branch and NO kahuna_branches history.
+
+    Backward-compat case — these fields were added additively by the
+    KAHUNA devspec. Reader must parse without error (AC-1 / AC-2).
+    """
+    return {
+        "current_wave": "wave-1",
+        "current_action": {
+            "action": "planning",
+            "label": "planning",
+            "detail": "wave-1",
+        },
+        "waves": {"wave-1": {"status": "in_progress", "mr_urls": {}}},
+        "issues": {"1": {"status": "open"}, "2": {"status": "open"}},
+        "deferrals": [],
+        "last_updated": "2026-04-24T00:00:00Z",
+    }
+
+
+def _kahuna_state(action: str = "in-flight", detail=None) -> dict:
+    """State with kahuna_branch + kahuna_branches populated.
+
+    History includes entries with BOTH variants — one with optional fields
+    present (``main_merge_sha``) and one missing them (``abort_reason``
+    only) — to exercise AC-2's "tolerates missing optional fields" clause.
+    """
+    return {
+        "current_wave": "wave-1",
+        "current_action": {
+            "action": action,
+            "label": action,
+            "detail": detail if detail is not None else "",
+        },
+        "waves": {"wave-1": {"status": "in_progress", "mr_urls": {}}},
+        "issues": {"1": {"status": "open"}, "2": {"status": "open"}},
+        "deferrals": [],
+        "last_updated": "2026-04-24T00:00:00Z",
+        "kahuna_branch": "kahuna/42-wave-status-cli",
+        "kahuna_branches": [
+            {
+                "branch": "kahuna/41-prior-epic",
+                "epic_id": 41,
+                "created_at": "2026-04-23T10:00:00Z",
+                "resolved_at": "2026-04-24T02:15:00Z",
+                "disposition": "merged",
+                "main_merge_sha": "abc123def456",
+            },
+            {
+                # Missing main_merge_sha; present abort_reason.
+                "branch": "kahuna/40-aborted-epic",
+                "epic_id": 40,
+                "created_at": "2026-04-22T08:00:00Z",
+                "resolved_at": "2026-04-22T09:30:00Z",
+                "disposition": "aborted",
+                "abort_reason": "code_reviewer_critical_findings",
+            },
+            {
+                # Missing BOTH optional fields.
+                "branch": "kahuna/39-abandoned-epic",
+                "epic_id": 39,
+                "created_at": "2026-04-21T08:00:00Z",
+                "resolved_at": "2026-04-21T09:30:00Z",
+                "disposition": "abandoned",
+            },
+        ],
+    }
+
+
+def _kahuna_flights() -> dict:
+    """Flights data with one completed flight and two non-completed."""
+    return {
+        "flights": {
+            "wave-1": [
+                {"issues": [1], "status": "completed"},
+                {"issues": [2], "status": "running"},
+                {"issues": [3], "status": "pending"},
+            ],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2: parser tolerates missing/optional fields
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyStateTolerance:
+    """Legacy state files without kahuna_* fields must render without error.
+
+    Maps to AC-1 (``kahuna_branch`` absent ignored) and AC-2
+    (``kahuna_branches`` array tolerated when absent).
+    """
+
+    def test_render_legacy_returns_empty(self) -> None:
+        """No kahuna fields -> empty string (no output at all)."""
+        html = render_kahuna_section(_legacy_state(), {"flights": {}})
+        assert html == ""
+
+    def test_legacy_state_full_dashboard_renders(self, tmp_path: Path) -> None:
+        """Full generate_dashboard with legacy state must not raise."""
+        phases = {
+            "project": "Legacy Project",
+            "phases": [
+                {
+                    "name": "Phase 1",
+                    "waves": [
+                        {
+                            "id": "wave-1",
+                            "issues": [
+                                {"number": 1, "title": "A"},
+                                {"number": 2, "title": "B"},
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+        out = generate_dashboard(
+            tmp_path, phases, _legacy_state(), {"flights": {}}
+        )
+        content = out.read_text(encoding="utf-8")
+        # No kahuna section should leak into the DOM.
+        assert 'class="kahuna-section"' not in content
+        # But the rest of the dashboard is intact.
+        assert "<!DOCTYPE html>" in content
+        assert "Legacy Project" in content
+
+
+class TestMissingOptionalFields:
+    """``kahuna_branches`` entries may omit ``main_merge_sha`` or
+    ``abort_reason`` — rendering must tolerate their absence (AC-2)."""
+
+    def test_missing_main_merge_sha_renders(self) -> None:
+        state = {
+            "kahuna_branches": [
+                {
+                    "branch": "kahuna/1-x",
+                    "epic_id": 1,
+                    "created_at": "2026-04-22T08:00:00Z",
+                    "resolved_at": "2026-04-22T09:30:00Z",
+                    "disposition": "aborted",
+                    "abort_reason": "manual_abandon",
+                },
+            ],
+        }
+        html = render_kahuna_section(state, {"flights": {}})
+        assert "kahuna/1-x" in html
+        assert "manual_abandon" in html
+        # A missing main_merge_sha renders as an em-dash placeholder.
+        assert "—" in html
+
+    def test_missing_abort_reason_renders(self) -> None:
+        state = {
+            "kahuna_branches": [
+                {
+                    "branch": "kahuna/2-y",
+                    "epic_id": 2,
+                    "created_at": "2026-04-22T08:00:00Z",
+                    "resolved_at": "2026-04-22T09:30:00Z",
+                    "disposition": "merged",
+                    "main_merge_sha": "deadbeef",
+                },
+            ],
+        }
+        html = render_kahuna_section(state, {"flights": {}})
+        assert "kahuna/2-y" in html
+        assert "deadbeef" in html
+
+    def test_both_optional_fields_missing_renders(self) -> None:
+        state = {
+            "kahuna_branches": [
+                {
+                    "branch": "kahuna/3-z",
+                    "epic_id": 3,
+                    "created_at": "2026-04-22T08:00:00Z",
+                    "resolved_at": "2026-04-22T09:30:00Z",
+                    "disposition": "abandoned",
+                },
+            ],
+        }
+        html = render_kahuna_section(state, {"flights": {}})
+        assert "kahuna/3-z" in html
+        assert "abandoned" in html
+
+
+# ---------------------------------------------------------------------------
+# AC-3: new action values rendered with emoji/label
+# ---------------------------------------------------------------------------
+
+
+class TestGateActionStates:
+    """``gate_evaluating`` and ``gate_blocked`` are registered in
+    ACTION_BANNER_STATES with emoji + css_class + animation (AC-3)."""
+
+    def test_gate_evaluating_registered(self) -> None:
+        assert "gate_evaluating" in ACTION_BANNER_STATES
+        state = ACTION_BANNER_STATES["gate_evaluating"]
+        # An icon (hex HTML entity, same style as existing "🧠 PLANNING").
+        assert state["icon"].startswith("&#x")
+        assert state["css_class"] == "action-gate-evaluating"
+        # Pulsing per devspec §5.2.5 ("pulsing?").
+        assert "pulse" in state["animation"]
+
+    def test_gate_blocked_registered(self) -> None:
+        assert "gate_blocked" in ACTION_BANNER_STATES
+        state = ACTION_BANNER_STATES["gate_blocked"]
+        assert state["icon"].startswith("&#x")
+        assert state["css_class"] == "action-gate-blocked"
+        # Red-emphasis border color (devspec §5.2.5).
+        assert state["border_color"] == "var(--red)"
+
+    def test_gate_evaluating_css_class_in_base_css(self) -> None:
+        css = render_base_css()
+        assert ".action-gate-evaluating" in css
+        assert "@keyframes pulse" in css
+
+    def test_gate_blocked_css_class_has_red_emphasis(self) -> None:
+        css = render_base_css()
+        # Either a dedicated override block or border color references --red.
+        assert ".action-gate-blocked" in css
+        assert "var(--red)" in css
+
+
+# ---------------------------------------------------------------------------
+# AC-4: CLI/dashboard includes Kahuna section when kahuna_branch present
+# ---------------------------------------------------------------------------
+
+
+class TestKahunaSectionPresence:
+    """AC-4: Kahuna section renders when kahuna_branch is set."""
+
+    def test_renders_kahuna_header(self) -> None:
+        html = render_kahuna_section(_kahuna_state(), _kahuna_flights())
+        assert '<div class="kahuna-section">' in html
+        assert "<h2>Kahuna</h2>" in html
+
+    def test_renders_active_branch(self) -> None:
+        html = render_kahuna_section(_kahuna_state(), _kahuna_flights())
+        assert "kahuna/42-wave-status-cli" in html
+
+    def test_renders_flight_counts(self) -> None:
+        """One completed flight, two non-completed -> "1 merged, 2 pending"."""
+        html = render_kahuna_section(_kahuna_state(), _kahuna_flights())
+        assert "1 merged, 2 pending" in html
+
+    def test_no_active_branch_but_history_still_shows_header(self) -> None:
+        """Epic complete, branch cleaned — history-only case still shows
+        the section so operators can see the audit trail."""
+        state = _kahuna_state()
+        state["kahuna_branch"] = None
+        html = render_kahuna_section(state, _kahuna_flights())
+        assert '<div class="kahuna-section">' in html
+        assert "No active Kahuna branch" in html
+        assert "kahuna/41-prior-epic" in html
+
+
+class TestFlightCountHelper:
+    """``_flight_counts`` partitions flight statuses by completion."""
+
+    def test_none_wave_returns_zero_zero(self) -> None:
+        assert _flight_counts({"flights": {}}, None) == (0, 0)
+
+    def test_unknown_wave_returns_zero_zero(self) -> None:
+        flights = {"flights": {"other": [{"status": "completed"}]}}
+        assert _flight_counts(flights, "wave-1") == (0, 0)
+
+    def test_mixed_statuses(self) -> None:
+        flights = {
+            "flights": {
+                "wave-1": [
+                    {"status": "completed"},
+                    {"status": "completed"},
+                    {"status": "running"},
+                    {"status": "pending"},
+                ],
+            },
+        }
+        assert _flight_counts(flights, "wave-1") == (2, 2)
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Dashboard HTML renders new fields per MV-02 / MV-03
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardIntegration:
+    """End-to-end: generate_dashboard includes the Kahuna section and the
+    new action banner CSS classes when the state carries KAHUNA context."""
+
+    def _phases(self) -> dict:
+        return {
+            "project": "Kahuna Project",
+            "phases": [
+                {
+                    "name": "Phase 1",
+                    "waves": [
+                        {
+                            "id": "wave-1",
+                            "issues": [
+                                {"number": 1, "title": "A"},
+                                {"number": 2, "title": "B"},
+                                {"number": 3, "title": "C"},
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+
+    def test_active_kahuna_appears_in_html(self, tmp_path: Path) -> None:
+        """MV-02: dashboard shows active kahuna_branch + flight counts."""
+        out = generate_dashboard(
+            tmp_path, self._phases(), _kahuna_state(), _kahuna_flights()
+        )
+        content = out.read_text(encoding="utf-8")
+        assert "kahuna/42-wave-status-cli" in content
+        assert "1 merged, 2 pending" in content
+
+    def test_gate_evaluating_shows_trust_signals(self, tmp_path: Path) -> None:
+        """MV-03: ``gate_evaluating`` shows trust-signal summary block."""
+        state = _kahuna_state(
+            action="gate_evaluating",
+            detail={
+                "signals": [
+                    "commutativity_verify",
+                    "ci_wait_run",
+                    "code-reviewer",
+                    "trivy vuln scan",
+                ],
+            },
+        )
+        out = generate_dashboard(
+            tmp_path, self._phases(), state, _kahuna_flights()
+        )
+        content = out.read_text(encoding="utf-8")
+        assert "action-gate-evaluating" in content
+        assert "kahuna-trust-signals" in content
+        assert "commutativity_verify" in content
+        assert "ci_wait_run" in content
+        assert "code-reviewer" in content
+        assert "trivy vuln scan" in content
+
+    def test_gate_blocked_shows_failure_detail(self, tmp_path: Path) -> None:
+        """MV-03: ``gate_blocked`` shows signal-failure detail block with
+        red-emphasis styling."""
+        state = _kahuna_state(
+            action="gate_blocked",
+            detail={
+                "failures": [
+                    {
+                        "signal": "commutativity_verify",
+                        "reason": "WEAK verdict on shared module",
+                    },
+                    {
+                        "signal": "trivy vuln scan",
+                        "reason": "CVE-2026-0001 HIGH severity",
+                    },
+                ],
+            },
+        )
+        out = generate_dashboard(
+            tmp_path, self._phases(), state, _kahuna_flights()
+        )
+        content = out.read_text(encoding="utf-8")
+        assert "action-gate-blocked" in content
+        assert "kahuna-signal-failures" in content
+        assert "commutativity_verify" in content
+        assert "WEAK verdict on shared module" in content
+        assert "CVE-2026-0001 HIGH severity" in content
+
+    def test_history_table_renders(self, tmp_path: Path) -> None:
+        """MV-02: kahuna_branches history table (collapsible, last 10)."""
+        out = generate_dashboard(
+            tmp_path, self._phases(), _kahuna_state(), _kahuna_flights()
+        )
+        content = out.read_text(encoding="utf-8")
+        # The table uses <details> for collapsibility (devspec §5.2.5).
+        assert '<details class="kahuna-history">' in content
+        assert "kahuna-history-table" in content
+        assert "kahuna/41-prior-epic" in content
+        assert "kahuna/40-aborted-epic" in content
+        assert "abc123def456" in content
+        assert "code_reviewer_critical_findings" in content
+
+    def test_history_caps_at_last_ten(self, tmp_path: Path) -> None:
+        """Last 10 of 12 entries rendered; first 2 dropped."""
+        state = _kahuna_state()
+        # Pad with 10 extra entries so we have 13 total; last 10 should win.
+        extra = [
+            {
+                "branch": f"kahuna/{i:03d}-past",
+                "epic_id": i,
+                "created_at": f"2026-03-{i:02d}T08:00:00Z",
+                "resolved_at": f"2026-03-{i:02d}T09:30:00Z",
+                "disposition": "merged",
+                "main_merge_sha": f"sha{i:03d}",
+            }
+            for i in range(10)
+        ]
+        state["kahuna_branches"] = extra + state["kahuna_branches"]
+        out = generate_dashboard(
+            tmp_path, self._phases(), state, _kahuna_flights()
+        )
+        content = out.read_text(encoding="utf-8")
+        # Oldest two dropped.
+        assert "kahuna/000-past" not in content
+        assert "kahuna/001-past" not in content
+        # Newest ones present.
+        assert "kahuna/41-prior-epic" in content
+        assert "kahuna/40-aborted-epic" in content
+
+
+# ---------------------------------------------------------------------------
+# HTML escaping — every string-in-state field is user-controlled
+# ---------------------------------------------------------------------------
+
+
+class TestHtmlEscaping:
+    """kahuna_* state fields route through html.escape so injected markup
+    doesn't break the DOM or enable XSS."""
+
+    def test_branch_name_escaped(self) -> None:
+        state = {
+            "kahuna_branch": '<script>alert(1)</script>',
+        }
+        html = render_kahuna_section(state, {"flights": {}})
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_failure_reason_escaped(self) -> None:
+        state = {
+            "kahuna_branch": "kahuna/1-x",
+            "current_action": {
+                "action": "gate_blocked",
+                "label": "gate_blocked",
+                "detail": {
+                    "failures": [
+                        {
+                            "signal": "x",
+                            "reason": '<img src=x onerror=alert(1)>',
+                        },
+                    ],
+                },
+            },
+        }
+        html = render_kahuna_section(state, {"flights": {}})
+        assert "<img src=x" not in html
+
+    def test_history_abort_reason_escaped(self) -> None:
+        state = {
+            "kahuna_branches": [
+                {
+                    "branch": "kahuna/1-x",
+                    "epic_id": 1,
+                    "created_at": "2026-04-22T08:00:00Z",
+                    "resolved_at": "2026-04-22T09:30:00Z",
+                    "disposition": "aborted",
+                    "abort_reason": "<script>alert(1)</script>",
+                },
+            ],
+        }
+        html = render_kahuna_section(state, {"flights": {}})
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+
+# ---------------------------------------------------------------------------
+# No external dependencies [CT-01]
+# ---------------------------------------------------------------------------
+
+
+class TestNoDependencies:
+    """kahuna_section module must only use Python 3.10+ stdlib + wave_status."""
+
+    def test_imports_only_stdlib_and_internals(self) -> None:
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "src",
+            "wave_status",
+            "dashboard",
+            "kahuna_section.py",
+        )
+        with open(path) as f:
+            source = f.read()
+        import_lines = [
+            line.strip()
+            for line in source.splitlines()
+            if line.strip().startswith(("import ", "from "))
+        ]
+        allowed_prefixes = (
+            "from __future__",
+            "import html",
+            "from wave_status",
+        )
+        for line in import_lines:
+            assert any(line.startswith(p) for p in allowed_prefixes), (
+                f"Disallowed import: {line}"
+            )

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -148,7 +148,8 @@ class TestPhaseColors:
 
 
 class TestActionBannerStates:
-    """All 7 action banner states from PRD Appendix A."""
+    """Action banner states — 7 from PRD Appendix A + 2 from the KAHUNA
+    devspec §5.2.5 (``gate_evaluating``, ``gate_blocked``)."""
 
     EXPECTED_ACTIONS = [
         "pre-flight",
@@ -158,10 +159,12 @@ class TestActionBannerStates:
         "post-wave-review",
         "waiting-on-meatbag",
         "idle",
+        "gate_evaluating",
+        "gate_blocked",
     ]
 
-    def test_seven_states(self) -> None:
-        assert len(ACTION_BANNER_STATES) == 7
+    def test_nine_states(self) -> None:
+        assert len(ACTION_BANNER_STATES) == 9
 
     def test_all_actions_present(self) -> None:
         for action in self.EXPECTED_ACTIONS:
@@ -170,6 +173,22 @@ class TestActionBannerStates:
     def test_no_extra_actions(self) -> None:
         extra = set(ACTION_BANNER_STATES.keys()) - set(self.EXPECTED_ACTIONS)
         assert extra == set(), f"Unexpected actions: {extra}"
+
+    # --- KAHUNA additions (devspec §5.2.5) ---
+
+    def test_gate_evaluating_properties(self) -> None:
+        s = ACTION_BANNER_STATES["gate_evaluating"]
+        assert s["css_class"] == "action-gate-evaluating"
+        assert s["border_color"] == "var(--yellow)"
+        # Pulsing animation to indicate active concurrent scoring.
+        assert "pulse" in s["animation"]
+
+    def test_gate_blocked_properties(self) -> None:
+        s = ACTION_BANNER_STATES["gate_blocked"]
+        assert s["css_class"] == "action-gate-blocked"
+        assert s["border_color"] == "var(--red)"
+        # Red emphasis drives the eye; the throb reinforces urgency.
+        assert "throb" in s["animation"]
 
     def test_each_state_has_required_keys(self) -> None:
         for action, state in ACTION_BANNER_STATES.items():
@@ -297,6 +316,16 @@ class TestRenderBaseCSS:
 
     def test_glow_animation_reference(self) -> None:
         assert "glow 2s ease-in-out infinite" in self.css
+
+    def test_pulse_keyframes_for_gate_evaluating(self) -> None:
+        """KAHUNA gate_evaluating uses the pulse animation (devspec §5.2.5)."""
+        assert "@keyframes pulse" in self.css
+
+    def test_gate_blocked_has_red_emphasis(self) -> None:
+        """KAHUNA gate_blocked class must have red emphasis (devspec §5.2.5)."""
+        assert ".action-banner.action-gate-blocked" in self.css
+        # Red rgba or var(--red) on the label colors it red.
+        assert "var(--red)" in self.css
 
     # --- Component styles ---
 

--- a/tests/test_wave_status.py
+++ b/tests/test_wave_status.py
@@ -806,6 +806,157 @@ class TestExtendAutoAdvance:
 # No external dependencies test [CT-01]
 # ---------------------------------------------------------------------------
 
+class TestShowKahuna:
+    """``wave-status show`` KAHUNA section rendering (issue #415, AC-4/AC-6).
+
+    Legacy state files render unchanged; KAHUNA state files add a Kahuna
+    block with branch, flight counts, conditional trust/failure blocks, and
+    a history listing.
+    """
+
+    def _init_and_load_state(self, repo: Path, run_cli) -> dict:
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["flight-plan", "flights.json"], repo)
+        state_path = repo / ".claude" / "status" / "state.json"
+        return json.loads(state_path.read_text(encoding="utf-8"))
+
+    def _write_state(self, repo: Path, state: dict) -> None:
+        state_path = repo / ".claude" / "status" / "state.json"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    def test_legacy_state_show_has_no_kahuna_block(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Legacy state (no kahuna_*) prints NO Kahuna section (AC-1/AC-2)."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+
+        rc, out, err = run_cli(["show"], repo)
+        assert rc == 0, f"show failed: {err}"
+        assert "Kahuna:" not in out
+        # But the standard fields remain.
+        assert "Project:" in out
+        assert "Progress:" in out
+
+    def test_kahuna_branch_show_renders_section(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """kahuna_branch set -> "Kahuna:" section with branch+counts (AC-4)."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        _write_flights(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["flight-plan", "flights.json"], repo)
+        run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+
+        rc, out, err = run_cli(["show"], repo)
+        assert rc == 0, f"show failed: {err}"
+        assert "Kahuna:" in out
+        assert "kahuna/42-foo" in out
+        # One pending flight (from _SAMPLE_FLIGHTS) -> "0 merged, 1 pending".
+        assert "0 merged, 1 pending" in out
+
+    def test_kahuna_branches_history_in_show(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Populated kahuna_branches history appears in show output."""
+        repo = temp_git_repo
+        state = self._init_and_load_state(repo, run_cli)
+        state["kahuna_branch"] = "kahuna/42-foo"
+        state["kahuna_branches"] = [
+            {
+                "branch": "kahuna/41-prior",
+                "epic_id": 41,
+                "created_at": "2026-04-23T10:00:00Z",
+                "resolved_at": "2026-04-24T02:15:00Z",
+                "disposition": "merged",
+                "main_merge_sha": "abc123",
+            },
+            {
+                "branch": "kahuna/40-aborted",
+                "epic_id": 40,
+                "created_at": "2026-04-22T08:00:00Z",
+                "resolved_at": "2026-04-22T09:30:00Z",
+                "disposition": "aborted",
+                "abort_reason": "code_reviewer_findings",
+            },
+        ]
+        self._write_state(repo, state)
+
+        rc, out, err = run_cli(["show"], repo)
+        assert rc == 0, f"show failed: {err}"
+        assert "History" in out
+        assert "kahuna/41-prior" in out
+        assert "kahuna/40-aborted" in out
+        assert "code_reviewer_findings" in out
+
+    def test_gate_evaluating_shows_trust_signals(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """action=gate_evaluating prints the Trust signals evaluating list."""
+        repo = temp_git_repo
+        state = self._init_and_load_state(repo, run_cli)
+        state["kahuna_branch"] = "kahuna/42-foo"
+        state["current_action"] = {
+            "action": "gate_evaluating",
+            "label": "gate_evaluating",
+            "detail": {
+                "signals": ["commutativity_verify", "ci_wait_run"],
+            },
+        }
+        self._write_state(repo, state)
+
+        rc, out, err = run_cli(["show"], repo)
+        assert rc == 0, f"show failed: {err}"
+        assert "Trust signals evaluating" in out
+        assert "commutativity_verify" in out
+        assert "ci_wait_run" in out
+
+    def test_gate_blocked_shows_failures(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """action=gate_blocked prints Gate blocked failure reasons."""
+        repo = temp_git_repo
+        state = self._init_and_load_state(repo, run_cli)
+        state["kahuna_branch"] = "kahuna/42-foo"
+        state["current_action"] = {
+            "action": "gate_blocked",
+            "label": "gate_blocked",
+            "detail": {
+                "failures": [
+                    {
+                        "signal": "commutativity_verify",
+                        "reason": "WEAK verdict",
+                    },
+                ],
+            },
+        }
+        self._write_state(repo, state)
+
+        rc, out, err = run_cli(["show"], repo)
+        assert rc == 0, f"show failed: {err}"
+        assert "Gate blocked" in out
+        assert "commutativity_verify" in out
+        assert "WEAK verdict" in out
+
+    def test_dashboard_html_has_kahuna_section(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Dashboard HTML renders the Kahuna section (AC-5, MV-02)."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        _write_flights(repo)
+        run_cli(["init", "plan.json"], repo)
+        run_cli(["flight-plan", "flights.json"], repo)
+        run_cli(["set-kahuna-branch", "kahuna/42-foo"], repo)
+
+        html = (repo / ".status-panel.html").read_text(encoding="utf-8")
+        assert 'class="kahuna-section"' in html
+        assert "kahuna/42-foo" in html
+
+
 class TestNoExternalDependencies:
     """Verify wave_status can be imported without pip install."""
 


### PR DESCRIPTION
## Summary

Extends the Python wave-status CLI and dashboard generator to parse and render KAHUNA wave-state fields (`kahuna_branch`, `kahuna_branches` history) and the two new gate action labels (`gate_evaluating`, `gate_blocked`) per devspec §5.1.4 and §5.2.5. Legacy state files continue to render byte-identically — Kahuna section short-circuits to empty when no KAHUNA context is present.

## Changes

- `src/wave_status/state.py` — `show()` surfaces `kahuna_branch`, `kahuna_branches`, structured `action_key`/`action_label`/`action_detail`, and per-current-wave `kahuna_flights_merged`/`kahuna_flights_pending` counts. Tolerates missing fields (AC-1, AC-2); also fixes a latent dict-shaped `current_action.detail` leak.
- `src/wave_status/__main__.py` — `_cmd_show` renders a Kahuna CLI block when state has KAHUNA context.
- `src/wave_status/dashboard/generator.py` — imports and inserts the Kahuna section between the action banner and the progress rail.
- `src/wave_status/dashboard/kahuna_section.py` (new) — renders active branch + counts, trust-signal summary (`gate_evaluating`), signal-failure detail block (`gate_blocked`), and collapsible history table capped at last 10 entries.
- `src/wave_status/dashboard/theme.py` — `ACTION_BANNER_STATES` grows `gate_evaluating` (🚦 pulse) and `gate_blocked` (🛑 throb); adds `@keyframes pulse`, red-emphasis overrides for `.action-gate-blocked`, and full `.kahuna-*` CSS block.
- `tests/test_kahuna_section.py` (new) — 23 unit tests covering AC-1 through AC-6 plus HTML-escaping and import-hygiene.
- `tests/test_theme.py` — expanded `TestActionBannerStates` (7 → 9 states) with `gate_evaluating`/`gate_blocked` assertions and CSS tests.
- `tests/test_wave_status.py` — added `TestShowKahuna` (6 CLI integration tests via subprocess).

## Linked Issues

Closes #415

## Test Plan

- `./scripts/ci/validate.sh` — 107 passed, 0 failed.
- `python3 -m pytest tests/test_kahuna_section.py tests/test_theme.py tests/test_generator.py` — 134 passed.
- `python3 -m pytest tests/test_wave_status.py` — 41 passed (incl. 6 new KAHUNA CLI tests).
- `python3 -m pytest tests/test_state.py` — 108 passed (no regressions).
- `python3 -m pytest tests/test_zipapp.py` — 11 passed.
- `./scripts/ci/build.sh` — Built: 2, Failed: 0 (AC-7 green for zipapp).
- Full suite (excluding pre-existing broken `tests/test_discord_status.py` collector): **1072 passed, 99 failed** — matches the #328 baseline, no regressions introduced.