### PR TITLE
feat(wavemachine): trust-score gate evaluation + kahuna→main auto-merge

### DIFF
--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -15,15 +15,22 @@ description: Autopilot for wave-pattern execution. Runs a top-level loop that ca
 
 - `mcp__sdlc-server__wave_health_check` — circuit breaker; called before every iteration
 - `mcp__sdlc-server__wave_next_pending` — identifies the next pending wave; loop exits when this returns null
-- `mcp__sdlc-server__wave_show` — pre-flight state inspection
+- `mcp__sdlc-server__wave_show` — pre-flight state inspection; also reads `kahuna_branch` for bootstrap and gate
+- `mcp__sdlc-server__wave_init` — pre-wave kahuna bootstrap (creates `kahuna/<epic_id>-<slug>` once per epic)
+- `mcp__sdlc-server__wave_finalize` — opens kahuna→main MR at epic completion
+- `mcp__sdlc-server__commutativity_verify` — trust-score signal; runs concurrently with the other three (R-23)
+- `mcp__sdlc-server__ci_wait_run` — trust-score signal; waits for CI on the kahuna branch
+- `mcp__sdlc-server__pr_merge` — auto-merge kahuna→main on all-green gate, with `skip_train: true`
 - `mcp__sdlc-server__wave_previous_merged` — pre-flight verification that prior wave is on main
 - `mcp__sdlc-server__wave_ci_trust_level` — cached by `/nextwave auto` for its internal gate decisions
 - `mcp__sdlc-server__wave_waiting` — mark the plan paused with a human-readable reason on any abort
-- `mcp__disc-server__disc_send` — announce to `#wave-status` (`1487386934094462986`) on start, completion, abort
-- The Skill tool — invokes `/nextwave auto` per iteration (the one place work is delegated)
+- `mcp__disc-server__disc_send` — announce to `#wave-status` (`1487386934094462986`) on start, completion, abort, gate pass/block
+- The `Agent` tool — invoked AT THE GATE only, for the `feature-dev:code-reviewer` trust signal (one of four concurrent signals). The loop body itself never spawns Agents — `/nextwave auto` owns wave-internal Agent spawning.
+- The `Bash` tool — invoked AT THE GATE for the `trivy fs` dependency scan trust signal.
+- The Skill tool — invokes `/nextwave auto` per iteration (the one place wave work is delegated)
 - `ScheduleWakeup` — OPTIONAL, fallback-only, used when a merge-queue idle is detected (not the primary execution model)
 
-**Not used:** the `Agent` tool is NEVER used directly from this skill — all sub-agent spawning is owned by `/nextwave`. Background Agent invocation is NEVER used anywhere in this skill; the loop is synchronous in the top-level session.
+**Not used in the loop body:** wave-internal `Agent` spawning is owned by `/nextwave` — the loop body itself never spawns sub-agents per iteration. The single exception is the gate's `feature-dev:code-reviewer` Agent at epic completion (one of four concurrent trust signals — see "Trust-Score Gate and Auto-Merge"). Background Agent invocation is NEVER used anywhere in this skill; the loop and the gate both run synchronously in the top-level session.
 
 ## Pre-Flight Checks (refuse to start on failure)
 
@@ -65,7 +72,27 @@ Once pre-flight passes:
 1. **Set the active flag** (see above).
 2. **Regenerate and open the status panel.** Run `./scripts/generate-status-panel`, then open `.status-panel.html` with `xdg-open` (Linux) or `open` (macOS). The panel is visible before work begins and updates as waves land.
 3. **Detect CI trust** by calling `wave_ci_trust_level()` once. (The value is also cached by each `/nextwave auto` iteration; calling it here is informational — it shapes the start announcement.)
