### PR TITLE
feat(skills): conditional recipe injection for cross-repo wave detection

### DIFF
--- a/skills/_shared/recipes/cross-repo-wave-orchestration.md
+++ b/skills/_shared/recipes/cross-repo-wave-orchestration.md
@@ -1,0 +1,167 @@
+# Cross-Repo Wave Orchestration Recipe
+
+A **cross-repo wave** is one whose sub-issues live in a *different* repo than
+the orchestrator's working directory (`CLAUDE_PROJECT_DIR`). Example: the wave
+plan lives in `claudecode-workflow` (because the epic does) but every story
+modifies code in `mcp-server-sdlc`. This is the standard shape for sdlc-mcp
+migration epics.
+
+The default `/nextwave` flow assumes same-repo execution. Cross-repo waves
+require a handful of adjustments — none of them obvious the first time you
+hit them. This file is the **canonical recipe**. Both `/prepwaves` and
+`/nextwave` `cat` from here on demand.
+
+## Plan-JSON schema additions
+
+When `/prepwaves` detects sub-issue refs that don't match the orchestrator's
+current repo, it sets two optional fields on each cross-repo phase in the
+wave plan JSON:
+
+```json
+{
+  "name": "Origin Operations (Phase 1)",
+  "cross_repo": true,
+  "target_repos": ["Wave-Engineering/mcp-server-sdlc"],
+  "waves": [...]
+}
+```
+
+- `cross_repo` (bool) — flag set when *any* sub-issue in the phase resolves
+  to a repo different from the orchestrator's project repo.
+- `target_repos` (string[]) — distinct list of `owner/repo` slugs across the
+  phase's sub-issues. Usually one entry; multi-target is allowed.
+
+Single-repo phases omit both fields. `wave-status init` round-trips them via
+the existing whole-plan persistence path (the JSON is written verbatim as
+`phases-waves.json` — extra keys are preserved without modification).
+
+## Seven non-obvious facts
+
+1. **`Agent` tool's `isolation: "worktree"` only works on the *current* repo.**
+   It creates worktrees of `CLAUDE_PROJECT_DIR`, not an arbitrary target. You
+   cannot use it to spawn parallel sub-agents in a different repo.
+2. **A single git checkout can only have one branch active at a time.** N
+   parallel sub-agents cannot each `git checkout` a different branch in the
+   same clone — they would race the working-tree state. You need N
+   independent working trees.
+3. **`git worktree add` is the cheap solution.** It creates an additional
+   working tree at a separate filesystem path with its own `HEAD`, sharing
+   the underlying `.git` directory. No full-clone overhead. Each worktree
+   can have a different branch checked out simultaneously.
+4. **The orchestrator (parent agent) must pre-create the worktrees.**
+   Sub-agents must not create their own — race conditions and naming
+   conflicts. Pre-create all N up front, one per issue, before spawning any
+   execution agents.
+5. **Sub-agents are pointed at worktree paths via their prompt, not via
+   `Agent` tool flags.** Each Flight prompt includes "Your working directory
+   is `/tmp/wt-<slug>-<num>`. Use absolute paths or `cd` to that directory
+   before any git/file operations." **No `isolation:` flag on the `Agent`
+   call.**
+6. **`gh`/`glab` commands must be repo-scoped via
+   `-R Wave-Engineering/<target-repo>`.** Since the orchestrator is not
+   running from the target repo's directory, every `gh issue view`,
+   `gh pr create`, `gh pr merge`, etc. needs `-R`. Do not rely on cwd-based
+   repo detection.
+7. **`wave-status` state stays in the master plan repo** (where the epic
+   lives), not the target repo. The wave-status CLI walks
+   `.claude/status/phases-waves.json` from `CLAUDE_PROJECT_DIR`.
+   Orchestrator and sub-agents have *different* working directories — that
+   is correct and intentional.
+
+## Recipe
+
+### Pre-flight target-repo setup (orchestrator, before Step 1)
+
+```bash
+TARGET_REPO=/home/bakerb/sandbox/github/mcp-server-sdlc
+
+# Verify target repo is clean and on main (or kahuna_branch if KAHUNA wave)
+git -C "$TARGET_REPO" status --short
+git -C "$TARGET_REPO" checkout main
+git -C "$TARGET_REPO" pull
+```
+
+### Worktree creation loop (one per issue)
+
+```bash
+for issue in 76 77 78 79 80 81 82 83 84 85 86 87 88 89; do
+  slug="$(gh issue view "$issue" -R Wave-Engineering/mcp-server-sdlc --json title --jq '.title' \
+          | sed 's/.*: //; s/[^a-zA-Z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//' \
+          | tr '[:upper:]' '[:lower:]' | cut -c1-40)"
+  branch="feature/${issue}-${slug}"
+  worktree="/tmp/wt-sdlc-${issue}"
+  git -C "$TARGET_REPO" worktree add "$worktree" -b "$branch" origin/main
+  # Worktrees lack node_modules — install dependencies if the project needs them
+  ( cd "$worktree" && bun install ) || true
+done
+```
+
+For KAHUNA waves, replace `origin/main` with `origin/<kahuna_branch>`.
+
+### Sub-agent prompt template snippet
+
+In the per-issue Flight prompt, drop in (replacing `<num>` and `<slug>`):
+
+```
+Your working directory is /tmp/wt-sdlc-<num> (use absolute paths or cd into it before any git/file operations).
+Your branch is feature/<num>-<slug> (already checked out in the worktree).
+
+For any GitHub interactions, repo-scope every command:
+  gh issue view <num> -R Wave-Engineering/mcp-server-sdlc
+  gh pr create   -R Wave-Engineering/mcp-server-sdlc ...
+  gh pr merge    -R Wave-Engineering/mcp-server-sdlc ...
+
+Run validation in the worktree:
+  cd /tmp/wt-sdlc-<num> && ./scripts/ci/validate.sh
+```
+
+**Do NOT pass `isolation: "worktree"` on the `Agent` call.** The pre-created
+worktree IS the isolation.
+
+### Per-agent commit / push / PR / merge (Prime(post-flight) or orchestrator)
+
+```bash
+git -C /tmp/wt-sdlc-<num> add <files>
+git -C /tmp/wt-sdlc-<num> commit -m "type(scope): description
+
+Closes #<num>"
+git -C /tmp/wt-sdlc-<num> push -u origin feature/<num>-<slug>
+
+gh pr create -R Wave-Engineering/mcp-server-sdlc \
+  --base main --head feature/<num>-<slug> \
+  --title "..." --body "..."
+
+gh pr merge <pr-num> -R Wave-Engineering/mcp-server-sdlc \
+  --squash --auto --delete-branch
+```
+
+For KAHUNA waves, swap `--base main` for `--base <kahuna_branch>` — every
+Flight PR targets the kahuna branch, never `main` (Dev Spec §5.2.2).
+
+### Post-wave worktree cleanup
+
+```bash
+for wt in /tmp/wt-sdlc-*; do
+  git -C "$TARGET_REPO" worktree remove "$wt" --force
+done
+```
+
+Run this after `wave_complete()` lands and the bus has been cleaned.
+
+## What can go wrong
+
+- **Forgetting `-R` on `gh`/`glab` commands** — they fail with "no PRs
+  found" or operate on the wrong repo silently. Every cross-repo `gh`
+  invocation needs `-R Wave-Engineering/<target-repo>`.
+- **Not pre-creating worktrees** — sub-agents racing each other to
+  `git checkout` will leave the target repo in a broken state (detached
+  HEAD, half-applied stashes). Pre-create all N before spawning Flights.
+- **Accidentally using `isolation: "worktree"` on the `Agent` call** — you
+  get a worktree of the *orchestrator's* repo (e.g. `claudecode-workflow`),
+  not the target repo. The Flight ends up in the wrong codebase entirely
+  and every file path it writes is wrong.
+- **Confusing orchestrator cwd with sub-agent cwd** — the orchestrator
+  stays in the master plan repo so `wave_show`, `wave_complete`, and
+  `wave-status` resolve against the right `.claude/status/`. Sub-agents
+  work in their assigned target-repo worktrees. Both are correct; mixing
+  them up corrupts wave state.

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -155,6 +155,15 @@ Run this after `wave_complete()` lands and the bus has been cleaned (Step 5).
 ## Step 1 — Orchestrator pre-flight
 
 1. `wave_preflight()` → `wave_next_pending()` → resolve wave id `N` and the issue list. If none, report and exit.
