### PR TITLE
feat(nerf): redefine modes as additive context-pressure signaling (#565)

### DIFF
--- a/config/statusline-command.sh
+++ b/config/statusline-command.sh
@@ -9,6 +9,11 @@ input=$(cat)
 cwd=$(echo "$input" | jq -r '.cwd // .workspace.current_dir // ""')
 model=$(echo "$input" | jq -r '.model.display_name // ""')
 remaining_pct=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
+session_id=$(echo "$input" | jq -r '.session_id // empty')
+ctx_used_tokens=$(echo "$input" | jq -r '
+    (.context_window.total_input_tokens // 0)
+    + (.context_window.total_output_tokens // 0)
+' 2>/dev/null)
 
 # ANSI colors
 c_purple='\033[38;5;97m'
@@ -18,6 +23,7 @@ c_blue='\033[01;34m'
 c_cyan='\033[36m'
 c_red='\033[31m'
 c_yellow='\033[33m'
+c_orange='\033[38;5;208m'
 c_reset='\033[00m'
 
 # Shorten path: replace $HOME with ~
@@ -173,16 +179,51 @@ if [ -n "$cwd" ] && git_output=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" status --por
 fi
 
 # --- Context remaining indicator ---
+# Colors key off nerf dart zones when a nerf config exists for this session;
+# otherwise fall back to the legacy 13%/25% thresholds against the full window.
 ctx_str=""
 if [ -n "$remaining_pct" ]; then
 	remaining_int=${remaining_pct%.*}
-	if ((remaining_int <= 13)); then
-		ctx_color="$c_red"
-	elif ((remaining_int <= 25)); then
-		ctx_color="$c_yellow"
-	else
-		ctx_color="$c_green"
+	ctx_color=""
+
+	nerf_config=""
+	if [ -n "$session_id" ]; then
+		candidate="/tmp/nerf-${session_id}.json"
+		[ -f "$candidate" ] && nerf_config="$candidate"
 	fi
+
+	if [ -n "$nerf_config" ] && [ -n "$ctx_used_tokens" ] && [ "$ctx_used_tokens" -gt 0 ] 2>/dev/null; then
+		nerf_soft=$(jq -r '.darts.soft // empty' "$nerf_config" 2>/dev/null)
+		nerf_hard=$(jq -r '.darts.hard // empty' "$nerf_config" 2>/dev/null)
+		nerf_ouch=$(jq -r '.darts.ouch // empty' "$nerf_config" 2>/dev/null)
+
+		if [ -n "$nerf_soft" ] && [ -n "$nerf_hard" ] && [ -n "$nerf_ouch" ]; then
+			if ((ctx_used_tokens >= nerf_ouch)); then
+				ctx_color="$c_red"
+			elif ((ctx_used_tokens >= nerf_hard)); then
+				ctx_color="$c_orange"
+			elif ((ctx_used_tokens >= nerf_soft)); then
+				ctx_color="$c_yellow"
+			else
+				ctx_color="$c_green"
+			fi
+		else
+			# Malformed nerf config — fall back to legacy thresholds
+			nerf_config=""
+			ctx_color=""
+		fi
+	fi
+
+	if [ -z "$ctx_color" ]; then
+		if ((remaining_int <= 13)); then
+			ctx_color="$c_red"
+		elif ((remaining_int <= 25)); then
+			ctx_color="$c_yellow"
+		else
+			ctx_color="$c_green"
+		fi
+	fi
+
 	ctx_str="  $(printf '%b' "${ctx_color}")ctx remaining: ${remaining_int}%$(printf '%b' "${c_reset}")"
 fi
 

--- a/context-crystallizer/hooks/post-tool-use.sh
+++ b/context-crystallizer/hooks/post-tool-use.sh
@@ -95,7 +95,10 @@ if [[ -n "$SESSION_ID" ]]; then
             "not-too-rough") CRYSTALLIZE_MODE="manual" ;;
             "hurt-me-plenty") CRYSTALLIZE_MODE="prompt" ;;
             "ultraviolence")  CRYSTALLIZE_MODE="yolo" ;;
-            *)                CRYSTALLIZE_MODE="prompt" ;;
+            *)
+                echo "[$(date -Iseconds)] [crystallizer-hook] WARN: unrecognized nerf mode '$_NERF_MODE' — defaulting to hurt-me-plenty behavior" >&2
+                CRYSTALLIZE_MODE="prompt"
+                ;;
         esac
 
         # Convert absolute darts to percentage thresholds of the real window
