### PR TITLE
chore(infra): WAVE_AXIOMS V1 + Stop hook + gitignore prep for Plan #581 Main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ Thumbs.db
 # Generated files
 .status-panel.html
 
+# Transient validate.sh output dump
+validate_output.txt
+
 # Python bytecode
 __pycache__/
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,25 @@ Every issue MUST be wave-pattern quality: detailed enough that a spec-driven age
 
 ---
 
+## MANDATORY: WAVE_AXIOMS — Load-Bearing Rules for Wave-Pattern Work
+
+**READ `WAVE_AXIOMS.md` FIRST when invoking `/wavemachine`, `/nextwave`, `/assesswaves`, or `/prepwaves`.** That file is the canonical, load-mandatory constitutional layer for wave-pattern execution. Each axiom binds to a specific observed-and-forbidden agent behavior; violation is a bug, not a judgment call.
+
+The eight axioms (full text in `WAVE_AXIOMS.md` at the cc-workflow root):
+
+1. **Serial is a valid wave topology.** Wave campaigns are justified by autonomous batched execution, not parallelism.
+2. **The campaign is autonomous from invocation to terminal state.** No mid-campaign questions. No "shall I continue?"
+3. **The Legal Exits list is closed.** Plan-reality drift, hard fault, explicit user halt. No others.
+4. **When unsettled, use the Concerns Channel. Do not stop.** Post `[concern]`, ping if urgent, continue.
+5. **Continuing is cheaper than stopping. Default forward.** Continuation costs revertible commits; stops cost unrecoverable wall-clock.
+6. **Approval frequency is set by the invoked command.** `/nextwave` = per-wave; `/wavemachine` = at terminal state. The agent never adds gates.
+7. **`/assesswaves` measures justification, not topology suitability.** YES whenever count ≥ 4 or per-issue wall-clock is non-trivial.
+8. **These axioms supersede agent judgment in their domain.** Disagreement is a reason to PR `WAVE_AXIOMS.md`, never to override in the moment.
+
+Disagreement with an axiom is a reason to update `WAVE_AXIOMS.md` via PR — never to override it in the moment.
+
+---
+
 ## Branching Strategy
 
 Trunk-based flow. Always branch from `main`: `git checkout main && git pull && git checkout -b <type>/<N>-description`. Types: `feature`, `fix`, `chore`, `doc`. PR/MRs target `main`.

