### PR TITLE
refactor(prepwaves): rename epic→Plan/Phase

### DIFF
--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -5,11 +5,11 @@ description: Analyze a master issue, validate sub-issue specs, compute dependenc
 
 # PrepWaves — Plan Wave Execution
 
-Analyze one or more epic issues, validate their sub-issue specs, compute dependency-ordered waves, and persist the plan so `/nextwave` can execute it. Supports parallel, serial, and mixed topologies.
+Analyze one or more Plan tracking issues, validate their sub-issue specs, compute dependency-ordered waves, and persist the plan so `/nextwave` can execute it. Supports parallel, serial, and mixed topologies.
 
 ## Tools Used
 
-- `mcp__sdlc-server__epic_sub_issues` — enumerate children of an epic
+- `mcp__sdlc-server__epic_sub_issues` — enumerate children of a Plan tracking issue (the tool name is a historical identifier; it enumerates sub-issues of any parent, and `/prepwaves` calls it on the Plan)
 - `mcp__sdlc-server__spec_validate_structure` — pre-flight check each sub-issue's shape (Changes / Tests / Acceptance / Dependencies)
 - `mcp__sdlc-server__spec_dependencies` — extract declared edges
 - `mcp__sdlc-server__wave_compute` — topological sort into waves
@@ -18,13 +18,13 @@ Analyze one or more epic issues, validate their sub-issue specs, compute depende
 
 ## Procedure
 
