### PR TITLE
feat(observability): localized flight-plan logging + scripts/mcp-log + tail viewer

### DIFF
--- a/docs/mcp-logging-standard.md
+++ b/docs/mcp-logging-standard.md
@@ -99,6 +99,60 @@ For servers that shell out to CLI tools (sdlc → `gh`/`glab`, commutativity →
 | `ms` | number | Cycle duration |
 | `via` | string | `direct` or `scream-hole` |
 
+### `wave_start` — Wave-pattern wave begins (cc-workflow skill)
+
+Emitted by `/nextwave` from `scripts/mcp-log` immediately after the wave id and target repo are resolved — before any per-issue `spec_validate_structure`, `wave_show`, or `wave_previous_merged` sdlc tool_call. The early emission is intentional: the anchor must precede the wave's sdlc calls so post-mortem temporal correlation finds the right window. Pairs with `wave_complete`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `wave` | number | Wave id (e.g., 3) |
+| `target` | string | Repo slug being executed against |
+| `issues` | array<number> | Issue numbers in this wave |
+| `kahuna` | string? | Kahuna integration branch if KAHUNA mode, else empty |
+
+### `flight_plan` — A flight has been planned (cc-workflow skill)
+
+Emitted by `/nextwave` once Prime(pre-wave) returns the plan. One event per flight in the wave. The temporal anchor for correlating sdlc-server `tool_call` events to a specific flight in post-mortem.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `wave` | number | Wave id |
+| `flight` | number | Flight number within the wave |
+| `issues` | array<number> | Issue numbers in this flight |
+
+### `wave_complete` — Wave-pattern wave terminal (cc-workflow skill)
+
+Emitted by `/nextwave` after Prime(post-wave) returns its terminal report. Pairs with `wave_start`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `wave` | number | Wave id |
+| `status` | string | `PASS` / `FAIL` / `BLOCKED` |
+| `merged` | number | Issues merged in this wave |
+| `deferred` | number | Issues deferred-and-accepted |
+
+### `wavemachine_start` — Autopilot loop entered (cc-workflow skill)
+
+Emitted by `/wavemachine` when the launch sequence completes and the loop begins. Pairs with `wavemachine_complete`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `epic` | string\|number | Epic ID for the autopiloted plan |
+| `waves` | number | Pending waves at start |
+| `kahuna` | string? | Kahuna integration branch if KAHUNA mode, else empty |
+
+### `wavemachine_complete` — Autopilot loop terminal (cc-workflow skill)
+
+Emitted by `/wavemachine` on every exit path (clean completion, gate block, circuit breaker, per-wave abort).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `epic` | string\|number | Epic ID |
+| `status` | string | `OK` / `BLOCKED` / `ABORTED` |
+| `reason` | string? | One-line cause when status ≠ OK |
+| `waves_merged` | number? | Successfully merged waves on OK paths |
+| `wave` | number? | The wave that aborted, on per-wave abort path |
+
 ### `startup` — Server initialization
 
 | Field | Type | Description |

--- a/scripts/mcp-log
+++ b/scripts/mcp-log
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# scripts/mcp-log — emit a structured log line to the fleet logfile.
+#
+# Used by cc-workflow skills (/nextwave, /wavemachine) to log
+# orchestration-layer lifecycle events alongside MCP-server tool_call events,
+# so post-mortem correlation works by temporal window. Schema conforms to
+# docs/mcp-logging-standard.md.
+#
+# Usage:
+#   mcp-log [--level LEVEL] [--server NAME] EVENT [KEY=VALUE...]
+#
+# Defaults:
+#   --level info
+#   --server wave
+#   LOG_FILE ${LOG_FILE:-~/.claude/logs/mcp.jsonl}
+#
+# KEY=VALUE pairs become fields on the emitted object. Values that parse as
+# JSON keep their JSON types (numbers, booleans, arrays, objects); anything
+# else is a string.
+#
+# Exit codes:
+#   0  success
+#   1  emission failed (jq error, write error)
+#   2  usage error
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: mcp-log [--level LEVEL] [--server NAME] EVENT [KEY=VALUE...]
+
+Append a single JSON line to the fleet logfile (default
+~/.claude/logs/mcp.jsonl, override with $LOG_FILE).
+
+Required:
+  EVENT               Event name (e.g. flight_plan, wave_complete)
+
+Optional:
+  --level LEVEL       debug | info | warn | error (default: info)
+  --server NAME       Producer name (default: wave)
+  KEY=VALUE...        Additional fields. JSON-typed if parseable, else string.
+
+Examples:
+  mcp-log flight_plan wave=3 flight=1 issues='[418,419,420]'
+  mcp-log --level warn approval_gate wave=3 reason="ci flaky"
+  mcp-log wave_complete wave=4 status=PASS merged=3 deferred=0
+EOF
+}
+
+level=info
+server=wave
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--level)
+		level="$2"
+		shift 2
+		;;
+	--server)
+		server="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	--)
+		shift
+		break
+		;;
+	-*)
+		echo "unknown flag: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	*) break ;;
+	esac
+done
+
+if [[ $# -lt 1 ]]; then
+	echo "EVENT name required" >&2
+	usage >&2
+	exit 2
+fi
+
+event="$1"
+shift
+
+LOG_FILE="${LOG_FILE:-$HOME/.claude/logs/mcp.jsonl}"
+LOG_FILE="${LOG_FILE/#\~/$HOME}"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# ISO 8601 with millisecond precision. GNU date — this script runs on dev
+# machines, not in containers, so %3N is fine.
+ts=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)
+
+# Build base JSON object.
+json=$(jq -n \
+	--arg ts "$ts" \
+	--arg server "$server" \
+	--arg level "$level" \
+	--arg event "$event" \
+	'{ts: $ts, server: $server, level: $level, event: $event}')
+
+# Merge in KEY=VALUE pairs. JSON-typed values keep their type; other values
+# become strings. Malformed (no =) entries are skipped with a warning.
+for kv in "$@"; do
+	if [[ "$kv" != *=* ]]; then
+		echo "mcp-log: skipping malformed KEY=VALUE: $kv" >&2
+		continue
+	fi
+	key="${kv%%=*}"
+	value="${kv#*=}"
+
+	if json_val=$(echo "$value" | jq -c . 2>/dev/null); then
+		json=$(echo "$json" | jq --arg k "$key" --argjson v "$json_val" '. + {($k): $v}')
+	else
+		json=$(echo "$json" | jq --arg k "$key" --arg v "$value" '. + {($k): $v}')
+	fi
+done
+
+# Append as single line.
+echo "$json" | jq -c . >>"$LOG_FILE"

--- a/scripts/mcp-tail-sdlc
+++ b/scripts/mcp-tail-sdlc
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# (jq filter literals use single-quoted '$var' syntax for jq-level variables,
+# which are passed via --argjson; they must NOT be shell-expanded here.)
+# scripts/mcp-tail-sdlc — live-tail the fleet logfile filtered to wave-pattern events.
+#
+# Shows mcp-server-sdlc tool_call events alongside cc-workflow orchestration
+# lifecycle events (wave_start, flight_plan, wave_complete, etc.) so you can
+# watch a wave in motion without drowning in discord-watcher poll noise.
+#
+# Usage:
+#   mcp-tail-sdlc [--since DURATION] [--level LEVEL] [--server NAME]...
+#
+# Examples:
+#   mcp-tail-sdlc                          # follow new events from now
+#   mcp-tail-sdlc --since 5m               # back up 5 min then follow
+#   mcp-tail-sdlc --since 1h --level warn  # back 1h, warnings+errors only
+#   mcp-tail-sdlc --server sdlc            # sdlc only (no skill events)
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: mcp-tail-sdlc [--since DURATION] [--level LEVEL] [--server NAME]...
+
+Tail ${LOG_FILE:-~/.claude/logs/mcp.jsonl}, filtered to wave-pattern events.
+
+Options:
+  --since DURATION    Seek back into history before following.
+                      Examples: 5m, 30m, 1h, 2h, 1d
+  --level LEVEL       Minimum level to show: debug | info | warn | error
+                      (default: info — debug is suppressed)
+  --server NAME       Only show this server. Repeatable.
+                      (default: sdlc + wave)
+  -h, --help          Show this help
+
+Default filter: server in {sdlc, wave}, level >= info.
+EOF
+}
+
+since=""
+min_level="info"
+servers=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--since)
+		since="$2"
+		shift 2
+		;;
+	--level)
+		min_level="$2"
+		shift 2
+		;;
+	--server)
+		servers+=("$2")
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "unknown flag: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+if [[ ${#servers[@]} -eq 0 ]]; then
+	servers=(sdlc wave)
+fi
+
+LOG_FILE="${LOG_FILE:-$HOME/.claude/logs/mcp.jsonl}"
+LOG_FILE="${LOG_FILE/#\~/$HOME}"
+
+if [[ ! -f "$LOG_FILE" ]]; then
+	echo "logfile not found: $LOG_FILE" >&2
+	exit 1
+fi
+
+# Map level name → numeric severity for jq comparison.
+level_num() {
+	case "$1" in
+	debug) echo 0 ;;
+	info) echo 1 ;;
+	warn) echo 2 ;;
+	error) echo 3 ;;
+	*)
+		echo "unknown level: $1" >&2
+		exit 2
+		;;
+	esac
+}
+min_num=$(level_num "$min_level")
+
+# Build server-set as a JSON array, passed via --argjson (no shell interpolation
+# inside the jq filter, so shellcheck stays happy and the filter stays readable).
+server_set_json=$(printf '%s\n' "${servers[@]}" | jq -R . | jq -s .)
+
+# Static jq filter — all dynamic values come in via --argjson.
+jq_filter='
+  ({"debug":0,"info":1,"warn":2,"error":3}) as $lvls
+  | select(.server as $s | $server_set | index($s))
+  | select($lvls[.level] >= $min_level)
+  | (.ts | sub("\\..*Z$"; "Z")) as $t
+  | (. | del(.ts, .server, .level, .event)) as $rest
+  | "\($t)  [\(.server)]  \(.level)  \(.event)  \($rest | tojson)"
+'
+
+# Build a grep pattern matching the server set — runs before jq to discard
+# discord-watcher noise (~99% of lines) at the cheap text level.
+grep_pattern=""
+for s in "${servers[@]}"; do
+	grep_pattern+="\"server\":\"${s}\"|"
+done
+grep_pattern="${grep_pattern%|}"
+
+if [[ -n "$since" ]]; then
+	# Translate Nm/Nh/Nd shorthand to GNU date's expected form.
+	case "$since" in
+	*m) since_arg="${since%m} minutes ago" ;;
+	*h) since_arg="${since%h} hours ago" ;;
+	*d) since_arg="${since%d} days ago" ;;
+	*) since_arg="$since ago" ;;
+	esac
+
+	cutoff=$(date -u -d "$since_arg" +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null) || {
+		echo "could not parse --since '$since' (try 5m, 30m, 1h, 1d)" >&2
+		exit 2
+	}
+
+	# History phase: grep pre-filter, then jq with timestamp cutoff prepended.
+	history_filter='select(.ts >= $cutoff) | '"$jq_filter"
+	grep -aE "$grep_pattern" "$LOG_FILE" 2>/dev/null |
+		jq -rc \
+			--argjson server_set "$server_set_json" \
+			--argjson min_level "$min_num" \
+			--arg cutoff "$cutoff" \
+			"$history_filter" 2>/dev/null ||
+		true
+fi
+
+# Live-tail phase: same grep pre-filter, then jq.
+tail -F -n0 "$LOG_FILE" 2>/dev/null |
+	grep --line-buffered -aE "$grep_pattern" |
+	jq -rc --unbuffered \
+		--argjson server_set "$server_set_json" \
+		--argjson min_level "$min_num" \
+		"$jq_filter" 2>/dev/null

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -28,6 +28,7 @@ CC sub-agents do not have the `Agent`/`Task` tool. Only the top-level session ca
 - CI trust (auto mode): `wave_ci_trust_level`
 - Bus primitives (bash): `scripts/wavebus/wave-init`, `scripts/wavebus/flight-finalize`, `scripts/wavebus/wave-cleanup`
 - Notifications: `mcp__disc-server__disc_send` — post wave status to `#wave-status` (`1487386934094462986`)
