### PR TITLE
docs: KAHUNA section in CHANGELOG + README (cc-workflow side)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `afk-notify` Stop hook — replaced by kill switch on discord-watcher
 
+## [KAHUNA MVP] - 2026-04-25
+
+### Added
+
+- **KAHUNA — autonomous epic delivery via per-epic integration branches.** Lets `/wavemachine` ship a whole epic to `main` in one autonomous run instead of stopping for human review on every Flight MR/PR. All Flights for an epic merge into a short-lived `kahuna/<epic-id>-<slug>` branch (CI-gated, no human review); when the epic is fully assembled and the four-signal trust score is green (commutativity STRONG/MEDIUM, CI green, code-reviewer-clean, trivy zero HIGH/CRITICAL), the system opens a single kahuna→main MR/PR and auto-merges it. Main's existing branch protection, required reviews, and merge rules are unchanged — KAHUNA only relaxes rules on `kahuna/*` branches. cc-workflow surface area in this release:
+
+  - **`/precheck` sandbox awareness** — Detects when a Flight Agent is operating inside a Kahuna sandbox (current branch's base ref matches `^kahuna/[0-9]+-`). When the full checklist passes (validation, code-reviewer no high+ findings, trivy clean, Discord `#precheck` post, vox announcement), `/precheck` emits the sentinel `[AUTO-APPROVED: kahuna sandbox]` and invokes `/scpmmr` directly instead of STOP-and-wait. Outside the sandbox, behavior is unchanged.
+  - **`/wavemachine` trust-score gate** — Wavemachine integrates four-signal trust-score evaluation at the kahuna→main MR/PR. Any red signal pauses for human review; degraded-signal fallback to human is automatic, not configured.
+  - **`/nextwave` kahuna base-ref plumbing** — Flight sub-agents branch off the kahuna integration branch (not main) and target it as their MR/PR base. The base ref is propagated end-to-end through wave planning, worktree creation, and PR creation.
+  - **`wave-status` CLI additions** — New `set-kahuna-branch` subcommand for KAHUNA state writes; renderers for `kahuna_branch` / `kahuna_branches` fields; gate-action surfacing in the dashboard and Discord wave-status embed.
+  - **New documentation** — [`docs/kahuna-guide.md`](docs/kahuna-guide.md) (engineer-facing how-to) and [`docs/kahuna-devspec.md`](docs/kahuna-devspec.md) (architecture, rationale, constraints, requirements).
+
+Companion changes ship in `mcp-server-sdlc` (kahuna lifecycle tools, `wave_finalize`, schema relaxations) and `gitlab-settings-automation` (per-platform sandbox configuration). See those repos' CHANGELOGs for details.
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ cd claudecode-workflow
 
 **New here?** Start with [Getting Started](docs/getting-started.md), then [Concepts](docs/concepts.md).
 
+## KAHUNA
+
+KAHUNA is a per-epic integration-branch pattern that lets `/wavemachine` ship a whole multi-issue epic to `main` in one autonomous run. Flights merge into a short-lived `kahuna/<epic-id>-<slug>` branch (CI-gated, no human review); a four-signal trust score (commutativity, CI, code-reviewer, trivy) gates the single kahuna→main MR/PR. Main's existing protection, required reviews, and merge rules are unchanged.
+
+See the [KAHUNA Guide](docs/kahuna-guide.md) for usage and the [Dev Spec](docs/kahuna-devspec.md) for architecture and rationale.
+
 ## What's Included
 
 ### CLAUDE.md Template


### PR DESCRIPTION
## Summary

Adds a KAHUNA section to `CHANGELOG.md` and `README.md` covering the cc-workflow surface area of the KAHUNA MVP delivery (precheck sandbox awareness, wavemachine trust-score gate, nextwave base-ref plumbing, wave-status CLI additions, kahuna docs).

## Changes

- `CHANGELOG.md`: New dated release header `[KAHUNA MVP] - 2026-04-25` between `[Unreleased]` and `[0.1.0] - 2026-03-22`, with five sub-bullets summarising cc-workflow KAHUNA changes and a pointer to sister-repo CHANGELOGs.
- `README.md`: New top-level `## KAHUNA` section between Quick Start and "What's Included" — one paragraph + links to `docs/kahuna-guide.md` and `docs/kahuna-devspec.md`. Does not duplicate the existing docs-table link.

## Cross-Repo Scope

This PR covers only the **cc-workflow** side of #425. The companion repos — `mcp-server-sdlc` and `gitlab-settings-automation` — have their own CHANGELOG/README updates tracked separately. The cc-workflow CHANGELOG points readers to those repos for their respective details.

## Test Plan

- `./scripts/ci/validate.sh` — PASS (107 passed, 0 failed; shellcheck/shfmt/SKILL.md frontmatter clean).
- `git diff main --stat` — confirms only `CHANGELOG.md` (+14) and `README.md` (+6) change. Pure prose; no code, scripts, CI YAML, or hooks touched.
- Pre-existing pytest failures (99) on `main` are unrelated to this docs-only diff.

Closes #425