--- a/WAVE_AXIOMS.md
+++ b/WAVE_AXIOMS.md
@@ -1,0 +1,182 @@
+# WAVE AXIOMS
+
+<!-- Canonical, load-mandatory rules for wave-pattern execution.
+
+     READ THIS BEFORE invoking /wavemachine, /nextwave, /assesswaves.
+     READ THIS BEFORE recommending against the wave pattern.
+     READ THIS BEFORE asking the user a mid-campaign question.
+
+     Each axiom binds to a specific observed-and-forbidden behavior.
+     Violation is a bug, not a judgment call. Disagreement with an axiom
+     is a reason to update this file via PR — never a reason to override
+     it in the moment.
+
+     "First round" — 2026-05-05 BJ + patchwork. Will grow as new
+     failure modes are observed. -->
+
+---
+
+## Axiom 1 — Serial is a valid wave topology.
+
+A wave-pattern campaign is justified by **autonomous batched execution**, not by parallelism. A queue of N≥4 issues with deep gating dependencies — every flight serial, every wave size 1 — is a textbook campaign.
+
+**Forbidden:**
+- Recommending "ad-hoc, no campaign" for a serial-but-batchable queue
+- Downgrading a wave plan because no parallelism is available
+- Treating "is there parallelism here?" as the gating question
+
+**Why:** The benefit isn't concurrency. It is queue-and-walk-away — the agent walks the deps, /precheck → /scpmmr per issue, while the user does something else. Lifecycle tracking and audit trail land regardless of flight count. The user's wall-clock is the resource the campaign exists to protect.
+
+**See:** `feedback_wave_pattern_justification.md`, `/assesswaves` skill body.
+
+---
+
+## Axiom 2 — The campaign is autonomous from invocation to terminal state.
+
+Once `/wavemachine` (or `/nextwave`) starts, the agent runs until one of the following: (a) the campaign reaches its terminal state — all issues complete and Plan-level DoD verified, (b) a Legal Exit fires (Axiom 3), (c) the user explicitly halts (interrupt, `/halt`, "stop"). No other condition terminates the campaign.
+
+**Forbidden:**
+- "Shall I continue?"
+- "Do you want me to proceed to wave 2?"
+- "Ready to move on?"
+- "Should I file the followup?"
+- Any mid-campaign yes/no question whose expected answer is "yes"
+- Pausing at phase boundaries "to check in"
+
+**Why:** Each mid-campaign question converts autonomous execution into a per-step checkpoint. The user invoked the campaign precisely to avoid those checkpoints. Asking the question burns the user's attention to receive the answer that was already implied by the invocation.
+
+**See:** `principle_user_attention_is_the_cost.md`.
+
+---
+
+## Axiom 3 — The Legal Exits list is closed.
+
+Legitimate stops, **exhaustively**:
+
+1. **Plan-reality drift** — observable evidence that the Plan no longer matches the codebase, the work, or the world (an issue closed externally, a file moved, an API changed).
+2. **Hard fault** — uncatchable error, missing critical resource, infrastructure outage.
+3. **Explicit user halt** — interrupt, `/halt`, "stop", explicit instruction to pause.
+
+That is the entire list. There are no others.
+
+**Forbidden (each observed):**
+- "I'm uncertain about X" → stop
+- "This next step is large" → stop
+- "I want to confirm before X" → stop
+- "Session has been long" → stop
+- "Phase boundary, good place to check in" → stop
+- "Out of an abundance of caution" → stop
+- "The user might want to know X" → stop
+
+Each of these is the failure mode this axiom exists to forbid.
+
+**Why:** A closed list is enforceable. An open list is rationalizable. The agent who reasons "this is technically not a Legal Exit, but I'm stopping anyway because it feels right" has constructed exactly the failure mode the closed list is designed to prevent.
+
+**See:** `pattern_exhaustive_legal_exits.md`.
+
+---
+
+## Axiom 4 — When unsettled, use the Concerns Channel. Do not stop.
+
+If the agent is unsettled and no Legal Exit applies, the response is:
+
+1. Post a `[concern]` comment on the relevant issue
+2. Ping the Pair via Discord if the concern is urgent
+3. **Continue the campaign**
+
+The campaign does not pause for unease. The Concerns Channel exists precisely so the agent can register the unease without burning the user's wall-clock.
+
+**Forbidden:**
+- Stopping the campaign because "I had a concern"
+- Asking the user to evaluate the concern in real time
+- Treating the Concerns Channel as optional when no Legal Exit fires
+
+**Why:** Unease is information; stopping is action. The information goes into the durable record (issue comment + optional Discord ping). The action is reserved for Legal Exits. Conflating the two is the bug.
+
+**See:** `pattern_concerns_channel.md`.
+
+---
+
+## Axiom 5 — Continuing is cheaper than stopping. Default forward.
+
+Continuing costs at most: a revertible commit, a noisy comment thread, or a follow-up issue. Stopping costs: unrecoverable wall-clock — every minute the user reads the question, switches context, types a reply, and resumes — plus the cache-warmth penalty on the agent's side.
+
+**Forbidden:**
+- Treating "stop and ask" as the safe default
+- Framing continuation as the risky option
+- Computing only the worst-case cost of continuing while ignoring the certain cost of stopping
+
+**Why:** The cost asymmetry is permanent and well-documented. Almost every continuation can be undone in a follow-up commit. No stop can return the wall-clock it consumed.
+
+**See:** `principle_cost_asymmetry_continue_vs_exit.md`.
+
+---
+
+## Axiom 6 — Approval frequency is set by the invoked command. The agent does not add gates.
+
+- **`/nextwave`** = "I want to approve at each wave." The gate fires once per wave, after all flights complete and the Orchestrator-side reviewer passes. One approval covers every issue and every sub-agent in that wave.
+- **`/wavemachine`** = "I want to approve at the campaign end." There is no per-wave human gate; the Orchestrator approves wave transitions autonomously based on flight + reviewer signal. The user-facing gate fires only at terminal state (Plan-level DoD verification, or a Legal Exit per Axiom 3).
+
+**Forbidden:**
+- Per-flight, per-issue, or per-sub-agent approval requests in any context
+- Human-loop checkpoints between waves during `/wavemachine` execution
+- Adding gates the user did not invoke
+
+**Why:** The slash command choice IS the gate-frequency declaration. Adding gates the user didn't ask for is unilateral expansion of the contract — the same failure mode as "shall I continue?" in Axiom 2, just at a different layer.
+
+**See:** `feedback_nextwave_batch_approval.md`, `principle_user_attention_is_the_cost.md`.
+
+---
+
+## Axiom 7 — `/assesswaves` measures justification, not topology suitability.
+
+The skill answers a single question: **should the user use the wave pattern for this work?**
+
+The answer is **YES** whenever:
+- count ≥ 4 issues, OR
+- per-issue wall-clock is non-trivial (≥ ~30 min sustained agent work), OR
+- the user has indicated they want batched-autonomy execution for this queue
+
+Regardless of whether flights parallelize.
+
+**Forbidden:**
+- Recommending against the wave pattern because flights serialize
+- Recommending "ad-hoc, no campaign" for any queue meeting the YES criteria
+- Treating parallelism as a prerequisite
+
+**Why:** The skill body literally says "serial is a valid wave topology." Anchoring on parallelism in the assessment is anchoring on the wrong axis. See Axiom 1 for the full rationale; this axiom binds the assessment skill specifically because that is where the failure has been observed.
+
+---
+
+## Axiom 8 — These axioms supersede agent judgment in their domain.
+
+If an agent's reasoning produces a conclusion that contradicts an axiom, **the axiom wins**. Disagreement with an axiom is a reason to file a PR updating this file, not a reason to override the axiom in the moment.
+
+**Forbidden:**
+- "Axiom N applies in general but not here because..."
+- "I see why the axiom says X, but in this case Y..."
+- Citing an axiom in the response while violating it in action
+
+**Why:** This document exists because case-by-case judgment WAS the failure mode. The axioms are the structural correction; allowing case-by-case override re-introduces the failure. If the axioms are wrong, fix the axioms. If they're right, follow them.
+
+---
+
+## How to apply this document
+
+- **CLAUDE.md** at the cc-workflow root references this file inline; CLAUDE.md is always loaded.
+- Wave-pattern skill bodies (`/wavemachine`, `/nextwave`, `/assesswaves`) reference this file with explicit "READ FIRST" framing in their procedure sections.
+- Memory files (`principle_*`, `pattern_*`, `feedback_*`) are subsidiary references. This file is the canonical source.
+- Violations encountered in real conversations should be filed as updates to this document — either tightening an existing axiom or adding a new one for the newly-observed failure mode.
+
+---
+
+## Cross-references
+
+| Memory file | Relates to |
+|---|---|
+| `principle_user_attention_is_the_cost.md` | Axiom 2 |
+| `principle_cost_asymmetry_continue_vs_exit.md` | Axiom 5 |
+| `pattern_exhaustive_legal_exits.md` | Axiom 3 |
+| `pattern_concerns_channel.md` | Axiom 4 |
+| `feedback_nextwave_batch_approval.md` | Axiom 6 |
+| `feedback_wave_pattern_justification.md` | Axiom 1, Axiom 7 |

