### PR TITLE
chore(hooks): add Stop hook detecting precheck-asking phrasings

### DIFF
--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -68,6 +68,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/precheck-asking-detector.sh"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/docs/operations/precheck-asking-hook.md
+++ b/docs/operations/precheck-asking-hook.md
@@ -1,0 +1,85 @@
+# Precheck-asking Stop hook
+
+A Claude Code `Stop` hook that catches "shall I run /precheck?" style asking phrasings and forces the agent to invoke `/precheck` instead. Closes the residual ~10% leak rate that the CLAUDE.md MANDATORY: Pre-Commit Gate prose alone doesn't catch.
+
+Issue: cc-workflow#542 (paired with #541 prose tightening).
+
+## What it does
+
+When the agent finishes a turn, CC fires the Stop hook. The hook reads the JSONL transcript at `$transcript_path` (passed via stdin JSON), extracts the most recent assistant text, and pattern-matches against two regexes:
+
+1. **Interrogative**: trigger word (`shall|should|can|may|do you want me to|ready (for|to)`) within ~40 chars of `precheck`, ending with `?` within ~80 chars.
+2. **Deferral**: `let me know` idiom within ~40 chars of `precheck` (no `?` required — deferral is asking-by-omission).
+
+If matched, the hook emits `{"decision":"block","reason":"..."}` to stdout, which forces the assistant to continue this turn with the corrective context — no human intervention required.
+
+If unmatched, the hook exits 0 silently. No-op cost: ~20ms on a 200-event transcript.
+
+## Negative cases (must NOT trigger)
+
+- Documenting precheck after it ran: `/precheck completed cleanly. Ready for your call.`
+- Different command: `Shall I run /scp?`
+- Distant trigger word and `precheck`: a sentence with both >40 chars apart
+- Ordinary checklist text: `Ready for /scp / /scpmr / /scpmmr`
+
+A regression test (`tests/regression/test_precheck_asking_detector.sh`) covers all positive and negative cases plus a performance budget (<500ms CI ceiling, <50ms target).
+
+## Disable temporarily
+
+Two layers, by escalation:
+
+1. **Per-session env var:**
+   ```bash
+   export PRECHECK_ASKING_HOOK_DISABLED=1
+   ```
+   The hook honors this on every invocation. Useful when meta-discussing the rule itself (this doc, code-review of the hook source, fixture transcripts) — quoting a forbidden phrase otherwise triggers the hook.
+
+2. **Per-machine: comment out the entry in `~/.claude/settings.json`.** The kit's installer will re-add it on the next `./install` unless you also remove it from `config/settings.template.json` (which would land in a PR).
+
+## Falsy edge — quoting the rule
+
+If the agent writes a message documenting the rule by quoting a forbidden phrase (e.g. *"Don't write 'shall I run /precheck?'"*), the regex will match the quoted phrase and the hook will fire. This is by design — the cost is small (one wasted continuation), and the kill-switch env var exists to suppress it during meta-discussion. Trying to make the regex distinguish "real ask" from "documenting an ask" is a false-precision exercise.
+
+## Performance budget
+
+The hook fires on every Stop in every CC session, so it must be cheap.
+
+| Operation | Cost |
+|-----------|------|
+| Read stdin JSON | <1ms |
+| `tail -n 200` of transcript | <5ms |
+| `jq` to extract last assistant text | <10ms |
+| Two `grep -P` passes | <5ms |
+| **Total target** | **<50ms** |
+| **CI ceiling** | **500ms** (tolerates VM variance) |
+
+## Architecture
+
+```
+CC agent finishes turn
+        │
+        ▼
+   Stop hook fires
+        │
+        ▼
+  reads $transcript_path via stdin JSON
+        │
+        ▼
+  extracts last assistant text via jq
+        │
+        ▼
+  greps for asking patterns
+        │
+        ├── match ──▶ emit {"decision":"block","reason":"..."} ──▶ agent continues turn with /precheck
+        │
+        └── no match ─▶ exit 0, agent's stop is honored
+```
+
+## See also
+
+- `scripts/precheck-asking-detector.sh` — hook source
+- `tests/regression/test_precheck_asking_detector.sh` — regression tests
+- `config/settings.template.json` — Stop hook entry (installed to `~/.claude/settings.json`)
+- `CLAUDE.md` — the rule itself (MANDATORY: Pre-Commit Gate)
+- Memory: `feedback_precheck_no_ask.md` — paired feedback record with phrasings list
+- Issues: cc-workflow#541 (prose half), #542 (this hook)