-4. **Post to Discord.** `disc_send` to `#wave-status` (`1487386934094462986`): `"🌊 **Wavemachine started** — <project>, <N> waves pending. Agent: **<dev-name>** <dev-avatar>"`. Resolve identity from `/tmp/claude-agent-<md5>.json`. If `disc_send` fails, log and continue — Discord is informational, not a gate.
+4. **Pre-wave kahuna bootstrap** (see "Pre-Wave Kahuna Bootstrap" below). Runs exactly once per epic on first `/wavemachine` invocation. On resume invocations the wave state already carries `kahuna_branch` and this step is a no-op.
+5. **Post to Discord.** `disc_send` to `#wave-status` (`1487386934094462986`): `"🌊 **Wavemachine started** — <project>, <N> waves pending. Agent: **<dev-name>** <dev-avatar>"`. Resolve identity from `/tmp/claude-agent-<md5>.json`. If `disc_send` fails, log and continue — Discord is informational, not a gate.
+
+## Pre-Wave Kahuna Bootstrap
+
+**When this runs:** once per epic, during the launch sequence (step 4 above), BEFORE the loop's first iteration. This is the kahuna sandbox setup step group from Dev Spec §5.2.2 ("New step group — pre-wave kahuna bootstrap").
+
+**Procedure:**
+
+1. Read wave state via `wave_show()`. Inspect the `kahuna_branch` field.
+2. **If `kahuna_branch` is present and non-empty:** SKIP — this is the resume path (Procedure D, §4.4.5). The kahuna branch already exists on the platform and in wave state; do nothing and continue to step 5 of the launch sequence.
+3. **If `kahuna_branch` is absent or empty:** invoke `wave_init` with the `kahuna: { epic_id, slug }` argument, where:
+   - `epic_id` is the master/epic issue number for the current plan (read from wave state's plan metadata).
+   - `slug` is a human-readable kebab-case slug derived from the epic title (the same slug computation `wave_init` already documents).
+   `wave_init` creates `kahuna/<epic_id>-<slug>` off the current main head, writes the branch name into wave state's `kahuna_branch` field, and returns success. (See Dev Spec §5.1.3 for the tool contract.)
+4. **Emit the bootstrap notification.** `disc_send` to `#wave-status` (`1487386934094462986`):
+   `"🏝 **Kahuna sandbox created** — <project>, epic #<epic_id>, branch `<kahuna_branch>`. Agent: **<dev-name>** <dev-avatar>"`. If `disc_send` fails, log and continue — Discord is informational.
+
+**Idempotency.** This step is idempotent by design: the `kahuna_branch` field is the marker. A second `/wavemachine` invocation on the same epic will see the field populated in step 1 and skip creation. This is the foundation for Procedure D crash-recovery.
+
+**Cross-reference.** Dev Spec §5.2.2 (gate behavior) and §5.1.3 (`wave_init` kahuna extension).
 
 ## The Loop (this is the whole skill; no background worker)
 
@@ -81,8 +108,13 @@ loop:
 
   2. next = wave_next_pending()
      if next is None:
-         announce completion (see "On Clean Completion")
-         python3 -m wave_status wavemachine-stop
+         # All waves merged — run the trust-score gate before announcing
+         # completion. KAHUNA mode (kahuna_branch present in wave state):
+         # invoke the gate step group below. Legacy mode (no kahuna_branch):
+         # skip the gate, announce completion as before.
+         run "Trust-Score Gate and Auto-Merge" step group
+         (gate result determines completion vs gate_blocked exit; either
+          branch unsets wavemachine_active and exits the loop)
          exit loop
 
   3. Invoke /nextwave auto
@@ -111,6 +143,72 @@ The loop exits cleanly when any of the following happens:
 - `wave_health_check()` returns a non-HEALTHY status (circuit breaker trips)
 - `/nextwave auto` returns BLOCKED or FAIL (per-wave abort)
 - The user interrupts (Ctrl+C or tool-denial mid-wave — see "Interrupt Handling")
+
+## Trust-Score Gate and Auto-Merge
+
+**When this runs:** exactly once per epic, at the loop's clean-completion path — after `wave_next_pending()` returns null and §7 Definition-of-Done checks pass. This replaces the v1 "On clean completion" simple announcement with the autonomous gate evaluation specified in Dev Spec §5.2.2 ("New step group — trust-score gate and auto-merge").
+
+**Legacy short-circuit.** If wave state has no `kahuna_branch` (legacy non-KAHUNA execution), skip this entire step group and fall through to the "On Clean Completion" announcement below — there is no kahuna→main MR to gate. This preserves backward compatibility with non-KAHUNA plans.
+
+### Gate procedure (KAHUNA mode only)
+
+1. **Run §7 Definition-of-Done checks.** Test suites, VRTM updates, etc. (See Dev Spec §7 for the full checklist.) If any DoD check fails, transition `action` → `gate_blocked` with the DoD failure recorded; emit notifications per Procedure C; preserve the kahuna branch; exit the loop. DoD failure short-circuits the gate before we open the kahuna→main MR.
+2. **Invoke `wave_finalize`.** Opens the kahuna→main MR with an auto-assembled body derived from wavebus artifacts (one bullet per flight, linking the original flight MRs into kahuna). `wave_finalize` is idempotent: if an open kahuna→main MR already exists (resume path / Procedure D), it is reused (`created: false`). Capture the returned MR number.
+3. **Transition wave state `action` → `gate_evaluating`.** This is the marker the wave-status CLI and dashboard read to render the trust-signal summary block (§5.2.5). It is also the marker Procedure D uses to detect a crashed-mid-gate session and re-enter idempotently (see "Procedure D — re-entry at the gate" below).
+4. **Invoke the four trust signals CONCURRENTLY (R-23).** This is a HARD requirement. All four signals MUST be issued in a **single tool-use block** — no signal sequenced behind another in the happy path. The wave-pattern parallelism pattern (one assistant message containing four parallel tool calls) applies here. The four signals are:
+
+   - **`commutativity_verify`** — `commutativity_verify(base_ref="main", changesets=[{id: "kahuna", head_ref: <kahuna_branch>}])`. Returns a verdict envelope (see "PROBE_UNAVAILABLE handling" below for the envelope shapes).
+   - **`ci_wait_run`** — `ci_wait_run(ref=<kahuna_branch>, timeout_sec=1800)`. Waits for the latest CI run on the kahuna branch to settle (success/failure/cancelled).
+   - **Code-reviewer Agent** — `Agent(subagent_type="feature-dev:code-reviewer", prompt=<composed diff over the full kahuna-vs-main range>)`. Returns a structured review with severity-tagged findings.
+   - **Trivy dependency scan** — `Bash("trivy fs --scanners vuln --severity HIGH,CRITICAL --format json --quiet <repo_path>")`. Returns JSON with any HIGH/CRITICAL vulnerability findings (with available fixes).
+
+   These four calls run concurrently in a single tool-use block. **Do NOT short-circuit** when one signal fails — collect all four results before evaluating the gate (per Procedure C, §4.4.4). The operator needs the complete signal set to triage a blocked gate.
+
+5. **Evaluate the gate.** Each signal is classified pass/fail per Procedure C:
+   - `commutativity_verify`: pass = verdict ∈ {`STRONG`, `MEDIUM`}; fail = verdict ∈ {`WEAK`, `ORACLE_REQUIRED`, `PROBE_UNAVAILABLE`}.
+   - `ci_wait_run`: pass = `final_status == "success"`; fail otherwise.
+   - Code-reviewer: pass = no critical or important findings; fail = one or more critical/important findings.
+   - Trivy: pass = no HIGH/CRITICAL findings with available fixes; fail otherwise.
+
+6. **All-green path** (every signal passes):
+   - Invoke `pr_merge({number: <kahuna_mr_number>, skip_train: true, squash_message: <assembled body from step 2>})`. `skip_train: true` is required because the kahuna→main MR has already been gated by the four signals — bypassing the project's standard merge train is the whole point of the autonomous gate.
+   - **Record disposition** in wave state's `kahuna_branches` history array: append `{branch: <kahuna_branch>, epic_id: <epic_id>, disposition: "merged", merged_at: <iso8601>, mr_number: <kahuna_mr_number>}`. (Schema per §5.1.)
+   - **Delete the kahuna branch** from the platform (per R-03). On GitHub: `gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<kahuna_branch>` (or equivalent). On GitLab: `glab api -X DELETE projects/:id/repository/branches/<kahuna_branch_url_encoded>`.
+   - **Emit `#wave-status` notification** (R-19): `"✅ **Kahuna gate passed** — <project>, epic #<epic_id> auto-merged to main. <N> flights, <M> commits. Agent: **<dev-name>** <dev-avatar>"`.
+   - **Vox announcement** (conversational, brief): name, team, project, "kahuna gate passed, epic merged to main".
+   - Then fall through to the standard "On Clean Completion" announcement and `wave_status wavemachine-stop`.
+
+7. **Any-red path** (one or more signals fail):
+   - Transition wave state `action` → `gate_blocked`, recording each failing signal's name + detail payload (so the dashboard's signal-failure detail block can render — §5.2.5).
+   - **Preserve the kahuna branch** (per Procedure C). Do NOT delete it. Do NOT merge the kahuna→main MR. The MR stays open for human review.
+   - **Emit `#wave-status` notification** per Procedure C, §4.4.4: epic name, each failing signal's name + short detail, kahuna branch name, the open kahuna→main MR URL.
+   - **Vox announcement**: "Kahuna gate blocked for epic <epic_id>. <N> signals red. Ready for your review."
+   - Call `wave_waiting("kahuna gate blocked: <one-line summary>")` so the plan is explicitly marked paused.
+   - `wave_status wavemachine-stop` and exit the loop.
+
+### PROBE_UNAVAILABLE handling
+
+`commutativity_verify` may return one of two outer envelope shapes (cross-server contract documented in `mcp-server-sdlc#218`):
+
+- **Probe present:** `{ok: true, verdict: "STRONG" | "MEDIUM" | "WEAK" | "ORACLE_REQUIRED", ...}`.
+- **Probe missing:** `{ok: true, verdict: "PROBE_UNAVAILABLE", warnings: [...]}`. This is a **synthesized verdict** the sdlc-server emits when the `commutativity-probe` binary is not installed in the runtime environment. It is NOT a probe-side classification — it is a graceful-degradation marker.
+
+**Treatment in the gate:** `PROBE_UNAVAILABLE` is **conservative-fail** — equivalent to `ORACLE_REQUIRED`. The gate MUST NOT auto-merge when the commutativity signal is unavailable. This is a deliberate cross-server contract: when we cannot verify commutativity, we refuse to grant the auto-merge privilege the gate normally extends. The any-red path applies; the operator triages by either installing the probe binary and re-running `/wavemachine` (which re-enters at the gate via Procedure D) or merging the kahuna→main MR manually after review.
+
+Document the treatment explicitly so future readers see it: the four-signal gate is a *unanimous* gate, and an unavailable signal is treated identically to a red signal.
+
+### Procedure D — re-entry at the gate
+
+When `/wavemachine` is restarted (Orchestrator crash, user Ctrl-C mid-gate, etc.) and the pre-flight pass discovers wave state `action == gate_evaluating`, the loop driver MUST re-invoke this entire gate step group from step 4 onward. The four signals are **pure reads** (or are guarded by upstream idempotency: `wave_finalize` reuses an existing open MR; `pr_merge` is idempotent per the tool's own contract) — re-invoking them is safe.
+
+The crash-recovery contract (per Dev Spec §4.4.5):
+- `wave_finalize` from step 2 is already idempotent — calling it again returns the existing MR number with `created: false`.
+- The four-signal block in step 4 is re-issued in a single tool-use block; results may differ from the prior attempt (e.g. CI now green where it was timing out before), and that is the desired behavior — the gate evaluates current truth.
+- `pr_merge` from step 6 returns success on an already-merged PR.
+
+The re-entry path is therefore: detect `gate_evaluating`, jump to step 4, run the gate to completion. Document this so the loop driver knows the gate is safe to retry.
+
+**Cross-reference.** Dev Spec §5.2.2 (gate behavior), §4.4.4 (Procedure C — gate signal failure), §4.4.5 (Procedure D — orchestrator crash mid-epic), §7 (Definition of Done), R-23 (concurrency requirement), R-19 (notification requirement), R-03 (kahuna branch deletion on success).
 
 ## Circuit Breaker — `wave_health_check`
 
@@ -144,10 +242,18 @@ Preserve the v1 announcement surface — one Discord post per lifecycle event, o
 
 - Discord `#wave-status`: `"🌊 **Wavemachine started** — <project>, <N> waves pending. Agent: **<dev-name>** <dev-avatar>"`
 
-**On clean completion** (`wave_next_pending()` returned null):
+**On clean completion** (`wave_next_pending()` returned null AND, in KAHUNA mode, the trust-score gate passed all-green):
 
+- This announcement runs AFTER the trust-score gate's all-green path (see "Trust-Score Gate and Auto-Merge"). In KAHUNA mode, the gate has already auto-merged kahuna→main and posted its own `✅ **Kahuna gate passed**` notification — this announcement closes out the wavemachine session.
+- In legacy non-KAHUNA mode (no `kahuna_branch` in wave state), the gate is skipped and this announcement runs directly when `wave_next_pending()` returns null.
 - Discord `#wave-status`: `"✅ **Wavemachine complete** — <project>, all <N> waves merged. Run /dod to verify. Agent: **<dev-name>** <dev-avatar>"`
 - Vox (conversational, brief): name, team, project, "wavemachine complete, all waves merged".
+
+**On gate-blocked completion** (KAHUNA mode, one or more trust signals failed):
+
+- Per Procedure C / "Trust-Score Gate and Auto-Merge" any-red path: `"🛑 **Kahuna gate blocked** — <project>, epic #<epic_id>: <failing-signals summary>. MR <url> open for review. Agent: **<dev-name>** <dev-avatar>"`
+- Vox alert: "Kahuna gate blocked for epic <epic_id>. <N> signals red. Ready for your review."
+- `wave_waiting("kahuna gate blocked: <one-line summary>")` so the plan is explicitly marked paused.
 
 **On circuit-breaker trip** (`wave_health_check` non-HEALTHY):
 
@@ -176,16 +282,29 @@ When waking up, re-enter the loop at step 1 (re-run `wave_health_check` from scr
 
 - **One plan at a time.** Pre-flight refuses to start if another wavemachine is active or another wave is in-flight.
 - **`wavemachine_active` flag must always reflect reality.** Set on entry via `wave_status wavemachine-start`; unset on EVERY exit path via `wave_status wavemachine-stop`. No `Edit` to `state.json`. The statusline 🌊 indicator is not allowed to lie.
-- **NEVER run the loop in a background sub-agent.** No background Agent invocation, ever — not with the `run_in_background` parameter, not shelled out, not via any other escape hatch. No nested `Agent` calls from this skill body. The loop is top-level, period.
-- **NEVER spawn Flights or Prime directly.** `/nextwave auto` owns the Orchestrator/Prime/Flight protocol for each wave — `/wavemachine` only delegates.
+- **NEVER run the loop in a background sub-agent.** No background Agent invocation, ever — not with the `run_in_background` parameter, not shelled out, not via any other escape hatch. The loop is top-level, period. (The gate's `feature-dev:code-reviewer` Agent runs *synchronously* at the top level — not in the background.)
+- **NEVER spawn Flights or Prime directly.** `/nextwave auto` owns the Orchestrator/Prime/Flight protocol for each wave — `/wavemachine` only delegates wave work to it.
 - **Circuit breaker before every iteration.** `wave_health_check` is called at the TOP of each loop iteration, not just the first.
 - **Leave the bus alone on abort.** On any non-happy exit, the in-flight wave's bus tree stays on disk for forensics. `wave-cleanup` runs only on PASS, inside `/nextwave auto`.
-- **Block on green CI.** `/nextwave auto` handles the per-wave CI gate; `/wavemachine` does not merge anything directly and does not fast-path around it.
-- **Structured blocker report on any abort.** Vague "something went wrong" is unacceptable — the Discord announcement + the session report must name the wave, the blocker type, and the remediation path.
+- **Block on green CI.** `/nextwave auto` handles the per-wave CI gate; `/wavemachine` does not merge wave PRs directly and does not fast-path around it. The kahuna→main MR is the *only* PR `/wavemachine` merges, and only after the four-signal gate passes all-green.
+- **R-23 — gate signals run concurrently in a single tool-use block.** The four trust signals (`commutativity_verify`, `ci_wait_run`, `feature-dev:code-reviewer` Agent, `trivy` Bash) MUST be issued in a single tool-use block — no signal sequenced behind another. Sequencing them silently would inflate the gate's wall-clock cost by ~4x and is a hard regression to catch in tests.
+- **Do not short-circuit the gate.** Collect all four signal results before evaluating pass/fail (Procedure C, §4.4.4). The operator needs the complete signal set to triage a blocked gate.
+- **`PROBE_UNAVAILABLE` is conservative-fail.** When `commutativity_verify` returns the synthesized `PROBE_UNAVAILABLE` verdict (probe binary not installed; cross-server contract per `mcp-server-sdlc#218`), the gate treats it identically to `ORACLE_REQUIRED` — no auto-merge. Document this so it cannot be silently relaxed.
+- **Gate re-entry is idempotent.** Procedure D: a `/wavemachine` restart that finds wave state in `gate_evaluating` MUST re-invoke the four signals. They are pure reads (or upstream-idempotent) — safe to retry. Do not assume crash-mid-gate is unrecoverable.
+- **Structured blocker report on any abort.** Vague "something went wrong" is unacceptable — the Discord announcement + the session report must name the wave (or the failing signals, at the gate), the blocker type, and the remediation path.
 
 ## Resuming After an Abort
 
 Wave state is persistent on disk (`.claude/status/state.json` + the bus tree). When the blocker is resolved, simply re-invoke `/wavemachine`. The pre-flight checks validate the new starting state; the loop picks up from the next pending wave.
+
+**Resuming at the gate (Procedure D, §4.4.5).** If the prior `/wavemachine` session crashed or was interrupted with wave state in `action == gate_evaluating`, the next invocation:
+1. Skips the pre-wave kahuna bootstrap (the `kahuna_branch` field is already populated).
+2. The loop's first iteration finds `wave_next_pending() == null` (all waves merged on the prior run) and falls into the "Trust-Score Gate and Auto-Merge" step group.
+3. `wave_finalize` is idempotent: it returns the existing open kahuna→main MR with `created: false`.
+4. The four trust signals are re-invoked in a single tool-use block (R-23). They are pure reads — re-evaluating yields current truth (e.g. CI may now be green where it was timing out before).
+5. Gate evaluation proceeds normally — all-green merges and exits clean; any-red transitions to `gate_blocked` and exits paused.
+
+This idempotent re-entry is what makes the gate crash-safe.
 
 ## Pair
 

--- a/tests/test_wavemachine_skill.py
+++ b/tests/test_wavemachine_skill.py
@@ -1,0 +1,551 @@
+"""Tests for skills/wavemachine/SKILL.md — trust-score gate + auto-merge (issue #418).
+
+Validates Dev Spec §5.2.2:
+- Pre-wave kahuna bootstrap step group exists, references ``wave_init`` with
+  ``kahuna: { epic_id, slug }``, is idempotent on resume.
+- Trust-score gate step group exists, lists the four signals, runs them
+  CONCURRENTLY in a single tool-use block (R-23).
+- All-green path documents ``pr_merge`` with ``skip_train: true``,
+  ``kahuna_branches`` history record, kahuna branch deletion, notification
+  + vox.
+- Any-red path documents ``gate_blocked`` transition, notification, kahuna
+  preservation, exit-loop.
+- ``PROBE_UNAVAILABLE`` synthesized verdict treated as conservative-fail.
+- Procedure D (crash recovery) at gate re-enters idempotently.
+
+Tests assert content of the live SKILL.md file. They exercise the real
+markdown — no mocks, no stubs, no live binaries (no trivy, no
+commutativity-probe required).
+
+IT-01 / IT-03 / IT-04 / IT-05 (AC-6 + AC-7) are integration-test-level
+acceptance criteria covered by the end-to-end harness (Dev Spec §6.2);
+they are out of scope for this unit-level skill test file. This is the same
+scoping convention used by ``test_nextwave_skill.py`` for AC-5/AC-6 of #417.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths and fixtures
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = _ROOT / "skills" / "wavemachine" / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Read the wavemachine SKILL.md file once per module."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _section(text: str, header: str) -> str:
+    """Return the slice of ``text`` from the matching header to the next
+    sibling/parent header (``## `` or ``### ``).
+
+    ``header`` is matched by substring on the line. The slice ends at the
+    next line beginning with ``## `` or ``### ``. Used to scope assertions
+    to a specific step rather than the whole document.
+    """
+    lines = text.splitlines(keepends=True)
+    start = None
+    for i, line in enumerate(lines):
+        if header in line and (line.startswith("## ") or line.startswith("### ")):
+            start = i
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## ") or lines[j].startswith("### "):
+            end = j
+            break
+    return "".join(lines[start:end])
+
+
+def _bootstrap(text: str) -> str:
+    return _section(text, "Pre-Wave Kahuna Bootstrap")
+
+
+def _gate(text: str) -> str:
+    """Return the entire gate section, including its ### subsections.
+
+    The ``_section`` helper stops at the first ``### `` heading, but the
+    gate section's ### subsections (gate procedure, PROBE_UNAVAILABLE,
+    Procedure D) are part of the same step group conceptually. Here we
+    take everything from the ``## Trust-Score Gate`` heading down to the
+    next top-level ``## `` heading.
+    """
+    lines = text.splitlines(keepends=True)
+    start = None
+    for i, line in enumerate(lines):
+        if line.startswith("## Trust-Score Gate"):
+            start = i
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## ") and not lines[j].startswith("## Trust-Score Gate"):
+            end = j
+            break
+    return "".join(lines[start:end])
+
+
+# ---------------------------------------------------------------------------
+# Existence + framing
+# ---------------------------------------------------------------------------
+
+
+class TestSkillFileShape:
+    """Sanity checks: file exists, frontmatter intact, gate / kahuna
+    terminology present at the document level."""
+
+    def test_skill_file_exists(self) -> None:
+        assert SKILL_PATH.is_file(), f"missing: {SKILL_PATH}"
+
+    def test_frontmatter_name(self, skill_text: str) -> None:
+        assert skill_text.startswith("---\nname: wavemachine\n")
+
+    def test_kahuna_branch_referenced(self, skill_text: str) -> None:
+        assert "kahuna_branch" in skill_text
+
+    def test_gate_evaluating_referenced(self, skill_text: str) -> None:
+        """Both new ``action`` values from §5.2.2 must appear."""
+        assert "gate_evaluating" in skill_text
+        assert "gate_blocked" in skill_text
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Pre-wave kahuna bootstrap
+# ---------------------------------------------------------------------------
+
+
+class TestAC1_PreWaveBootstrap:
+    """Pre-wave kahuna bootstrap section exists and references ``wave_init``
+    with the ``kahuna: { epic_id, slug }`` argument, runs once per epic, is
+    idempotent on resume."""
+
+    def test_bootstrap_section_exists(self, skill_text: str) -> None:
+        bootstrap = _bootstrap(skill_text)
+        assert bootstrap, "Pre-Wave Kahuna Bootstrap section not found"
+
+    def test_bootstrap_calls_wave_init_with_kahuna_arg(
+        self, skill_text: str
+    ) -> None:
+        """The bootstrap step must name ``wave_init`` and pass the
+        ``kahuna: { epic_id, slug }`` argument shape from §5.1.2."""
+        bootstrap = _bootstrap(skill_text)
+        assert "wave_init" in bootstrap
+        # Tolerate small whitespace variations around the JSON-ish object.
+        assert re.search(
+            r"kahuna:\s*\{\s*epic_id\s*,\s*slug\s*\}",
+            bootstrap,
+        ), "Bootstrap must call wave_init with `kahuna: { epic_id, slug }`"
+
+    def test_bootstrap_skips_when_kahuna_branch_present(
+        self, skill_text: str
+    ) -> None:
+        """Resume path: when ``kahuna_branch`` is already in wave state,
+        the bootstrap is a no-op."""
+        bootstrap = _bootstrap(skill_text)
+        assert re.search(
+            r"kahuna_branch.*(present|non-empty).*SKIP|SKIP.*kahuna_branch",
+            bootstrap,
+            re.IGNORECASE | re.DOTALL,
+        ), "Bootstrap must skip when kahuna_branch is already present (resume path)"
+
+    def test_bootstrap_runs_once_per_epic(self, skill_text: str) -> None:
+        """Bootstrap is anchored as once-per-epic, not per-wave."""
+        bootstrap = _bootstrap(skill_text)
+        assert re.search(
+            r"once per epic|first.*invocation",
+            bootstrap,
+            re.IGNORECASE,
+        ), "Bootstrap must declare once-per-epic semantics"
+
+
+# ---------------------------------------------------------------------------
+# AC-2 + AC-5 (R-23): Gate documents the four signals AND mandates
+# concurrent invocation in a single tool-use block.
+# ---------------------------------------------------------------------------
+
+
+class TestAC2_GateStepGroupAndConcurrency:
+    """Gate step group documents the four trust signals, calls them
+    concurrently in a single tool-use block, and explicitly cites R-23."""
+
+    def test_gate_section_exists(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        assert gate, "Trust-Score Gate and Auto-Merge section not found"
+
+    def test_gate_runs_at_epic_completion(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        # The gate must be anchored to the loop's clean-completion path
+        # (after wave_next_pending() returns null and DoD passes).
+        assert re.search(
+            r"wave_next_pending.*null|epic completion|after.*final wave|"
+            r"clean.completion",
+            gate,
+            re.IGNORECASE | re.DOTALL,
+        ), "Gate must be anchored at epic completion / clean completion path"
+
+    def test_gate_invokes_wave_finalize(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        assert "wave_finalize" in gate
+
+    def test_gate_transitions_to_gate_evaluating(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        # The transition must be explicit and tied to action ->
+        # gate_evaluating.
+        assert re.search(
+            r"action.*gate_evaluating|gate_evaluating",
+            gate,
+        ), "Gate must transition wave state action to gate_evaluating"
+
+    def test_gate_lists_all_four_signals(self, skill_text: str) -> None:
+        """All four trust-score signals must be enumerated by name within
+        the gate section. They are the contract being implemented."""
+        gate = _gate(skill_text)
+        assert "commutativity_verify" in gate, "missing commutativity_verify"
+        assert "ci_wait_run" in gate, "missing ci_wait_run"
+        # Code-reviewer Agent — accept either bare subagent_type form or
+        # explicit Agent(... feature-dev:code-reviewer ...).
+        assert re.search(
+            r"feature-dev:code-reviewer|code-reviewer",
+            gate,
+        ), "missing feature-dev:code-reviewer Agent signal"
+        assert "trivy" in gate, "missing trivy Bash signal"
+
+    def test_gate_signals_run_concurrently_per_r23(self, skill_text: str) -> None:
+        """R-23: the four signals must run concurrently in a single
+        tool-use block. This is the load-bearing assertion — the test
+        exists specifically to catch regressions where signals get
+        sequenced behind one another."""
+        gate = _gate(skill_text)
+        # Literal R-23 reference must be present.
+        assert "R-23" in gate, "Gate must cite R-23"
+        # "concurrent" wording (catches both "concurrently" and
+        # "concurrent").
+        assert re.search(
+            r"concurrent", gate, re.IGNORECASE
+        ), "Gate must declare concurrent invocation"
+        # "single tool-use block" wording — the wave-pattern parallelism
+        # idiom that maps to actual concurrent tool calls in CC.
+        assert re.search(
+            r"single tool.use block",
+            gate,
+            re.IGNORECASE,
+        ), "Gate must require a single tool-use block for the four signals"
+
+    def test_gate_does_not_short_circuit(self, skill_text: str) -> None:
+        """Procedure C, §4.4.4: collect all four results before evaluating.
+        Do not bail out on the first failure."""
+        gate = _gate(skill_text)
+        assert re.search(
+            r"do.*not.*short.circuit|collect all four",
+            gate,
+            re.IGNORECASE | re.DOTALL,
+        ), "Gate must explicitly forbid short-circuit on first failure"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: All-green path — auto-merge, history, branch deletion,
+# notifications.
+# ---------------------------------------------------------------------------
+
+
+class TestAC3_AllGreenPath:
+    """When all four trust signals pass, the gate auto-merges
+    kahuna→main, records disposition in ``kahuna_branches`` history,
+    deletes the kahuna branch, and emits notifications + vox."""
+
+    def test_all_green_invokes_pr_merge_skip_train(
+        self, skill_text: str
+    ) -> None:
+        gate = _gate(skill_text)
+        assert "pr_merge" in gate
+        # skip_train: true is the load-bearing flag — without it the
+        # auto-merge falls into the project's standard merge train and
+        # the autonomous gate is moot.
+        assert re.search(
+            r"skip_train\s*:\s*true",
+            gate,
+        ), "All-green path must call pr_merge with skip_train: true"
+
+    def test_all_green_records_kahuna_branches_history(
+        self, skill_text: str
+    ) -> None:
+        gate = _gate(skill_text)
+        assert "kahuna_branches" in gate, (
+            "All-green path must record disposition in kahuna_branches "
+            "history"
+        )
+        assert re.search(
+            r'disposition\s*:\s*"merged"|"merged"',
+            gate,
+        ), "kahuna_branches entry must record disposition: 'merged'"
+
+    def test_all_green_deletes_kahuna_branch(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        # R-03 — branch must be deleted on success. Tolerate either an
+        # English description or platform-specific commands.
+        assert re.search(
+            r"[Dd]elete the kahuna branch|R-03",
+            gate,
+        ), "All-green path must delete the kahuna branch (R-03)"
+
+    def test_all_green_emits_notification_and_vox(
+        self, skill_text: str
+    ) -> None:
+        gate = _gate(skill_text)
+        # R-19 — Discord notification must fire.
+        assert re.search(
+            r"#wave-status.*[Kk]ahuna gate passed|[Kk]ahuna gate passed.*"
+            r"#wave-status",
+            gate,
+            re.DOTALL,
+        ), "All-green path must emit a #wave-status 'kahuna gate passed' notification"
+        # Vox announcement.
+        assert re.search(
+            r"[Vv]ox.*kahuna gate passed",
+            gate,
+            re.IGNORECASE | re.DOTALL,
+        ), "All-green path must emit a vox announcement"
+
+
+# ---------------------------------------------------------------------------
+# AC-4: Any-red path — gate_blocked transition, notification, kahuna
+# preservation, exit loop.
+# ---------------------------------------------------------------------------
+
+
+class TestAC4_AnyRedPath:
+    """When one or more signals fail, the gate transitions to
+    ``gate_blocked``, emits Procedure C notifications, preserves the
+    kahuna branch, and exits the loop."""
+
+    def test_any_red_transitions_to_gate_blocked(
+        self, skill_text: str
+    ) -> None:
+        gate = _gate(skill_text)
+        assert re.search(
+            r"action.*gate_blocked",
+            gate,
+            re.DOTALL,
+        ), "Any-red path must transition action -> gate_blocked"
+
+    def test_any_red_preserves_kahuna_branch(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        assert re.search(
+            r"[Pp]reserve the kahuna branch|kahuna branch.*preserved|"
+            r"[Dd]o NOT delete",
+            gate,
+            re.DOTALL,
+        ), "Any-red path must preserve the kahuna branch"
+
+    def test_any_red_exits_loop(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        # Exit condition. wave_status wavemachine-stop or exit the loop.
+        assert re.search(
+            r"exit the loop|wavemachine-stop",
+            gate,
+            re.IGNORECASE,
+        ), "Any-red path must exit the loop"
+
+    def test_any_red_emits_procedure_c_notification(
+        self, skill_text: str
+    ) -> None:
+        gate = _gate(skill_text)
+        # Procedure C — must be cited.
+        assert re.search(
+            r"Procedure C|§\s*4\.4\.4",
+            gate,
+        ), "Any-red path must cite Procedure C / §4.4.4"
+        # Notification must list the failing signals + the open MR URL.
+        assert re.search(
+            r"#wave-status.*[Kk]ahuna gate blocked|"
+            r"failing signal|MR.*open for review",
+            gate,
+            re.DOTALL,
+        ), "Any-red path must emit #wave-status notification with failing signals + MR URL"
+
+    def test_any_red_calls_wave_waiting(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        assert "wave_waiting" in gate, (
+            "Any-red path must call wave_waiting to mark the plan paused"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PROBE_UNAVAILABLE: synthesized verdict, conservative-fail treatment.
+# ---------------------------------------------------------------------------
+
+
+class TestProbeUnavailable:
+    """The synthesized ``PROBE_UNAVAILABLE`` verdict (cross-server
+    contract per ``mcp-server-sdlc#218``) must be treated as
+    conservative-fail in the gate — no auto-merge."""
+
+    def test_probe_unavailable_documented(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        assert "PROBE_UNAVAILABLE" in gate, (
+            "Gate must document the PROBE_UNAVAILABLE verdict"
+        )
+
+    def test_probe_unavailable_is_conservative_fail(
+        self, skill_text: str
+    ) -> None:
+        """The treatment must be explicit: same dispatch as
+        ``ORACLE_REQUIRED`` — never auto-merge when commutativity is
+        unavailable."""
+        gate = _gate(skill_text)
+        assert re.search(
+            r"PROBE_UNAVAILABLE.*conservative.fail|"
+            r"conservative.fail.*PROBE_UNAVAILABLE|"
+            r"PROBE_UNAVAILABLE.*equivalent.*ORACLE_REQUIRED|"
+            r"PROBE_UNAVAILABLE.*ORACLE_REQUIRED",
+            gate,
+            re.IGNORECASE | re.DOTALL,
+        ), (
+            "Gate must declare PROBE_UNAVAILABLE as conservative-fail / "
+            "equivalent to ORACLE_REQUIRED"
+        )
+
+    def test_probe_unavailable_no_auto_merge(self, skill_text: str) -> None:
+        """Belt-and-suspenders: the must-not-auto-merge contract is
+        spelled out so it cannot be silently relaxed."""
+        gate = _gate(skill_text)
+        assert re.search(
+            r"MUST NOT auto.merge|not auto.merge",
+            gate,
+            re.IGNORECASE,
+        ), "Gate must explicitly forbid auto-merge when commutativity is unavailable"
+
+    def test_probe_unavailable_cross_server_contract_cited(
+        self, skill_text: str
+    ) -> None:
+        """The contract source must be findable — the
+        ``mcp-server-sdlc#218`` cross-reference anchors the synthesized
+        verdict to its authoritative spec."""
+        gate = _gate(skill_text)
+        assert re.search(
+            r"mcp-server-sdlc#218",
+            gate,
+        ), "Gate must cite the cross-server contract (mcp-server-sdlc#218)"
+
+
+# ---------------------------------------------------------------------------
+# AC-8: Procedure D — idempotent re-evaluation when re-entering at
+# gate_evaluating.
+# ---------------------------------------------------------------------------
+
+
+class TestAC8_ProcedureDReentry:
+    """When ``/wavemachine`` is restarted with wave state in
+    ``gate_evaluating``, the gate is re-invoked idempotently — pure-read
+    signals are safe to retry."""
+
+    def test_procedure_d_documented(self, skill_text: str) -> None:
+        gate = _gate(skill_text)
+        assert re.search(
+            r"Procedure D|§\s*4\.4\.5",
+            gate,
+        ), "Gate must cite Procedure D / §4.4.5 for crash recovery"
+
+    def test_re_entry_at_gate_evaluating(self, skill_text: str) -> None:
+        """The skill must specify the re-entry trigger: state
+        ``action == gate_evaluating``."""
+        gate = _gate(skill_text)
+        assert re.search(
+            r"gate_evaluating.*re.invoke|re.invoke.*gate_evaluating|"
+            r"gate_evaluating.*re.enter|re.enter.*gate",
+            gate,
+            re.IGNORECASE | re.DOTALL,
+        ), "Gate must specify re-entry behavior when action == gate_evaluating"
+
+    def test_signals_safe_to_retry(self, skill_text: str) -> None:
+        """Signals are pure reads (or upstream-idempotent) — the rationale
+        for safe retry must be documented."""
+        gate = _gate(skill_text)
+        assert re.search(
+            r"pure read|safe to retry|idempoten",
+            gate,
+            re.IGNORECASE,
+        ), "Gate must explain why re-invoking signals is safe (pure reads / idempotent)"
+
+    def test_resuming_section_documents_gate_re_entry(
+        self, skill_text: str
+    ) -> None:
+        """The "Resuming After an Abort" section also documents gate
+        re-entry — readers approaching the skill from the abort-recovery
+        angle need this signpost too."""
+        resuming = _section(skill_text, "Resuming After an Abort")
+        assert resuming, "Resuming After an Abort section not found"
+        assert re.search(
+            r"gate_evaluating",
+            resuming,
+        ), "Resuming section must mention gate_evaluating re-entry"
+        assert "wave_finalize" in resuming, (
+            "Resuming section must call out wave_finalize idempotency"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference: Dev Spec §5.2.2 must be cited at least once.
+# ---------------------------------------------------------------------------
+
+
+class TestDevSpecCrossReference:
+    """The Dev Spec §5.2.2 reference must remain in the skill so future
+    readers can find the authoritative gate contract."""
+
+    def test_devspec_5_2_2_referenced(self, skill_text: str) -> None:
+        assert re.search(r"§\s*5\.2\.2|Dev Spec.*5\.2\.2", skill_text), (
+            "Dev Spec §5.2.2 must be cross-referenced from the skill"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Non-Negotiables: R-23 and PROBE_UNAVAILABLE must appear as hard rules.
+# Catches regressions where the gate body documents the rule but the
+# Non-Negotiables list (the load-bearing summary) drifts out of sync.
+# ---------------------------------------------------------------------------
+
+
+class TestNonNegotiables:
+    def test_r23_in_non_negotiables(self, skill_text: str) -> None:
+        non_neg = _section(skill_text, "Non-Negotiables")
+        assert non_neg, "Non-Negotiables section not found"
+        assert "R-23" in non_neg
+        assert re.search(
+            r"single tool.use block", non_neg, re.IGNORECASE
+        ), "Non-Negotiables must encode 'single tool-use block' for R-23"
+
+    def test_probe_unavailable_in_non_negotiables(
+        self, skill_text: str
+    ) -> None:
+        non_neg = _section(skill_text, "Non-Negotiables")
+        assert "PROBE_UNAVAILABLE" in non_neg, (
+            "Non-Negotiables must encode the PROBE_UNAVAILABLE rule"
+        )
+        assert re.search(
+            r"conservative.fail",
+            non_neg,
+            re.IGNORECASE,
+        ), "Non-Negotiables must mark PROBE_UNAVAILABLE as conservative-fail"
+
+    def test_no_short_circuit_in_non_negotiables(
+        self, skill_text: str
+    ) -> None:
+        non_neg = _section(skill_text, "Non-Negotiables")
+        assert re.search(
+            r"short.circuit",
+            non_neg,
+            re.IGNORECASE,
+        ), "Non-Negotiables must encode 'do not short-circuit the gate'"


### PR DESCRIPTION
## Summary

Extends the `/wavemachine` skill with the trust-score gate step group and pre-wave kahuna bootstrap per Dev Spec §5.2.2. At epic completion the gate invokes four trust signals concurrently in a single tool-use block (R-23); all-green auto-merges kahuna→main with `skip_train`, any-red transitions to `gate_blocked` with the kahuna branch preserved.

## Changes

- `skills/wavemachine/SKILL.md` — adds three top-level sections:
  - **Pre-Wave Kahuna Bootstrap** — idempotent first-invocation bootstrap via `wave_init({kahuna: {epic_id, slug}})`; slotted as launch-sequence step 4
  - **Trust-Score Gate and Auto-Merge** — gate procedure (DoD checks → `wave_finalize` → `gate_evaluating` → 4 concurrent signals → classify → all-green merge OR any-red `gate_blocked`)
  - **Procedure D re-entry at the gate** — safe-to-retry rationale (pure-read signals + upstream idempotency); resumption point at gate step 4
- Four trust signals invoked CONCURRENTLY in single tool-use block (R-23): `commutativity_verify`, `ci_wait_run`, `feature-dev:code-reviewer` Agent, `trivy fs` Bash. Explicit "do not short-circuit" wording.
- All-green path: `pr_merge({skip_train: true})` → append to `kahuna_branches` history with `disposition: "merged"` → delete kahuna branch (R-03) → Discord + vox notifications.
- Any-red path: `gate_blocked` transition → kahuna preserved → Procedure C notification with failing signals + open MR URL → vox alert → `wave_waiting()` → exit loop.
- PROBE_UNAVAILABLE handled as conservative-fail (cross-server contract per `Wave-Engineering/mcp-server-sdlc#218`); MUST NOT auto-merge when commutativity is unavailable.
- Tools Used / Non-Negotiables / Resuming After an Abort sections updated; loop-body Agent prohibition preserved (gate's code-reviewer is the single approved Agent invocation, explicitly scoped as gate-only).
- `tests/test_wavemachine_skill.py` — 36 new unit tests covering all 8 ACs (skill-prose level; IT-01/03/04/05 explicitly scoped to integration harness per Dev Spec §6.2).

## Linked Issues

Closes #418

## Test Plan

What was actually run:

- `pytest tests/test_wavemachine_skill.py -v` — 36 passed in 0.18s
- `pytest tests/ --ignore=tests/test_discord_status.py` — 1150 passed / 99 failed (vs. main baseline 1114 passed / 99 failed; **net delta: +36 passes, 0 new failures**; the 99 pre-existing failures in `test_install.py` / `test_install_merge.py` reproduce on `main` HEAD)
- `./scripts/ci/validate.sh` — 107 passed, 0 failed (shellcheck, shfmt, py_compile, SKILL.md frontmatter, install-script registration)
- Manual structured self-review for spec fidelity, R-23 concurrency wording, PROBE_UNAVAILABLE conservative-fail, idempotency contracts, Procedure C/D citations, v2 invariants. (The mechanical `feature-dev:code-reviewer` Agent step is unavailable inside CC sub-agent Flight sessions per `lesson_cc_subagent_tools.md`; manual review found no findings.)