### PR TITLE
docs(kahuna-devspec): §5.3.1 amendment — merge trains enabled, approval rule scoped per-branch

### DIFF
--- a/docs/kahuna-devspec.md
+++ b/docs/kahuna-devspec.md
@@ -610,11 +610,12 @@ Today `gl-settings` manages branch protection, tag protection, MR approval rules
 
 **New operation — `kahuna-sandbox` (composite):**
 - For a given project, applies the settings that establish the kahuna sandbox property:
-  - `PUT /projects/:id/merge_request_approval_settings` — 0 approvals required on target branches matching `kahuna/*`
-  - `PUT /projects/:id/settings` — `only_allow_merge_if_pipeline_succeeds=true` (so kahuna merges still gate on CI), `squash_option=default_on` (per CT-02)
-  - Merge queue configuration: disabled for kahuna target branches (specific API TBD — GitLab's merge trains are controlled per-project; a per-branch overlay may be needed if that's not supported)
+  - `PUT /projects/:id/protected_branches` — protect the `kahuna/*` pattern (developer push + developer merge). Required as a prerequisite for the per-branch approval rule below: GitLab approval rules can only be scoped to *protected* branches.
+  - `POST /projects/:id/approval_rules` — create a `kahuna-zero-approvals` rule with `approvals_required: 0`, scoped via `protected_branch_ids: [<kahuna_pattern_id>]` to the protected branch above. **Must NOT use `merge_request_approval_settings`** — that endpoint is project-wide and would unprotect main.
+  - `PUT /projects/:id/settings` — `only_allow_merge_if_pipeline_succeeds=true` (so kahuna merges still gate on CI), `squash_option=default_on` (per CT-02), `merge_pipelines_enabled=true`, `merge_trains_enabled=true`. **Merge trains ENABLED**, not disabled — they batch flight-MRs into one pipeline run per train, which is the throughput story autonomous execution needs (R-08). The previous "disabled" wording was an error.
 - Provides a single-command bootstrap: `gl-settings kahuna-sandbox <project-url>`
-- Includes drift-check mode for auditing which projects have KAHUNA sandbox settings applied
+- Includes drift-check mode (via `--dry-run` and `action="would_apply"` per gl-settings convention) for auditing which projects have KAHUNA sandbox settings applied
+- As-shipped: `bakeb7j0/gitlab-settings-automation` PR #29 (commit `b2af3d7`)
 
 #### 5.3.2 GitHub — no `gh-settings` tool today
 


### PR DESCRIPTION
## Summary

Amend `docs/kahuna-devspec.md` §5.3.1 to match the as-shipped reality of `gl-settings kahuna-sandbox` ([gl-settings PR #29](https://github.com/bakeb7j0/gitlab-settings-automation/pull/29) merged at `b2af3d7`).

## Changes

- §5.3.1 — replace project-wide `merge_request_approval_settings` bullet with per-branch `approval_rules` + `protected_branch_ids` scoping
- §5.3.1 — add `protect-branch` prereq bullet (required by GitLab to scope an approval rule to a branch pattern)
- §5.3.1 — flip "merge queue disabled" → **ENABLED** with one-line rationale tying it to R-08 throughput
- §5.3.1 — drift-check description aligned with gl-settings `--dry-run` + `would_apply` convention
- §5.3.1 — note the as-shipped commit (`b2af3d7`)

## Linked Issues

Closes #448

## Test Plan

- [x] `git diff main -- docs/kahuna-devspec.md` shows only §5.3.1 edits (5 insertions, 4 deletions)
- [x] `./scripts/ci/validate.sh` → 107/0
- [x] `devspec_verify_approved` → `ok: true` (bakerb, 2026-04-24, 7/7; frontmatter preserved)
- [x] `trivy fs --severity HIGH,CRITICAL` → 0 findings
- [ ] Post-merge: 1-line Discord notice in Big Kahuna thread per spec-freeze discipline