--- a/scripts/precheck-asking-detector.sh
+++ b/scripts/precheck-asking-detector.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# precheck-asking-detector.sh — CC Stop hook.
+#
+# Detects when the assistant has just written a "shall I run /precheck?"
+# style question and forces the turn to continue with corrective context,
+# per CLAUDE.md MANDATORY: Pre-Commit Gate.
+#
+# Contract (Claude Code Stop hook):
+#   stdin:  JSON with .transcript_path, .session_id, .stop_hook_active
+#   stdout: JSON with {"decision":"block","reason":"..."} to force the
+#           assistant to continue this turn; empty stdout (exit 0) to no-op.
+#
+# Disable: export PRECHECK_ASKING_HOOK_DISABLED=1
+#
+# Performance budget: <50ms. Single jq pass over the tail of the transcript;
+# no MCP calls, no network, no file writes.
+#
+# Issue: cc-workflow#542 — paired with #541 prose tightening.
+
+set -uo pipefail
+
+# Honor the kill-switch env var before any work.
+if [[ "${PRECHECK_ASKING_HOOK_DISABLED:-0}" == "1" ]]; then
+	exit 0
+fi
+
+# Read hook stdin.
+INPUT=$(cat 2>/dev/null || true)
+TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+	exit 0
+fi
+
+# Pull the last assistant text content. The transcript is JSONL where each
+# line is an event. Reverse-iterate, take the first event of type=assistant
+# with role=assistant, concat all blocks where .type == "text" (skipping
+# thinking and tool_use blocks — thinking is not user-visible and tool_use
+# has no .text). Limit to the last 200 lines for performance; an asking
+# message will always be the most recent assistant turn.
+LAST_ASSISTANT_TEXT=$(
+	tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
+		jq -rs '
+        [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
+        | last
+        | (.message.content // [])
+        | map(select(.type == "text") | .text)
+        | join(" ")
+    ' 2>/dev/null
+)
+
+if [[ -z "$LAST_ASSISTANT_TEXT" || "$LAST_ASSISTANT_TEXT" == "null" ]]; then
+	exit 0
+fi
+
+# Two alternations:
+#   1. Interrogative — trigger word (shall/should/can/may/do you want me to/
+#      ready for|to) within ~40 chars of "precheck", ending with "?" within
+#      ~80 chars. Catches direct asking like "Shall I run /precheck?".
+#   2. Deferral — "let me know" idiom near "precheck", no "?" required.
+#      Catches "Let me know when I should run precheck." which is asking by
+#      deferral.
+# Both case-insensitive. Negative cases the regex must NOT match: past-tense
+# precheck mentions, different-command questions ("Shall I run /scp?"),
+# distant trigger-and-precheck pairs, and ordinary checklist text.
+#
+# Falsy edge: an assistant message documenting the rule by quoting a
+# forbidden phrase will trigger the hook. The PRECHECK_ASKING_HOOK_DISABLED
+# kill-switch exists for those cases.
+PATTERN_INTERROGATIVE='(?i)\b(shall|should|can|may|do you want me to|ready (for|to))\b.{0,40}/?precheck.{0,80}\?'
+PATTERN_DEFERRAL='(?i)\blet me know\b.{0,40}/?precheck'
+
+if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_INTERROGATIVE" 2>/dev/null ||
+	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_DEFERRAL" 2>/dev/null; then
+	cat <<'JSON'
+{"decision":"block","reason":"Per CLAUDE.md MANDATORY Pre-Commit Gate: don't ask whether to run /precheck — run it. The checklist that /precheck presents is the approval gate; the start of /precheck is unilateral. Continue this turn by invoking /precheck now."}
+JSON
+	exit 0
+fi
+
+exit 0

--- a/tests/regression/test_precheck_asking_detector.sh
+++ b/tests/regression/test_precheck_asking_detector.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# test_precheck_asking_detector.sh — regression tests for the Stop hook
+# that detects "shall I run /precheck?" style asking phrasings.
+#
+# Hook source: scripts/precheck-asking-detector.sh
+# Issue: cc-workflow#542
+#
+# Strategy: build minimal CC-transcript JSONL fixtures in a tmpdir, pipe
+# the hook input contract (stdin JSON with .transcript_path) through the
+# hook, and assert on its stdout (block JSON) and exit code.
+#
+# Wired into CI via scripts/ci/validate.sh.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$REPO_DIR/scripts/precheck-asking-detector.sh"
+
+if [[ ! -x "$HOOK" ]]; then
+	echo "  [FAIL] hook missing or not executable: $HOOK"
+	exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASSES=0
+FAILS=0
+
+pass() {
+	echo "  [PASS] $*"
+	PASSES=$((PASSES + 1))
+}
+fail() {
+	echo "  [FAIL] $*"
+	FAILS=$((FAILS + 1))
+}
+
+# Build a minimal transcript JSONL with one assistant message containing
+# the given text. Returns the path.
+make_transcript() {
+	local label="$1"
+	local text="$2"
+	local path="$TMPDIR/transcript-$label.jsonl"
+	# Use jq to safely encode the text into a JSON string — handles quotes,
+	# newlines, backslashes correctly.
+	jq -nc --arg text "$text" '{
+        type: "assistant",
+        message: {
+            role: "assistant",
+            content: [
+                { type: "text", text: $text }
+            ]
+        }
+    }' >"$path"
+	echo "$path"
+}
+
+run_hook() {
+	local transcript_path="$1"
+	jq -nc --arg p "$transcript_path" '{transcript_path: $p, session_id: "test"}' |
+		"$HOOK"
+}
+
+# ---------------------------------------------------------------------------
+# Positive cases — hook MUST emit block JSON
+# ---------------------------------------------------------------------------
+
+assert_blocks() {
+	local label="$1"
+	local text="$2"
+	local path
+	path=$(make_transcript "$label" "$text")
+	local out
+	out=$(run_hook "$path")
+	if [[ "$out" == *'"decision":"block"'* ]]; then
+		pass "blocks: $label"
+	else
+		fail "should-block: $label — got: ${out:-<empty>}"
+	fi
+}
+
+assert_blocks "shall_i_run" "Shall I run /precheck?"
+assert_blocks "should_i_run" "Should I run precheck now?"
+assert_blocks "ready_for_precheck" "Ready for /precheck?"
+assert_blocks "let_me_know_when" "Let me know when I should run precheck."
+assert_blocks "do_you_want" "Do you want me to run /precheck?"
+assert_blocks "may_i_run" "May I run /precheck?"
+
+# ---------------------------------------------------------------------------
+# Negative cases — hook MUST NOT block
+# ---------------------------------------------------------------------------
+
+assert_passes() {
+	local label="$1"
+	local text="$2"
+	local path
+	path=$(make_transcript "$label" "$text")
+	local out
+	out=$(run_hook "$path")
+	if [[ -z "$out" || "$out" != *'"decision":"block"'* ]]; then
+		pass "passes:  $label"
+	else
+		fail "should-pass: $label — got: $out"
+	fi
+}
+
+assert_passes "past_tense_completed" "/precheck completed cleanly. Ready for your call."
+assert_passes "no_question_mark" "I would run /precheck next."
+assert_passes "different_command" "Shall I run /scp?"
+assert_passes "checklist_text" "Validation green, trivy 0, reviewer clean. Ready for /scp / /scpmr / /scpmmr."
+
+# Distance test: trigger word and "precheck" >40 chars apart.
+assert_passes "distant_words" \
+	"Should we, given everything that has happened in this very long sentence with lots of detail, also do a precheck?"
+
+# ---------------------------------------------------------------------------
+# Disable env var
+# ---------------------------------------------------------------------------
+
+label="disabled_via_env"
+path=$(make_transcript "$label" "Shall I run /precheck?")
+out=$(jq -nc --arg p "$path" '{transcript_path: $p, session_id: "test"}' |
+	PRECHECK_ASKING_HOOK_DISABLED=1 "$HOOK")
+if [[ -z "$out" ]]; then
+	pass "env-disable: positive input but PRECHECK_ASKING_HOOK_DISABLED=1 — silent"
+else
+	fail "env-disable: should be silent, got: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Missing transcript path
+# ---------------------------------------------------------------------------
+
+label="missing_transcript"
+out=$(echo '{"transcript_path": "/nonexistent/path/xyz.jsonl"}' | "$HOOK")
+if [[ -z "$out" ]]; then
+	pass "missing-transcript: silent no-op"
+else
+	fail "missing-transcript: should be silent, got: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Performance: hook must complete <500ms wall-clock on a realistic transcript
+# size. (Budget-spec is <50ms; using 500ms here as a soft CI ceiling that
+# tolerates VM variance.)
+# ---------------------------------------------------------------------------
+
+label="perf"
+path=$(make_transcript "$label" "Shall I run /precheck?")
+# Pad transcript with 200 noise events to simulate a real session.
+for i in $(seq 1 200); do
+	jq -nc --arg t "noise message $i with no asking phrasing in it." '{
+        type: "assistant",
+        message: { role: "assistant", content: [{type:"text", text:$t}] }
+    }' >>"$path"
+done
+# The asking message is now early in the file; append it again at the end so
+# it's the LAST assistant turn (matching real-world ordering).
+jq -nc --arg t "Shall I run /precheck?" '{
+    type:"assistant",
+    message:{ role:"assistant", content:[{type:"text", text:$t}] }
+}' >>"$path"
+
+start_ms=$(($(date +%s%N) / 1000000))
+out=$(run_hook "$path")
+end_ms=$(($(date +%s%N) / 1000000))
+elapsed=$((end_ms - start_ms))
+
+if [[ "$out" == *'"decision":"block"'* ]] && ((elapsed < 500)); then
+	pass "perf: 200-event transcript handled in ${elapsed}ms (budget <500ms CI / <50ms target)"
+elif [[ "$out" != *'"decision":"block"'* ]]; then
+	fail "perf: did not block on positive input — got: $out"
+else
+	fail "perf: ${elapsed}ms exceeds 500ms budget"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "  Results: $PASSES passed, $FAILS failed"
+
+if ((FAILS > 0)); then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CC `Stop` hook that fires on every assistant turn-end, reads the most recent assistant text from the transcript, and pattern-matches "shall I run /precheck?" style asking phrasings. On match, emits `{"decision":"block","reason":"..."}` to force the assistant to continue the turn by invoking `/precheck` — converting wasted turns into auto-corrections without human intervention.

