### PR TITLE
feat(issue): wave-pattern-ready templates with required H2 sections

### DIFF
--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: issue
-description: Create structured issues (feature, bug, chore, docs, epic) with proper templates and labels. Supports both GitHub (gh) and GitLab (glab). Self-contained — does not depend on CLAUDE.md for templates.
+description: Create structured issues (feature, story, bug, chore, docs, epic) with proper templates and labels. Supports both GitHub (gh) and GitLab (glab). Self-contained — does not depend on CLAUDE.md for templates. Sub-issue templates (feature, story, chore, docs, bug) emit the H2 sections that `/prepwaves` and `spec_validate_structure` require, so issues are wave-pattern-ready on first try.
 usage: |
-  /issue feature <prompt>  Create a feature issue
+  /issue feature <prompt>  Create a feature issue (alias: story)
+  /issue story <prompt>    Create a story issue (alias: feature)
   /issue bug <prompt>      Create a bug issue
   /issue chore <prompt>    Create a chore issue
   /issue docs <prompt>     Create a docs issue
@@ -24,7 +25,8 @@ Create properly templated and labeled issues from a natural language prompt.
 ## Usage
 
 ```
-/issue feature <prompt>       Create a feature issue
+/issue feature <prompt>       Create a feature issue (alias: story)
+/issue story <prompt>          Create a story issue (alias: feature)
 /issue bug <prompt>            Create a bug issue
 /issue chore <prompt>          Create a chore issue
 /issue docs <prompt>           Create a docs issue
@@ -32,6 +34,32 @@ Create properly templated and labeled issues from a natural language prompt.
 /issue <prompt>                Infer type from the prompt
 /issue                         Infer from recent conversation context
 ```
+
+## Wave-Pattern-Ready Output Guarantee
+
+The sub-issue templates emitted by this skill (`feature`, `story`, `chore`,
+`docs`, `bug`) include the six H2 sections required for downstream wave
+execution:
+
+- `## Summary`
+- `## Implementation Steps` (alias accepted by parser: `## Changes`)
+- `## Test Procedures` (alias accepted by parser: `## Tests`)
+- `## Acceptance Criteria`
+- `## Dependencies`
+- `## Metadata`
+
+This means an issue created via `/issue` passes
+`mcp__sdlc-server__spec_validate_structure` on first try and is ready to be
+picked up by `/prepwaves` without mid-flight body fixes. If a particular
+section does not apply to a given issue, emit the heading with a single-line
+rationale (e.g. `None` or `N/A — because ...`); never omit the heading.
+
+The `epic` template is intentionally different — epics are parent issues
+that decompose into sub-issues, so they are not validated against the
+sub-issue grammar.
+
+See `docs/issue-body-grammar.md` in `mcp-server-sdlc` for the authoritative
+parser specification.
 
 ## Tools Used
 - `mcp__sdlc-server__work_item` — create issues cross-platform (handles GitHub/GitLab detection internally)
@@ -45,12 +73,13 @@ No arguments — infer the issue from the most recent topic of conversation. Det
 {{/if}}
 
 Extract two things:
-1. **Type** — the first word if it matches: `feature`, `bug`, `chore`, `docs`, `epic`. If it doesn't match a type, treat the entire argument as the prompt and infer the type.
+1. **Type** — the first word if it matches: `feature`, `story`, `bug`, `chore`, `docs`, `epic`. `feature` and `story` are aliases and use the same template. If it doesn't match a type, treat the entire argument as the prompt and infer the type.
 2. **Prompt** — everything after the type (or the entire argument if no type prefix).
 
 **Type inference rules** (when no explicit type):
 - Mentions broken, fails, crash, error, wrong → `bug`
 - Mentions add, create, build, implement, new → `feature`
+- Mentions story, user story, sub-issue under epic → `story`
 - Mentions update, fix, clean, refactor, rename, move, upgrade → `chore`
 - Mentions document, write docs, README, guide → `docs`
 - Mentions epic, phase, milestone, multi-part → `epic`
@@ -62,16 +91,23 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 
 **Quality standard:** Every issue should be detailed enough that a spec-driven agent can execute without making design decisions. Implementation steps should read like paint-by-numbers. Acceptance criteria should be evaluable before PR/MR merge.
 