@@ -155,6 +158,51 @@ EOF
 fi
 
 # ---------------------------------------------------------------------------
+# Zone classification + per-crossing debounce
+# ---------------------------------------------------------------------------
+# Map ACTION to a dart zone. The in-chat message fires only on zone transitions,
+# so the agent sees one message per crossing rather than one per tool call.
+# Downward crossings (after /compact) update the tracked zone so a subsequent
+# climb re-announces.
+#
+# ultraviolence wants re-fires on every crossing; that's achieved naturally —
+# a /compact drops the zone back to "none", then climbing re-triggers the
+# transition detection.
+# ---------------------------------------------------------------------------
+case "$ACTION" in
+    "warn")        CURRENT_ZONE="soft" ;;
+    "crystallize") CURRENT_ZONE="hard" ;;
+    "critical")    CURRENT_ZONE="critical" ;;
+    *)             CURRENT_ZONE="none" ;;
+esac
+
+# Key by session_id; fall back to a hash of the transcript path so concurrent
+# sessions without a session_id don't share state.
+_CROSSING_KEY="${SESSION_ID:-$(echo "$TRANSCRIPT_PATH" | md5sum | cut -c1-8)}"
+CROSSING_FILE="/tmp/nerf-crossing-${_CROSSING_KEY}.json"
+
+LAST_ZONE="none"
+if [[ -f "$CROSSING_FILE" ]]; then
+    LAST_ZONE=$(jq -r '.last_zone // "none"' "$CROSSING_FILE" 2>/dev/null || echo "none")
+fi
+
+SHOULD_ANNOUNCE=false
+if [[ "$CURRENT_ZONE" != "$LAST_ZONE" ]]; then
+    SHOULD_ANNOUNCE=true
+    # Update the crossing-state file atomically (temp file + rename) so
+    # concurrent hook invocations don't tear each other's writes.
+    _CROSSING_TMP="${CROSSING_FILE}.tmp.$$"
+    if echo "{\"last_zone\":\"${CURRENT_ZONE}\"}" > "$_CROSSING_TMP" 2>/dev/null; then
+        mv -f "$_CROSSING_TMP" "$CROSSING_FILE" 2>/dev/null || rm -f "$_CROSSING_TMP" 2>/dev/null
+    fi
+fi
+
+# not-too-rough mode silences all in-chat messages; crystallization still runs.
+if [[ "$_NERF_MODE" == "not-too-rough" ]]; then
+    SHOULD_ANNOUNCE=false
+fi
+
+# ---------------------------------------------------------------------------
 # Per-session cooldown: prevent calling crystallizer.sh on every tool use
 # once the threshold is crossed. The warning still fires every call; only
 # the expensive crystallizer.sh subprocess is rate-limited.
@@ -204,90 +252,85 @@ case "$ACTION" in
         ;;
 
     "warn")
-        # Return a warning via additionalContext (message field doesn't work per CC bug)
-        cat << EOF
+        # Soft dart crossed. Message only on transition; silent in not-too-rough.
+        if [[ "$SHOULD_ANNOUNCE" == "true" ]]; then
+            case "$_NERF_MODE" in
+                "ultraviolence")
+                    cat << EOF
 {
-    "additionalContext": "⚠️ CONTEXT WARNING: Usage at ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT} tokens). Consider wrapping up current task and crystallizing state soon."
+    "additionalContext": "⚠ ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT}). Rip and tear — but also /compact. Do it at your next tool break."
 }
 EOF
+                    ;;
+                *)  # hurt-me-plenty (default)
+                    cat << EOF
+{
+    "additionalContext": "⚠ Context at ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT}). The Imps are stirring. Consider /compact at your next natural break."
+}
+EOF
+                    ;;
+            esac
+        fi
         exit 0
         ;;
 
     "crystallize")
