### PR TITLE
chore(changelog): aggregate P3W3a entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Renamed `/prd` skill to `/devspec`** (Development Specification). The old name collided with PM usage of "PRD" (customer need, ROI, value prop); the skill produces an implementation spec for a coding agent, which is semantically distinct. Template renamed to `docs/devspec-template.md`, translation protocol to `docs/DDD-to-devspec-protocol.md`, and output files use the `-devspec.md` suffix. The approval metadata marker changed from `<!-- PRD-APPROVAL -->` to `<!-- DEV-SPEC-APPROVAL -->`. Internal campaign-status stage ID `prd` is preserved for backward compatibility with existing `.sdlc/` state files; only the user-facing display label is updated to "Dev Spec". Closes #327.
 
+### Chore
+
+- **regression test**: grep-based test enforcing R-19 (no pipeline reads of `epic::N` labels); wired into CI. [#517, Story 3.6]
+
 ### Added
 
 - **Nerf MCP server** — Deterministic context budget management via `nerf-server` MCP. Includes dart thresholds (soft/hard/ouch), behavior modes (not-too-rough, hurt-me-plenty, ultraviolence), statusline indicators, and a terminal-based scope monitor


### PR DESCRIPTION
## Summary

Append the P3W3a CHANGELOG fragment under `## [Unreleased]` / `### Chore`. P3W3a was a single-issue regression test (#517, Story 3.6) enforcing R-19 (no pipeline reads of `epic::N` labels).

## Changes

- Insert `### Chore` subsection under `## [Unreleased]` in `CHANGELOG.md`
- One bullet: grep-based regression test wired into CI [#517, Story 3.6]

## Linked Issues

Part of Plan #499 (Phase/Epic taxonomy rework). No issues closed by this PR.

## Test Plan

- Visually verified the insertion point and formatting (Keep-a-Changelog style, Chore category between Changed and Added).
- Docs-only change; no test tooling impacted.