Tier-2 of paired effort. Tier-1 prose tightening merged earlier as PR #543 (closes #541).

## Why

The existing CLAUDE.md MANDATORY: Pre-Commit Gate rule has a measured ~10% leak rate where agents still write "shall I run /precheck?" instead of just running it. Prose alone fights against the base-model safety prior; structural enforcement (a hook) closes the gap.

## Changes

- **`scripts/precheck-asking-detector.sh`** (NEW) — the hook itself. Reads stdin JSON contract (`.transcript_path`), tail+jq extracts last assistant text, two regex alternations: (1) interrogative `(shall|should|can|may|do you want me to|ready (for|to))` near `precheck` ending in `?`; (2) deferral `let me know` near `precheck` (no `?` required). Honors `PRECHECK_ASKING_HOOK_DISABLED=1` env kill-switch. Performance: 21-23ms on a 200-event transcript (target <50ms).
- **`tests/regression/test_precheck_asking_detector.sh`** (NEW) — 14-case regression test auto-discovered by `validate.sh`. 6 positive, 5 negative, env-disable, missing-transcript, perf budget assertion.
- **`config/settings.template.json`** — added `Stop` hook entry pointing at `~/.local/bin/precheck-asking-detector.sh` (where the kit's installer drops `scripts/precheck-asking-detector.sh`).
- **`docs/operations/precheck-asking-hook.md`** (NEW) — operator doc covering negative cases, disable mechanics, the falsy edge (rule-quoting → kill-switch), perf budget, architecture diagram.

## Linked Issues

Closes #542
Pairs with #541 (already closed via PR #543)

## Test Plan

- [x] `./scripts/ci/validate.sh` — 118/118 pass (was 115; +3 = shellcheck on hook + shfmt on hook+test + new regression test)
- [x] All 14 fixtures pass: shall/should/ready/let-me-know/do-you-want/may all block; past-tense/no-?/different-cmd/checklist/distant all pass; env-disable silent; missing-transcript silent
- [x] Perf budget: 21-23ms on 200-event transcript vs <500ms CI ceiling, <50ms target
- [x] Trivy: 0 HIGH/CRITICAL
- [x] Code reviewer dispatched — clean on install path, hook protocol, failure-mode safety; flagged ONE confidence-83 false-negative for inverted-order phrasings (e.g. "Is /precheck something I should run?") — not an AC violation, will file as a follow-up post-merge

## Known limitation (will be filed as follow-up)

The regex assumes trigger word *before* `precheck`. Inverted phrasings like "Is /precheck something I should run?" escape both patterns. Low-frequency in observed transcripts; broadening the regex risks false-positives. Will file a follow-up issue after merge to capture the gap and decide the right fix (third alternation vs ML-based detector vs accept the gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;