### PR TITLE
fix(skills): migrate /name and /ccwork off deprecated discord-bot CLI

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -22,11 +22,13 @@ The kit ships a `settings.template.json` that gets copied to `~/.claude/settings
 
 ### Layer 2: Scripts
 
-**What:** Shell scripts installed to `~/.local/bin/` -- things like `discord-bot`, `slackbot-send`, `vox`, `file-opener`, and `statusline-command.sh`.
+**What:** Shell scripts installed to `~/.local/bin/` -- things like `slackbot-send`, `vox`, `file-opener`, and `statusline-command.sh`.
 
-**What they do:** Provide capabilities that Claude Code does not have natively. `discord-bot` is a REST client for the Discord API. `vox` converts text to speech via a Chatterbox endpoint. `slackbot-send` posts Slack messages as a bot. These are standalone tools that work from the command line independent of Claude Code.
+**What they do:** Provide capabilities that Claude Code does not have natively. `vox` converts text to speech via a Chatterbox endpoint. `slackbot-send` posts Slack messages as a bot. `file-opener` opens files in the user's GUI editor. These are standalone tools that work from the command line independent of Claude Code.
 
-**Why they are scripts, not skills:** Skills are prompts -- they tell Claude *what to do*. Scripts are executables -- they *do things*. A skill like `/disc` (Discord integration) calls the `discord-bot` script under the hood. The skill provides the intelligence (resolving intent, formatting messages, signing with identity), while the script provides the capability (HTTP calls to the Discord API). This separation means scripts can be tested independently, used outside of Claude Code, and updated without changing the skill logic.
+**Why they are scripts, not skills:** Skills are prompts -- they tell Claude *what to do*. Scripts are executables -- they *do things*. A skill like `/vox` calls the `vox` script under the hood. The skill provides the intelligence (resolving intent, formatting the announcement); the script provides the capability (calling the TTS provider). This separation means scripts can be tested independently, used outside of Claude Code, and updated without changing the skill logic.
+
+For richer integrations that need bidirectional data (Discord, GitLab/GitHub origin operations), the kit uses **MCP servers** instead of scripts -- e.g. `disc-server` for Discord, `sdlc-server` for origin operations. MCP servers expose typed tool calls that skills invoke directly, with the server handling auth, rate-limiting, and protocol details. The Discord integration was originally a `discord-bot` shell script and migrated to the `disc-server` MCP because the typed-tool surface is easier for skills to call correctly.
 
 ### Layer 3: Skills
 

--- a/docs/discord-config.md
+++ b/docs/discord-config.md
@@ -29,7 +29,7 @@ their agents at their own Discord server without modifying source.
 |-------|------|----------|-------------|
 | `guild_id` | string | Yes | Discord server (guild) ID |
 | `token_path` | string | No | Path to bot token file (default: `~/secrets/discord-bot-token`) |
-| `scream_hole_url` | string | No | Base URL of a [scream-hole](https://github.com/Wave-Engineering/scream-hole) proxy (e.g., `http://scream-hole:3000`). When set, `discord-bot` and `discord-watcher` route all Discord REST API calls through the proxy instead of hitting Discord directly. Omit to use direct Discord API. |
+| `scream_hole_url` | string | No | Base URL of a [scream-hole](https://github.com/Wave-Engineering/scream-hole) proxy (e.g., `http://scream-hole:3000`). When set, `disc-server` MCP and `discord-watcher` route Discord REST API calls through the proxy instead of hitting Discord directly. Omit to use direct Discord API. |
 | `channels` | object | Yes | Map of channel roles to channel info |
 | `channels.<role>.name` | string | Yes | Human-readable channel name (without `#`) |
 | `channels.<role>.id` | string | Yes | Discord channel snowflake ID |
@@ -38,7 +38,7 @@ their agents at their own Discord server without modifying source.
 
 | Role | Purpose | Used By |
 |------|---------|---------|
-| `default` | General agent communications | `discord-bot`, `disc` skill |
+| `default` | General agent communications | `disc-server` MCP, `disc` skill |
 | `roll-call` | Agent check-in on session start | `disc` skill, `CLAUDE.md` identity |
 | `wave-status` | Auto-updating wave execution status | `discord-status-post` |
 
@@ -70,7 +70,7 @@ rate-limiting issues when multiple agents share the same bot token.
 
 When `scream_hole_url` is set:
 
-- **discord-bot** and **discord-watcher** route all Discord REST API calls
+- **disc-server** MCP and **discord-watcher** route Discord REST API calls
   through the proxy (reads from cache, writes forwarded to Discord)
 - On startup, both hit `${scream_hole_url}/health` to verify reachability
 - If unreachable, they fall back to direct Discord API with a logged warning

--- a/docs/discord-watcher.md
+++ b/docs/discord-watcher.md
@@ -9,8 +9,8 @@ If the session was started with `--channels` (or `--dangerously-load-development
 
 ## When you receive a `<channel source="discord_watcher">` notification
 
-1. Run `discord-bot read <channel_id> --limit 10` to get the full messages
-2. If a message is addressed to you (`@<dev-team>`, `@<dev-name>`, or `@all`), process it and respond via `discord-bot send`
+1. Call `mcp__disc-server__disc_read` with `channel_id` and `limit: 10` to get the full messages
+2. If a message is addressed to you (`@<dev-team>`, `@<dev-name>`, or `@all`), process it and respond via `mcp__disc-server__disc_send`
 3. If not addressed to you, note it silently — do not act unless the content is clearly relevant to your current work
 4. Ignore messages that contain your own signature (e.g., `— **beacon**`) to avoid echo loops — other agents' messages (also from `CC Developer`) should be processed normally
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,8 +25,8 @@ Skills:
   ...
 
 Scripts:
-  discord-bot     ... in sync
   slackbot-send   ... in sync
+  vox             ... in sync
   ...
 ```
 

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -391,7 +391,7 @@ Unified Discord integration for the Oak and Wave server. Handles sending message
 /disc thread "session-42" in #agent-ops  # Create a thread
 ```
 
-All messages are signed with the agent's Dev-Name, Dev-Avatar, and Dev-Team. Channel names are resolved via the `discord-bot resolve` command. Configuration is read from `~/.claude/discord.json` (see [Discord Configuration](discord-config.md)).
+All messages are signed with the agent's Dev-Name, Dev-Avatar, and Dev-Team. Channel names are resolved via `mcp__disc-server__disc_resolve`. Configuration is read from `~/.claude/discord.json` (see [Discord Configuration](discord-config.md)).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -126,9 +126,9 @@ The identity file at `/tmp/claude-agent-<hash>.json` is keyed by the md5 hash of
 
 ---
 
-## 6. Discord bot commands failing with authentication errors
+## 6. Discord MCP calls failing with authentication errors
 
-**Symptom:** Running `discord-bot send` or `discord-bot read` fails with a 401 Unauthorized or "Missing Access" error.
+**Symptom:** Calling `mcp__disc-server__disc_send` or `disc_read` returns a 401 Unauthorized or "Missing Access" error.
 
 **Cause:** The bot token is invalid, expired, or the bot does not have the required permissions in the Discord server.
 
@@ -143,7 +143,7 @@ Common causes:
 **Fix:**
 
 1. Verify the token file exists and is not empty: `cat ~/secrets/discord-bot-token | head -c 20` (check the first 20 characters -- do not print the full token).
-2. Test a simple read: `discord-bot read <channel-id> --limit 1`.
+2. Test a simple read: call `mcp__disc-server__disc_read` with a known `channel_id` and `limit: 1`.
 3. In the [Discord Developer Portal](https://discord.com/developers/applications), verify the bot's token, that Message Content Intent is enabled, and that the bot has been added to your server.
 4. Check the bot's permissions in the server: it needs Send Messages and Read Message History at minimum.
 5. Run `/ccwork setup discord` for a guided walk-through of the full configuration.

--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -439,11 +439,11 @@ Ask: *"What's your Discord server (guild) ID? You can find it by right-clicking 
 
 After receiving the guild ID, verify bot access AND auto-discover channels in one step:
 
-```bash
-discord-bot list-channels <guild_id> --type text
+```
+mcp__disc-server__disc_list({ guild_id: "<guild_id>", type: "text" })
 ```
 
-- **If the command succeeds:** The bot has access. Display the discovered text channels as a numbered list for the user:
+- **If the call succeeds:** The bot has access. Display the discovered text channels as a numbered list for the user:
 
   ```
   Found N text channels in your server:
@@ -456,15 +456,15 @@ discord-bot list-channels <guild_id> --type text
 
   Proceed to Step 4.
 
-- **If the command fails:** The bot token is invalid or the bot hasn't been invited to this server. Help troubleshoot:
+- **If the call fails:** The bot token is invalid or the bot hasn't been invited to this server. Help troubleshoot:
   - "Make sure the bot has been invited to your server with the correct permissions."
   - "Verify the guild ID is correct."
   - "Check that your token file contains a valid bot token."
-  - Do NOT proceed until `list-channels` succeeds.
+  - Do NOT proceed until `disc_list` succeeds.
 
 ### Step 4: Assign Channel Roles
 
-Using the discovered channel list from Step 3, ask the user to assign each role. Present all four roles, one at a time, with the channel list visible:
+Using the discovered channel list from Step 3, ask the user to assign each role. Present all three roles, one at a time, with the channel list visible:
 
 1. **default** — "Which channel should be the **default** for agent messages? (e.g., `#agent-ops`). Enter the number from the list above, or a channel name."
 2. **roll-call** — "Which channel for **roll-call** check-ins? Enter a number or name."
@@ -478,15 +478,7 @@ For each assignment, resolve the user's input (number or name) to the channel's 
 
 If any required role (`default`, `roll-call`) could not be filled from existing channels, or the user wants channels that don't exist yet, offer to create them.
 
-**First, create an "Agent Comms" category** to group agent channels visually:
-
-```bash
-discord-bot create-channel <guild_id> "Agent Comms" --type category
-```
-
-Capture the category ID from the output.
-
-Then for each missing channel, ask:
+For each missing channel, ask:
 
 *"Your server doesn't have a channel for **<role>**. I can create one for you. Want me to create `#<suggested-name>`?"*
 
@@ -497,11 +489,15 @@ Suggested default names per role:
 
 For each channel the user approves:
 
-```bash
-discord-bot create-channel <guild_id> <name> --category <category_id>
+```
+mcp__disc-server__disc_create_channel({
+  guild_id: "<guild_id>",
+  name: "<name>",
+  type: "text"
+})
 ```
 
-Capture the channel ID from the command output and use it in the config. If the user declines creation for a required role, ask them to provide an existing channel instead — `default` and `roll-call` are mandatory.
+Capture the channel ID from the response and use it in the config. The new channel is created at the top level of the server — the user can drag it into a category in Discord's UI for visual grouping if they want. If the user declines creation for a required role, ask them to provide an existing channel instead — `default` and `roll-call` are mandatory.
 
 ### Step 6: Write Config
 
@@ -526,16 +522,20 @@ Only include `wave-status` if the user assigned it. The config must match the sc
 
 ### Step 7: Verify
 
-Send a test message to the default channel to confirm the full pipeline works:
+Send a test message to the default channel to confirm the full pipeline works. Resolve the channel ID and name from the just-written config (the `default` key in `channels` is a *role*, not a channel name — the actual Discord channel name and ID live under `.channels.default.id` / `.channels.default.name`):
 
 ```bash
-discord-bot send $(jq -r '.channels.default.id' ~/.claude/discord.json) "Discord integration configured successfully. This is a test message from /ccwork setup discord."
+CHANNEL_ID=$(jq -r '.channels.default.id' ~/.claude/discord.json)
+CHANNEL_NAME=$(jq -r '.channels.default.name' ~/.claude/discord.json)
 ```
 
-Resolve the channel name for the confirmation:
+Then call:
 
-```bash
-CHANNEL_NAME=$(jq -r '.channels.default.name' ~/.claude/discord.json)
+```
+mcp__disc-server__disc_send({
+  channel_id: "<CHANNEL_ID>",
+  message: "Discord integration configured successfully. This is a test message from /ccwork setup discord."
+})
 ```
 
 ### Step 8: Verify Discord Watcher

--- a/skills/ccwork/tours/orientation.md
+++ b/skills/ccwork/tours/orientation.md
@@ -25,10 +25,10 @@ Narration: "These are your skills — slash commands you can use in any Claude C
 ### Check installed scripts
 
 ```bash
-ls ~/.local/bin/discord-bot ~/.local/bin/slackbot-send ~/.local/bin/vox ~/.local/bin/file-opener ~/.local/bin/statusline-command.sh 2>/dev/null || echo "(some scripts not installed)"
+ls ~/.local/bin/slackbot-send ~/.local/bin/vox ~/.local/bin/file-opener ~/.local/bin/statusline-command.sh 2>/dev/null || echo "(some scripts not installed)"
 ```
 
-Narration: "These are your scripts — standalone tools that skills call under the hood. `discord-bot` talks to Discord, `vox` does text-to-speech, `file-opener` opens files in your GUI apps. Skills provide the intelligence; scripts provide the capabilities."
+Narration: "These are your scripts — standalone tools that skills call under the hood. `vox` does text-to-speech, `file-opener` opens files in your GUI apps, `slackbot-send` talks to Slack. Discord lives in an MCP server (`disc-server`) rather than a script. Skills provide the intelligence; scripts and MCP tools provide the capabilities."
 
 ### Check settings
 

--- a/skills/name/SKILL.md
+++ b/skills/name/SKILL.md
@@ -53,15 +53,22 @@ Report the current session identity, or pick one if not yet established.
    ```
    Example: `/rename neuron ⚡ (cc-workflow)`. Skip silently if `/rename` is unavailable.
 
-7. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`:
-   ```bash
-   ROLL_CALL=$(jq -r '.channels["roll-call"].id' ~/.claude/discord.json 2>/dev/null || echo "1487382005036617851")
-   discord-bot send "$ROLL_CALL" "<message>"
+7. **Check in via Discord** — Call `mcp__disc-server__disc_send` to announce yourself in `#roll-call`:
+
    ```
+   mcp__disc-server__disc_send({
+     channel_id: "roll-call",
+     message: "<formatted message — see below>"
+   })
+   ```
+
+   The MCP accepts the channel name directly (`"roll-call"`), so no jq lookup against `~/.claude/discord.json` is needed.
+
    Message format:
    ```
    **<dev-name>** <dev-avatar> online — team `<dev-team>` @ <project-root>
 
    — **<dev-name>** <dev-avatar> (<dev-team>)
    ```
-   If `discord-bot` is not available or the send fails, skip silently — check-in is best-effort.
+
+   If the `disc-server` MCP is not registered or the call fails, skip silently — check-in is best-effort.


### PR DESCRIPTION
## Summary

Migrates the three skill bodies that still invoked the deprecated `discord-bot` bash CLI (removed in commit b079782) to use the `disc-server` MCP. Triggered by a live `/name` failure: the discord-bot CLI routes through the scream-hole proxy without an `/api/v10` prefix and returns HTTP 404, surfacing as a noisy onboarding error.

## Changes

- **`skills/name/SKILL.md`** — step 7 replaces `discord-bot send "$ROLL_CALL"` with `mcp__disc-server__disc_send({channel_id: "roll-call", message: ...})`. Drops the jq lookup against `~/.claude/discord.json` since the MCP accepts channel names directly.
- **`skills/ccwork/SKILL.md`** — Setup-Discord wizard:
  - `discord-bot list-channels` → `mcp__disc-server__disc_list`
  - `discord-bot create-channel` → `mcp__disc-server__disc_create_channel`
  - `discord-bot send` → `mcp__disc-server__disc_send`
  - **Behavioral change:** the "Agent Comms" category-creation step is removed. The MCP's `disc_create_channel` schema (`{guild_id, name, type}`) doesn't accept a parent-category parameter, so auto-created channels land at the top level. Users can drag them into a category in Discord's UI for visual grouping.
  - **Critical reviewer fix:** the test-message step originally passed `channel_id: "default"` (a config role-key, not a Discord channel name — the actual default channel is typically named `agent-ops`). Replaced with a `jq` lookup against the just-written config to resolve the snowflake ID.
  - Stale "four roles" count corrected to "three" after the category-removal.
- **`skills/ccwork/tours/orientation.md`** — drops `~/.local/bin/discord-bot` from the installed-scripts `ls` and updates the narration to describe `disc-server` MCP instead of the removed CLI.
- **`docs/`** (6 files) — sweeps leftover CLI references surfaced by code review:
  - `docs/discord-config.md` — `scream_hole_url` description and "Used By" cell now reference `disc-server` MCP
  - `docs/discord-watcher.md` — instructions now call `mcp__disc-server__disc_read` / `disc_send` instead of CLI
  - `docs/getting-started.md` — drops `discord-bot` from the example `--check` output
  - `docs/troubleshooting.md` — section 6 now describes MCP auth errors
  - `docs/concepts.md` — Layer 2 narrative recasts the example scripts as `vox`/`slackbot-send`/`file-opener` and adds a paragraph on MCP servers, with a one-line historical reference to the discord-bot → disc-server migration as concrete grounding
  - `docs/skill-reference.md` — channel-name resolution citation updated

The token-file path `~/secrets/discord-bot-token` is intentionally preserved verbatim everywhere — that names the bot's secret token file, not the deprecated CLI tool.

## Linked Issues

Closes #558

## Test Plan

- [x] `./scripts/ci/validate.sh` → 122 passed, 0 failed (after each edit)
- [x] `rg 'discord-bot[^-]' skills/ docs/` returns only the deliberate historical reference in `concepts.md` (zero CLI invocations)
- [x] `rg 'discord-bot-token' skills/ docs/` confirms token-file references are preserved (5 hits, all the bot token file path)
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL .` → 0 findings
- [x] Code review caught a Critical bug (`channel_id: "default"` would not resolve through Discord's name-lookup) and 2 Important issues (stale count + 6 leftover doc references); all fixed in this PR
- [ ] Live verification post-merge: invoke `/name` in a fresh CC session, confirm roll-call check-in succeeds via the MCP path
- [ ] Live verification post-merge: walk `/ccwork setup discord` against a test guild, confirm list/create/send all complete via the MCP

## Notes

The Critical finding is worth calling out — the migration could've shipped a non-functional `/ccwork setup discord` if the reviewer hadn't caught the role-key-vs-channel-name confusion. The `disc-server` MCP resolves channel **names** against Discord's API; it doesn't read the user's `~/.claude/discord.json` to dereference role keys. So `channel_id: "default"` is meaningless to the MCP — the role key has to be dereferenced *before* the MCP call.
