### PR TITLE
ci(gitlab): release stage parity with .github/workflows/release.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - validate
+  - release
 
 validate:
   stage: validate
@@ -11,3 +12,42 @@ validate:
     - ./scripts/ci/validate.sh
   rules:
     - if: $CI_MERGE_REQUEST_IID
+
+# Build the cc-workflow.tar.gz release artifact on v* tag push.
+# Mirrors .github/workflows/release.yml — same scripts, same artifact.
+release-build:
+  stage: release
+  image: ubuntu:24.04
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq python3 > /dev/null 2>&1
+  script:
+    - ./scripts/ci/build.sh
+    - ./scripts/ci/package-release.sh "$CI_COMMIT_TAG"
+  artifacts:
+    paths:
+      - cc-workflow.tar.gz
+    expire_in: never
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v/
+
+# Publish a GitLab Release entry pointing at the artifact from release-build.
+# release-cli ships on the GitLab-provided release-cli image.
+release-publish:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  needs:
+    - job: release-build
+      artifacts: true
+  script:
+    - echo "Publishing GitLab Release for $CI_COMMIT_TAG"
+  release:
+    tag_name: "$CI_COMMIT_TAG"
+    name: "Release $CI_COMMIT_TAG"
+    description: "cc-workflow $CI_COMMIT_TAG — see CHANGELOG.md for details."
+    assets:
+      links:
+        - name: "cc-workflow.tar.gz"
+          url: "$CI_PROJECT_URL/-/jobs/artifacts/$CI_COMMIT_TAG/raw/cc-workflow.tar.gz?job=release-build"
+          link_type: "package"
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v/


### PR DESCRIPTION
## Summary

Add `release-build` + `release-publish` jobs to `.gitlab-ci.yml` so projects adopting the cc-workflow GitLab scaffold get tag-driven release automation matching the GitHub side. Same scripts (`build.sh`, `package-release.sh`), same artifact (`cc-workflow.tar.gz`), same `v*` tag gate.

## Changes

- `.gitlab-ci.yml` — new `release` stage with two jobs gated on `$CI_COMMIT_TAG =~ /^v/`
- `release-publish` uses `release-cli` image + `release:` keyword to publish the GitLab Release
- Stable artifact-by-ref URL `$CI_PROJECT_URL/-/jobs/artifacts/$CI_COMMIT_TAG/raw/cc-workflow.tar.gz?job=release-build` — the original draft used `$CI_JOB_ID` which would have resolved to the *publish* job (404). Caught and fixed during self-review.

## Test Plan

- `./scripts/ci/validate.sh` — 113 passed / 0 failed
- `python3 -c "import yaml; yaml.safe_load(open('.gitlab-ci.yml'))"` — well-formed
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- All `script:` blocks ≤ 5 lines (max 2)

Closes #460