### PR TITLE
feat(issue): add type=plan + --epic N; on-demand label creation

### DIFF
--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: issue
-description: Create structured issues (feature, story, bug, chore, docs, epic) with proper templates and labels. Supports both GitHub (gh) and GitLab (glab). Self-contained — does not depend on CLAUDE.md for templates. Sub-issue templates (feature, story, chore, docs, bug) emit the H2 sections that `/prepwaves` and `spec_validate_structure` require, so issues are wave-pattern-ready on first try.
+description: Create structured issues (plan, epic, feature, story, bug, chore, docs) with proper templates and labels. Supports both GitHub (gh) and GitLab (glab). Self-contained — does not depend on CLAUDE.md for templates. Sub-issue templates (feature, story, chore, docs, bug) emit the H2 sections that `/prepwaves` and `spec_validate_structure` require, so issues are wave-pattern-ready on first try. The `plan` type emits the canonical Plan tracking-issue body per Dev Spec `phase-epic-taxonomy-devspec.md` §5.1.2, and Story creation accepts an optional `--epic N` flag that attaches the `epic::N` PM-layer label.
 usage: |
-  /issue feature <prompt>  Create a feature issue (alias: story)
-  /issue story <prompt>    Create a story issue (alias: feature)
-  /issue bug <prompt>      Create a bug issue
-  /issue chore <prompt>    Create a chore issue
-  /issue docs <prompt>     Create a docs issue
-  /issue epic <prompt>     Create an epic issue
-  /issue <prompt>          Infer type from the prompt
+  /issue plan <prompt>     Create a Plan tracking issue (canonical §5.1.2 body)
+  /issue epic <prompt>     Create an Epic parent tracker (PM-layer)
+  /issue feature <prompt>  Create a feature Story (alias: story)
+  /issue story <prompt>    Create a story Story (alias: feature)
+  /issue bug <prompt>      Create a bug Story
+  /issue chore <prompt>    Create a chore Story
+  /issue docs <prompt>     Create a docs Story
+  /issue <type> <prompt> --epic N  Attach epic::N PM-layer label to the Story
+  /issue <prompt>          Infer type from the prompt (never infers "plan")
   /issue                   Infer from recent conversation context
 ---
 
@@ -25,15 +27,36 @@ Create properly templated and labeled issues from a natural language prompt.
 ## Usage
 
 ```
-/issue feature <prompt>       Create a feature issue (alias: story)
-/issue story <prompt>          Create a story issue (alias: feature)
-/issue bug <prompt>            Create a bug issue
-/issue chore <prompt>          Create a chore issue
-/issue docs <prompt>           Create a docs issue
-/issue epic <prompt>           Create an epic issue
-/issue <prompt>                Infer type from the prompt
-/issue                         Infer from recent conversation context
+/issue plan <prompt>              Create a Plan tracking issue (canonical §5.1.2 body)
+/issue epic <prompt>              Create an Epic parent tracker (PM-layer)
+/issue feature <prompt>           Create a feature Story (alias: story)
+/issue story <prompt>             Create a story Story (alias: feature)
+/issue bug <prompt>               Create a bug Story
+/issue chore <prompt>             Create a chore Story
+/issue docs <prompt>              Create a docs Story
+/issue <type> <prompt> --epic N   Attach epic::N PM-layer label to the Story
+/issue <prompt>                   Infer type from the prompt (never infers "plan")
+/issue                            Infer from recent conversation context
 ```
+
+## Taxonomy Overview
+
+The `/issue` skill creates three distinct layers of issue, each with its own
+template and label family (authoritative source: `docs/phase-epic-taxonomy-devspec.md`
+§5.5, cross-ref `docs/kahuna-devspec.md` Terminology section):
+
+| Layer | Type | Label | Role |
+|-------|------|-------|------|
+| **Plan** | `plan` | `type::plan` | Top-level wave-pipeline tracking issue. Has a canonical frozen body; runtime state lives in comments. One Plan per `/devspec` walk. |
+| **Epic** | `epic` | `type::epic` | **PM-layer concept only.** A parent thematic tracker for human project management. The pipeline ignores `type::epic` and `epic::N` labels entirely (per Dev Spec R-03). |
+| **Story** | `feature`, `story`, `bug`, `chore`, `docs` | `type::<sub>` | The unit of implementable work — one issue, one branch, one PR/MR, one Flight. Optionally carries an `epic::N` label applied via `--epic N` on creation. |
+
+**Load-bearing distinction:** a Plan is not an Epic. A Plan is a pipeline
+artifact the Orchestrator reads; an Epic is a PM-layer grouping the pipeline
+never reads. If you find pipeline code inspecting `type::epic` or `epic::N`,
+it's a taxonomy leak (Dev Spec R-19). The two types share label colour
+`#5319E7` because they sit in the same visual family on the project board,
+not because they share any pipeline semantics.
 
 ## Wave-Pattern-Ready Output Guarantee
 