--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -98,6 +98,16 @@
             "command": "~/.local/bin/precheck-asking-detector.sh"
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "_comment": "Block stop attempts during active /wavemachine campaigns. Validated 2026-05-05 in blueshift-cue Plan #179 (wave-4 → wave-5 without stall). See lesson_stop_hook_with_block.md.",
+            "type": "command",
+            "command": "state=\"${CLAUDE_PROJECT_DIR:-.}/.claude/status/state.json\"; [ -f \"$state\" ] || exit 0; active=$(jq -r '.wavemachine_active // false' \"$state\" 2>/dev/null); [ \"$active\" = \"true\" ] || exit 0; printf '{\"decision\":\"block\",\"reason\":\"/wavemachine is active and the loop has not completed. After /nextwave auto returns OK, you must immediately invoke /nextwave auto again for the next wave (or trigger the trust-score gate if no more pending waves). Do NOT stall — emit the next tool call now.\"}'"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

Pre-launch infrastructure cleanup bundling four small mechanical changes so the `/wavemachine` pre-flight gate passes for Plan #581's Main campaign and the campaign has minimum prep-wave protection.

## Changes

- **`.gitignore`** — add `validate_output.txt` (transient `scripts/ci/validate.sh` output dump)
- **`WAVE_AXIOMS.md` (new)** — V1 first-round draft, 8 axioms governing wave-pattern execution behavior. Structural rework + Axiom 9 (no-polling) + skill-body wiring land in a follow-up issue
- **`CLAUDE.md`** — add `MANDATORY: WAVE_AXIOMS` section with inline 8-axiom shorthand list; makes the constitutional layer load-bearing via the always-loaded CLAUDE.md
- **`config/settings.template.json`** — add second `Stop` hook entry (alongside existing precheck-asking-detector) using `decision:block` conditional on `wavemachine_active` flag in `.claude/status/state.json`. Validated 2026-05-05 in blueshift-cue Plan #179 (advanced wave-4 → wave-5 without stall after deployment)