+- Observability: `scripts/mcp-log` — emit lifecycle events to `~/.claude/logs/mcp.jsonl` for temporal correlation against sdlc-server `tool_call` events. See `docs/mcp-logging-standard.md`.
 
 ## Concepts
 
@@ -52,14 +53,15 @@ CC sub-agents do not have the `Agent`/`Task` tool. Only the top-level session ca
 
 ## Step 1 — Orchestrator pre-flight
 
-1. `wave_preflight()` → `wave_next_pending()` → resolve wave id `N`. If none, report and exit.
+1. `wave_preflight()` → `wave_next_pending()` → resolve wave id `N` and the issue list. If none, report and exit.
 2. Resolve **target repo slug** for the bus path. Same-repo waves: use the current repo's slug. Cross-repo waves (wave plan lives in this repo, stories live elsewhere): use the target repo's slug per `lesson_cross_repo_wave_orchestration.md`.
-3. Verify main is clean in the target repo; `wave_previous_merged()` confirms prior wave landed; `spec_validate_structure(issue)` for each issue in the wave.
-4. Call `scripts/wavebus/wave-init <repo-slug> <N> 1`. Flight count is `1` initially — Prime may re-invoke it with the real count (script is idempotent). Capture the printed wave root.
-5. **Read `kahuna_branch` from wave state** via `wave_show()` (or by reading `.claude/status/state.json` in the target repo). If the field is present and non-empty, the wave is executing under KAHUNA — capture the value (e.g. `kahuna/<epic-id>-<slug>`) and pass it into the Prime(pre-wave) prompt as the `kahuna_branch` input. If absent or empty, the wave is a legacy non-KAHUNA execution — flights base off `main` as before. Pre-created worktree branches (Step 6, cross-repo path) and `pr_create` `base` (Step 3e) honor this same value. See Dev Spec §5.2.3 for the authoritative contract.
-6. Pre-create worktrees per issue. Same-repo: `Agent` calls in Step 3 can use `isolation: "worktree"`. Cross-repo: create them now via `git -C <target-repo> worktree add /tmp/wt-<slug>-<issue> -b feature/<issue>-<desc> origin/<base-ref>` (one per issue), where `<base-ref>` is `kahuna_branch` if set, else `main`.
-7. Resolve identity from `/tmp/claude-agent-<md5>.json`; post to `#wave-status` (`1487386934094462986`): `"🏄 **Wave <N> started** — <project>, <issue-count> issues. Agent: **<dev-name>** <dev-avatar>"`. If `disc_send` fails, log and continue.
-8. Spawn **Prime(pre-wave)** — single `Agent` call, `subagent_type: general-purpose`. Prompt template below.
+3. **Emit observability anchor.** Run `scripts/mcp-log wave_start wave=<N> target=<repo-slug> issues=<COMPACT JSON array, no spaces, e.g. [418,419,420]>` so this anchor *precedes* every per-issue `spec_validate_structure`, `wave_show`, and `wave_previous_merged` call below — that ordering is what makes post-mortem temporal correlation work. The `kahuna` field is added later (Step 1.5) once `wave_show` has been called; it is fine for the initial `wave_start` to omit it.
+4. Verify main is clean in the target repo; `wave_previous_merged()` confirms prior wave landed; `spec_validate_structure(issue)` for each issue in the wave.
+5. Call `scripts/wavebus/wave-init <repo-slug> <N> 1`. Flight count is `1` initially — Prime may re-invoke it with the real count (script is idempotent). Capture the printed wave root.
+6. **Read `kahuna_branch` from wave state** via `wave_show()` (or by reading `.claude/status/state.json` in the target repo). If the field is present and non-empty, the wave is executing under KAHUNA — capture the value (e.g. `kahuna/<epic-id>-<slug>`) and pass it into the Prime(pre-wave) prompt as the `kahuna_branch` input. If absent or empty, the wave is a legacy non-KAHUNA execution — flights base off `main` as before. Pre-created worktree branches (Step 7, cross-repo path) and `pr_create` `base` (Step 3e) honor this same value. See Dev Spec §5.2.3 for the authoritative contract.
+7. Pre-create worktrees per issue. Same-repo: `Agent` calls in Step 3 can use `isolation: "worktree"`. Cross-repo: create them now via `git -C <target-repo> worktree add /tmp/wt-<slug>-<issue> -b feature/<issue>-<desc> origin/<base-ref>` (one per issue), where `<base-ref>` is `kahuna_branch` if set, else `main`.
+8. Resolve identity from `/tmp/claude-agent-<md5>.json`; post to `#wave-status` (`1487386934094462986`): `"🏄 **Wave <N> started** — <project>, <issue-count> issues. Agent: **<dev-name>** <dev-avatar>"`. If `disc_send` fails, log and continue.
+9. Spawn **Prime(pre-wave)** — single `Agent` call, `subagent_type: general-purpose`. Prompt template below.
 
 ## Step 2 — Prime(pre-wave) prompt contract
 
