### PR TITLE
fix(hooks): refresh nerf statusline on PreCompact + SessionStart:compact

### DIFF
--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -56,6 +56,26 @@
             "command": "~/.claude/context-crystallizer/hooks/session-start.sh"
           }
         ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/hooks/nerf/session-start-compact.sh"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/hooks/nerf/pre-compact.sh"
+          }
+        ]
       }
     ],
     "SubagentStop": [

--- a/scripts/hooks/nerf/pre-compact.sh
+++ b/scripts/hooks/nerf/pre-compact.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# pre-compact.sh — CC PreCompact hook for nerf statusline.
+#
+# Wipes the stale `nerf:` entry from the shared statusline file before
+# compaction replaces the conversation context. Without this, the widget
+# keeps displaying the pre-compact token count (e.g. 126%) until the next
+# nerf_* MCP tool call repaints it. Paired with session-start-compact.sh,
+# which paints a fresh indicator after the compact resume.
+#
+# Contract (CC PreCompact hook):
+#   stdin:  JSON with .session_id, .transcript_path, .cwd, .trigger
+#   exit:   always 0 (best-effort; never block compaction)
+#
+# Override the binary path with NERF_BIN. Logs to stderr on subprocess
+# failure per CLAUDE.md / lesson_best_effort_must_log.md — invisible
+# best-effort failures are an anti-pattern.
+#
+# Issue: cc-workflow#555.
+
+set -uo pipefail
+
+LOG() { printf '[hooks/nerf/pre-compact] %s\n' "$*" >&2; }
+
+INPUT=$(cat 2>/dev/null || true)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+
+NERF_BIN="${NERF_BIN:-$HOME/.local/bin/nerf-server}"
+if [[ ! -x "$NERF_BIN" ]]; then
+	LOG "nerf-server not executable at $NERF_BIN — skipping"
+	exit 0
+fi
+
+if [[ -n "$SESSION_ID" ]]; then
+	if ! "$NERF_BIN" clear-indicator --session-id "$SESSION_ID" 2>/dev/null; then
+		LOG "clear-indicator failed (session_id=$SESSION_ID)"
+	fi
+else
+	if ! "$NERF_BIN" clear-indicator 2>/dev/null; then
+		LOG "clear-indicator failed (no session_id in stdin)"
+	fi
+fi
+
+exit 0

--- a/scripts/hooks/nerf/session-start-compact.sh
+++ b/scripts/hooks/nerf/session-start-compact.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# session-start-compact.sh — CC SessionStart hook (matcher: "compact").
+#
+# Repaints the nerf statusline indicator after a compact resume so the
+# widget reflects the post-compact context size. Paired with
+# pre-compact.sh, which clears the stale entry before compaction.
+#
+# Contract (CC SessionStart hook, matcher: "compact"):
+#   stdin:  JSON with .session_id, .transcript_path, .cwd, .source
+#   exit:   always 0 (best-effort; never block resume)
+#
+# Override the binary path with NERF_BIN. Logs to stderr on subprocess
+# failure per CLAUDE.md / lesson_best_effort_must_log.md — invisible
+# best-effort failures are an anti-pattern.
+#
+# Issue: cc-workflow#555.
+
+set -uo pipefail
+
+LOG() { printf '[hooks/nerf/session-start-compact] %s\n' "$*" >&2; }
+
+INPUT=$(cat 2>/dev/null || true)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+
+NERF_BIN="${NERF_BIN:-$HOME/.local/bin/nerf-server}"
+if [[ ! -x "$NERF_BIN" ]]; then
+	LOG "nerf-server not executable at $NERF_BIN — skipping"
+	exit 0
+fi
+
+if [[ -n "$SESSION_ID" ]]; then
+	if ! "$NERF_BIN" refresh-indicator --session-id "$SESSION_ID" 2>/dev/null; then
+		LOG "refresh-indicator failed (session_id=$SESSION_ID)"
+	fi
+else
+	if ! "$NERF_BIN" refresh-indicator 2>/dev/null; then
+		LOG "refresh-indicator failed (no session_id in stdin)"
+	fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Layer 2 of the stale-statusline fix. Wires mcp-server-nerf v1.2.3's new `clear-indicator` and `refresh-indicator` subcommands into Claude Code's hook system so the nerf widget clears before compaction and repaints after the compact resume — fixing the ~126% pre-compact percentage that lingered until a manual `/nerf status`.

## Changes

- **`scripts/hooks/nerf/pre-compact.sh`** (new) — CC `PreCompact` hook. Reads stdin JSON, shells out to `~/.local/bin/nerf-server clear-indicator` (with `--session-id` when present). Best-effort: always exits 0; logs to stderr on subprocess failure per `lesson_best_effort_must_log.md`.
- **`scripts/hooks/nerf/session-start-compact.sh`** (new) — CC `SessionStart` hook scoped to `matcher: "compact"`. Same shape, calls `refresh-indicator --session-id <id>`.
- **`config/settings.template.json`** — adds the new `PreCompact` block (`matcher: "*"`) and a second `SessionStart` array entry (`matcher: "compact"`) alongside the preserved crystallizer entry.

Both scripts pass `shellcheck` and run cleanly when `~/.local/bin/nerf-server` is missing/older (graceful no-op via `[[ -x "$NERF_BIN" ]]` guard plus best-effort exit 0).

## Linked Issues

Closes #555

## Dependencies

- **mcp-server-nerf v1.2.3** ([release](https://github.com/Wave-Engineering/mcp-server-nerf/releases/tag/v1.2.3), [PR #27](https://github.com/Wave-Engineering/mcp-server-nerf/pull/27), [issue #26](https://github.com/Wave-Engineering/mcp-server-nerf/issues/26)) — installs to `~/.local/bin/nerf-server`. Older binaries don't recognize the subcommands; the hooks log and exit 0 in that case (no breakage).

## Upgrade gap (acknowledged, follow-up #556)

`merge_settings()` in `install` only adds *new event keys* from the template — it does not union-merge new matcher entries into an existing event array. So a user who already has `SessionStart` in their `~/.claude/settings.json` will get `PreCompact` (genuinely new) but **will NOT get the second `SessionStart: matcher "compact"` entry**. Workaround: fresh install (`mv ~/.claude/settings.json{,.bak} && ./install`) or manually copy the new SessionStart entry from `config/settings.template.json`.

The complete fix to the merge logic is tracked in **#556** so this PR doesn't expand scope.

## Test Plan

- [x] `./scripts/ci/validate.sh` → 122 passed, 0 failed (`shellcheck` + `shfmt` + regression suite)
- [x] `./install --check` → confirms new hook scripts deploy to `~/.local/bin/hooks/nerf/` and `PreCompact` is recognized as a missing event key
- [x] Manual smoke: `echo '{"session_id":"<uuid>",...}' | scripts/hooks/nerf/pre-compact.sh` → exit 0, no stderr noise; same for `session-start-compact.sh` against a freshly-installed v1.2.3 binary
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL .` → 0 findings
- [x] Code review: 1 Important fixed (misleading "falling back to resolver" log string in `session-start-compact.sh`); 1 Important deferred to **#556** (install merge gap, predates this PR)
- [ ] End-to-end: trigger a compact in a live Claude Code session post-merge, confirm indicator clears during PreCompact and repaints with post-compact size after SessionStart:compact (requires this PR merged + a fresh-install or manual settings.json edit per upgrade-gap caveat above)
