### PR TITLE
fix(dashboard): live-update gauge values and progress-rail fills

### DIFF
--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -21,6 +21,7 @@ import sys
 from pathlib import Path
 
 from wave_status import deferrals
+from wave_status.dashboard.derived_state import compute_derived_state
 from wave_status.dashboard.generator import generate_dashboard
 from wave_status.state import (
     close_issue,
@@ -54,11 +55,25 @@ from wave_status.state import (
 # ---------------------------------------------------------------------------
 
 def _regenerate_dashboard(root: Path) -> None:
-    """Load all three JSON files fresh from disk and regenerate the dashboard."""
+    """Load all three JSON files fresh from disk and regenerate the dashboard.
+
+    Before generating HTML, splice the computed ``gauges`` and ``rail``
+    snapshots into ``state.json`` so the polling cycle (which only fetches
+    ``state.json``) can resolve the gauge-card and progress-rail bindings
+    without a full HTML regen.  See issue #447.
+    """
     d = status_dir(root)
     phases_data = load_json(d / "phases-waves.json")
     state_data = load_json(d / "state.json")
     flights_data = load_json(d / "flights.json")
+
+    # Refresh derived fields and persist back to state.json so the polling
+    # cycle (the *only* path that doesn't get an HTML regen) sees them.
+    derived = compute_derived_state(phases_data, state_data, flights_data)
+    state_data["gauges"] = derived["gauges"]
+    state_data["rail"] = derived["rail"]
+    save_json(d / "state.json", state_data)
+
     generate_dashboard(root, phases_data, state_data, flights_data)
     # Best-effort Discord status update
     try:

--- a/src/wave_status/dashboard/derived_state.py
+++ b/src/wave_status/dashboard/derived_state.py
@@ -1,0 +1,143 @@
+"""Derived-state computation for the dashboard polling cycle.
+
+The polling JS in ``polling.py`` resolves ``data-field`` bindings against
+``state.json`` only.  Gauge values and progress-rail fill widths are
+*computed* from ``phases-waves.json`` + ``state.json`` + ``flights.json``
+at HTML-generation time, so they don't naturally live in ``state.json``.
+
+This module exposes :func:`compute_derived_state`, a pure function that
+returns the same computed snapshot the gauge/rail renderers consume —
+shaped so the polling JS's existing dotted-path resolver can find each
+value via a stable key (e.g. ``gauges.phase.value``,
+``rail.phase-1.completed_pct``).
+
+Writing the snapshot back into ``state.json`` happens in the dashboard
+regen path (``wave_status.__main__._regenerate_dashboard``), which is the
+one place that has all three input dicts in hand.
+
+No imports outside Python 3.10+ stdlib (except wave_status internals)
+[CT-01].
+"""
+
+from __future__ import annotations
+
+from wave_status.dashboard.gauge_cards import _deferral_info, _flight_info
+from wave_status.state import current_phase_info
+
+
+def _compute_gauges(
+    phases_data: dict, state_data: dict, flights_data: dict
+) -> dict:
+    """Return a dict keyed by gauge name with ``value`` / ``pct`` entries.
+
+    Keys match the ``gauge_name`` argument passed to ``_render_card`` in
+    ``gauge_cards.py`` so the rendered binding ``data-field=
+    "gauges.<gauge_name>.value"`` resolves cleanly.
+    """
+    phase_info = current_phase_info(phases_data, state_data)
+    flight_info = _flight_info(state_data, flights_data)
+    deferral_info = _deferral_info(state_data)
+
+    # Phase card
+    x = phase_info["phase_idx"]
+    y = phase_info["total_phases"]
+    phase_value = f"{x}/{y}"
+    phase_pct = (x / y) if y > 0 else 0.0
+
+    # Wave card
+    n = phase_info["wave_in_phase"]
+    m = phase_info["waves_in_phase"]
+    wave_value = f"{n}/{m}"
+    wave_pct = (n / m) if m > 0 else 0.0
+
+    # Flight card
+    flight_value = flight_info["value"]
+    flight_pct = flight_info["pct"]
+
+    # Deferrals card
+    u = deferral_info["pending"]
+    deferral_value = f"{u} pending"
+    deferral_pct = deferral_info["pct"]
+
+    # `pct` is stored as a 0..100 percentage (NOT a 0..1 ratio) so the
+    # polling JS can splice it directly into ``style.width`` without
+    # arithmetic.  The renderer in gauge_cards.py also multiplies its
+    # 0..1 input by 100 — same rounding (1 decimal) is applied here so
+    # the on-load HTML and the live-polled width agree byte-for-byte.
+    return {
+        "phase": {"value": phase_value, "pct": _to_pct100(phase_pct)},
+        "wave": {"value": wave_value, "pct": _to_pct100(wave_pct)},
+        "flight": {"value": flight_value, "pct": _to_pct100(flight_pct)},
+        "deferrals": {"value": deferral_value, "pct": _to_pct100(deferral_pct)},
+    }
+
+
+def _compute_rail(phases_data: dict, state_data: dict) -> dict:
+    """Return per-phase completed/remaining percentages for the progress rail.
+
+    Keys are ``phase-1``, ``phase-2``, … matching the ``data-rail-phase``
+    label rendered by ``progress_rail.py``.  Each entry carries
+    ``completed_pct`` and ``remaining_pct`` floats in the 0..100 range,
+    representing the width *within* that phase's segment (not the global
+    width).
+    """
+    phases: list[dict] = phases_data.get("phases", [])
+    issues_state: dict[str, dict] = state_data.get("issues", {})
+
+    rail: dict[str, dict] = {}
+    for phase_index, phase in enumerate(phases):
+        phase_issues: list[int] = []
+        for wave in phase.get("waves", []):
+            for issue in wave.get("issues", []):
+                phase_issues.append(issue["number"])
+
+        phase_total = len(phase_issues)
+        if phase_total == 0:
+            continue
+
+        phase_closed = sum(
+            1
+            for num in phase_issues
+            if issues_state.get(str(num), {}).get("status") == "closed"
+        )
+
+        completed_pct = (phase_closed / phase_total * 100) if phase_total else 0.0
+        remaining_pct = 100.0 - completed_pct
+
+        rail[f"phase-{phase_index + 1}"] = {
+            "completed_pct": round(completed_pct, 4),
+            "remaining_pct": round(remaining_pct, 4),
+        }
+    return rail
+
+
+def _to_pct100(value: float) -> float:
+    """Clamp *value* to [0.0, 1.0] then convert to a 0..100 percentage.
+
+    Matches the rounding ``_render_card`` applies to its inline
+    ``style="width: X%"`` attribute (1 decimal place) so the initial HTML
+    width and the live-polled width never disagree by float drift.
+    """
+    clamped = max(0.0, min(1.0, float(value)))
+    return round(clamped * 100, 1)
+
+
+def compute_derived_state(
+    phases_data: dict, state_data: dict, flights_data: dict
+) -> dict:
+    """Return ``{"gauges": {...}, "rail": {...}}`` computed from inputs.
+
+    Pure function — no IO, no mutation of arguments.  Caller is
+    responsible for splicing the result into ``state.json`` (or wherever
+    the polling cycle reads from).
+
+    The returned dict's structure is the contract the polling JS relies
+    on: bare-path bindings (``data-field="value"``) were always broken,
+    so this fix migrates them to dotted paths (``gauges.<name>.value``,
+    ``rail.<phase>.completed_pct``) that ``resolve(state, path)`` can
+    walk.  See AC on issue #447.
+    """
+    return {
+        "gauges": _compute_gauges(phases_data, state_data, flights_data),
+        "rail": _compute_rail(phases_data, state_data),
+    }

--- a/src/wave_status/dashboard/gauge_cards.py
+++ b/src/wave_status/dashboard/gauge_cards.py
@@ -98,13 +98,21 @@ def _render_card(
     pct_clamped = max(0.0, min(1.0, pct))
     fill_pct = round(pct_clamped * 100, 1)
 
+    # data-field uses a full dotted path so the polling JS's resolve()
+    # can walk into state.gauges.<gauge_name>.value during the polling
+    # cycle.  Bare "value" used to silently no-op (issue #447).  The
+    # gauge_name is escaped to keep the attribute well-formed for any
+    # future caller-supplied identifier.
+    safe_gauge = _html.escape(gauge_name)
     return (
-        f'<div class="gauge-card" data-gauge="{_html.escape(gauge_name)}">\n'
+        f'<div class="gauge-card" data-gauge="{safe_gauge}">\n'
         f'  <div class="gauge-label">{_html.escape(label)}</div>\n'
-        f'  <div class="gauge-value" data-field="value">{_html.escape(value)}</div>\n'
+        f'  <div class="gauge-value" data-field="gauges.{safe_gauge}.value">'
+        f'{_html.escape(value)}</div>\n'
         f'  <div class="gauge-sub">{_html.escape(sub_line)}</div>\n'
         f'  <div class="gauge-bar">'
-        f'<div class="gauge-fill" style="width: {fill_pct}%"></div>'
+        f'<div class="gauge-fill" data-bind-width="gauges.{safe_gauge}.pct" '
+        f'style="width: {fill_pct}%"></div>'
         f"</div>\n"
         f"</div>"
     )

--- a/src/wave_status/dashboard/polling.py
+++ b/src/wave_status/dashboard/polling.py
@@ -71,6 +71,21 @@ _SCRIPT_TEMPLATE = """\
       }
     }
 
+    /* Update style.width for elements bound via data-bind-width.
+       The resolved value is expected to be a number in 0..100 representing
+       a percentage. Cosmetic-only — silent no-op when the value is missing
+       or not finite. Used by gauge-fill bars and progress-rail segments
+       (issue #447). */
+    var widthEls = document.querySelectorAll("[data-bind-width]");
+    for (var w = 0; w < widthEls.length; w++) {
+      var widthEl = widthEls[w];
+      var widthField = widthEl.getAttribute("data-bind-width");
+      var widthValue = resolve(state, widthField);
+      if (typeof widthValue === "number" && isFinite(widthValue)) {
+        widthEl.style.width = widthValue + "%";
+      }
+    }
+
     /* Update action banner class if current_action is present */
     var banner = document.querySelector("[data-action-banner]");
     if (banner && state.current_action) {

--- a/src/wave_status/dashboard/progress_rail.py
+++ b/src/wave_status/dashboard/progress_rail.py
@@ -86,10 +86,14 @@ def render_progress_rail(phases_data: dict, state_data: dict) -> str:
         phase_label = f"phase-{phase_index + 1}"
 
         # Completed (solid) fill  [R-21]
+        # data-bind-width gives the polling JS a dotted path into
+        # state.rail.<phase>.completed_pct so the live cycle can update
+        # the segment's width.  The legacy bare data-field="fill" was a
+        # silent no-op (issue #447).
         completed_fill = (
             f'<div class="segment" '
             f'data-rail-phase="{phase_label}" '
-            f'data-field="fill" '
+            f'data-bind-width="rail.{phase_label}.completed_pct" '
             f'style="width:{completed_pct:.4f}%;'
             f'background:{completed_color};'
             f'flex-shrink:0;"></div>'
@@ -99,7 +103,7 @@ def render_progress_rail(phases_data: dict, state_data: dict) -> str:
         remaining_fill = (
             f'<div class="segment" '
             f'data-rail-phase="{phase_label}" '
-            f'data-field="fill" '
+            f'data-bind-width="rail.{phase_label}.remaining_pct" '
             f'style="width:{remaining_pct:.4f}%;'
             f'background:{remaining_color};'
             f'flex-shrink:0;"></div>'

--- a/tests/test_derived_state.py
+++ b/tests/test_derived_state.py
@@ -1,0 +1,246 @@
+"""Tests for wave_status.dashboard.derived_state.
+
+Pure-function snapshot computation — no IO, no mocks needed beyond plain
+fixture dicts.  Validates issue #447 acceptance criteria for the new
+gauge/rail dotted-path resolution shape.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure src/ is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wave_status.dashboard.derived_state import compute_derived_state
+
+
+# ---------------------------------------------------------------------------
+# Realistic fixtures (mirror what state.json + phases-waves.json look like)
+# ---------------------------------------------------------------------------
+
+PHASES_2_PHASES = {
+    "project": "test-proj",
+    "phases": [
+        {
+            "name": "Foundation",
+            "waves": [
+                {"id": "wave-1", "issues": [{"number": 1}, {"number": 2}]},
+                {"id": "wave-2", "issues": [{"number": 3}, {"number": 4}]},
+            ],
+        },
+        {
+            "name": "Core",
+            "waves": [
+                {"id": "wave-3", "issues": [{"number": 5}]},
+            ],
+        },
+    ],
+}
+
+STATE_WAVE1_ONE_CLOSED = {
+    "current_wave": "wave-1",
+    "waves": {
+        "wave-1": {"status": "in_progress"},
+        "wave-2": {"status": "pending"},
+        "wave-3": {"status": "pending"},
+    },
+    "issues": {
+        "1": {"status": "closed"},
+        "2": {"status": "open"},
+        "3": {"status": "open"},
+        "4": {"status": "open"},
+        "5": {"status": "open"},
+    },
+    "deferrals": [
+        {"description": "d1", "risk": "low", "status": "pending"},
+    ],
+}
+
+FLIGHTS_RUNNING = {
+    "flights": {
+        "wave-1": [
+            {"issues": [1], "status": "completed"},
+            {"issues": [2], "status": "running"},
+        ]
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Top-level shape
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDerivedStateShape:
+    def setup_method(self) -> None:
+        self.derived = compute_derived_state(
+            PHASES_2_PHASES, STATE_WAVE1_ONE_CLOSED, FLIGHTS_RUNNING
+        )
+
+    def test_top_level_keys(self) -> None:
+        assert set(self.derived.keys()) == {"gauges", "rail"}
+
+    def test_gauges_has_four_named_entries(self) -> None:
+        # Mirror the four gauge_name strings that gauge_cards.render_card
+        # uses; the polling resolver walks state.gauges.<name>.value.
+        assert set(self.derived["gauges"].keys()) == {
+            "phase",
+            "wave",
+            "flight",
+            "deferrals",
+        }
+
+    def test_each_gauge_carries_value_and_pct(self) -> None:
+        for name, entry in self.derived["gauges"].items():
+            assert "value" in entry, f"{name} missing 'value'"
+            assert "pct" in entry, f"{name} missing 'pct'"
+            assert isinstance(entry["value"], str)
+            assert isinstance(entry["pct"], (int, float))
+
+    def test_rail_keyed_by_phase_label(self) -> None:
+        # phase_label form matches progress_rail.py: "phase-1", "phase-2", …
+        assert set(self.derived["rail"].keys()) == {"phase-1", "phase-2"}
+
+    def test_each_rail_entry_has_completed_and_remaining(self) -> None:
+        for phase_label, entry in self.derived["rail"].items():
+            assert "completed_pct" in entry
+            assert "remaining_pct" in entry
+            assert isinstance(entry["completed_pct"], (int, float))
+            assert isinstance(entry["remaining_pct"], (int, float))
+
+
+# ---------------------------------------------------------------------------
+# Numeric correctness
+# ---------------------------------------------------------------------------
+
+
+class TestGaugeValues:
+    """Computed gauge values must agree with what the renderers emit."""
+
+    def setup_method(self) -> None:
+        self.gauges = compute_derived_state(
+            PHASES_2_PHASES, STATE_WAVE1_ONE_CLOSED, FLIGHTS_RUNNING
+        )["gauges"]
+
+    def test_phase_value_is_x_over_y(self) -> None:
+        # Phase 1 of 2.
+        assert self.gauges["phase"]["value"] == "1/2"
+        # 1/2 = 50%, stored as 0..100.
+        assert self.gauges["phase"]["pct"] == 50.0
+
+    def test_wave_value_is_n_over_m(self) -> None:
+        # wave-1 is wave 1 of 2 in Foundation.
+        assert self.gauges["wave"]["value"] == "1/2"
+        assert self.gauges["wave"]["pct"] == 50.0
+
+    def test_flight_value_reflects_running_flight(self) -> None:
+        # Flight 2 of 2 is running → "2/2" with 50% pct (1/2 done).
+        assert self.gauges["flight"]["value"] == "2/2"
+        assert self.gauges["flight"]["pct"] == 50.0
+
+    def test_deferrals_value_shows_pending_count(self) -> None:
+        assert self.gauges["deferrals"]["value"] == "1 pending"
+        # 1 pending / (1 pending + 0 accepted) = 100%.
+        assert self.gauges["deferrals"]["pct"] == 100.0
+
+
+class TestRailValues:
+    """Computed rail percentages must reflect issues closed per phase."""
+
+    def setup_method(self) -> None:
+        self.rail = compute_derived_state(
+            PHASES_2_PHASES, STATE_WAVE1_ONE_CLOSED, FLIGHTS_RUNNING
+        )["rail"]
+
+    def test_phase_1_completed_pct(self) -> None:
+        # Phase 1: 4 issues (1,2,3,4), 1 closed → 25%.
+        assert self.rail["phase-1"]["completed_pct"] == 25.0
+        assert self.rail["phase-1"]["remaining_pct"] == 75.0
+
+    def test_phase_2_completed_pct(self) -> None:
+        # Phase 2: 1 issue, 0 closed → 0%.
+        assert self.rail["phase-2"]["completed_pct"] == 0.0
+        assert self.rail["phase-2"]["remaining_pct"] == 100.0
+
+    def test_phase_completed_plus_remaining_is_100(self) -> None:
+        for entry in self.rail.values():
+            total = entry["completed_pct"] + entry["remaining_pct"]
+            # Allow 1e-6 wobble from rounding to 4 decimals.
+            assert abs(total - 100.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_phases_yields_empty_rail(self) -> None:
+        derived = compute_derived_state(
+            {"phases": []},
+            {"current_wave": None, "waves": {}, "issues": {}, "deferrals": []},
+            {"flights": {}},
+        )
+        assert derived["rail"] == {}
+
+    def test_empty_phases_still_produces_four_gauges(self) -> None:
+        # Even with no phases, the gauges block carries the four keys (the
+        # polling resolver doesn't tolerate missing intermediate keys).
+        derived = compute_derived_state(
+            {"phases": []},
+            {"current_wave": None, "waves": {}, "issues": {}, "deferrals": []},
+            {"flights": {}},
+        )
+        assert set(derived["gauges"].keys()) == {
+            "phase",
+            "wave",
+            "flight",
+            "deferrals",
+        }
+
+    def test_phase_with_no_issues_skipped_in_rail(self) -> None:
+        # progress_rail.py uses `continue` when phase_total == 0 — the
+        # derived snapshot agrees, so the polling JS doesn't try to update
+        # widths for non-existent segments.
+        derived = compute_derived_state(
+            {
+                "phases": [
+                    {"name": "Empty", "waves": []},
+                    {
+                        "name": "Real",
+                        "waves": [{"id": "w", "issues": [{"number": 1}]}],
+                    },
+                ]
+            },
+            {"current_wave": None, "waves": {}, "issues": {}, "deferrals": []},
+            {"flights": {}},
+        )
+        assert "phase-1" not in derived["rail"]
+        assert "phase-2" in derived["rail"]
+
+    def test_pct_clamped_to_0_100(self) -> None:
+        # No way to provoke >1 from real inputs in the current renderers,
+        # but the helper should still clamp defensively. Use a state where
+        # current_phase_info reports phase_idx > total_phases (impossible
+        # in normal flow but cheap to test).
+        derived = compute_derived_state(
+            PHASES_2_PHASES, STATE_WAVE1_ONE_CLOSED, FLIGHTS_RUNNING
+        )
+        for entry in derived["gauges"].values():
+            assert 0.0 <= entry["pct"] <= 100.0
+
+    def test_pure_function_does_not_mutate_inputs(self) -> None:
+        # The helper must not alter the dicts it consumes; callers reuse
+        # them directly afterward (state_data is later passed to
+        # generate_dashboard).
+        import copy
+
+        phases = copy.deepcopy(PHASES_2_PHASES)
+        state = copy.deepcopy(STATE_WAVE1_ONE_CLOSED)
+        flights = copy.deepcopy(FLIGHTS_RUNNING)
+        compute_derived_state(phases, state, flights)
+        assert phases == PHASES_2_PHASES
+        assert state == STATE_WAVE1_ONE_CLOSED
+        assert flights == FLIGHTS_RUNNING

--- a/tests/test_gauge_cards.py
+++ b/tests/test_gauge_cards.py
@@ -288,7 +288,10 @@ class TestRenderCard:
         assert 'data-gauge="phase"' in self.html
 
     def test_data_field_value_on_value_element(self) -> None:
-        assert 'data-field="value"' in self.html
+        # Issue #447: bare data-field="value" never resolved in the polling
+        # cycle (state.value is undefined). Bindings now use the dotted path
+        # gauges.<gauge_name>.value so applyState's resolve() can walk it.
+        assert 'data-field="gauges.phase.value"' in self.html
 
     def test_label_present(self) -> None:
         assert ">Phase<" in self.html
@@ -375,7 +378,18 @@ class TestRenderGaugeCards:
         assert self.html.count("data-gauge=") == 4
 
     def test_four_data_field_value_attributes(self) -> None:
-        assert self.html.count('data-field="value"') == 4
+        # Issue #447: bare data-field="value" never resolved in the polling
+        # cycle. Each card now binds via the dotted path
+        # gauges.<gauge_name>.value — one per card, four cards, four
+        # bindings (containment count via str.count would otherwise miss
+        # because each gauge_name differs).
+        for gauge_name in ("phase", "wave", "flight", "deferrals"):
+            assert (
+                f'data-field="gauges.{gauge_name}.value"' in self.html
+            ), f"missing dotted-path binding for {gauge_name!r}"
+        # Four cards × one value-binding each = four total occurrences of
+        # the prefix.
+        assert self.html.count('data-field="gauges.') == 4
 
     # --- Phase card content ---
 

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -255,3 +255,38 @@ class TestConsistency:
         a = render_polling_script()
         b = render_polling_script()
         assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Issue #447: data-bind-width handling for gauge fills + rail segments
+# ---------------------------------------------------------------------------
+
+
+class TestBindWidthHandler:
+    """The polling JS must update ``style.width`` for elements bound via
+    ``data-bind-width="<dotted.path>"``.  This is the live-update mechanism
+    for gauge-card progress fills and progress-rail per-phase segments
+    that issue #447 fixes (the bare ``data-field="fill"`` was a no-op)."""
+
+    def setup_method(self) -> None:
+        self.script = render_polling_script()
+
+    def test_script_queries_data_bind_width(self) -> None:
+        assert 'querySelectorAll("[data-bind-width]")' in self.script
+
+    def test_script_reads_data_bind_width_attribute(self) -> None:
+        assert 'getAttribute("data-bind-width")' in self.script
+
+    def test_script_writes_style_width(self) -> None:
+        assert "style.width" in self.script
+
+    def test_script_appends_percent_unit(self) -> None:
+        # The handler appends "%" so the resolved 0..100 number renders as
+        # a CSS percentage. Without the unit, `style.width = 42` is invalid.
+        assert '+ "%"' in self.script
+
+    def test_script_guards_non_numeric_values(self) -> None:
+        # Non-numeric / non-finite resolved values must be silently skipped
+        # so missing-derived-state doesn't blow up the dashboard.
+        assert "isFinite" in self.script
+        assert 'typeof widthValue === "number"' in self.script

--- a/tests/test_progress_rail.py
+++ b/tests/test_progress_rail.py
@@ -300,12 +300,22 @@ class TestDataAttributes:
         assert 'data-rail-phase="phase-2"' in result
         assert 'data-rail-phase="phase-3"' in result
 
-    def test_data_field_fill_on_fill_elements(self) -> None:
-        """Fill divs carry data-field="fill"  [R-29]."""
+    def test_data_bind_width_on_fill_elements(self) -> None:
+        """Fill divs carry a dotted-path data-bind-width binding  [R-29].
+
+        Issue #447: the legacy ``data-field="fill"`` attribute was a bare
+        path that ``resolve(state, "fill")`` could never find — silent
+        no-op in the polling cycle.  The completed/remaining segments now
+        bind via ``data-bind-width="rail.<phase_label>.{completed,remaining}_pct"``
+        so the polling JS can update ``style.width`` from the live state.
+        """
         phases_data = _make_phases_data([[1, 2]])
         state_data = _make_state_data([1])
         result = render_progress_rail(phases_data, state_data)
-        assert 'data-field="fill"' in result
+        assert 'data-bind-width="rail.phase-1.completed_pct"' in result
+        assert 'data-bind-width="rail.phase-1.remaining_pct"' in result
+        # Legacy bare path must not regress.
+        assert 'data-field="fill"' not in result
 
     def test_data_rail_phase_on_all_phases(self) -> None:
         """Four phases → data-rail-phase attributes for all four."""


### PR DESCRIPTION
## Summary

Two data-field bindings used bare paths (`value`, `fill`) that `resolve(state, ...)` could never find — silently no-op'd by the polling guard, so gauge values and rail fills froze between HTML regenerations.

## Changes

- New `derived_state.compute_derived_state()` snapshots gauges + rail percentages into a stable dotted-path shape.
- `_regenerate_dashboard` splices the snapshot into `state.json` so polling sees fresh values.
- `gauge_cards` bindings: `data-field="value"` → `gauges.<name>.value`.
- `progress_rail` bindings: `data-field="fill"` → `data-bind-width` with `rail.<phase>.{completed,remaining}_pct`.
- `polling.js` extended with `[data-bind-width]` handler.
- 22 new tests; existing data-field assertions migrated.

Closes #447