@@ -92,6 +94,8 @@ Prompt template (fill in `<repo-slug>`, `<N>`, `<wave-root>`, the issue list, an
 > ```
 
 Orchestrator parses that JSON. If `status=BLOCKED`, print the blocker from `plan.md`, post a BLOCKED notice to `#wave-status`, exit (leave bus in place for forensics). In **auto mode**, emit the canonical status line (see "Step 6 — Final status emission") before returning control. Else continue.
+
+If `status=READY`, for each flight in the parsed `flights` array emit `scripts/mcp-log flight_plan wave=<N> flight=<M> issues=<COMPACT JSON array, no spaces, e.g. [418,419,420]>` so the planned partition is recorded in the fleet logfile. This is the temporal anchor for correlating sdlc-server tool_call events to a specific flight in post-mortem. **Important:** the array must be compact (no inner spaces) — pretty-printed arrays will be word-split by the shell into broken tokens.
 
 ## Step 3 — Per-flight execution loop
 
@@ -185,8 +189,9 @@ After every flight has merged:
    > ```
 
 2. Orchestrator reads the report, surfaces a human-readable summary, and — in interactive mode — prompts: "Wave N complete. Run `/nextwave` for Wave N+1, or `/cryo` to preserve state."
-3. Post to `#wave-status` (`1487386934094462986`): `"✅ **Wave <N> complete** — <project>, <merged> merged, <deferred> deferred. Agent: **<dev-name>** <dev-avatar>"`, then vox announcement (conversational: name, team, project, wave, counts).
-4. In **auto mode**, emit the canonical status line (see "Step 6 — Final status emission") as the final assistant message. If Prime(post-wave) returned FAIL/BLOCKED, emit that status; otherwise emit OK.
+3. Emit `scripts/mcp-log wave_complete wave=<N> status=<PASS|FAIL|BLOCKED> merged=<count> deferred=<count>` so the wave terminal state is timestamped in the fleet logfile.
+4. Post to `#wave-status` (`1487386934094462986`): `"✅ **Wave <N> complete** — <project>, <merged> merged, <deferred> deferred. Agent: **<dev-name>** <dev-avatar>"`, then vox announcement (conversational: name, team, project, wave, counts).
+5. In **auto mode**, emit the canonical status line (see "Step 6 — Final status emission") as the final assistant message. If Prime(post-wave) returned FAIL/BLOCKED, emit that status; otherwise emit OK.
 
 ## Step 5 — Cleanup
 

--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -74,6 +74,7 @@ Once pre-flight passes:
 3. **Detect CI trust** by calling `wave_ci_trust_level()` once. (The value is also cached by each `/nextwave auto` iteration; calling it here is informational — it shapes the start announcement.)
 4. **Pre-wave kahuna bootstrap** (see "Pre-Wave Kahuna Bootstrap" below). Runs exactly once per epic on first `/wavemachine` invocation. On resume invocations the wave state already carries `kahuna_branch` and this step is a no-op.
 5. **Post to Discord.** `disc_send` to `#wave-status` (`1487386934094462986`): `"🌊 **Wavemachine started** — <project>, <N> waves pending. Agent: **<dev-name>** <dev-avatar>"`. Resolve identity from `/tmp/claude-agent-<md5>.json`. If `disc_send` fails, log and continue — Discord is informational, not a gate.
+6. **Emit observability event.** `scripts/mcp-log wavemachine_start epic=<epic_id> waves=<N> kahuna=<kahuna_branch>` — timestamps autopilot start in the fleet logfile so post-mortem can correlate with sdlc-server tool_call events.
 
 ## Pre-Wave Kahuna Bootstrap
 
@@ -247,22 +248,26 @@ Preserve the v1 announcement surface — one Discord post per lifecycle event, o
 - This announcement runs AFTER the trust-score gate's all-green path (see "Trust-Score Gate and Auto-Merge"). In KAHUNA mode, the gate has already auto-merged kahuna→main and posted its own `✅ **Kahuna gate passed**` notification — this announcement closes out the wavemachine session.
 - In legacy non-KAHUNA mode (no `kahuna_branch` in wave state), the gate is skipped and this announcement runs directly when `wave_next_pending()` returns null.
 - Discord `#wave-status`: `"✅ **Wavemachine complete** — <project>, all <N> waves merged. Run /dod to verify. Agent: **<dev-name>** <dev-avatar>"`
+- `scripts/mcp-log wavemachine_complete epic=<epic_id> status=OK waves_merged=<N>`
 - Vox (conversational, brief): name, team, project, "wavemachine complete, all waves merged".
 
 **On gate-blocked completion** (KAHUNA mode, one or more trust signals failed):
 
 - Per Procedure C / "Trust-Score Gate and Auto-Merge" any-red path: `"🛑 **Kahuna gate blocked** — <project>, epic #<epic_id>: <failing-signals summary>. MR <url> open for review. Agent: **<dev-name>** <dev-avatar>"`
 - Vox alert: "Kahuna gate blocked for epic <epic_id>. <N> signals red. Ready for your review."
+- `scripts/mcp-log --level warn wavemachine_complete epic=<epic_id> status=BLOCKED reason="kahuna gate blocked: <signals>"`
 - `wave_waiting("kahuna gate blocked: <one-line summary>")` so the plan is explicitly marked paused.
 
 **On circuit-breaker trip** (`wave_health_check` non-HEALTHY):
 
 - Discord `#wave-status`: `"🛑 **Wavemachine aborted (circuit breaker)** — <project>: <one-line health summary>. Agent: **<dev-name>** <dev-avatar>"`
+- `scripts/mcp-log --level error wavemachine_complete epic=<epic_id> status=ABORTED reason="circuit breaker: <summary>"`
 - Call `wave_waiting("wavemachine aborted (circuit breaker): <one-line summary>")` so the plan is explicitly marked paused.
 
 **On per-wave BLOCKED or FAIL** (from `/nextwave auto` return):
 
 - Discord `#wave-status`: `"🛑 **Wavemachine aborted** — <project>, wave <id>: <one-line failure summary>. Agent: **<dev-name>** <dev-avatar>"`
+- `scripts/mcp-log --level error wavemachine_complete epic=<epic_id> status=ABORTED wave=<id> reason="<summary>"`
 - Call `wave_waiting("wavemachine aborted: <one-line summary>")`.
 
 **On user interrupt** (see "Interrupt Handling" above).


### PR DESCRIPTION
## Summary

cc-workflow's skills (`/nextwave`, `/wavemachine`) currently leave no trace in the fleet logfile (`~/.claude/logs/mcp.jsonl`). When a wave goes sideways, you can see what `mcp-server-sdlc` tools were invoked and how long each took, but you can't see *which wave* / *which flight* the calls belong to. This MR adds a thin localized logger so cc-workflow skills emit lifecycle events to the same logfile, conforming to the existing `docs/mcp-logging-standard.md` schema.

**Correlation strategy:** temporal window. sdlc tool_calls within a few seconds of a `flight_plan` event belong to that flight. No correlation_id passing, no cross-repo coordination required.

## Changes

- **`scripts/mcp-log`** — bash JSON-line emitter. KEY=VALUE args; values that parse as JSON keep their type. Writes to `${LOG_FILE:-~/.claude/logs/mcp.jsonl}`.
- **`scripts/mcp-tail-sdlc`** — live-tail viewer. Filters to sdlc + wave events (defaults), with `--since 5m|1h|1d` history seek and `--level info|warn|error` filtering. Pre-filters with grep before jq for performance against the 600MB+ fleet logfile.
- **`skills/nextwave/SKILL.md`** — emits `wave_start` (early, before per-issue `spec_validate_structure` calls so the anchor precedes those sdlc events), `flight_plan` per flight after Prime(pre-wave) returns, `wave_complete` at terminal.
- **`skills/wavemachine/SKILL.md`** — emits `wavemachine_start` in launch sequence, `wavemachine_complete` on every exit path (clean / gate-blocked / circuit-breaker / per-wave abort).
- **`docs/mcp-logging-standard.md`** — registers 5 new event types under "Standard Events" with field tables.

## Linked Issues

Closes #465

## Test Plan

- [x] `bash -n scripts/mcp-log scripts/mcp-tail-sdlc` — syntax OK
- [x] `shellcheck scripts/mcp-log scripts/mcp-tail-sdlc` — exit 0, no findings
- [x] `./scripts/ci/validate.sh` — 113/0
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `mcp-log flight_plan wave=3 flight=1 issues='[418,419,420]'` — round-trips through `jq` cleanly with correct types
- [x] `mcp-log --level warn approval_gate wave=3 reason="ci flaky"` — emits warn-level event, all fields correct
- [x] `mcp-tail-sdlc --since 5m` — captured 66 events in 2s window, includes both sdlc tool_calls and the just-emitted wave events
- [x] Code-reviewer Agent: 3 findings — 2 fixed (wave_start emission moved earlier; compact-array shell-quoting note added), 1 informational (logfile rotation race — no rotation in v1 design)

## Sidebar findings during smoke (filing separately)

The tail script immediately surfaced `commutativity-probe: command not found` + `tree-sitter parse failed` errors in the live logfile — sdlc#218 (probe install + graceful degradation) may be partially regressed. Following up with tachikoma after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)