-        if _is_cooling_down; then
-            cat << EOF
-{
-    "additionalContext": "🔶 CONTEXT DANGER: ${PERCENT}% used. (State already crystallized this cycle — next crystallization in ${CRYSTALLIZER_COOLDOWN_MINUTES}m.)"
-}
-EOF
-            exit 0
+        # Hard dart crossed. Run crystallization if cooldown allows (independent
+        # of mode — even not-too-rough gets automatic crystallization). Emit an
+        # in-chat message only on zone transition and only if mode warrants it.
+        if ! _is_cooling_down; then
+            CRYSTAL_FILE=""
+            _run_crystallizer
         fi
 
-        CRYSTAL_FILE=""
-        _run_crystallizer
-
-        case "$CRYSTALLIZE_MODE" in
-            "yolo")
-                cat << EOF
+        if [[ "$SHOULD_ANNOUNCE" == "true" ]]; then
+            case "$_NERF_MODE" in
+                "ultraviolence")
+                    cat << EOF
 {
-    "additionalContext": "🔶 CONTEXT DANGER: ${PERCENT}% used.\n\n**State crystallized to:** ${CRYSTAL_FILE}\n\n🤖 **AUTO-CLEAR ENGAGED (YOLO MODE)**\n\nI have saved the conversation state. Now executing automatic context clear to avoid lossy auto-compact.\n\n**IMPORTANT: Run /clear now, then read ${CRYSTAL_FILE} to restore context and continue.**"
+    "additionalContext": "⚠⚠ ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT}). /compact NOW. Hold the line no longer."
 }
 EOF
-                ;;
-            "prompt")
-                cat << EOF
+                    ;;
+                *)  # hurt-me-plenty (default)
+                    cat << EOF
 {
-    "additionalContext": "🔶 CONTEXT DANGER: ${PERCENT}% used.\n\n**State automatically crystallized to:** ${CRYSTAL_FILE}\n\n📋 **PLEASE REVIEW CRYSTALLIZED STATE:**\n\nRead and summarize the contents of \`${CRYSTAL_FILE}\` for the user, then ask:\n\n\"I've saved our conversation state to avoid losing context. Would you like me to run /clear now and resume from the saved state? (yes/no)\"\n\nIf user confirms, run /clear and then read the state file to continue."
+    "additionalContext": "⚠⚠ Context at ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT}). Cacodemon sighted. Strongly recommend /compact — don't let the session rot."
 }
 EOF
-                ;;
-            *)
-                cat << EOF
-{
-    "additionalContext": "🔶 CONTEXT DANGER: Usage at ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT} tokens).\n\n**State automatically crystallized to:** ${CRYSTAL_FILE}\n\nRecommended actions:\n1. Complete your current atomic task\n2. Review the crystallized state file\n3. Run /clear to reset context\n4. Resume with fresh context (state file will be loaded)"
-}
-EOF
-                ;;
-        esac
+                    ;;
+            esac
+        fi
         exit 0
         ;;
 
     "critical")
-        if _is_cooling_down; then
-            cat << EOF
-{
-    "additionalContext": "🚨 CRITICAL: ${PERCENT}% - AUTO-COMPACT IMMINENT! State already crystallized this cycle. Run /clear NOW and resume from ${STATE_DIR}/context-state.md — no re-crystallization needed."
-}
-EOF
-            exit 0
+        # Ouch dart crossed — auto-compact imminent. Run crystallization
+        # regardless of mode (safety net); in-chat message only on transition
+        # and only if mode warrants it.
+        if ! _is_cooling_down; then
+            CRYSTAL_FILE=""
+            _run_crystallizer
         fi
 
-        CRYSTAL_FILE=""
-        _run_crystallizer
-
-        case "$CRYSTALLIZE_MODE" in
-            "yolo")
-                cat << EOF
+        if [[ "$SHOULD_ANNOUNCE" == "true" ]]; then
+            case "$_NERF_MODE" in
+                "ultraviolence")
+                    cat << EOF
 {
-    "additionalContext": "🚨 CRITICAL: ${PERCENT}% - AUTO-COMPACT IMMINENT!\n\n**State crystallized to:** ${CRYSTAL_FILE:-FAILED}\n\n🤖 **EMERGENCY AUTO-CLEAR (YOLO MODE)**\n\n**STOP EVERYTHING. Run /clear RIGHT NOW.**\n\nAfter clear, immediately read ${CRYSTAL_FILE} to restore context and continue where we left off."
+    "additionalContext": "⚠⚠⚠ ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT}). /compact THIS TURN. No excuses, no deferrals, no \"just one more thing.\" The session ends now or it ends worse later."
 }
 EOF
