### PR TITLE
feat(nextwave): Prime/Flight kahuna base-ref plumbing

### DIFF
--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -56,15 +56,16 @@ CC sub-agents do not have the `Agent`/`Task` tool. Only the top-level session ca
 2. Resolve **target repo slug** for the bus path. Same-repo waves: use the current repo's slug. Cross-repo waves (wave plan lives in this repo, stories live elsewhere): use the target repo's slug per `lesson_cross_repo_wave_orchestration.md`.
 3. Verify main is clean in the target repo; `wave_previous_merged()` confirms prior wave landed; `spec_validate_structure(issue)` for each issue in the wave.
 4. Call `scripts/wavebus/wave-init <repo-slug> <N> 1`. Flight count is `1` initially — Prime may re-invoke it with the real count (script is idempotent). Capture the printed wave root.
-5. Pre-create worktrees per issue. Same-repo: `Agent` calls in Step 3 can use `isolation: "worktree"`. Cross-repo: create them now via `git -C <target-repo> worktree add /tmp/wt-<slug>-<issue> -b feature/<issue>-<desc>` (one per issue).
-6. Resolve identity from `/tmp/claude-agent-<md5>.json`; post to `#wave-status` (`1487386934094462986`): `"🏄 **Wave <N> started** — <project>, <issue-count> issues. Agent: **<dev-name>** <dev-avatar>"`. If `disc_send` fails, log and continue.
-7. Spawn **Prime(pre-wave)** — single `Agent` call, `subagent_type: general-purpose`. Prompt template below.
+5. **Read `kahuna_branch` from wave state** via `wave_show()` (or by reading `.claude/status/state.json` in the target repo). If the field is present and non-empty, the wave is executing under KAHUNA — capture the value (e.g. `kahuna/<epic-id>-<slug>`) and pass it into the Prime(pre-wave) prompt as the `kahuna_branch` input. If absent or empty, the wave is a legacy non-KAHUNA execution — flights base off `main` as before. Pre-created worktree branches (Step 6, cross-repo path) and `pr_create` `base` (Step 3e) honor this same value. See Dev Spec §5.2.3 for the authoritative contract.
+6. Pre-create worktrees per issue. Same-repo: `Agent` calls in Step 3 can use `isolation: "worktree"`. Cross-repo: create them now via `git -C <target-repo> worktree add /tmp/wt-<slug>-<issue> -b feature/<issue>-<desc> origin/<base-ref>` (one per issue), where `<base-ref>` is `kahuna_branch` if set, else `main`.
+7. Resolve identity from `/tmp/claude-agent-<md5>.json`; post to `#wave-status` (`1487386934094462986`): `"🏄 **Wave <N> started** — <project>, <issue-count> issues. Agent: **<dev-name>** <dev-avatar>"`. If `disc_send` fails, log and continue.
+8. Spawn **Prime(pre-wave)** — single `Agent` call, `subagent_type: general-purpose`. Prompt template below.
 
 ## Step 2 — Prime(pre-wave) prompt contract
 
 Prime(pre-wave) is a sub-agent. It does NOT have `Agent`; it cannot spawn Flights. Its job is to plan the wave into the bus.
 
-Prompt template (fill in `<repo-slug>`, `<N>`, `<wave-root>`, and the issue list):
+Prompt template (fill in `<repo-slug>`, `<N>`, `<wave-root>`, the issue list, and `<kahuna_branch>` — leave `<kahuna_branch>` blank or omit the line entirely if wave state had no `kahuna_branch`):
 
 > You are the Prime agent for wave `<N>` of `<repo-slug>`. You plan the wave into the filesystem bus at `<wave-root>`.
 >
