### PR TITLE
chore(changelog): aggregate P3W2 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **wavemachine skill**: rename epic→Plan/Phase; add Exhaustive Legal Exits section per Dev Spec §5.3.3. [#512, Story 3.1]
 - **nextwave skill**: rename epic→Plan/Phase; add Exhaustive Legal Exits section per Dev Spec §5.3.3. [#513, Story 3.2]
+- **prepwaves skill**: rename epic→Plan/Phase; annotate surviving "epic" references as PM-layer. [#514, Story 3.3]
+- **devspec skill**: teach Plan/Phase/Wave/Story vocabulary; append Decision-Ledger comments to Plan issue during walk; `/devspec upshift` emits `phases-waves.json` with `plan_id` + per-Story `depends_on`. [#515, Story 3.4]
+- **issue skill**: add `type=plan` with Dev Spec §5.1.2 body template; add `--epic N` flag for Story creation; on-demand `label_create` for missing `type::plan` / `epic::N`. [#516, Story 3.5]
 - **Refactored `vox` around the provider-hook pattern.** The previous `scripts/vox-tts` embedded five coupled backends (VOX_COMMAND, VOX_ENDPOINT, espeak, piper, say) in one cascade; it has been removed. `scripts/vox` is now a thin dispatcher that resolves a *provider* (synthesis) and a *player* (playback) at runtime. Providers live in `~/.config/vox/provider`; copy-and-adapt examples ship in `scripts/vox-providers/` (`silent.sh`, `openai-endpoint.sh`, `piper-local.sh`, `espeak.sh`, `macos-say.sh`). Contract documented in `scripts/vox-providers/README.md` (VOX_PROVIDER_CONTRACT=1). Closes #398.
 
   **Migration (existing vox users)**: your prior `VOX_COMMAND` / `VOX_ENDPOINT` settings no longer auto-dispatch. Run `vox --setup` once to pick a provider, or manually:


### PR DESCRIPTION
## Summary

Aggregates the three P3W2 CHANGELOG fragments under `## [Unreleased] → Changed` in issue-number ascending order. Targets `kahuna/499-phase-epic-taxonomy`, not `main`.

## Changes

- `#514` prepwaves skill (Story 3.3) — rename epic→Plan/Phase
- `#515` devspec skill (Story 3.4) — teach Plan/Phase/Wave/Story + ledger comments
- `#516` issue skill (Story 3.5) — add `type=plan` + `--epic N`

All three categorised as Changed per P3W1 precedent (skill-layer refactors for the Plan/Phase/Epic taxonomy rework).

## Linked Issues

Refs #499 (no closes — aggregation only; source stories closed by their own PRs).

## Test Plan

- [x] Diff inspected: 3 insertions, placement above pre-existing vox entry, below P3W1 entries
- [x] Deterministic ordering verified (514, 515, 516)
- [ ] CI green
- [ ] Merge-queue enrollment