-### Feature Template
+### Wave-Pattern Sub-Issue Templates
+
+The five templates below (`feature`, `story`, `chore`, `docs`, `bug`) all
+emit the same six required H2 sections so they are recognized by
+`spec_validate_structure` and ready for `/prepwaves`. The body inside each
+section is tailored to the issue type. **Always emit all six headings**, even
+when a section is `None` or `N/A` — the parser only sees H2s.
+
+### Feature Template (alias: Story)
 
 ```markdown
 ## Summary
 
-[1-2 sentences: what this feature delivers and why]
-
-## Context
-
-[Background, motivation, link to Epic or Dev Spec if applicable]
+[1-2 sentences: what this feature delivers and why. Include Context — background,
+motivation, link to Epic or Dev Spec if applicable — as a short sub-paragraph
+under the Summary heading rather than a separate H2, so the parser sees the
+canonical Summary section.]
 
 ## Implementation Steps
 
@@ -84,15 +120,15 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 
 ## Test Procedures
 
-### Unit Tests
+*Unit tests:*
 
 | Test Name | Purpose | File Location |
 |-----------|---------|---------------|
 | `test_function_name` | [what it verifies] | `tests/test_module.py` |
 
-### Integration/E2E Coverage
+*Integration coverage:*
 
-- [References to integration tests if applicable]
+- [IT-## or test reference, or `None` if not applicable]
 
 ## Acceptance Criteria
 
@@ -102,47 +138,81 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 
 ## Dependencies
 
-- None (or #NNN — description)
+- None
+- [or `[#NNN](url) — description` per dependency]
+
+## Metadata
+
+**Wave:** [N or N/A]
+**Parent Epic:** [#NNN or N/A]
+**Wave Master:** [#NNN or N/A]
 ```
+
+### Story Template
+
+The Story template is identical to the Feature template — `story` and
+`feature` are aliases. The underlying `mcp__sdlc-server__work_item` tool's
+`type` enum uses `story`; the `/issue` skill exposes both names so callers
+can use whichever matches their mental model.
 
 ### Bug Template
 
 ```markdown
 ## Summary
 
-[Concise description of the defect]
+[Concise description of the defect.]
 
-## Environment
+**Environment:** [page, component, CLI command, API endpoint]
+**Version/commit:** [git SHA or release tag]
+**Frequency:** intermittent | consistent
 
-- **Where observed:** [page, component, CLI command, API endpoint]
-- **Version/commit:** [git SHA or release tag]
-- **Frequency:** intermittent | consistent
-
-## Steps to Reproduce
+**Steps to reproduce:**
 
 1. [Step one]
 2. [Step two]
 3. [Step three]
 
-## Expected Behavior
+**Expected:** [What should happen]
+**Actual:** [What actually happens]
 
-[What should happen]
+## Implementation Steps
 
-## Actual Behavior
+[Paint-by-numbers fix steps. If root cause is unknown, state the diagnostic
+plan first, then the fix steps to be filled in once root cause is confirmed.]
 
-[What actually happens]
+1. [Locate offending code at exact path]
+2. [Describe the change]
+3. [Update or add the regression test]
 
-## Severity
+## Test Procedures
 
-[`severity::critical` | `severity::major` | `severity::minor` | `severity::cosmetic`]
+*Regression test:*
 
-## Artifacts
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `test_<bug_name>_regression` | reproduces the original failure and proves the fix | `tests/test_module.py` |
 
-- [Links to logs, screenshots, error traces]
+*Manual verification:* [steps to manually confirm the fix in the affected
+environment, or `N/A`]
 
-## Workaround
+## Acceptance Criteria
 
-[Describe workaround if known, or "None known"]
+- [ ] Regression test added and passing
+- [ ] Original repro steps produce expected behavior
+- [ ] No related regressions introduced
+- [ ] [Additional testable conditions]
+
+## Dependencies
+
+- None
+- [or `[#NNN](url) — description` per dependency]
+
+## Metadata
+
+**Severity:** [`severity::critical` | `severity::major` | `severity::minor` | `severity::cosmetic`]
+**Wave:** [N or N/A]
+**Artifacts:** [links to logs, screenshots, error traces, or `None`]
+**Workaround:** [describe if known, or `None known`]
 ```
 
 ### Chore Template
@@ -150,7 +220,7 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 ```markdown
 ## Summary
 
-[Description of the maintenance task and its rationale]
+[Description of the maintenance task and its rationale.]
 
 ## Implementation Steps
 
@@ -159,10 +229,27 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 1. [Step]
 2. [Step]
 
+## Test Procedures
+
+*Verification:*
+
+- [Command to run after the chore completes, or specific test file to confirm green]
+- [`N/A — chore is doc-only / config-only` if no executable verification applies]
+
 ## Acceptance Criteria
 
 - [ ] [Testable condition]
 - [ ] [Testable condition]
+
+## Dependencies
+
+- None
+- [or `[#NNN](url) — description` per dependency]
+
+## Metadata
+
+**Wave:** [N or N/A]
+**Parent Epic:** [#NNN or N/A]
 ```
 
 ### Docs Template
@@ -170,19 +257,26 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 ```markdown
 ## Summary
 
-[Which document(s) to create or update, and why]
+[Which document(s) to create or update, and why.]
 
-## Target Audience
+**Target audience:** [developers, operators, end users, agents]
+**What's missing, outdated, or incorrect:** [specific gaps or inaccuracies]
+**Source material:** [pointers to code, PRDs, conversations]
 
-[Who will read this — developers, operators, end users, agents]
+## Implementation Steps
 
-## What's Missing, Outdated, or Incorrect
+1. [File path to create or update]
+2. [Outline of sections to add or revise]
+3. [Cross-references to update elsewhere]
 
-[Specific gaps or inaccuracies]
+## Test Procedures
 
-## Source Material
+*Verification:*
 
-- [Pointers to code, PRDs, conversations]
+- [ ] Markdown lint passes (if a linter is configured)
+- [ ] All links resolve (manual or scripted check)
+- [ ] Code samples, if any, run as written against current `main`
+- [`N/A` for any item that does not apply]
 
 ## Acceptance Criteria
 
@@ -190,6 +284,16 @@ Use the prompt (or conversation context) to fill in the appropriate template bel
 - [ ] Coverage is complete for the stated scope
 - [ ] No broken links
 - [ ] [Additional testable conditions]
+
+## Dependencies
+
+- None
+- [or `[#NNN](url) — description` per dependency]
+
+## Metadata
+
+**Wave:** [N or N/A]
+**Parent Epic:** [#NNN or N/A]
 ```
 
 ### Epic Template
@@ -241,6 +345,7 @@ Labels use the `group::value` convention. Within each group, labels are mutually
 | Type | Label |
 |------|-------|
 | feature | `type::feature` |
+| story | `type::story` |
 | bug | `type::bug` |
 | chore | `type::chore` |
 | docs | `type::docs` |

--- a/skills/issue/introduction.md
+++ b/skills/issue/introduction.md
@@ -6,12 +6,15 @@ Create properly templated issues from natural language:
 
 ```
 /issue feature "add dark mode support"
-/issue bug "login fails on Safari"
-/issue chore "update dependencies"
+/issue story   "user can reset password from profile page"
+/issue bug     "login fails on Safari"
+/issue chore   "update dependencies"
 /issue "the search results are wrong"     ← type inferred
 /issue                                     ← uses conversation context
 ```
 
-Every issue gets the right template (feature, bug, chore, docs, epic), the right labels (`type::`, `priority::`, `urgency::`, `size::`, `severity::`), and is written to wave-quality — detailed enough for a spec-driven agent to execute without design decisions.
+Every issue gets the right template (feature, story, bug, chore, docs, epic), the right labels (`type::`, `priority::`, `urgency::`, `size::`, `severity::`), and is written to wave-quality — detailed enough for a spec-driven agent to execute without design decisions.
+
+**Wave-pattern-ready output guarantee:** the sub-issue templates (feature, story, chore, docs, bug) emit the six H2 sections required by `/prepwaves` and `spec_validate_structure` — `## Summary`, `## Implementation Steps`, `## Test Procedures`, `## Acceptance Criteria`, `## Dependencies`, `## Metadata` — so issues created via `/issue` pass the wave-readiness check on first try, with no mid-flight body fixes. The `epic` template is intentionally different because epics are parents, not sub-issues.
 
 You review and approve the draft before it's created. Works on both GitHub and GitLab.

--- a/tests/test_issue_skill.py
+++ b/tests/test_issue_skill.py
@@ -1,0 +1,686 @@
+"""Tests for skills/issue/SKILL.md — wave-pattern-ready issue templates.
+
+Issue #427 — Update /issue templates so every sub-issue type emits the H2
+sections that /prepwaves and spec_validate_structure expect:
+
+  Required H2 sections (canonical names used by /issue):
+    ## Summary
+    ## Implementation Steps   (alias accepted by parser: ## Changes)
+    ## Test Procedures        (alias accepted by parser: ## Tests)
+    ## Acceptance Criteria
+    ## Dependencies
+    ## Metadata
+
+The parser (spec_validate_structure) treats ## Implementation Steps and
+## Test Procedures as the canonical sub-issue heading aliases for the
+required `changes` and `tests` keys (see docs/issue-body-grammar.md in
+mcp-server-sdlc). This skill is the authoring side of that contract.
+
+These tests guard the contract:
+
+1. Frontmatter & usage block list `feature`, `story`, `chore`, `docs`, `bug`
+   as supported types and reference the wave-pattern-ready guarantee.
+2. Each of the five sub-issue templates emits the six required H2 headings.
+3. The `epic` template is intentionally excluded — epics are parents, not
+   sub-issues, and have a different shape.
+4. The `introduction.md` documents the wave-pattern-ready output guarantee
+   so first-time users see it.
+5. Smoke check: a representative rendered issue body for each sub-issue
+   type satisfies the same `spec_validate_structure` rules in-process
+   (required canonical keys all present, dependencies optional).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = _ROOT / "skills" / "issue" / "SKILL.md"
+INTRO_PATH = _ROOT / "skills" / "issue" / "introduction.md"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Canonical H2 headings emitted by the /issue sub-issue templates.
+REQUIRED_H2_HEADINGS = (
+    "## Summary",
+    "## Implementation Steps",
+    "## Test Procedures",
+    "## Acceptance Criteria",
+    "## Dependencies",
+    "## Metadata",
+)
+
+# Sub-issue types that must be wave-pattern-ready.
+SUB_ISSUE_TYPES = ("feature", "story", "chore", "docs", "bug")
+
+# Section-name → set of H2 headings that satisfy the parser contract,
+# mirroring spec_validate_structure / docs/issue-body-grammar.md.
+PARSER_REQUIRED = {
+    "changes": ("## Changes", "## Implementation Steps"),
+    "tests": ("## Tests", "## Test Procedures"),
+    "acceptance_criteria": ("## Acceptance Criteria",),
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Read the /issue SKILL.md file."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def intro_text() -> str:
+    """Read the /issue introduction.md file."""
+    return INTRO_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_template_block(text: str, header: str) -> str:
+    """Extract the fenced ```markdown block immediately following an H3
+    heading like `### Feature Template`. Returns the block contents
+    (without the fence lines) or empty string if not found.
+
+    We intentionally do not assume <!-- BEGIN/END --> markers because the
+    /issue skill keeps each template inline as a fenced block under its
+    H3 heading, which is the human-readable shape we want to preserve.
+    """
+    # Find the H3 heading.
+    pattern = re.compile(
+        rf"^###\s+{re.escape(header)}\s*$", re.MULTILINE
+    )
+    m = pattern.search(text)
+    if not m:
+        return ""
+    # From the heading position, find the next ```markdown fence.
+    rest = text[m.end():]
+    fence_open = re.search(r"^```markdown\s*$", rest, re.MULTILINE)
+    if not fence_open:
+        return ""
+    body_start = fence_open.end()
+    fence_close = re.search(r"^```\s*$", rest[body_start:], re.MULTILINE)
+    if not fence_close:
+        return ""
+    return rest[body_start:body_start + fence_close.start()]
+
+
+def _h2_headings(body: str) -> list[str]:
+    """Return all H2 headings in `body`, in order."""
+    return [
+        line.strip()
+        for line in body.splitlines()
+        if line.startswith("## ") and not line.startswith("### ")
+    ]
+
+
+# Mirror of spec_parser.parseSections for the in-process smoke check.
+# Only `## H2` headings create sections. Heading titles are normalized:
+# lowercase, punctuation stripped, whitespace/hyphens collapsed to `_`.
+def _normalize_key(title: str) -> str:
+    # Strip leading "## " then normalize.
+    t = title[3:].strip() if title.startswith("## ") else title.strip()
+    # Lowercase, replace hyphens/spaces with `_`, drop other punctuation.
+    t = t.lower()
+    t = re.sub(r"[^\w\s-]", "", t)
+    t = re.sub(r"[\s\-]+", "_", t).strip("_")
+    return t
+
+
+def _parse_sections(body: str) -> dict[str, str]:
+    """Mimic spec_parser.parseSections. Returns canonical_key -> content."""
+    lines = body.splitlines()
+    sections: dict[str, str] = {}
+    current_key: str | None = None
+    buf: list[str] = []
+    for line in lines:
+        if line.startswith("## ") and not line.startswith("### "):
+            # Flush previous section.
+            if current_key is not None:
+                sections[current_key] = "\n".join(buf).strip()
+            current_key = _normalize_key(line)
+            buf = []
+        else:
+            if current_key is not None:
+                buf.append(line)
+    if current_key is not None:
+        sections[current_key] = "\n".join(buf).strip()
+    return sections
+
+
+def _spec_validate_structure(body: str) -> dict:
+    """In-process replica of mcp__sdlc-server__spec_validate_structure
+    for testing without a network round-trip. Returns a dict with
+    `valid: bool`, `missing: list[str]`, and `present: list[str]`.
+
+    Required canonical keys: `changes`, `tests`, `acceptance_criteria`.
+    Each is satisfied by any of its accepted H2 alias headings.
+    """
+    sections = _parse_sections(body)
+    present: list[str] = []
+    missing: list[str] = []
+    for canonical, aliases in PARSER_REQUIRED.items():
+        # The parser normalizes alias headings the same way; check via
+        # normalized keys.
+        alias_keys = {_normalize_key(a) for a in aliases}
+        satisfied = any(
+            sections.get(k, "").strip() != "" for k in alias_keys
+        )
+        if satisfied:
+            present.append(canonical)
+        else:
+            missing.append(canonical)
+    return {"valid": not missing, "present": present, "missing": missing}
+
+
+# Sample minimal-but-realistic fillings of each template, used for the
+# in-process spec_validate_structure smoke check. These mirror what an
+# implementing agent would produce after the /issue skill draft is filled
+# in — the goal is to verify the *shape*, not the prose.
+SAMPLE_BODIES: dict[str, str] = {
+    "feature": """## Summary
+
+Add dark mode support to the settings page.
+
+## Implementation Steps
+
+1. Add `theme` field to `UserSettings` in `src/models/user.py`.
+2. Wire the toggle in `src/ui/settings_page.tsx`.
+3. Persist via `PUT /api/user/settings`.
+
+## Test Procedures
+
+*Unit tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `test_theme_toggle_persists` | round-trip the new field | `tests/test_user_settings.py` |
+
+*Integration coverage:* IT-12
+
+## Acceptance Criteria
+
+- [ ] `theme` field round-trips through the API
+- [ ] Toggle visible in the settings page
+- [ ] Selection persists across reloads
+
+## Dependencies
+
+- None
+
+## Metadata
+
+**Wave:** 2
+**Parent Epic:** #100
+**Wave Master:** #110
+""",
+    "bug": """## Summary
+
+Login fails on Safari 17 with `TypeError: undefined is not an object`.
+
+**Steps to reproduce:**
+
+1. Open `/login` in Safari 17.
+2. Enter valid credentials, click Sign In.
+3. Observe console error.
+
+**Expected:** Successful login.
+**Actual:** Console error and the form does not submit.
+
+## Implementation Steps
+
+1. Reproduce locally with Safari Technology Preview.
+2. Add a guard in `src/ui/login.tsx` for the missing global.
+3. Patch the polyfill in `src/lib/compat.ts`.
+
+## Test Procedures
+
+*Regression test:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `test_safari_login_no_typeerror` | reproduces and proves fix | `tests/test_login.py` |
+
+*Manual verification:* sign in from Safari 17 on macOS 14.
+
+## Acceptance Criteria
+
+- [ ] Regression test added and passing
+- [ ] Login works on Safari 17
+
+## Dependencies
+
+- None
+
+## Metadata
+
+**Severity:** severity::major
+**Wave:** N/A
+**Artifacts:** browser console screenshot
+**Workaround:** use Chrome
+""",
+    "chore": """## Summary
+
+Bump `requests` from 2.31.0 to 2.32.3 to pick up the urllib3 security fix.
+
+## Implementation Steps
+
+1. Update `pyproject.toml` and lockfile.
+2. Run the test suite locally.
+3. Verify no API surface change in callers.
+
+## Test Procedures
+
+*Verification:* `pytest tests/test_http_client.py`.
+
+## Acceptance Criteria
+
+- [ ] `requests` pinned to 2.32.3
+- [ ] All existing tests pass
+
+## Dependencies
+
+- None
+
+## Metadata
+
+**Wave:** N/A
+**Parent Epic:** N/A
+""",
+    "docs": """## Summary
+
+Document the wave-pattern-ready output guarantee for the /issue skill.
+
+**Target audience:** Claude Code agents and human contributors.
+**What's missing:** the guarantee is implicit in the templates but never stated.
+**Source material:** issue #427.
+
+## Implementation Steps
+
+1. Update `skills/issue/SKILL.md` with a guarantee section.
+2. Mention it in `skills/issue/introduction.md`.
+3. Cross-link to `docs/issue-body-grammar.md` in mcp-server-sdlc.
+
+## Test Procedures
+
+*Verification:*
+
+- [ ] Markdown lint passes
+- [ ] Cross-references resolve
+
+## Acceptance Criteria
+
+- [ ] Guarantee documented in SKILL.md
+- [ ] Mentioned in introduction.md
+
+## Dependencies
+
+- None
+
+## Metadata
+
+**Wave:** N/A
+**Parent Epic:** N/A
+""",
+    "story": """## Summary
+
+User can reset their password from the profile page.
+
+## Implementation Steps
+
+1. Add `Reset password` button to `src/ui/profile.tsx`.
+2. Wire to `POST /api/account/password-reset`.
+3. Email template lives in `templates/email/password_reset.html`.
+
+## Test Procedures
+
+*Unit tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `test_password_reset_email_sent` | verifies email dispatch | `tests/test_account.py` |
+
+*Integration coverage:* IT-22
+
+## Acceptance Criteria
+
+- [ ] Reset link works end-to-end
+- [ ] Old password invalidated after reset
+
+## Dependencies
+
+- None
+
+## Metadata
+
+**Wave:** 1
+**Parent Epic:** #200
+**Wave Master:** #210
+""",
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatter:
+    """Frontmatter advertises wave-pattern-ready output and lists all types."""
+
+    def test_frontmatter_lists_all_sub_issue_types(self, skill_text: str) -> None:
+        """The frontmatter description references every sub-issue type."""
+        end = skill_text.index("---", 4)
+        frontmatter = skill_text[:end + 3]
+        for t in SUB_ISSUE_TYPES:
+            assert t in frontmatter.lower(), (
+                f"frontmatter description omits sub-issue type {t!r}"
+            )
+
+    def test_frontmatter_mentions_wave_pattern_ready(self, skill_text: str) -> None:
+        """The frontmatter advertises the wave-pattern-ready guarantee."""
+        end = skill_text.index("---", 4)
+        frontmatter = skill_text[:end + 3]
+        lower = frontmatter.lower()
+        # Either the literal phrase or the parser tool name should appear.
+        assert (
+            "wave-pattern" in lower
+            or "spec_validate_structure" in lower
+            or "/prepwaves" in lower
+        ), "frontmatter must advertise wave-pattern-ready guarantee"
+
+    def test_usage_lists_story(self, skill_text: str) -> None:
+        """Usage block exposes the new `story` alias."""
+        end = skill_text.index("---", 4)
+        frontmatter = skill_text[:end + 3]
+        # The `usage:` literal block is part of the frontmatter.
+        assert "/issue story" in frontmatter, (
+            "usage block must expose `/issue story`"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Wave-pattern-ready output guarantee — documented in body
+# ---------------------------------------------------------------------------
+
+
+class TestGuaranteeDocumented:
+    """The skill body and introduction document the guarantee."""
+
+    def test_skill_body_lists_required_h2_sections(self, skill_text: str) -> None:
+        """SKILL.md body lists each of the six required H2 sections so the
+        contract is visible to a reader without going to the parser docs."""
+        for h in REQUIRED_H2_HEADINGS:
+            assert h in skill_text, (
+                f"SKILL.md body missing reference to required heading {h!r}"
+            )
+
+    def test_skill_body_references_parser(self, skill_text: str) -> None:
+        """SKILL.md body links the guarantee to the parser tool name."""
+        lower = skill_text.lower()
+        assert (
+            "spec_validate_structure" in lower or "/prepwaves" in lower
+        ), "SKILL.md must name the downstream parser/tool"
+
+    def test_introduction_documents_guarantee(self, intro_text: str) -> None:
+        """introduction.md mentions the wave-pattern-ready guarantee."""
+        lower = intro_text.lower()
+        assert (
+            "wave-pattern" in lower
+            or "/prepwaves" in lower
+            or "spec_validate_structure" in lower
+        )
+
+    def test_introduction_lists_all_sub_issue_types(self, intro_text: str) -> None:
+        """introduction.md lists every sub-issue type."""
+        for t in SUB_ISSUE_TYPES:
+            assert t in intro_text.lower(), (
+                f"introduction.md omits sub-issue type {t!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Each sub-issue template emits the six required H2 headings
+# ---------------------------------------------------------------------------
+
+
+# Mapping from issue type → H3 heading used in SKILL.md for that template.
+TEMPLATE_HEADERS = {
+    "feature": "Feature Template (alias: Story)",
+    "bug": "Bug Template",
+    "chore": "Chore Template",
+    "docs": "Docs Template",
+}
+
+
+@pytest.mark.parametrize("issue_type", ["feature", "bug", "chore", "docs"])
+class TestSubIssueTemplateHeadings:
+    """Every fenced sub-issue template in SKILL.md emits the six required
+    H2 headings, in the canonical names this skill commits to."""
+
+    def test_template_block_present(
+        self, skill_text: str, issue_type: str
+    ) -> None:
+        """The fenced markdown block exists under its H3 heading."""
+        body = _extract_template_block(skill_text, TEMPLATE_HEADERS[issue_type])
+        assert body, (
+            f"could not locate fenced ```markdown block under H3 "
+            f"`### {TEMPLATE_HEADERS[issue_type]}`"
+        )
+
+    def test_template_emits_all_required_h2s(
+        self, skill_text: str, issue_type: str
+    ) -> None:
+        """Every required H2 heading appears in the template body."""
+        body = _extract_template_block(skill_text, TEMPLATE_HEADERS[issue_type])
+        headings = _h2_headings(body)
+        for required in REQUIRED_H2_HEADINGS:
+            assert required in headings, (
+                f"{issue_type} template missing required H2 heading "
+                f"{required!r}; saw {headings!r}"
+            )
+
+    def test_template_required_h2s_in_canonical_order(
+        self, skill_text: str, issue_type: str
+    ) -> None:
+        """The required H2 headings appear in their canonical order so
+        the rendered issue reads top-to-bottom the way agents expect."""
+        body = _extract_template_block(skill_text, TEMPLATE_HEADERS[issue_type])
+        headings = _h2_headings(body)
+        # Filter to just the required ones, preserving order of appearance.
+        required_set = set(REQUIRED_H2_HEADINGS)
+        seen_in_order = [h for h in headings if h in required_set]
+        assert seen_in_order == list(REQUIRED_H2_HEADINGS), (
+            f"{issue_type} template H2 ordering is "
+            f"{seen_in_order!r}, expected {list(REQUIRED_H2_HEADINGS)!r}"
+        )
+
+
+class TestStoryAliasDocumented:
+    """Story is an explicit alias of feature, documented in SKILL.md."""
+
+    def test_story_template_section_present(self, skill_text: str) -> None:
+        """SKILL.md has an H3 specifically calling out the Story alias."""
+        assert "### Story Template" in skill_text
+
+    def test_story_aliases_feature(self, skill_text: str) -> None:
+        """The Story Template section explains it is identical to Feature."""
+        idx = skill_text.find("### Story Template")
+        assert idx != -1
+        # Take the section up to the next H3.
+        rest = skill_text[idx:]
+        next_h3 = rest.find("\n### ", 1)
+        section = rest if next_h3 == -1 else rest[:next_h3]
+        lower = section.lower()
+        assert "alias" in lower
+        assert "feature" in lower
+
+
+# ---------------------------------------------------------------------------
+# 4. Epic template is intentionally excluded
+# ---------------------------------------------------------------------------
+
+
+class TestEpicExcluded:
+    """The epic template is intentionally NOT held to the sub-issue grammar.
+
+    Epics are parents (decompose into sub-issues), not sub-issues themselves.
+    This guard documents and preserves that distinction so a future edit
+    doesn't accidentally break the epic shape while "fixing" issue grammar.
+    """
+
+    def test_epic_template_present(self, skill_text: str) -> None:
+        """The Epic Template still exists."""
+        body = _extract_template_block(skill_text, "Epic Template")
+        assert body, "Epic Template block is missing entirely"
+
+    def test_epic_template_keeps_epic_specific_headings(
+        self, skill_text: str
+    ) -> None:
+        """The epic template retains its epic-specific structure
+        (Goal / Scope / Definition of Done / Sub-Issues / Wave Map)."""
+        body = _extract_template_block(skill_text, "Epic Template")
+        headings = _h2_headings(body)
+        for required in ("## Goal", "## Scope", "## Definition of Done", "## Sub-Issues"):
+            assert required in headings, (
+                f"Epic template missing epic-specific heading {required!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. Smoke check: representative bodies pass spec_validate_structure rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("issue_type", list(SAMPLE_BODIES.keys()))
+class TestRenderedBodiesValidate:
+    """A filled-in body for each sub-issue type satisfies the
+    spec_validate_structure contract (in-process replica)."""
+
+    def test_rendered_body_validates(self, issue_type: str) -> None:
+        body = SAMPLE_BODIES[issue_type]
+        result = _spec_validate_structure(body)
+        assert result["valid"], (
+            f"{issue_type} sample body failed in-process "
+            f"spec_validate_structure: missing={result['missing']!r}"
+        )
+
+    def test_rendered_body_has_dependencies_section(
+        self, issue_type: str
+    ) -> None:
+        """Dependencies is optional for the parser but required by this
+        skill's templates so wave assembly can mechanically harvest deps."""
+        body = SAMPLE_BODIES[issue_type]
+        sections = _parse_sections(body)
+        assert "dependencies" in sections, (
+            f"{issue_type} sample body missing ## Dependencies"
+        )
+
+    def test_rendered_body_has_metadata_section(
+        self, issue_type: str
+    ) -> None:
+        """Metadata is required by this skill's templates so wave/epic
+        backrefs are always present."""
+        body = SAMPLE_BODIES[issue_type]
+        sections = _parse_sections(body)
+        assert "metadata" in sections, (
+            f"{issue_type} sample body missing ## Metadata"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Internal parser-replica self-check
+# ---------------------------------------------------------------------------
+
+
+class TestParserReplicaSanity:
+    """The in-process spec_validate_structure replica must reject the
+    obvious failure cases — otherwise the smoke checks above are vacuous."""
+
+    def test_empty_body_invalid(self) -> None:
+        result = _spec_validate_structure("")
+        assert not result["valid"]
+        assert set(result["missing"]) == {
+            "changes",
+            "tests",
+            "acceptance_criteria",
+        }
+
+    def test_missing_acceptance_criteria_invalid(self) -> None:
+        body = """## Summary
+
+Body.
+
+## Implementation Steps
+
+1. step
+
+## Test Procedures
+
+*Unit tests:* none
+"""
+        result = _spec_validate_structure(body)
+        assert not result["valid"]
+        assert "acceptance_criteria" in result["missing"]
+
+    def test_changes_alias_satisfies_changes_key(self) -> None:
+        """The parser accepts `## Changes` as an alias for the `changes` key."""
+        body = """## Summary
+
+Body.
+
+## Changes
+
+- thing
+
+## Tests
+
+- thing
+
+## Acceptance Criteria
+
+- [ ] thing
+"""
+        result = _spec_validate_structure(body)
+        assert result["valid"]
+        assert set(result["present"]) == {
+            "changes",
+            "tests",
+            "acceptance_criteria",
+        }
+
+    def test_empty_section_does_not_satisfy(self) -> None:
+        """A heading with no non-whitespace content does not count."""
+        body = """## Summary
+
+Body.
+
+## Implementation Steps
+
+
+## Test Procedures
+
+- thing
+
+## Acceptance Criteria
+
+- [ ] thing
+"""
+        result = _spec_validate_structure(body)
+        assert not result["valid"]
+        assert "changes" in result["missing"]


### PR DESCRIPTION
## Summary

Update `/issue` templates so every sub-issue type (feature, story, chore, docs, bug) emits the six H2 sections that `/prepwaves` and `spec_validate_structure` require: `## Summary`, `## Implementation Steps`, `## Test Procedures`, `## Acceptance Criteria`, `## Dependencies`, `## Metadata`. Removes the recurring wave-pattern stumbling block where every sub-issue had to be hand-fixed mid-flight.

## Changes

- `skills/issue/SKILL.md`, `skills/issue/introduction.md` — wave-pattern-ready output guarantee + per-template H2 enforcement
- `story` aliased to `feature` (matches `work_item` MCP tool's `type` enum)
- `tests/test_issue_skill.py` — 42 tests covering frontmatter, per-type H2 emission, and an in-process `spec_validate_structure` replica

## Test Plan

- `./scripts/ci/validate.sh` — 113 passed / 0 failed
- `pytest tests/test_issue_skill.py` — 42 passed
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings

Closes #427