@@ -73,13 +74,14 @@ Prompt template (fill in `<repo-slug>`, `<N>`, `<wave-root>`, and the issue list
 > - Issues in this wave: `<list-of-issue-numbers>`
 > - Wave root: `<wave-root>`
 > - Target repo: `<target-repo>`
+> - Kahuna branch: `<kahuna_branch>` (omit or leave empty for legacy non-KAHUNA waves)
 >
 > Steps:
 > 1. For each issue, fetch the spec via `spec_get` and acceptance criteria via `spec_acceptance_criteria`. Summarize files-to-create / files-to-modify / test files per issue.
 > 2. Run `flight_overlap` + `flight_partition` on the per-issue manifests to determine flight structure. Flight 1 maximizes issue count; later flights resolve file-level conflicts. When in doubt, sequence.
 > 3. If the partition needs more flights than the bus was pre-created for, call `scripts/wavebus/wave-init <repo-slug> <N> <final-flight-count>` (idempotent).
 > 4. Write `<wave-root>/plan.md` summarizing the flight structure (flight M → issues, per-issue file manifest, rationale).
-> 5. For each flight M and each issue X in it, write `<wave-root>/flight-<M>/issue-<X>/prompt.md` containing the full Flight instructions (see "Flight stub prompt" in the caller's skill body — reproduce verbatim, fill placeholders).
+> 5. For each flight M and each issue X in it, write `<wave-root>/flight-<M>/issue-<X>/prompt.md` containing the full Flight instructions (see "Flight stub prompt" in the caller's skill body — reproduce verbatim, fill placeholders). **If `kahuna_branch` is set on this wave, pass it into each Flight prompt as `<kahuna_branch>` so the Flight bases its work on `origin/<kahuna_branch>` instead of `main`. If `kahuna_branch` is empty, omit the kahuna lines from the Flight prompt — flights branch off `main` as in legacy non-KAHUNA execution.**
 > 6. Register the plan via `wave_flight_plan`.
 > 7. If any issue's spec is unbuildable (missing AC, structural contradiction, etc.), mark the plan `BLOCKED` and name the failing issue + reason in `plan.md`.
 >
@@ -119,7 +121,7 @@ In **auto mode**: call `wave_ci_trust_level`; if trust is sufficient, skip the g
 
 ### 3e. Spawn Prime(post-flight).
 
-One `Agent` call, `subagent_type: general-purpose`. Prompt template:
+One `Agent` call, `subagent_type: general-purpose`. Pass the wave's `kahuna_branch` (captured in Step 1.5) into the prompt — set base for `pr_create`. Empty/absent → flights PR against `main` as in legacy execution. Prompt template:
 
 > You are the Prime(post-flight) agent for wave `<N>`, flight `<M>` of `<repo-slug>`. Flights have already committed in their worktrees. You push, PR, wait CI, verify commutativity, and merge.
 >
@@ -128,10 +130,11 @@ One `Agent` call, `subagent_type: general-purpose`. Prompt template:
 > - Flight: `<M>`
 > - Issues in this flight: `<list>`
 > - Target repo: `<target-repo>`
+> - Kahuna branch: `<kahuna_branch>` (omit or leave empty for legacy non-KAHUNA waves)
 >
 > Steps:
 > 1. For each issue X in this flight, read `<wave-root>/flight-<M>/issue-<X>/results.md` and verify `DONE` contains `PASS`. If any FAIL, stop and write a `BLOCKED` report naming the failing issues.
-> 2. For each issue, push the Flight's commit from its worktree (`git -C <worktree> push -u origin <branch>`), create a PR via `pr_create`, wait for CI via `pr_wait_ci`.
+> 2. For each issue, push the Flight's commit from its worktree (`git -C <worktree> push -u origin <branch>`), create a PR via `pr_create({base: <kahuna_branch>})` if `kahuna_branch` is set else `pr_create({base: "main"})`, then wait for CI via `pr_wait_ci`. **Every Flight PR in a KAHUNA wave targets the kahuna branch — never `main`. The kahuna→main MR is opened separately by `wave_finalize` per Dev Spec §5.2.2.**
 > 3. If this flight has multiple issues, run `commutativity_verify` on the changesets `{id, head_ref}`. Interpret the group verdict:
 >    - `STRONG` / `MEDIUM` → `pr_merge(skip_train=true)` for all.
 >    - `WEAK` / `ORACLE_REQUIRED` → sequential merge via the merge queue (no skip).
@@ -220,6 +223,7 @@ This prompt is what each Flight sub-agent receives. Preserve the SPEC EXECUTOR b
 >
 > Your working directory is `<worktree-path>` (use absolute paths or `cd` into it before any git/file operations).
 > Your branch is `<branch-name>` (already checked out in the worktree).
+> **Base your work on origin/`<kahuna_branch>`, not main.** This wave is executing under KAHUNA; your branch was created from `origin/<kahuna_branch>` and your PR will target `<kahuna_branch>`. *(Omit this line entirely when `kahuna_branch` is unset — flights then base off `main` as in legacy non-KAHUNA execution.)*
 > Full instructions for this issue are at `<wave-root>/flight-<M>/issue-<X>/prompt.md` — re-read that file now; this block is only the contract for your return.
 >
 > **SPEC EXECUTOR rules (preserve verbatim):**

--- a/tests/test_nextwave_skill.py
+++ b/tests/test_nextwave_skill.py
@@ -1,0 +1,302 @@
+"""Tests for skills/nextwave/SKILL.md — kahuna base-ref plumbing (issue #417).
+
+Validates Dev Spec §5.2.3:
+- Step 1 (Orchestrator pre-flight) reads ``kahuna_branch`` from wave state and
+  passes it forward to Prime(pre-wave).
+- Prime(pre-wave) prompt template accepts ``kahuna_branch`` as input and
+  forwards it into each Flight prompt when set.
+- Flight stub prompt includes the literal directive
+  ``Base your work on origin/<kahuna_branch>, not main`` when
+  ``kahuna_branch`` is set.
+- Prime(post-flight) prompt template uses ``kahuna_branch`` as the
+  ``pr_create`` ``base`` parameter when set, and ``main`` otherwise.
+- Legacy non-KAHUNA waves (no ``kahuna_branch`` in state) are explicitly
+  preserved as a no-change path.
+
+Tests assert content of the live SKILL.md file. They exercise the real
+markdown — no mocks, no stubs. Maps to AC-1..AC-4 of the issue.
+AC-5 / AC-6 are integration-test-level acceptance criteria (Dev Spec §6.2)
+and are out of scope for the SKILL.md unit-level coverage here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths and fixtures
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = _ROOT / "skills" / "nextwave" / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Read the nextwave SKILL.md file once per module."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _section(text: str, header: str) -> str:
+    """Return the slice of ``text`` from the matching header to the next
+    sibling/parent header (``## `` or ``### ``).
+
+    ``header`` is matched by substring on the line. The slice ends at the
+    next line beginning with ``## `` or ``### ``. Used to scope assertions
+    to a specific step rather than the whole document.
+    """
+    lines = text.splitlines(keepends=True)
+    start = None
+    for i, line in enumerate(lines):
+        if header in line and (line.startswith("## ") or line.startswith("### ")):
+            start = i
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## ") or lines[j].startswith("### "):
+            end = j
+            break
+    return "".join(lines[start:end])
+
+
+def _flight_stub(text: str) -> str:
+    """Return the Flight stub prompt section (## heading at end of file)."""
+    return _section(text, "Flight stub prompt")
+
+
+# ---------------------------------------------------------------------------
+# Existence + framing
+# ---------------------------------------------------------------------------
+
+
+class TestSkillFileShape:
+    """Sanity checks: file exists, frontmatter intact, kahuna terminology
+    present at the document level."""
+
+    def test_skill_file_exists(self) -> None:
+        assert SKILL_PATH.is_file(), f"missing: {SKILL_PATH}"
+
+    def test_frontmatter_name(self, skill_text: str) -> None:
+        assert skill_text.startswith("---\nname: nextwave\n")
+
+    def test_kahuna_branch_referenced(self, skill_text: str) -> None:
+        """``kahuna_branch`` MUST appear at least once — sanity check that
+        the kahuna plumbing landed somewhere."""
+        assert "kahuna_branch" in skill_text
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Prime reads kahuna_branch from wave state and passes into Flight
+# prompt (orchestrator + Prime(pre-wave) sides of the chain)
+# ---------------------------------------------------------------------------
+
+
+class TestAC1_PrimeReadsKahunaBranch:
+    """The Orchestrator (Step 1) reads ``kahuna_branch`` from wave state and
+    feeds it into the Prime(pre-wave) prompt; Prime(pre-wave)'s template
+    accepts that input and forwards it into each Flight prompt."""
+
+    def test_step1_reads_wave_state_for_kahuna_branch(self, skill_text: str) -> None:
+        """Step 1 explicitly instructs the Orchestrator to read
+        ``kahuna_branch`` from wave state."""
+        step1 = _section(skill_text, "Step 1 — Orchestrator pre-flight")
+        assert step1, "Step 1 section not found"
+        assert "kahuna_branch" in step1
+        # State source — wave_show or state.json must be named.
+        assert "wave_show" in step1 or "state.json" in step1
+
+    def test_step1_routes_kahuna_branch_into_prime_prompt(
+        self, skill_text: str
+    ) -> None:
+        """Step 1 must say the captured kahuna_branch is passed into the
+        Prime(pre-wave) prompt."""
+        step1 = _section(skill_text, "Step 1 — Orchestrator pre-flight")
+        assert "Prime(pre-wave) prompt" in step1 or "Prime(pre-wave)" in step1
+        # The capture-and-forward intent must be expressed.
+        assert re.search(
+            r"pass(?:e[ds])?.*kahuna_branch|kahuna_branch.*(?:pass|input)",
+            step1,
+            re.IGNORECASE,
+        ), "Step 1 must describe passing kahuna_branch into Prime prompt"
+
+    def test_prime_prewave_prompt_lists_kahuna_branch_input(
+        self, skill_text: str
+    ) -> None:
+        """Prime(pre-wave) prompt template's Inputs section lists
+        ``Kahuna branch:``."""
+        step2 = _section(skill_text, "Step 2 — Prime(pre-wave) prompt contract")
+        assert step2, "Step 2 section not found"
+        # The bullet form used by other inputs.
+        assert re.search(r"-\s+Kahuna branch:\s*`<kahuna_branch>`", step2), (
+            "Prime(pre-wave) Inputs must include `- Kahuna branch: "
+            "`<kahuna_branch>`` bullet"
+        )
+
+    def test_prime_prewave_forwards_kahuna_to_flight_prompt(
+        self, skill_text: str
+    ) -> None:
+        """Prime(pre-wave) instructions tell it to propagate kahuna_branch
+        into each Flight prompt when set."""
+        step2 = _section(skill_text, "Step 2 — Prime(pre-wave) prompt contract")
+        # The instruction must be inside Step 2's prompt body.
+        assert "kahuna_branch" in step2
+        assert re.search(
+            r"pass(?:e[ds])?\s+it\s+into\s+each\s+Flight\s+prompt",
+            step2,
+            re.IGNORECASE,
+        ), "Step 2 must instruct Prime to pass kahuna_branch into Flight prompts"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Flight prompt template includes the literal directive
+# ``Base your work on origin/$KAHUNA_BRANCH, not main``
+# ---------------------------------------------------------------------------
+
+
+class TestAC2_FlightPromptKahunaDirective:
+    """Flight stub prompt carries the literal ``Base your work on
+    origin/<kahuna_branch>, not main`` directive when ``kahuna_branch`` is
+    set."""
+
+    def test_flight_stub_has_base_directive(self, skill_text: str) -> None:
+        """The literal directive must appear in the Flight stub prompt
+        section. We accept the placeholder form with backticks because the
+        skill uses ``<kahuna_branch>`` placeholders throughout."""
+        stub = _flight_stub(skill_text)
+        assert stub, "Flight stub prompt section not found"
+        # Tolerate both backtick-wrapped placeholder and bare form.
+        assert re.search(
+            r"Base your work on origin/`?<kahuna_branch>`?,\s*not main",
+            stub,
+        ), "Flight stub must contain 'Base your work on origin/<kahuna_branch>, not main'"
+
+    def test_flight_stub_directive_conditional_on_kahuna_set(
+        self, skill_text: str
+    ) -> None:
+        """The directive must be marked as conditional — omitted when
+        ``kahuna_branch`` is unset — to preserve legacy behavior."""
+        stub = _flight_stub(skill_text)
+        # Some phrasing must mark the line as conditional / omitted in
+        # legacy mode. Accept either ``omit`` or ``unset`` wording.
+        assert re.search(
+            r"omit.*kahuna_branch|kahuna_branch.*unset|legacy",
+            stub,
+            re.IGNORECASE,
+        ), "Flight stub must mark the kahuna directive as conditional"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Flight's pr_create call uses base=<kahuna_branch> when set, else main
+# ---------------------------------------------------------------------------
+
+
+class TestAC3_PrCreateBaseRouting:
+    """Prime(post-flight) — which actually calls ``pr_create`` — uses
+    ``base=<kahuna_branch>`` when set, else ``base=main``."""
+
+    def test_post_flight_prompt_lists_kahuna_branch_input(
+        self, skill_text: str
+    ) -> None:
+        """Prime(post-flight) prompt template Inputs section lists
+        ``Kahuna branch:``."""
+        step3e = _section(skill_text, "3e. Spawn Prime(post-flight)")
+        assert step3e, "Step 3e section not found"
+        assert re.search(r"-\s+Kahuna branch:\s*`<kahuna_branch>`", step3e), (
+            "Prime(post-flight) Inputs must include `- Kahuna branch: "
+            "`<kahuna_branch>`` bullet"
+        )
+
+    def test_post_flight_pr_create_base_branches(self, skill_text: str) -> None:
+        """The pr_create call must reference ``base: <kahuna_branch>`` when
+        set, and ``base: "main"`` (or equivalent) otherwise."""
+        step3e = _section(skill_text, "3e. Spawn Prime(post-flight)")
+        # Both forms must be present somewhere in the step body.
+        assert re.search(
+            r"pr_create\(\{base:\s*<kahuna_branch>\}\)", step3e
+        ), "pr_create must take base: <kahuna_branch> when set"
+        assert re.search(
+            r"pr_create\(\{base:\s*\"main\"\}\)|base=main",
+            step3e,
+        ), "pr_create must fall back to base=main when kahuna_branch unset"
+
+    def test_post_flight_describes_kahuna_target(self, skill_text: str) -> None:
+        """Step 3e must call out that KAHUNA wave Flight PRs target the
+        kahuna branch — never main directly. Cross-reference Dev Spec
+        §5.2.2 for the kahuna→main MR."""
+        step3e = _section(skill_text, "3e. Spawn Prime(post-flight)")
+        assert re.search(
+            r"target.*kahuna.*never.*main|never.*main.*kahuna",
+            step3e,
+            re.IGNORECASE | re.DOTALL,
+        ), "Step 3e must specify Flight PRs target kahuna, not main, in KAHUNA mode"
+
+
+# ---------------------------------------------------------------------------
+# AC-4: Legacy non-KAHUNA waves behave identically to today
+# ---------------------------------------------------------------------------
+
+
+class TestAC4_LegacyNonKahunaUnchanged:
+    """When wave state has no ``kahuna_branch``, behavior is identical to
+    pre-KAHUNA execution: branches off main, PRs target main."""
+
+    def test_step1_describes_legacy_path(self, skill_text: str) -> None:
+        """Step 1 must say absent/empty kahuna_branch → legacy behavior
+        (base off main)."""
+        step1 = _section(skill_text, "Step 1 — Orchestrator pre-flight")
+        assert re.search(
+            r"absent.*main|empty.*main|legacy.*main|base off `?main`?",
+            step1,
+            re.IGNORECASE | re.DOTALL,
+        ), "Step 1 must describe legacy fallback (no kahuna_branch → base off main)"
+
+    def test_prime_prewave_prompt_describes_legacy_omission(
+        self, skill_text: str
+    ) -> None:
+        """Prime(pre-wave) prompt body must instruct: when kahuna_branch is
+        empty, omit the kahuna lines from the Flight prompt."""
+        step2 = _section(skill_text, "Step 2 — Prime(pre-wave) prompt contract")
+        assert re.search(
+            r"empty.*omit|omit.*empty|legacy",
+            step2,
+            re.IGNORECASE,
+        ), "Step 2 must describe the empty/legacy path for the Flight prompt"
+
+    def test_pre_create_worktree_uses_kahuna_or_main(
+        self, skill_text: str
+    ) -> None:
+        """Cross-repo worktree pre-creation step must base off
+        ``kahuna_branch`` when set, else ``main``."""
+        step1 = _section(skill_text, "Step 1 — Orchestrator pre-flight")
+        # Worktree command form: ``origin/<base-ref>`` plus a description of
+        # the base-ref selection.
+        assert re.search(r"origin/<base-ref>|origin/<kahuna_branch>", step1), (
+            "Worktree pre-creation must reference origin/<base-ref> "
+            "or origin/<kahuna_branch>"
+        )
+        assert re.search(
+            r"kahuna_branch.*if set.*main|kahuna_branch.*else.*main",
+            step1,
+            re.IGNORECASE | re.DOTALL,
+        ), "Step 1 worktree section must select kahuna_branch if set, else main"
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference: Dev Spec §5.2.3 must be cited at least once.
+# Anchors the prose to the authoritative contract per the issue body.
+# ---------------------------------------------------------------------------
+
+
+class TestDevSpecCrossReference:
+    """The Dev Spec §5.2.3 reference must remain in the skill so future
+    readers can find the authoritative contract."""
+
+    def test_devspec_5_2_3_referenced(self, skill_text: str) -> None:
+        assert re.search(r"§\s*5\.2\.3|Dev Spec.*5\.2\.3", skill_text), (
+            "Dev Spec §5.2.3 must be cross-referenced from the skill"
+        )


### PR DESCRIPTION
## Summary

Threads `kahuna_branch` through `/nextwave`'s Orchestrator → Prime(pre-wave) → Flight → Prime(post-flight) chain per Dev Spec §5.2.3. When `kahuna_branch` is set, Flights branch off `origin/<kahuna_branch>` and PR against the kahuna branch; when unset/empty, behavior is identical to today's main-based legacy path.

## Changes

- `skills/nextwave/SKILL.md` — Step 1 reads `kahuna_branch` from wave state; Step 2 Prime(pre-wave) Inputs propagate it; Flight stub prompt gains the literal directive `Base your work on origin/<kahuna_branch>, not main` (conditional on kahuna_branch); Step 3e Prime(post-flight) routes `pr_create({base: <kahuna_branch>})` when set, else `base: "main"`.
- `tests/test_nextwave_skill.py` — new test file (16 tests, 0 mocks) mapped 1:1 to AC-1..AC-4 + cross-reference + sanity classes.

## Linked Issues

Closes #417

## Test Plan

- `./scripts/ci/validate.sh` — 107 passed, 0 failed
- `python3 -m pytest tests/test_nextwave_skill.py -v` — 16 passed in 0.20s
- `python3 -m pytest tests/ --ignore=tests/test_discord_status.py` — 1094 passed, 99 failed (same #328 baseline as `main`; verified via `git stash` re-run; zero net regressions)
- AC-5 / AC-6 (IT-01 / IT-02 multi-flight wave end-to-end) deferred to integration test infrastructure per Dev Spec §6.2.