### PR TITLE
docs(CLAUDE.md): sandbox exception on pre-commit gate + /precheck /scp* prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,17 @@ When work is done, run `/precheck` immediately — don't ask permission, just ru
 
 The full procedure lives in `/precheck` (`skills/precheck/SKILL.md`).
 
+### Exception: Kahuna Sandbox Auto-Approval
+
+The "explicit user approval" requirement is **suspended** — and only suspended — when **both** of the following hold:
+
+1. The Flight Agent is operating inside a **Kahuna sandbox** — i.e. the current branch's base ref matches the regex `^kahuna/[0-9]+-` (a per-wave integration branch, not `main`).
+2. The full `/precheck` checklist has passed end-to-end: validation, code-reviewer (no unresolved high+ findings), trivy dependency scan, plus the Discord `#precheck` post and `vox` announcement.
+
+When both conditions are met, `/precheck` emits the sentinel line `[AUTO-APPROVED: kahuna sandbox]` and invokes `/scpmmr` directly — no human STOP. The exception is enforced **by `/precheck`'s own detection logic, not by agent discretion**: an agent on a `main`-targeted feature branch never qualifies, regardless of context. Outside the sandbox the original rule is unchanged — checklist, STOP, wait for `/scp` / `/scpmr` / `/scpmmr` / affirmative.
+
+Authoritative rule: Dev Spec §5.2.1. Mechanical detection + sentinel: `skills/precheck/SKILL.md` ("Sandbox Auto-Approval (KAHUNA Flight Agents)").
+
 ---
 
 ## MANDATORY: Story Completion Verification

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -57,6 +57,8 @@ Ready for `/scp` / `/scpmr` / `/scpmmr` or rework.
 
 Flight Agents working inside a KAHUNA sandbox push to a per-wave integration branch (`kahuna/<N>-<slug>`), not to `main`. In that context the human gate is a redundant pause — the wave Orchestrator has already decided the wave runs autonomously and reviews aggregated results at the wave gate, not per-flight. The full checklist (validation, code-reviewer, trivy) and Discord/`vox` notifications still run; only the STOP-and-wait step is bypassed.
 
+**Why this exists (narrative).** A wave can dispatch dozens of Flight Agents in parallel; a per-flight human STOP would serialise the wave back to one-at-a-time and defeat the orchestration. The Orchestrator's contract with the human is "I will surface the *wave* result, not every flight." Flight Agents inside the sandbox honour that contract by completing their own quality bar (the full checklist) and then auto-progressing; they never bypass quality, only the human pause. Outside the sandbox — i.e. an agent operating directly against `main` — the original rule applies in full and the STOP is non-negotiable. See Dev Spec §5.2.1 for the authoritative statement; the mechanical detection (regex `^kahuna/[0-9]+-`, sentinel `[AUTO-APPROVED: kahuna sandbox]`) lives below and in the procedure summary above.
+
 **Detection:**
 ```
 current_branch = git rev-parse --abbrev-ref HEAD

--- a/skills/scp/SKILL.md
+++ b/skills/scp/SKILL.md
@@ -26,6 +26,8 @@ Git commit workflow with context awareness. Reasoning layer (commit message draf
 - If `/precheck` was run and the user approved (via `/scp`, `/scpmr`, `/scpmmr`, or an affirmative like "yes", "approved", "go ahead") → proceed to execution.
 - If `/precheck` has NOT been run → run it first and wait for approval before proceeding.
 
+**Sandbox auto-approval path.** When `/precheck` detects a KAHUNA sandbox context (base ref matches `^kahuna/[0-9]+-`), it emits the sentinel `[AUTO-APPROVED: kahuna sandbox]` and invokes `/scpmmr` directly — `/scp` is reached transitively through that auto-invocation, not by a human typing `/scp`. The approval here is structural (the wave Orchestrator dispatched a Flight Agent into a sandbox) rather than per-commit. See `skills/precheck/SKILL.md` and Dev Spec §5.2.1 for the rule. Non-sandbox behaviour is unchanged.
+
 ## Execution
 
 ### Step 1: Branch + Issue Gate

--- a/skills/scpmmr/SKILL.md
+++ b/skills/scpmmr/SKILL.md
@@ -27,3 +27,5 @@ Requires `/precheck` first — invoking `/scpmmr` after `/precheck` is approval 
 - `/precheck` must run and be approved first
 - CI verification before merge is handled by `pr_wait_ci` inside `/mmr`
 - Any step failure → STOP and report, do NOT continue to the next step
+
+**Sandbox invocation path.** `/scpmmr` is the skill `/precheck` auto-invokes when a KAHUNA sandbox is detected (base ref matches `^kahuna/[0-9]+-`). The sentinel `[AUTO-APPROVED: kahuna sandbox]` printed by `/precheck` is the approval signal — there is no separate human STOP for Flight Agents inside the sandbox. The merge here lands the flight onto the per-wave integration branch (`kahuna/<N>-<slug>`), not `main`; the wave Orchestrator handles the eventual `main` merge at the wave gate. Non-sandbox callers (humans typing `/scpmmr`) continue to work exactly as before. See `skills/precheck/SKILL.md` and Dev Spec §5.2.1.

--- a/skills/scpmr/SKILL.md
+++ b/skills/scpmr/SKILL.md
@@ -22,3 +22,5 @@ Requires `/precheck` first — invoking `/scpmr` after `/precheck` is approval t
 3. `vox` announcement (best-effort): identity from `/tmp/claude-agent-<md5>.json`, then name/team/project/issue/PR/"pushed and CI is running"
 
 Do NOT merge — that's the distinction from `/scpmmr`. Convenience shortcut; does NOT skip any safety checks.
+
+**Sandbox note.** In KAHUNA sandbox contexts `/precheck` auto-invokes `/scpmmr` (full merge), not `/scpmr`, because Flight Agents land into the per-wave integration branch and the wave gate — not the flight gate — is where review happens. `/scpmr` therefore retains its no-merge semantics for non-sandbox use. See `skills/precheck/SKILL.md` and Dev Spec §5.2.1.


### PR DESCRIPTION
## Summary

Add an explicit "Exception: Kahuna Sandbox Auto-Approval" block to `CLAUDE.md` under the MANDATORY pre-commit gate, and complementary narrative prose to `skills/precheck/SKILL.md` (atop #416's mechanical spec) plus sandbox-invocation-path notes to `skills/scp/`, `skills/scpmr/`, `skills/scpmmr/`.

## Changes

- `CLAUDE.md` — new "Exception: Kahuna Sandbox Auto-Approval" subsection enumerating the two conditions (base ref `^kahuna/[0-9]+-` AND full checklist passed), the sentinel line, and a link to Dev Spec §5.2.1.
- `skills/precheck/SKILL.md` — narrative "Why this exists" paragraph complementing #416's regex+sentinel mechanical spec.
- `skills/scp/SKILL.md` — sandbox auto-approval path note (transitive via `/scpmmr`).
- `skills/scpmr/SKILL.md` — sandbox note clarifying `/scpmr` is NOT the auto-invoked skill (no-merge semantics retained for human-driven non-sandbox use).
- `skills/scpmmr/SKILL.md` — sandbox invocation path documentation (auto-invoked target; merge lands on per-wave integration branch).

## Linked Issues

Closes #419

## Test Plan

- `./scripts/ci/validate.sh` — 107 passed, 0 failed.
- `python3 -m pytest tests/ --ignore=tests/test_discord_status.py` — 1114 passed, 99 failed; the 99 failures match the pre-existing #328 baseline (verified via stash on unmodified base).
- Docs-only change (5 markdown files, +19 lines, no code); no new tests required.