### PR TITLE
fix(doc): use singular `doc/` branch prefix in CLAUDE.md and workflow tour

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Authoritative rule: Dev Spec §5.2.1. Mechanical detection + sentinel: `skills/p
 **IMMUTABLE rules — cannot be overridden.**
 
 1. **Always have an issue.** Never begin work without one. Create it or ask the user to. Set it to in-progress. No code until tracked.
-2. **Branches MUST link to their issue.** Name format: `feature/<N>-description` (or `fix/`, `chore/`, `docs/`).
+2. **Branches MUST link to their issue.** Name format: `feature/<N>-description` (or `fix/`, `chore/`, `doc/`).
 3. **On merge, close ALL linked issues.** Check the PR/MR description for `Closes #N`, close each via `gh issue close` / `glab issue close`, verify closure — even if auto-close misbehaves.
 
 ---
@@ -76,7 +76,7 @@ Every issue MUST be wave-pattern quality: detailed enough that a spec-driven age
 
 ## Branching Strategy
 
-Trunk-based flow. Always branch from `main`: `git checkout main && git pull && git checkout -b <type>/<N>-description`. Types: `feature`, `fix`, `chore`, `docs`. PR/MRs target `main`.
+Trunk-based flow. Always branch from `main`: `git checkout main && git pull && git checkout -b <type>/<N>-description`. Types: `feature`, `fix`, `chore`, `doc`. PR/MRs target `main`.
 
 ---
 

--- a/skills/ccwork/tours/workflow.md
+++ b/skills/ccwork/tours/workflow.md
@@ -56,7 +56,7 @@ echo "Branch naming convention:"
 echo "  feature/<issue-number>-description"
 echo "  fix/<issue-number>-description"
 echo "  chore/<issue-number>-description"
-echo "  docs/<issue-number>-description"
+echo "  doc/<issue-number>-description"
 ```
 
 Narration: "The branch name format is `<type>/<issue-number>-<description>`. When `/precheck` runs, it extracts the issue number from your branch name to verify the issue exists and is open. If you're on `main` or a branch without an issue number, it stops you."


### PR DESCRIPTION
## Summary

Branch prefix names the topic, not the file type. Per the project's singular-topic convention (feature, fix, chore, bug), the documentation prefix is `doc/`, not `docs/`. Three references updated.

## Changes

- `CLAUDE.md:66` — branch name format `docs/` → `doc/`
- `CLAUDE.md:79` — branch types list `docs` → `doc`
- `skills/ccwork/tours/workflow.md:59` — tour echo example `docs/<issue-number>-description` → `doc/<issue-number>-description`

The `docs/` directory and Conventional-Commits `docs:` commit type at `CLAUDE.md:129` are intentionally untouched (different conventions; commit-type decision deferred per the issue).

## Test Plan

- `./scripts/ci/validate.sh` — 113 passed / 0 failed
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- `grep -rnE 'docs/<' CLAUDE.md skills/` — only legitimate file-path placeholders remain

Closes #464