+1a. **Cross-repo recipe re-emit.** Read the active phase from `.claude/status/phases-waves.json` (the phase containing wave `N`). If the phase has `cross_repo: true`, `cat` `skills/_shared/recipes/cross-repo-wave-orchestration.md` into your context now and emit it as a preflight section formatted as:
+
+   ```
+   ## Cross-Repo Recipe (auto-loaded because Wave <N> spans repos: <target_repos>)
+
+   <recipe content here>
+   ```
+
+   This handles the multi-session case: `/prepwaves` may have run in a different session and its scrollback is gone. The recipe content lives in one place — both skills `cat` from the same file. Single-repo waves skip this step entirely.
 2. Resolve **target repo slug** for the bus path. Same-repo waves: use the current repo's slug. Cross-repo waves (wave plan lives in this repo, stories live elsewhere): use the target repo's slug per `lesson_cross_repo_wave_orchestration.md`.
 3. **Emit observability anchor.** Run `scripts/mcp-log wave_start wave=<N> target=<repo-slug> issues=<COMPACT JSON array, no spaces, e.g. [418,419,420]>` so this anchor *precedes* every per-issue `spec_validate_structure`, `wave_show`, and `wave_previous_merged` call below — that ordering is what makes post-mortem temporal correlation work. The `kahuna` field is added later (Step 1.5) once `wave_show` has been called; it is fine for the initial `wave_start` to omit it.
 4. Verify main is clean in the target repo; `wave_previous_merged()` confirms prior wave landed; `spec_validate_structure(issue)` for each issue in the wave.

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -21,9 +21,19 @@ Analyze one or more epic issues, validate their sub-issue specs, compute depende
 1. **Inputs.** Master issue numbers passed by the user (`/prepwaves #2` or `/prepwaves #2 #3 ...`). Each epic becomes one phase.
 2. **Pre-flight readiness table.** For each epic: call `epic_sub_issues(N)`; for each child call `spec_validate_structure(N)`. Present a table (Issue | Title | Deps | Changes | Tests | AC | Ready?). If any sub-issue is not ready, stop and ask the user how to proceed.
 3. **Compute waves.** Call `wave_compute(epic_ref)` to get the topologically-sorted wave plan, then `wave_topology(...)` to classify. Present the wave plan (waves, issues, dependency chain, branch naming `feature/<N>-<desc>`).