-                ;;
-            "prompt")
-                cat << EOF
+                    ;;
+                *)  # hurt-me-plenty (default)
+                    cat << EOF
 {
-    "additionalContext": "🚨 CRITICAL: ${PERCENT}% - AUTO-COMPACT IMMINENT!\n\n**State crystallized to:** ${CRYSTAL_FILE:-FAILED}\n\n⚡ **URGENT: We need to /clear NOW to avoid lossy auto-compact!**\n\nQuickly confirm: Should I run /clear and resume from the saved state? We have seconds, not minutes.\n\n(Responding 'yes' or just pressing enter will proceed with /clear)"
+    "additionalContext": "⚠⚠⚠ Context at ${PERCENT}% (${TOTAL}/${CONTEXT_LIMIT}). Cyberdemon in the corridor. /compact immediately. The auto-compact is merciless."
 }
 EOF
-                ;;
-            *)
-                cat << EOF
-{
-    "additionalContext": "🚨 CRITICAL CONTEXT ALERT: Usage at ${PERCENT}% - AUTO-COMPACT IMMINENT!\n\n**State crystallized to:** ${CRYSTAL_FILE:-FAILED}\n\n⚡ STOP CURRENT WORK and run /clear NOW to avoid lossy auto-compact!\n\nThe crystallized state file contains your conversation context. After /clear, read that file to resume."
-}
-EOF
-                ;;
-        esac
+                    ;;
+            esac
+        fi
         exit 0
         ;;
 esac


### PR DESCRIPTION
## Summary

Redefines the three nerf modes as additive behavior stacks keyed to dart crossings, replacing the vestigial crystallization-oriented semantics that became meaningless after `/cryo` was removed in #563.

| Mode | Statusline | In-chat at soft/hard | In-chat at ouch |
|---|---|---|---|
| not-too-rough | colors at darts | silent | silent |
| hurt-me-plenty | colors at darts | recommendation | recommendation |
| ultraviolence | colors at darts | imperative | imperative (blunt) |

## Changes

**`context-crystallizer/hooks/post-tool-use.sh`**
- Zone classification + per-crossing debounce via `/tmp/nerf-crossing-<key>.json`, atomic temp+rename write to avoid races across concurrent hook invocations
- Mode-branched Doom-witty messaging at `warn`/`crystallize`/`critical` cases; `not-too-rough` silences all in-chat messages (crystallization still runs)
- Crystallization decoupled from mode — runs purely on cooldown check, no more `$CRYSTALLIZE_MODE` sub-branching inside crystallize/critical cases
- Unknown-mode path now logs to stderr before defaulting to hurt-me-plenty behavior

**`config/statusline-command.sh`**
- Color thresholds retargeted from arbitrary 13%/25% of full CC window to nerf dart zones (green/yellow/orange/red at none/soft/hard/critical)
- Reads `session_id` from stdin to locate `/tmp/nerf-<session_id>.json`; falls back to legacy 13%/25% logic when no nerf config exists or darts are malformed
- New `c_orange` ANSI 256 color (38;5;208)

## Linked Issues

Closes #565

## Test Plan

- [x] `scripts/ci/validate.sh` → 121 passed, 0 failed
- [x] trivy HIGH/CRITICAL scan → 0 findings
- [x] bash syntax check both files → OK
- [x] Zone/debounce logic walked through compact-then-re-climb scenario by hand — transitions track correctly, downward-crossing re-enables re-announcement
- [x] Statusline rendered with simulated stdin across all 4 zones (below-soft, soft, hard, ouch) and fallback path — all colors correct
- [x] Code review: 3 high + 1 medium findings addressed (uninitialized ctx_color, crossing-file race, malformed-darts fallback, unknown-mode warning)
- [ ] End-to-end in a live session requires `./install` to deploy — covered after merge

## Deployment notes

Changes don't take effect until `./install` pushes the new hook + statusline to `~/.claude/`. Standard rollout path.