### PR TITLE
docs(kahuna-devspec): §5.1 amendment — body_sha always computed; add warnings?

### DIFF
--- a/docs/kahuna-devspec.md
+++ b/docs/kahuna-devspec.md
@@ -402,6 +402,8 @@ wave_finalize({
   state: "open" | "merged",
   created: boolean,         // true if newly created, false if already existed
   body_sha: string          // hash of the assembled body, for drift detection
+                            // (computed on EVERY call, including created:false —
+                            //  compare across successive calls to detect body drift)
 }
 ```
 
@@ -433,7 +435,11 @@ commutativity_verify({
   mode: "pairwise" | "single_target",  // NEW field — disambiguates behavior
   verdict: "STRONG" | "MEDIUM" | "WEAK" | "ORACLE_REQUIRED",
   pairwise_results?: Array<PairResult>,  // populated iff mode === "pairwise"
-  single_target_result?: SingleTargetResult  // populated iff mode === "single_target"
+  single_target_result?: SingleTargetResult,  // populated iff mode === "single_target"
+  warnings?: string[]       // optional; emitted when the probe returns an unknown
+                            // verdict OR when a defensive guard fires for an
+                            // unexpected single-target pair. Consumers should log
+                            // and surface these to the operator.
 }
 ```
 


### PR DESCRIPTION
## Summary

Two comment-only clarifications to Dev Spec §5.1 per tachikoma's drift flags from Phase 1 sdlc-server completion:

- §5.1.1 `wave_finalize`: `body_sha` is computed on every call (including `created: false`) for drift detection across successive invocations.
- §5.1.2 `commutativity_verify`: adds `warnings?: string[]` response field, emitted on unknown verdicts and defensive guards.

## Changes

- `docs/kahuna-devspec.md` — 7 lines added, 1 changed; edits scoped to §5.1.1 and §5.1.2 response shapes only.

## Linked Issues

Closes #442

## Test Plan

- [x] `git diff main -- docs/kahuna-devspec.md` confirms only §5.1.1/§5.1.2 edits
- [x] `./scripts/ci/validate.sh` → 107/0
- [x] `devspec_verify_approved` → `ok: true` (bakerb, 2026-04-24, 7/7; frontmatter preserved)
- [x] `trivy fs --severity HIGH,CRITICAL` → 0 findings
- [ ] Post-merge: 1-line Discord notice in Big Kahuna thread so tachikoma + fleet see the spec change (per AC)
