### PR TITLE
chore(changelog): aggregate P3W1 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **wavemachine skill**: rename epic→Plan/Phase; add Exhaustive Legal Exits section per Dev Spec §5.3.3. [#512, Story 3.1]
+- **nextwave skill**: rename epic→Plan/Phase; add Exhaustive Legal Exits section per Dev Spec §5.3.3. [#513, Story 3.2]
 - **Refactored `vox` around the provider-hook pattern.** The previous `scripts/vox-tts` embedded five coupled backends (VOX_COMMAND, VOX_ENDPOINT, espeak, piper, say) in one cascade; it has been removed. `scripts/vox` is now a thin dispatcher that resolves a *provider* (synthesis) and a *player* (playback) at runtime. Providers live in `~/.config/vox/provider`; copy-and-adapt examples ship in `scripts/vox-providers/` (`silent.sh`, `openai-endpoint.sh`, `piper-local.sh`, `espeak.sh`, `macos-say.sh`). Contract documented in `scripts/vox-providers/README.md` (VOX_PROVIDER_CONTRACT=1). Closes #398.
 
   **Migration (existing vox users)**: your prior `VOX_COMMAND` / `VOX_ENDPOINT` settings no longer auto-dispatch. Run `vox --setup` once to pick a provider, or manually:


### PR DESCRIPTION
## Summary

Aggregates CHANGELOG fragments from wave P3W1 flight 1 into the `[Unreleased]` section under `### Changed`.

Targets the `kahuna/499-phase-epic-taxonomy` sandbox branch (SAME-repo KAHUNA wave).

## Changes

- `CHANGELOG.md`: 2 entries added to `[Unreleased] → Changed`
  - wavemachine skill rename/exits (#512)
  - nextwave skill rename/exits (#513)

## Linked Issues

Closes cc-workflow#524 (aggregation pattern reference).

## Test Plan

- [x] Fragments read from `/tmp/wavemachine/claudecode-workflow/wave-P3W1/flight-1/issue-{512,513}/CHANGELOG.fragment.md`
- [x] Issue-number ordering preserved (512 before 513)
- [x] Base ref is `kahuna/499-phase-epic-taxonomy`, not `main`