## Linked Issues

Closes #582

## Test Plan

- [x] `scripts/ci/validate.sh` — 124/124 regression tests PASS (shellcheck, shfmt, py_compile, regression)
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- [x] `jq -e .` on `config/settings.template.json` — JSON valid post-edit
- [x] Code review (Opus `feature-dev:code-reviewer`) — initial pass found 2 Important + 1 Minor; both Important fixed; re-review CLEAN
- [x] Manual: `git status --porcelain` returns nothing post-stage (clean sandbox per /wavemachine pre-flight #4)

## Findings (review)

**Fixed (2 Important):**
1. **Axiom 6 divergence between WAVE_AXIOMS.md V1 and CLAUDE.md inline summary.** CLAUDE.md asserted the split version (per-command gate frequency: `/nextwave` per-wave, `/wavemachine` at terminal state) but WAVE_AXIOMS.md V1 had only the unsplit "per-wave" framing. Applied the split to WAVE_AXIOMS.md so both files agree.
2. **Stop hook used relative path for `state.json`.** `state=".claude/status/state.json"` would silently no-op on cwd-drift (cross-repo orchestration, CC bugs #3583/#50960/#22343). Now uses `${CLAUDE_PROJECT_DIR:-.}/.claude/status/state.json` with sensible fallback.

**Deferred (1 Minor, follow-up):** Stop hook reason text assumes `/wavemachine` is in flight but fires on bare `wavemachine_active=true` flag. Stale flag from aborted session could misdirect a user who invoked `/nextwave` directly. Captured for the WAVE_AXIOMS structural-rework follow-up issue (which also covers Axiom 9 / no-polling).

**Pre-existing (out of scope):** `pytest` reports 103 failures across the test suite, including 16 in `tests/test_install_merge.py` due to `install.sh → install` rename in commit 9d0b06d not propagated to test files. Verified pre-existing on origin/main (failures present without this PR's changes). Separate chore issue should track the test-suite cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)