### PR TITLE
chore(skills): parallel sub-agent patterns for /devspec upshift and /nextwave pre-flight

### DIFF
--- a/skills/devspec/SKILL.md
+++ b/skills/devspec/SKILL.md
@@ -443,18 +443,47 @@ Ask the user (or read from conversation context if previously established) for t
 
 Call `devspec_parse_section_8(path)` — returns `{ ok, phases: [{ name, dod, waves: [{ name, stories: [{ id, title, summary, implementation_steps, test_procedures, acceptance_criteria, wave, depends_on }] }] }] }`. Each Story carries an `id` (stable identifier from §8, e.g. `3.4`), a `wave` label (e.g. `P3W2`), and a `depends_on` array of Story IDs (may be empty `[]`).
 
-### Step 4: Create Story Issues (one per Story)
+### Step 4: Create Story Issues (parallel batch)
 
-For each Story in §8, call `work_item(type: <subtype>, title: story.title, body, labels: [<subtype label>])`. The subtype is the Story's declared kind: `type::feature` / `type::bug` / `type::chore` / `type::docs` (default `type::feature` if not declared).
+Launch all Stories as **parallel Sonnet sub-agents in a single message** — they have no creation-time dependencies on each other. Do NOT loop serially.
 
-The Story issue body includes:
-- `## Summary` (from `story.summary`)
-- `## Implementation Steps` (from `story.implementation_steps`)
-- `## Test Procedures` (from `story.test_procedures`)
-- `## Acceptance Criteria` (as checkboxes from `story.acceptance_criteria`)
-- `## Metadata` block with **Plan:** #<plan_id>, **Phase:** <phase-name>, **Wave:** <wave-name>, **Depends on:** <story IDs or "none">
+Sub-agent template (one per Story, all launched in a single message):
+```
+subagent_type: general-purpose
+model: sonnet
+prompt: "Create a <subtype> issue in repo <owner/repo> using mcp__sdlc-server__work_item.
 
-Record each returned issue number (keyed by Story ID).
+Type: <feature|bug|chore|docs>  (default: feature if not declared)
+Title: <story.title>
+Labels: [<type::<subtype>>]
+
+Body (use exactly these H2 sections):
+
+## Summary
+<story.summary>
+
+## Implementation Steps
+<story.implementation_steps>
+
+## Test Procedures
+<story.test_procedures>
+
+## Acceptance Criteria
+<story.acceptance_criteria as checkboxes>
+
+## Dependencies
+<depends_on story IDs, or 'None'>
+
+## Metadata
+**Plan:** #<plan_id>
+**Phase:** <phase-name>
+**Wave:** <wave-name>
+**Depends on:** <story IDs or 'none'>
+
+Return: the issue number and URL only. No other output."
+```
+
+Wait for all sub-agents to return. Record each issue number keyed by Story ID (e.g. `{ "1.1": 501, "1.2": 502, ... }`). If any sub-agent fails, report the failure but continue collecting the rest — do not abort the batch. Failed Stories get a `FAILED` marker in the summary; the Pair resolves them manually.
 
 ### Step 5 (Optional): Create a PM-Layer Epic Parent Tracker
 

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -172,7 +172,14 @@ Run this after `wave_complete()` lands and the bus has been cleaned (Step 5).
    This handles the multi-session case: `/prepwaves` may have run in a different session and its scrollback is gone. The recipe content lives in one place — both skills `cat` from the same file. Single-repo waves skip this step entirely.
 2. Resolve **target repo slug** for the bus path. Same-repo waves: use the current repo's slug. Cross-repo waves (wave plan lives in this repo, stories live elsewhere): use the target repo's slug per `lesson_cross_repo_wave_orchestration.md`.
 3. **Emit observability anchor.** Run `mcp-log wave_start wave=<N> target=<repo-slug> issues=<COMPACT JSON array, no spaces, e.g. [418,419,420]>` so this anchor *precedes* every per-issue `spec_validate_structure`, `wave_show`, and `wave_previous_merged` call below — that ordering is what makes post-mortem temporal correlation work. The `kahuna` field is added later (Step 1.5) once `wave_show` has been called; it is fine for the initial `wave_start` to omit it.
