### PR TITLE
chore(skills): /nerf passes session_id on every nerf_* call

### DIFF
--- a/skills/nerf/SKILL.md
+++ b/skills/nerf/SKILL.md
@@ -27,15 +27,17 @@ deterministic MCP tool calls — do NOT implement any logic in this skill file.
 
 Parse the user's input and call the corresponding MCP tool:
 
+**Every routing entry MUST pass `session_id`.** See "Session ID" below.
+
 | User Input | MCP Tool | Arguments |
 |------------|----------|-----------|
-| `/nerf` | `nerf_status` | *(none)* |
-| `/nerf status` | `nerf_status` | *(none)* |
-| `/nerf mode` | `nerf_mode` | *(none — returns current)* |
-| `/nerf mode <mode>` | `nerf_mode` | `{ "mode": "<mode>" }` |
-| `/nerf darts` | `nerf_darts` | *(none — returns current)* |
-| `/nerf darts <s> <h> <o>` | `nerf_darts` | `{ "soft": <s>, "hard": <h>, "ouch": <o> }` |
-| `/nerf <limit>` | `nerf_budget` | `{ "ouch": <limit> }` |
+| `/nerf` | `nerf_status` | `{ "session_id": "<current session ID>" }` |
+| `/nerf status` | `nerf_status` | `{ "session_id": "<current session ID>" }` |
+| `/nerf mode` | `nerf_mode` | `{ "session_id": "<current session ID>" }` |
+| `/nerf mode <mode>` | `nerf_mode` | `{ "mode": "<mode>", "session_id": "<current session ID>" }` |
+| `/nerf darts` | `nerf_darts` | `{ "session_id": "<current session ID>" }` |
+| `/nerf darts <s> <h> <o>` | `nerf_darts` | `{ "soft": <s>, "hard": <h>, "ouch": <o>, "session_id": "<current session ID>" }` |
+| `/nerf <limit>` | `nerf_budget` | `{ "ouch": <limit>, "session_id": "<current session ID>" }` |
 | `/nerf scope` | `nerf_scope` | `{ "session_id": "<current session ID>" }` |
 
 ## Parsing Rules
@@ -44,13 +46,22 @@ Parse the user's input and call the corresponding MCP tool:
 - A bare number (e.g., `/nerf 200k`) routes to `nerf_budget`, not `nerf_darts`
 - Mode names are exact: `not-too-rough`, `hurt-me-plenty`, `ultraviolence`
 
-## Session ID for Scope
+## Session ID (required for all calls)
 
-When calling `nerf_scope`, you MUST pass the real Claude Code session ID.
-The MCP server cannot discover it automatically in multi-session environments.
+You MUST pass the real Claude Code session ID on every `nerf_*` call. The MCP
+server has a multi-strategy resolver (env var → per-project transcript scan →
+md5 fallback), but the explicit override is the only path that's free of
+filesystem-state assumptions. Passing `session_id` keeps the skill working
+even if the server's heuristic resolver regresses or runs in an environment
+where transcript paths differ.
 
-Find it from: the transcript path in conversation context, the crystallizer
-state, or `tail -1 ~/.claude/history.jsonl | jq -r '.sessionId'` as a last resort.
+Find the session ID from, in order of preference: the transcript path in
+conversation context, or the crystallizer state. If neither is available,
+omit `session_id` entirely — do NOT attempt to derive it from shell commands
+or filesystem reads (`history.jsonl` and similar files are racy across
+concurrent CC sessions and would silently feed the wrong UUID). Falling
+through to the server's resolver chain is safe; injecting a wrong value
+is not.
 
 ## Important
 


### PR DESCRIPTION
## Summary

Pairs with mcp-server-nerf#24 / PR #25 (merged). The server-side resolver fix is the primary defense against `Context: unavailable`; this skill change is belt-and-suspenders — the explicit `session_id` override is the only resolver path free of filesystem-state assumptions, so the skill keeps working even if the server resolver regresses again.

## Changes

- `skills/nerf/SKILL.md` — routing table: every `nerf_*` row now specifies `session_id` (previously only `nerf_scope` did).
- `skills/nerf/SKILL.md` — section "Session ID for Scope" → "Session ID (required for all calls)"; explains why explicit override beats the server's heuristic chain.
- `skills/nerf/SKILL.md` — **removed** the `tail -1 ~/.claude/history.jsonl | jq -r .sessionId` last-resort instruction. That command is racy across concurrent CC sessions (BJ runs 5+ at once) and would silently feed the wrong UUID. Replaced with: omit `session_id` entirely if it can't be resolved from context/crystallizer state, and let the server resolver fall through gracefully.

## Linked Issues

Closes #553

## Test Plan

- [x] `./scripts/ci/validate.sh` — 118/118 pass
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 1 Critical finding fixed (the racy `history.jsonl` fallback above)
- [ ] Post-merge smoke: invoke `/nerf status` from a Claude Code session, confirm `Context: <N>k/<M>k (<P>%)` returns instead of "Context: unavailable" (this requires the server-side fix to be locally installed; install + CC restart is a separate follow-up tracked in conversation, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)