-4. **Approval gate.** Wait for explicit user approval. Iterate on the plan here — not during `/nextwave`.
-5. **Persist.** Call `wave_init(plan_json)` — the tool auto-detects existing plans and uses extend mode, preserving completed waves. Use phase-prefixed wave IDs (e.g., `wave-2a`) to avoid collisions when extending.
-6. **Confirm.** Report wave count, issue count, readiness summary, and "Run `/nextwave` to begin execution."
+4. **Cross-repo detection.** For each phase about to be persisted, walk every sub-issue's ref. Resolve each ref's `owner/repo` (per-issue `repo` field, else plan-level `repo`, else the orchestrator's current project repo). Collect distinct repo slugs that differ from the orchestrator's project repo. If the set is non-empty, set `cross_repo: true` and `target_repos: [<slug>, ...]` on that phase in the plan JSON. Single-repo phases leave both fields unset. Cheap — no extra LLM calls; pure walk over refs already in `wave_compute`'s output.
+5. **Approval gate.** Wait for explicit user approval. Iterate on the plan here — not during `/nextwave`.
+6. **Persist.** Call `wave_init(plan_json)` — the tool auto-detects existing plans and uses extend mode, preserving completed waves. Use phase-prefixed wave IDs (e.g., `wave-2a`) to avoid collisions when extending. Cross-repo fields (`cross_repo`, `target_repos`) round-trip without modification (the underlying `wave-status init` writes the plan dict verbatim to `phases-waves.json`).
+7. **Conditional recipe injection.** If any prepped phase has `cross_repo: true`, append the cross-repo recipe to this skill's output by `cat`ing `skills/_shared/recipes/cross-repo-wave-orchestration.md`. Format:
+
+   ```
+   ## Cross-Repo Recipe (auto-loaded because Phase X spans repos: <target_repos>)
+
+   <recipe content here>
+   ```
+
+   Single-repo runs skip this step entirely — no context bloat. The recipe's content lives in one place; both `/prepwaves` (here) and `/nextwave` (preflight) `cat` from the same file.
+8. **Confirm.** Report wave count, issue count, readiness summary, cross-repo status (if any), and "Run `/nextwave` to begin execution."
 
 ## Reasoning Rules (Preserve)
 

--- a/tests/test_wave_status.py
+++ b/tests/test_wave_status.py
@@ -803,6 +803,190 @@ class TestExtendAutoAdvance:
 
 
 # ---------------------------------------------------------------------------
+# Cross-repo plan field round-trip (issue #319)
+# ---------------------------------------------------------------------------
+
+class TestCrossRepoPlanRoundTrip:
+    """``wave-status init`` accepts and round-trips ``cross_repo`` and
+    ``target_repos`` fields on phases without dropping or modifying them.
+
+    These fields are populated by ``/prepwaves``' cross-repo detection step
+    so that ``/nextwave`` can read them back at preflight and conditionally
+    inject the cross-repo orchestration recipe. The CLI must persist them
+    to ``phases-waves.json`` verbatim — no schema gate, no rewrite.
+    """
+
+    _CROSS_REPO_PLAN: dict = {
+        "project": "test-cross-repo",
+        "base_branch": "main",
+        "master_issue": 200,
+        "phases": [
+            {
+                "name": "Cross-Repo Phase",
+                "cross_repo": True,
+                "target_repos": ["Wave-Engineering/mcp-server-sdlc"],
+                "waves": [
+                    {
+                        "id": "wave-1",
+                        "name": "Wave 1",
+                        "issues": [
+                            {
+                                "number": 76,
+                                "title": "Cross-repo issue 76",
+                                "deps": [],
+                                "repo": "Wave-Engineering/mcp-server-sdlc",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "name": "Same-Repo Phase",
+                "waves": [
+                    {
+                        "id": "wave-2",
+                        "name": "Wave 2",
+                        "issues": [
+                            {"number": 7, "title": "Local issue 7", "deps": []},
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    _MULTI_TARGET_PLAN: dict = {
+        "project": "test-multi-target",
+        "base_branch": "main",
+        "master_issue": 300,
+        "phases": [
+            {
+                "name": "Multi-Target Cross-Repo Phase",
+                "cross_repo": True,
+                "target_repos": [
+                    "Wave-Engineering/mcp-server-sdlc",
+                    "Wave-Engineering/mcp-server-nerf",
+                ],
+                "waves": [
+                    {
+                        "id": "wave-1",
+                        "name": "Wave 1",
+                        "issues": [
+                            {
+                                "number": 10,
+                                "title": "Issue in sdlc",
+                                "deps": [],
+                                "repo": "Wave-Engineering/mcp-server-sdlc",
+                            },
+                            {
+                                "number": 20,
+                                "title": "Issue in nerf",
+                                "deps": [],
+                                "repo": "Wave-Engineering/mcp-server-nerf",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    def _read_phases(self, repo: Path) -> dict:
+        phases_path = repo / ".claude" / "status" / "phases-waves.json"
+        return json.loads(phases_path.read_text(encoding="utf-8"))
+
+    def test_init_round_trips_cross_repo_fields(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """init persists cross_repo + target_repos verbatim on the cross-repo
+        phase, leaves the same-repo phase unchanged (no spurious fields)."""
+        repo = temp_git_repo
+        _write_plan(repo, self._CROSS_REPO_PLAN)
+
+        rc, _, err = run_cli(["init", "plan.json"], repo)
+        assert rc == 0, f"init failed: {err}"
+
+        persisted = self._read_phases(repo)
+        assert persisted["phases"][0]["cross_repo"] is True
+        assert persisted["phases"][0]["target_repos"] == [
+            "Wave-Engineering/mcp-server-sdlc",
+        ]
+        # Same-repo phase MUST NOT be polluted with the new fields.
+        assert "cross_repo" not in persisted["phases"][1]
+        assert "target_repos" not in persisted["phases"][1]
+
+    def test_init_round_trips_multi_target_repos(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """A phase with multiple target repos round-trips the full list in
+        order, no de-dup or sort the agent didn't ask for."""
+        repo = temp_git_repo
+        _write_plan(repo, self._MULTI_TARGET_PLAN)
+
+        rc, _, err = run_cli(["init", "plan.json"], repo)
+        assert rc == 0, f"init failed: {err}"
+
+        persisted = self._read_phases(repo)
+        assert persisted["phases"][0]["cross_repo"] is True
+        assert persisted["phases"][0]["target_repos"] == [
+            "Wave-Engineering/mcp-server-sdlc",
+            "Wave-Engineering/mcp-server-nerf",
+        ]
+
+    def test_init_extend_round_trips_cross_repo_fields(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """init --extend appending a cross-repo phase preserves both
+        new-phase cross_repo fields and the existing phases verbatim."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        rc, _, err = run_cli(["init", "plan.json"], repo)
+        assert rc == 0, f"init failed: {err}"
+
+        # Extend with a cross-repo phase that has no wave/issue overlap
+        # against the sample plan (sample uses wave-1..3, issues 1..13;
+        # extension uses wave-9 and issue 999).
+        extend_plan: dict = {
+            "phases": [
+                {
+                    "name": "Late-Added Cross-Repo Phase",
+                    "cross_repo": True,
+                    "target_repos": ["Wave-Engineering/mcp-server-sdlc"],
+                    "waves": [
+                        {
+                            "id": "wave-9",
+                            "name": "Wave 9",
+                            "issues": [
+                                {
+                                    "number": 999,
+                                    "title": "Late issue",
+                                    "deps": [],
+                                    "repo": "Wave-Engineering/mcp-server-sdlc",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+        extend_path = repo / "extend.json"
+        extend_path.write_text(json.dumps(extend_plan), encoding="utf-8")
+
+        rc, _, err = run_cli(["init", "--extend", "extend.json"], repo)
+        assert rc == 0, f"extend failed: {err}"
+
+        persisted = self._read_phases(repo)
+        # Original two phases unchanged (no cross_repo).
+        assert "cross_repo" not in persisted["phases"][0]
+        assert "cross_repo" not in persisted["phases"][1]
+        # Newly-appended phase carries both fields verbatim.
+        assert persisted["phases"][2]["cross_repo"] is True
+        assert persisted["phases"][2]["target_repos"] == [
+            "Wave-Engineering/mcp-server-sdlc",
+        ]
+
+
+# ---------------------------------------------------------------------------
 # No external dependencies test [CT-01]
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Introduces a "detect → persist → conditionally inject" pattern for orchestration knowledge that's only relevant in a subset of wave runs. Cross-repo waves are the first recipe shipped under this convention.

## Changes

- New `skills/_shared/recipes/cross-repo-wave-orchestration.md` — canonical source for the seven non-obvious cross-repo facts, bash recipe, and pitfalls. Both `/prepwaves` and `/nextwave` cat from this single file.
- `/prepwaves`: detect cross-repo phases by walking sub-issue refs against the orchestrator's project repo; set `cross_repo` + `target_repos` on each affected phase in the plan JSON; cat the recipe into output when the flag fires.
- `/nextwave`: preflight step reads `phases-waves.json` for the active phase; if `cross_repo: true`, re-emit the recipe (handles multi-session case where `/prepwaves`' scrollback is gone).
- `tests/test_wave_status.py`: three new round-trip tests covering single cross-repo phase, multi-target cross-repo phase, and `init --extend` with a cross-repo phase appended.

Single-repo runs see no extra context; cross-repo runs see exactly the recipe they need at the moment they need it. `wave-status init` round-trips the new fields verbatim via the existing whole-plan persistence path — no schema gate needed.

## Linked Issues

Closes #319

## Test Plan

- [x] `tests/test_wave_status.py` — three new round-trip tests pass locally
- [x] CI green