@@ -54,35 +77,57 @@ picked up by `/prepwaves` without mid-flight body fixes. If a particular
 section does not apply to a given issue, emit the heading with a single-line
 rationale (e.g. `None` or `N/A — because ...`); never omit the heading.
 
-The `epic` template is intentionally different — epics are parent issues
-that decompose into sub-issues, so they are not validated against the
-sub-issue grammar.
+The `plan` and `epic` templates are intentionally different:
+
+- **Plan** uses the canonical frozen-body template from Dev Spec §5.1.2
+  (Goal / Scope / Plan-level DoD / Phases / References). It's not validated
+  against the sub-issue grammar; it's the Orchestrator's worldview.
+- **Epic** is a PM-layer parent tracker; its body carries Goal / Scope /
+  sub-issue checklist for human reference. The pipeline ignores epics.
 
 See `docs/issue-body-grammar.md` in `mcp-server-sdlc` for the authoritative
-parser specification.
+parser specification (sub-issue grammar), and `docs/plan-issue-template.md`
+in this repo for the operator reference on Plan issues.
 
 ## Tools Used
+
 - `mcp__sdlc-server__work_item` — create issues cross-platform (handles GitHub/GitLab detection internally)
+- `mcp__sdlc-server__label_create` — on-demand label creation for `type::plan` and `epic::N` when the target repo doesn't yet carry them (Dev Spec R-14)
+- `mcp__sdlc-server__label_list` — optional pre-check that a label exists before `work_item`; the recommended pattern is to call `label_create` unconditionally and rely on its idempotent behaviour, but `label_list` is available if you need to inspect
+- `mcp__sdlc-server__work_item` (read path) — pre-check that `--epic N` references an existing open issue with `type::epic` label before creating the Story (Dev Spec §5.5.4 step 1)
 
 ## Step 1: Parse Arguments
 
 {{#if args}}
 Parse: `{{args}}`
 {{else}}
-No arguments — infer the issue from the most recent topic of conversation. Determine the type and content from context and create directly. State your interpretation in the report so the user can edit if the inference was wrong.
+No arguments — infer the issue from the most recent topic of conversation. Determine the type and content from context and create directly. State your interpretation in the report so the user can edit if the inference was wrong. Never infer `plan` — Plan creation is always intentional; if the conversation implies a Plan, ask explicitly.
 {{/if}}
 
-Extract two things:
-1. **Type** — the first word if it matches: `feature`, `story`, `bug`, `chore`, `docs`, `epic`. `feature` and `story` are aliases and use the same template. If it doesn't match a type, treat the entire argument as the prompt and infer the type.
-2. **Prompt** — everything after the type (or the entire argument if no type prefix).
+Extract three things:
 
-**Type inference rules** (when no explicit type):
+1. **Type** — the first word if it matches one of:
+   `plan`, `epic`, `feature`, `story`, `bug`, `chore`, `docs`.
+   `feature` and `story` are aliases and use the same sub-issue template.
+   If it doesn't match a type, treat the entire argument (minus flags) as the
+   prompt and infer the type from keywords (see table below).
+2. **`--epic N` flag** — optional flag anywhere after the type. When present
+   on a Story-type invocation (`feature`/`story`/`bug`/`chore`/`docs`),
+   captures the integer `N`. Invalid on `plan` and `epic` invocations — if
+   `--epic` appears with type=`plan` or type=`epic`, fail with a clear error.
+3. **Prompt** — everything after the type (or the entire argument if no type
+   prefix), with the `--epic N` token removed if present.
+
+**Type inference rules** (when no explicit type — never infers `plan`):
+
 - Mentions broken, fails, crash, error, wrong → `bug`
 - Mentions add, create, build, implement, new → `feature`
 - Mentions story, user story, sub-issue under epic → `story`
 - Mentions update, fix, clean, refactor, rename, move, upgrade → `chore`
 - Mentions document, write docs, README, guide → `docs`
-- Mentions epic, phase, milestone, multi-part → `epic`
+- Mentions epic, phase, milestone, multi-part, thematic parent → `epic`
+- Mentions plan, dev spec, kahuna, wave pipeline → **ask explicitly**; do not
+  infer `plan`. Creating a Plan tracking issue is intentional (Dev Spec §5.5.6).
 - Ambiguous → ask the user
 
 ## Step 2: Draft the Issue
@@ -90,6 +135,73 @@ Extract two things:
 Use the prompt (or conversation context) to fill in the appropriate template below. The agent should flesh out the template sections intelligently — don't just echo the prompt back. Think about what a spec-driven implementing agent would need.
 
 **Quality standard:** Every issue should be detailed enough that a spec-driven agent can execute without making design decisions. Implementation steps should read like paint-by-numbers. Acceptance criteria should be evaluable before PR/MR merge.
+
+### Plan Template
+
+**Authoritative source:** Dev Spec §5.1.2 (`docs/phase-epic-taxonomy-devspec.md`).
+Operator reference: `docs/plan-issue-template.md`.
+
+When `/issue plan <prompt>` is invoked:
+
+1. **Parse the prompt** into Plan metadata. Extract (via the same LLM reasoning
+   used for type inference):
+   - A one-sentence Goal.
+   - A suggested slug (kebab-case) from the Goal — used as a reminder only;
+     the kahuna branch name is chosen later by `/devspec`.
+   - Initial In-scope / Out-of-scope bullets as placeholders the Pair fills
+     during `/devspec create`.
+2. **Render the canonical body** verbatim using the template below. Every
+   heading is frozen content per §5.1.6 mutation rule 1; the body is hand-
+   edited during `/devspec create` and frozen at `/devspec approve`.
+   Post-creation, runtime state flows through comments (never the body) —
+   see `docs/plan-issue-template.md` for the comment typed-prefix table.
+3. **Title** is `Plan: <short name derived from prompt>`, matching the body's
+   `# Plan: <Name>` heading. If the inferred name is wrong, the Pair edits
+   the issue directly — cheaper than a re-invocation.
+4. **Post NO comments at creation.** Empty comment log is the correct initial
+   state (Dev Spec §5.1.6 rule 1). The Decision Ledger starts empty; entries
+   append during `/devspec create` and runtime.
+
+```markdown
+# Plan: <Name>
+
+<!-- PLAN-ISSUE v1 — frozen content only. Runtime state lives in comments. -->
+
+## Goal
+<one sentence describing what this Plan delivers>
+
+## Scope
+### In scope
+- <bullet>
+### Out of scope
+- <bullet>
+
+## Plan-level Definition of Done
+- [ ] Phase 1 DoD satisfied
+- [ ] Phase 2 DoD satisfied
+- [ ] (... one line per Phase)
+- [ ] Kahuna→main MR merged clean
+- [ ] VRTM complete
+- [ ] (... cross-cutting conditions)
+
+## Phases
+
+### Phase 1 — <Phase Name>
+**DoD:**
+- [ ] <verifiable condition> [R-XX]
+- [ ] <verifiable condition>
+
+### Phase 2 — <Phase Name>
+**DoD:**
+- [ ] <verifiable condition>
+
+### (... one section per Phase)
+
+## References
+- Dev Spec: `docs/<slug>-devspec.md`
+- Memory files: `decision_<topic>.md`, `principle_<topic>.md`
+- Related Plans: #NNN (if any)
+```
 
 ### Wave-Pattern Sub-Issue Templates
 
@@ -105,7 +217,7 @@ when a section is `None` or `N/A` — the parser only sees H2s.
 ## Summary
 
 [1-2 sentences: what this feature delivers and why. Include Context — background,
-motivation, link to Epic or Dev Spec if applicable — as a short sub-paragraph
+motivation, link to Plan or Dev Spec if applicable — as a short sub-paragraph
 under the Summary heading rather than a separate H2, so the parser sees the
 canonical Summary section.]
 
@@ -144,7 +256,7 @@ canonical Summary section.]
 ## Metadata
 
 **Wave:** [N or N/A]
-**Parent Epic:** [#NNN or N/A]
+**Plan:** [#NNN or N/A]
 **Wave Master:** [#NNN or N/A]
 ```
 
@@ -249,7 +361,7 @@ environment, or `N/A`]
 ## Metadata
 
 **Wave:** [N or N/A]
-**Parent Epic:** [#NNN or N/A]
+**Plan:** [#NNN or N/A]
 ```
 
 ### Docs Template
@@ -293,15 +405,22 @@ environment, or `N/A`]
 ## Metadata
 
 **Wave:** [N or N/A]
-**Parent Epic:** [#NNN or N/A]
+**Plan:** [#NNN or N/A]
 ```
 
-### Epic Template
+### Epic Template (PM-layer only)
+
+The `epic` type creates a `type::epic` parent tracker for **project-management
+thematic grouping**. It is a PM-layer concept: the wave-pipeline (Orchestrator,
+`/wavemachine`, `/nextwave`, `/prepwaves`) reads neither `type::epic` issues
+nor `epic::N` labels (Dev Spec R-03, R-19). Use `epic` when a human PM wants
+to group Stories thematically across multiple Plans or across none at all.
+**Do not confuse with `plan`** — Plans are pipeline artifacts, Epics are not.
 
 ```markdown
 ## Goal
 
-[One sentence: what this epic proves or delivers]
+[One sentence: what this epic proves or delivers (PM-thematic, not pipeline)]
 
 ## Scope
 
@@ -324,17 +443,15 @@ environment, or `N/A`]
 | 1 | #NNN | [title] | None |
 | 2 | #NNN | [title] | #NNN |
 
-## Wave Map
-
-| Wave | Issues | Parallel? |
-|------|--------|-----------|
-| 1 | #NNN | Single |
-| 2 | #NNN, #NNN | Yes |
-
 ## Success Metrics
 
 [Quantitative or qualitative measures of success]
 ```
+
+Epic issues created by this skill do NOT receive a `Wave Map` section; wave
+planning belongs to the Plan's `/devspec` → `/prepwaves` pipeline, not to the
+PM-layer Epic. If human users want a thematic grouping with a wave map, they
+can add one by hand after creation.
 
 ## Step 3: Determine Labels
 
@@ -344,12 +461,65 @@ Labels use the `group::value` convention. Within each group, labels are mutually
 
 | Type | Label |
 |------|-------|
+| plan | `type::plan` |
+| epic | `type::epic` |
 | feature | `type::feature` |
 | story | `type::story` |
 | bug | `type::bug` |
 | chore | `type::chore` |
 | docs | `type::docs` |
-| epic | `type::epic` |
+
+### `--epic N` Flag — Optional PM-Layer Label (Dev Spec §5.5.4)
+
+When a Story-type invocation (`feature`, `story`, `bug`, `chore`, `docs`)
+includes `--epic N`:
+
+1. **Pre-check `N` exists and is an Epic.** Call `work_item` (read path) to
+   fetch issue `#N` on the target repo. Assert it is open and carries the
+   `type::epic` label. If the issue doesn't exist, is closed, or lacks
+   `type::epic`, fail with a clear error message directing the Pair to first
+   create the Epic via `/issue epic <prompt>`. Do not create the Story.
+2. **Attach both labels** to the Story being created: `type::<subtype>` AND
+   `epic::N`.
+3. **On-demand label creation** for the `epic::N` label family — see
+   "On-demand label creation" below.
+4. **No comment is posted on the Epic issue.** The parent-child relationship
+   is represented by the `epic::N` label alone (Dev Spec §5.5.4 step 4).
+   The wave pipeline ignores both `type::epic` and `epic::N`; PMs who care
+   can filter the Epic's project board by its label.
+
+**`--epic N` is invalid with type=`plan` or type=`epic`.** A Plan is not an
+Epic sub-issue; an Epic is not attached to another Epic. If `--epic` appears
+on either of those invocations, fail before any create calls.
+
+### On-demand Label Creation (Dev Spec R-14 / §5.5.3 step 2)
+
+Two label families are created on-demand when absent from the target repo:
+
+| Label | Colour | Description | Created by |
+|-------|--------|-------------|------------|
+| `type::plan` | `#5319E7` | `"Plan tracking issue — top-level pipeline container"` | `/issue plan` invocations |
+| `epic::<N>` | `#5319E7` | `"Story belongs to Epic #N (PM-layer thematic grouping)"` (substitute `<N>`) | `/issue <story> --epic N` invocations |
+
+Both share colour `#5319E7` with `type::epic` — they sit in the same visual
+family on the project board. This does NOT mean the pipeline treats them
+alike; the colour is cosmetic, the semantics are different.
+
+**Procedure (applied before `work_item` creates the issue):**
+
+1. Call `mcp__sdlc-server__label_create` for the required label with its
+   canonical colour and description. The tool is idempotent — creating an
+   already-existing label succeeds silently. There is no need to pre-check
+   via `label_list`; the recommended pattern is unconditional `label_create`.
+2. If `label_create` fails for any reason OTHER than "already exists"
+   (e.g. permissions, platform outage), surface the error to the Pair and
+   abort the issue creation. Do not proceed to `work_item`.
+3. Once the label exists, proceed to `work_item` with both the type label
+   and (if applicable) the `epic::N` label in the label list.
+
+**Rationale for unconditional `label_create`.** It's one call either way;
+the pre-check-then-create pattern is two calls and is no safer. The tool's
+idempotent contract lets us skip the branch.
 
 ### Inferred Labels
 
@@ -359,9 +529,13 @@ Assess and apply values for these groups using judgment. Do not pause to confirm
 |-------|--------|---------------|
 | **Priority** | `priority::critical`, `priority::high`, `priority::medium`, `priority::low` | All issues |
 | **Urgency** | `urgency::immediate`, `urgency::soon`, `urgency::normal`, `urgency::eventual` | All issues |
-| **Size** | `size::S`, `size::M`, `size::L`, `size::XL` | Features, chores, docs (optional on bugs, omit for epics) |
+| **Size** | `size::S`, `size::M`, `size::L`, `size::XL` | Features, chores, docs (optional on bugs, omit for plans and epics) |
 | **Severity** | `severity::critical`, `severity::major`, `severity::minor`, `severity::cosmetic` | Bugs only |
-| **Wave** | `wave::1`, `wave::2`, etc. | Wave-planned issues only — omit otherwise |
+| **Wave** | `wave::1`, `wave::2`, etc. | Wave-planned Stories only — omit otherwise. Never applied to plan or epic types. |
+
+**Plan defaults.** A Plan typically gets `priority::medium`, `urgency::normal`,
+and no `size::` label (Plans are not sized — they decompose into Phases which
+decompose into Stories). The Pair can override after creation.
 
 **Priority vs Urgency are orthogonal:**
 - **Priority** = business value importance. How much does this matter?
@@ -373,9 +547,21 @@ Assess labels based on the content — do not ask the user to confirm each one. 
 
 Create immediately — do not ask for approval. Issues are cheap to edit and close. The user gave intent when they invoked `/issue`; the real review happens in the project board where the editing tools are better.
 
-Call `work_item` with the drafted title, body, and labels. The tool handles platform detection and issue creation internally — no `gh` or `glab` CLI calls.
+**Order of operations (all invocations):**
 
-If a label doesn't exist on the repo, the tool or platform will report it. Offer to create missing labels via CLI as a one-time setup step (label CRUD MCP tool is planned but not yet available).
+1. If the invocation is `/issue plan ...`, call `label_create` for `type::plan`
+   (idempotent, see Step 3 "On-demand label creation").
+2. If the invocation carries `--epic N`:
+   a. Call `work_item` (read path) on `#N` and verify it exists, is open,
+      and carries `type::epic`. Abort on failure.
+   b. Call `label_create` for `epic::N` (idempotent).
+3. Call `mcp__sdlc-server__work_item` with the drafted title, body, and the
+   full label list (type label + `epic::N` if applicable + inferred labels).
+   The tool handles platform detection and issue creation internally — no
+   `gh` or `glab` CLI calls.
+
+If `work_item` reports a missing label at create-time (race or pre-existing
+`epic::X` for a different `X`), surface the error; do not silently retry.
 
 ## Step 5: Report
 
@@ -385,7 +571,25 @@ Confirm creation with the issue number, URL, and a nudge to review:
 > Labels: `type::feature`, `priority::medium`, `urgency::normal`, `size::M`
 > Review and edit: `<issue URL>`
 
-When creating multiple issues in a batch (e.g., epic decomposition), report all of them at the end in a table rather than one at a time:
+For a Plan invocation:
+
+> Created Plan **#NNN** — `Plan: <Name>`
+> Labels: `type::plan`, `priority::medium`, `urgency::normal`
+> Body: canonical §5.1.2 template (Goal / Scope / DoD / Phases / References)
+> Comments: none (correct initial state per Dev Spec §5.1.6 rule 1)
+> Next: run `/devspec create <N>` to begin the Dev Spec walk.
+> Review and edit: `<issue URL>`
+
+For a Story invocation with `--epic N`:
+
+> Created **#NNN** — `feat(scope): description`
+> Labels: `type::feature`, `epic::42`, `priority::medium`, `urgency::normal`, `size::M`
+> Epic: #42 (PM-layer thematic grouping; pipeline ignores)
+> Review and edit: `<issue URL>`
+
+When creating multiple issues in a batch (e.g., Plan decomposition from a
+devspec walk), report all of them at the end in a table rather than one at a
+time:
 
 > | # | Title | Labels |
 > |---|-------|--------|
@@ -394,15 +598,18 @@ When creating multiple issues in a batch (e.g., epic decomposition), report all 
 >
 > Review in your project board: `<project URL>`
 
-## Label Color Reference
+## Label Colour Reference
 
-When creating labels, use these colors for consistency. **Note:** `gh` expects hex without `#` prefix; `glab` expects it with `#`.
+When creating labels, use these colours for consistency. **Note:** `gh` expects hex without `#` prefix; `glab` expects it with `#`. The `mcp__sdlc-server__label_create` tool handles platform translation; pass the `#`-prefixed form.
 
-| Group | Color (glab) | Color (gh) |
-|-------|-------------|------------|
-| `type::` | `#0E8A16` | `0E8A16` |
+| Group | Colour (glab / label_create) | Colour (gh) |
+|-------|------------------------------|-------------|
+| `type::plan` | `#5319E7` | `5319E7` |
+| `type::epic` | `#5319E7` | `5319E7` |
+| `type::<story-subtype>` | `#0E8A16` | `0E8A16` |
 | `priority::` | `#D93F0B` | `D93F0B` |
 | `urgency::` | `#FBCA04` | `FBCA04` |
 | `size::` | `#1D76DB` | `1D76DB` |
 | `severity::` | `#B60205` | `B60205` |
 | `wave::` | `#5319E7` | `5319E7` |
+| `epic::<N>` | `#5319E7` | `5319E7` |

--- a/tests/skills/test_issue_epic_flag.sh
+++ b/tests/skills/test_issue_epic_flag.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# test_issue_epic_flag.sh — structural regression tests for the `--epic N`
+# flag on skills/issue/SKILL.md per Dev Spec §5.5.4.
+#
+# Covers `test_issue_epic_flag` called out in issue #516:
+#   - `/issue feature --epic 42` applies both labels (type::feature, epic::42)
+#   - Pre-check on Epic existence is documented
+#   - --epic is invalid on plan/epic invocations
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SKILL="$REPO_DIR/skills/issue/SKILL.md"
+
+FAILS=0
+
+fail() {
+	echo "  [FAIL] $*"
+	FAILS=$((FAILS + 1))
+}
+
+pass() {
+	echo "  [PASS] $*"
+}
+
+echo "test_issue_epic_flag"
+echo "──────────────────────────────────────────"
+
+if [[ ! -f "$SKILL" ]]; then
+	echo "  [FAIL] SKILL.md missing: $SKILL"
+	exit 1
+fi
+
+# --- --epic flag recognition -------------------------------------------------
+if grep -qE '\-\-epic N|\-\-epic <N>|\-\-epic [0-9]+' "$SKILL"; then
+	pass "'--epic N' flag documented"
+else
+	fail "'--epic N' flag not documented"
+fi
+
+# Section heading for the flag's mechanics.
+if grep -qE '^### .*--epic N' "$SKILL"; then
+	pass "'--epic N' flag mechanics section present"
+else
+	fail "'--epic N' flag mechanics section missing"
+fi
+
+# --- Both labels applied (Dev Spec §5.5.4 step 2) ----------------------------
+# Look for mention that both type::<subtype> AND epic::N are attached.
+if grep -qE 'type::.*(AND|and|\+).*epic::|epic::.*(AND|and|\+).*type::|both labels' "$SKILL"; then
+	pass "both-labels rule documented"
+else
+	fail "both-labels rule (type::<sub> + epic::N) not documented"
+fi
+
+# --- Pre-check on Epic existence (Dev Spec §5.5.4 step 1) --------------------
+if grep -qiE 'pre-check|pre check|verify.*type::epic|exists.*type::epic|open.*type::epic' "$SKILL"; then
+	pass "Epic-existence pre-check documented"
+else
+	fail "Epic-existence pre-check (§5.5.4 step 1) not documented"
+fi
+
+# --- Clear error path --------------------------------------------------------
+if grep -qiE "fail.*clear error|error message|abort" "$SKILL"; then
+	pass "failure-mode error path documented"
+else
+	fail "failure-mode error path not documented"
+fi
+
+# --- --epic invalid with type=plan/epic --------------------------------------
+if grep -qE "invalid with type=.plan|invalid.*plan.*epic|--epic.*plan.*epic" "$SKILL"; then
+	pass "'--epic invalid with plan/epic' rule documented"
+else
+	fail "'--epic invalid with plan/epic' rule missing"
+fi
+
+# --- No comment on Epic (Dev Spec §5.5.4 step 4) -----------------------------
+if grep -qiE 'No comment.*Epic|no comment is posted on the Epic|label alone' "$SKILL"; then
+	pass "'no comment on Epic' rule documented"
+else
+	fail "'no comment on Epic' rule (§5.5.4 step 4) not documented"
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+if [[ $FAILS -gt 0 ]]; then
+	echo "  $FAILS check(s) failed"
+	exit 1
+fi
+echo "  all checks passed"

--- a/tests/skills/test_issue_label_create.sh
+++ b/tests/skills/test_issue_label_create.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# test_issue_label_create.sh — structural regression tests for on-demand
+# label_create logic on skills/issue/SKILL.md per Dev Spec R-14, §5.5.3 step 2,
+# and §5.5.4 step 3.
+#
+# Covers `test_issue_label_create_ondemand` called out in issue #516:
+#   - Missing `type::plan` triggers label_create call
+#   - Missing `epic::N` triggers label_create call
+#   - Canonical colour #5319E7 documented
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SKILL="$REPO_DIR/skills/issue/SKILL.md"
+
+FAILS=0
+
+fail() {
+	echo "  [FAIL] $*"
+	FAILS=$((FAILS + 1))
+}
+
+pass() {
+	echo "  [PASS] $*"
+}
+
+echo "test_issue_label_create_ondemand"
+echo "──────────────────────────────────────────"
+
+if [[ ! -f "$SKILL" ]]; then
+	echo "  [FAIL] SKILL.md missing: $SKILL"
+	exit 1
+fi
+
+# --- Tool reference ----------------------------------------------------------
+if grep -q 'label_create' "$SKILL"; then
+	pass "'label_create' tool referenced in SKILL.md"
+else
+	fail "'label_create' tool not referenced"
+fi
+
+if grep -q 'mcp__sdlc-server__label_create' "$SKILL"; then
+	pass "fully-qualified 'mcp__sdlc-server__label_create' name present"
+else
+	fail "fully-qualified 'mcp__sdlc-server__label_create' name missing"
+fi
+
+# --- Canonical colour (Dev Spec §5.5.3 step 2, §5.5.4 step 3, R-14) ----------
+if grep -q '#5319E7' "$SKILL"; then
+	pass "canonical colour '#5319E7' documented"
+else
+	fail "canonical colour '#5319E7' missing"
+fi
+
+# --- type::plan label creation path (R-14, §5.5.3 step 2) --------------------
+if grep -qE 'type::plan.*label_create|label_create.*type::plan|Plan tracking issue' "$SKILL"; then
+	pass "type::plan on-demand creation path documented"
+else
+	fail "type::plan on-demand creation path missing"
+fi
+
+# Canonical description for type::plan.
+if grep -q 'Plan tracking issue' "$SKILL"; then
+	pass "type::plan canonical description present"
+else
+	fail "type::plan canonical description ('Plan tracking issue ...') missing"
+fi
+
+# --- epic::N label creation path (§5.5.4 step 3) -----------------------------
+if grep -qE "epic::.*label_create|label_create.*epic::|epic::<N>|epic::N" "$SKILL"; then
+	pass "epic::N on-demand creation path documented"
+else
+	fail "epic::N on-demand creation path missing"
+fi
+
+# Canonical description for epic::N.
+if grep -q 'PM-layer thematic grouping' "$SKILL"; then
+	pass "epic::N canonical description ('PM-layer thematic grouping') present"
+else
+	fail "epic::N canonical description missing"
+fi
+
+# --- Idempotent behaviour documented -----------------------------------------
+if grep -qiE 'idempotent' "$SKILL"; then
+	pass "idempotent-label_create behaviour documented"
+else
+	fail "idempotent-label_create behaviour not documented"
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+if [[ $FAILS -gt 0 ]]; then
+	echo "  $FAILS check(s) failed"
+	exit 1
+fi
+echo "  all checks passed"

--- a/tests/skills/test_issue_plan.sh
+++ b/tests/skills/test_issue_plan.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test_issue_plan.sh — structural regression tests for skills/issue/SKILL.md's
+# `plan` type per Dev Spec `phase-epic-taxonomy-devspec.md` §5.1.2 and §5.5.3.
+#
+# Covers `test_issue_plan_body_template` called out in issue #516:
+#   - `/issue plan` output matches Dev Spec §5.1.2 template
+#
+# Scope: asserts structural presence in the skill body (the canonical Plan
+# body-template block is present, frozen-content marker is present, all §5.1.2
+# section headings appear). The skill body IS the specification for the Plan
+# body it will render; equating the two is the tightest test we have short of
+# an end-to-end run against a real repo (covered by IT-ISSUE-PLAN-01 + MV-04).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SKILL="$REPO_DIR/skills/issue/SKILL.md"
+
+FAILS=0
+
+fail() {
+	echo "  [FAIL] $*"
+	FAILS=$((FAILS + 1))
+}
+
+pass() {
+	echo "  [PASS] $*"
+}
+
+echo "test_issue_plan_body_template"
+echo "──────────────────────────────────────────"
+
+if [[ ! -f "$SKILL" ]]; then
+	echo "  [FAIL] SKILL.md missing: $SKILL"
+	exit 1
+fi
+
+# --- Plan template presence --------------------------------------------------
+# §5.1.2 body shape MUST appear verbatim in the Plan Template section. Check
+# for each frozen heading as a line the skill body will emit.
+
+if grep -q '^### Plan Template' "$SKILL"; then
+	pass "'### Plan Template' section heading present"
+else
+	fail "'### Plan Template' section heading missing"
+fi
+
+if grep -q '<!-- PLAN-ISSUE v1' "$SKILL"; then
+	pass "frozen-content marker '<!-- PLAN-ISSUE v1 -->' present"
+else
+	fail "frozen-content marker '<!-- PLAN-ISSUE v1 -->' missing"
+fi
+
+# The §5.1.2 template requires these headings inside the rendered Plan body.
+# Each is embedded in a fenced-code block inside SKILL.md; grep matches them
+# regardless of fence context since they appear at column 0 inside the block.
+REQUIRED_HEADINGS=(
+	'^## Goal$'
+	'^## Scope$'
+	'^### In scope$'
+	'^### Out of scope$'
+	'^## Plan-level Definition of Done$'
+	'^## Phases$'
+	'^## References$'
+)
+
+for h in "${REQUIRED_HEADINGS[@]}"; do
+	if grep -qE "$h" "$SKILL"; then
+		pass "§5.1.2 heading present: ${h#^}"
+	else
+		fail "§5.1.2 heading missing: ${h#^}"
+	fi
+done
+
+# --- Creation rules ----------------------------------------------------------
+# Dev Spec §5.1.6 mutation rule 1 + §5.5.3 step 5: /issue plan posts NO
+# comments at creation (empty comment log is the correct initial state).
+if grep -qE 'Post NO comments|no comments|empty comment log' "$SKILL"; then
+	pass "'no comments at creation' rule documented"
+else
+	fail "Dev Spec §5.1.6 rule 1 (no comments at creation) not documented"
+fi
+
+# §5.5.3 step 1: naming convention 'Plan: <short name>'.
+if grep -q 'Plan: <' "$SKILL"; then
+	pass "'Plan: <Name>' naming convention documented"
+else
+	fail "'Plan: <Name>' naming convention missing"
+fi
+
+# AC-1: /issue plan is listed in the usage/type table.
+if grep -qE '^\s*/issue plan' "$SKILL"; then
+	pass "'/issue plan' listed in usage"
+else
+	fail "'/issue plan' missing from usage"
+fi
+
+# `type::plan` label association.
+if grep -q 'type::plan' "$SKILL"; then
+	pass "'type::plan' label association documented"
+else
+	fail "'type::plan' label association missing"
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+if [[ $FAILS -gt 0 ]]; then
+	echo "  $FAILS check(s) failed"
+	exit 1
+fi
+echo "  all checks passed"


### PR DESCRIPTION
## Summary

Extends `skills/issue/SKILL.md` per Dev Spec `docs/phase-epic-taxonomy-devspec.md` §5.5 (R-13, R-14, R-15):

- Adds `plan` as a first-class type emitting the canonical §5.1.2 frozen-body template (Goal / Scope / Plan-level DoD / Phases / References, with `<!-- PLAN-ISSUE v1 -->` marker).
- Calls out `epic` explicitly as a PM-layer concept the wave pipeline ignores (R-03).
- Adds `--epic N` flag for Story creation with a pre-check that `#N` is an open `type::epic` issue, attaching both `type::<sub>` and `epic::N` labels; rejects `--epic` combined with type=`plan` or type=`epic`.
- Documents on-demand `label_create` calls for `type::plan` and `epic::N` families with canonical `#5319E7` colour and idempotent behaviour.
- Never infers `plan` from prompt keywords — Plan creation is intentional (§5.5.6).

## Changes

- `skills/issue/SKILL.md` — rewritten to cover Plan/Epic/Story layering, `--epic N`, on-demand label creation, and Plan body template.
- `tests/skills/test_issue_plan.sh` — asserts §5.1.2 headings, frozen-content marker, naming convention.
- `tests/skills/test_issue_epic_flag.sh` — asserts `--epic N` mechanics, pre-check, both-labels rule, invalid-with-plan/epic rule.
- `tests/skills/test_issue_label_create.sh` — asserts `label_create` tool reference, canonical colour, idempotent pattern.

## Linked Issues

Closes #516

## Test Plan

- `./scripts/ci/validate.sh` — 114 passed, 0 failed
- `./tests/skills/test_issue_plan.sh` — all checks pass (13 assertions)
- `./tests/skills/test_issue_epic_flag.sh` — all checks pass (7 assertions)
- `./tests/skills/test_issue_label_create.sh` — all checks pass (8 assertions)
- `./tests/skills/test_nextwave_structure.sh` — sanity: all green
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings

## KAHUNA sandbox

Base: `kahuna/499-phase-epic-taxonomy`. `/precheck` emitted `[AUTO-APPROVED: kahuna sandbox]`; this PR is being auto-merged to the sandbox branch. The wave Orchestrator handles the eventual `main` merge at the gate.