-4. Verify main is clean in the target repo; `wave_previous_merged()` confirms prior wave landed; `spec_validate_structure(issue)` for each issue in the wave.
+4. Verify main is clean in the target repo; `wave_previous_merged()` confirms prior wave landed. Then validate all issues in parallel — launch **one Haiku sub-agent per issue in a single message**:
+   ```
+   subagent_type: general-purpose
+   model: haiku
+   prompt: "Call mcp__sdlc-server__spec_validate_structure for issue #<X> in repo <owner/repo>.
+            Return a single line: #<X> | <VALID or INVALID: list missing sections>"
+   ```
+   Collect results. Any INVALID → stop, report which issue(s) failed validation, exit.
 5. Call `scripts/wavebus/wave-init <repo-slug> <N> 1`. Flight count is `1` initially — Prime may re-invoke it with the real count (script is idempotent). Capture the printed wave root.
 6. **Read `kahuna_branch` from wave state** via `wave_show()` (or by reading `.claude/status/state.json` in the target repo). If the field is present and non-empty, the wave is executing under KAHUNA — capture the value (e.g. `kahuna/<plan-id>-<slug>`) and pass it into the Prime(pre-wave) prompt as the `kahuna_branch` input. If absent or empty, the wave is a legacy non-KAHUNA execution — flights base off `main` as before. Pre-created worktree branches (Step 7, cross-repo path) and `pr_create` `base` (Step 3e) honor this same value. See Dev Spec §5.2.3 for the authoritative contract.
 7. Pre-create worktrees per issue. Same-repo: `Agent` calls in Step 3 can use `isolation: "worktree"`. Cross-repo: create them now via `git -C <target-repo> worktree add /tmp/wt-<slug>-<issue> -b feature/<issue>-<desc> origin/<base-ref>` (one per issue), where `<base-ref>` is `kahuna_branch` if set, else `main`.
@@ -237,7 +244,7 @@ Each Flight's last message is exactly one line matching `^(/tmp/wavemachine/[^\s
 
 Code-reviewer findings must be in hand at gate time so the human sees them in the batched checklist. Flights cannot dispatch the reviewer themselves (sub-agents lack the `Agent`/`Task` tool — see `lesson_cc_subagent_tools.md`). The Orchestrator does have `Agent`, so it dispatches the reviewer pass here, BEFORE the consolidated approval gate.
 
-In a SINGLE tool-use block, issue one `Agent` call per issue X in this flight, `subagent_type: feature-dev:code-reviewer`. Each call's prompt: `"Review the diff for issue #<X> against the SPEC EXECUTOR rubric. Worktree: <worktree-path>. Diff: run git -C <worktree-path> diff origin/<base-ref>...HEAD. Report any high-confidence findings (correctness bugs, security issues, AC mismatches)."`
+In a SINGLE tool-use block, issue one `Agent` call per issue X in this flight, `subagent_type: feature-dev:code-reviewer`, `model: opus`. Each call's prompt: `"Review the diff for issue #<X> against the SPEC EXECUTOR rubric. Worktree: <worktree-path>. Diff: run git -C <worktree-path> diff origin/<base-ref>...HEAD. Report any high-confidence findings (correctness bugs, security issues, AC mismatches)."`
 
 Collect the reviewer outputs and stash them keyed by issue — they feed directly into the per-issue rows of the gate's batch checklist (Step 3d) and into the Prime(post-flight) prompt (Step 3e). If ANY issue surfaces a high-confidence finding, the gate at 3d still fires (so the human sees the finding in context), but the orchestrator must surface the finding prominently and recommend rejection.
 


### PR DESCRIPTION
## Summary

Applies parallel sub-agent patterns to `/devspec` upshift and `/nextwave` pre-flight, completing the skill optimization pass started in #571.

## Changes

- **`skills/devspec/SKILL.md`** — upshift Step 4: serial `work_item` loop replaced with N parallel Sonnet sub-agents in a single message. Partial failure handled per-row (failed Story gets a FAILED marker, batch continues). Story numbers collected after all return for `phases-waves.json` assembly.
- **`skills/nextwave/SKILL.md`** — Step 1.4: serial `spec_validate_structure` loop replaced with N parallel Haiku sub-agents (one per issue, single message, one-line return each); any INVALID is a hard stop. Step 3c.5: explicit `model: opus` added to the already-parallel reviewer pass Agent calls.

## Linked Issues

Closes #575

## Test Plan

- `./scripts/ci/validate.sh` — PASS (124/124)
- Trivy — PASS (0 HIGH/CRITICAL)
- Code review (Opus) — No findings