-1. **Inputs.** Master issue numbers passed by the user (`/prepwaves #2` or `/prepwaves #2 #3 ...`). Each epic becomes one phase.
-2. **Pre-flight readiness table.** For each epic: call `epic_sub_issues(N)`; for each child call `spec_validate_structure(N)`. Present a table (Issue | Title | Deps | Changes | Tests | AC | Ready?). If any sub-issue is not ready, stop and ask the user how to proceed.
-3. **Compute waves.** Call `wave_compute(epic_ref)` to get the topologically-sorted wave plan, then `wave_topology(...)` to classify. Present the wave plan (waves, issues, dependency chain, branch naming `feature/<N>-<desc>`).
-4. **Cross-repo detection.** For each phase about to be persisted, walk every sub-issue's ref. Resolve each ref's `owner/repo` (per-issue `repo` field, else plan-level `repo`, else the orchestrator's current project repo). Collect distinct repo slugs that differ from the orchestrator's project repo. If the set is non-empty, set `cross_repo: true` and `target_repos: [<slug>, ...]` on that phase in the plan JSON. Single-repo phases leave both fields unset. Cheap — no extra LLM calls; pure walk over refs already in `wave_compute`'s output.
+1. **Inputs.** Plan tracking-issue numbers passed by the user (`/prepwaves #2` or `/prepwaves #2 #3 ...`). Each Plan becomes one Phase in `phases-waves.json`.
+2. **Pre-flight readiness table.** For each Plan: call `epic_sub_issues(N)` (tool name is a historical identifier — the call enumerates the Plan's sub-issues); for each child call `spec_validate_structure(N)`. Present a table (Issue | Title | Deps | Changes | Tests | AC | Ready?). If any sub-issue is not ready, stop and ask the user how to proceed.
+3. **Compute waves.** Call `wave_compute(epic_ref)` (param name is historical — pass the Plan's issue ref) to get the topologically-sorted wave plan, then `wave_topology(...)` to classify. Present the wave plan (waves, issues, dependency chain, branch naming `feature/<N>-<desc>`).
+4. **Cross-repo detection.** For each Phase about to be persisted, walk every sub-issue's ref. Resolve each ref's `owner/repo` (per-issue `repo` field, else plan-level `repo`, else the orchestrator's current project repo). Collect distinct repo slugs that differ from the orchestrator's project repo. If the set is non-empty, set `cross_repo: true` and `target_repos: [<slug>, ...]` on that Phase in the plan JSON. Single-repo Phases leave both fields unset. Cheap — no extra LLM calls; pure walk over refs already in `wave_compute`'s output.
 5. **Approval gate.** Wait for explicit user approval. Iterate on the plan here — not during `/nextwave`.
-6. **Persist.** Call `wave_init(plan_json)` — the tool auto-detects existing plans and uses extend mode, preserving completed waves. Use phase-prefixed wave IDs (e.g., `wave-2a`) to avoid collisions when extending. Cross-repo fields (`cross_repo`, `target_repos`) round-trip without modification (the underlying `wave-status init` writes the plan dict verbatim to `phases-waves.json`).
-7. **Conditional recipe injection.** If any prepped phase has `cross_repo: true`, append the cross-repo recipe to this skill's output by `cat`ing `skills/_shared/recipes/cross-repo-wave-orchestration.md`. Format:
+6. **Persist.** Call `wave_init(plan_json)` — the tool auto-detects existing plans and uses extend mode, preserving completed waves. Use Phase-prefixed wave IDs (e.g., `wave-2a`) to avoid collisions when extending. Cross-repo fields (`cross_repo`, `target_repos`) round-trip without modification (the underlying `wave-status init` writes the plan dict verbatim to `phases-waves.json`).
+7. **Conditional recipe injection.** If any prepped Phase has `cross_repo: true`, append the cross-repo recipe to this skill's output by `cat`ing `skills/_shared/recipes/cross-repo-wave-orchestration.md`. Format:
 
    ```
    ## Cross-Repo Recipe (auto-loaded because Phase X spans repos: <target_repos>)

--- a/tests/skills/test_prepwaves_structure.sh
+++ b/tests/skills/test_prepwaves_structure.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# test_prepwaves_structure.sh — structural regression tests for
+# skills/prepwaves/SKILL.md per Dev Spec §8 Story 3.3 (phase-epic-taxonomy).
+#
+# Covers the one unit test called out in the issue body:
+#   - test_prepwaves_no_unqualified_epic: `\bepic\b` (case-insensitive) in the
+#     pipeline-operational contexts of the skill body returns zero. [R-11]
+#
+# Scope: asserts structural absence of unqualified "epic" prose. Tool/param
+# identifiers like `epic_sub_issues` and `epic_ref` contain underscores, so
+# `\bepic\b` word-boundary matching does not flag them — they are code
+# references, not pipeline-layer vocabulary, and they stay.
+#
+# /prepwaves is a pre-wave planning tool, not an autonomy-loop skill, so no
+# Exhaustive Legal Exits section is required here (contrast: nextwave,
+# wavemachine).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SKILL="$REPO_DIR/skills/prepwaves/SKILL.md"
+
+FAILS=0
+
+fail() {
+	echo "  [FAIL] $*"
+	FAILS=$((FAILS + 1))
+}
+
+pass() {
+	echo "  [PASS] $*"
+}
+
+echo "test_prepwaves_structure"
+echo "──────────────────────────────────────────"
+
+if [[ ! -f "$SKILL" ]]; then
+	echo "  [FAIL] SKILL.md missing: $SKILL"
+	exit 1
+fi
+
+# --- test_prepwaves_no_unqualified_epic --------------------------------------
+# Per Dev Spec §3.3 and R-11: `\bepic\b` (case-insensitive) must return zero
+# in pipeline-operational contexts. /prepwaves is a pipeline skill (not PM
+# layer), so the skill body MUST NOT mention unqualified "epic" at all.
+# Tool/param identifiers with underscores (epic_sub_issues, epic_ref) are
+# not flagged by `\bepic\b` — the underscore is a word character.
+if grep -n -i '\bepic\b' "$SKILL" >/dev/null; then
+	grep -n -i '\bepic\b' "$SKILL" | sed 's/^/    /'
+	fail "test_prepwaves_no_unqualified_epic: 'epic' still present in SKILL.md"
+else
+	pass "test_prepwaves_no_unqualified_epic: no unqualified 'epic' in SKILL.md"
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+if [[ $FAILS -gt 0 ]]; then
+	echo "  $FAILS check(s) failed"
+	exit 1
+fi
+echo "  all checks passed"


### PR DESCRIPTION
## Summary

Rewrites `skills/prepwaves/SKILL.md` to remove unqualified "epic" from pipeline-operational contexts per Dev Spec §8 Story 3.3 (R-11). Adds a structural regression test mirroring the sibling `test_nextwave_structure.sh` pattern.

`/prepwaves` is a pre-wave planning tool that runs once per Plan, not an autonomy-loop skill — so **no Exhaustive Legal Exits section** is required (contrast: nextwave, wavemachine).

## Changes

- `skills/prepwaves/SKILL.md`: 4 unqualified "epic" prose references replaced with Plan/Phase equivalents:
  - Overview: "Plan tracking issues"
  - Tools Used: `epic_sub_issues` tool annotated as a historical identifier that enumerates a Plan's children
  - Procedure step 1: "Each Plan becomes one Phase in `phases-waves.json`"
  - Procedure step 2: "For each Plan: call `epic_sub_issues(N)` (tool name is a historical identifier — …)"
  - Procedure step 3: `wave_compute(epic_ref)` annotated — param name is historical; pass the Plan's issue ref
- Phase-capitalization pass in procedure steps 4, 6, 7 for narrative consistency with the new Plan/Phase/Wave/Story taxonomy.
- `tests/skills/test_prepwaves_structure.sh` (new): asserts `\bepic\b` (case-insensitive) returns zero in the SKILL body. Tool/param identifiers with underscores (`epic_sub_issues`, `epic_ref`) are not flagged by `\bepic\b` word-boundary matching — they are code references, not pipeline-layer vocabulary, and they stay.

## Linked Issues

Closes #514

## Test Plan

- [x] `./scripts/ci/validate.sh` — 114 passed, 0 failed
- [x] `tests/skills/test_prepwaves_structure.sh` — passes (zero `\bepic\b` matches in SKILL.md)
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- [x] Self-review: 4 prose edits + 1 new test; mechanical, on-spec; no high+ issues

## KAHUNA Sandbox

Wave P3W2, Phase 3 (Plan #499). Base ref `kahuna/499-phase-epic-taxonomy`. Precheck auto-approved via `[AUTO-APPROVED: kahuna sandbox]` sentinel per Dev Spec §5.2.1.