### PR TITLE
chore(hooks): catch inverted precheck-asking phrasings — closes #545

### DIFF
--- a/scripts/precheck-asking-detector.sh
+++ b/scripts/precheck-asking-detector.sh
@@ -53,14 +53,23 @@ if [[ -z "$LAST_ASSISTANT_TEXT" || "$LAST_ASSISTANT_TEXT" == "null" ]]; then
 	exit 0
 fi
 
-# Two alternations:
+# Three alternations:
 #   1. Interrogative — trigger word (shall/should/can/may/do you want me to/
 #      ready for|to) within ~40 chars of "precheck", ending with "?" within
 #      ~80 chars. Catches direct asking like "Shall I run /precheck?".
 #   2. Deferral — "let me know" idiom near "precheck", no "?" required.
 #      Catches "Let me know when I should run precheck." which is asking by
 #      deferral.
-# Both case-insensitive. Negative cases the regex must NOT match: past-tense
+#   3. Inverted — "precheck" appears BEFORE the trigger word (broadened
+#      trigger set: should/shall/need/ready/appropriate), within the same
+#      sentence (no sentence-terminating punctuation between), ending with
+#      "?". Catches "Is /precheck something I should run?", "Would /precheck
+#      be appropriate here?", "Precheck — should I do that now?". The
+#      sentence-boundary character class ([^.?!\n]) is the false-positive
+#      guard for cases like "/precheck completed. Should I commit now?" —
+#      the period severs precheck from the trigger word so the inverted
+#      pattern declines to fire. Issue cc-workflow#545.
+# All case-insensitive. Negative cases the regex must NOT match: past-tense
 # precheck mentions, different-command questions ("Shall I run /scp?"),
 # distant trigger-and-precheck pairs, and ordinary checklist text.
 #
@@ -69,9 +78,11 @@ fi
 # kill-switch exists for those cases.
 PATTERN_INTERROGATIVE='(?i)\b(shall|should|can|may|do you want me to|ready (for|to))\b.{0,40}/?precheck.{0,80}\?'
 PATTERN_DEFERRAL='(?i)\blet me know\b.{0,40}/?precheck'
+PATTERN_INVERTED='(?i)/?precheck[^.?!\n]{0,40}\b(should|shall|need|ready|appropriate)\b[^.?!\n]{0,40}\?'
 
 if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_INTERROGATIVE" 2>/dev/null ||
-	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_DEFERRAL" 2>/dev/null; then
+	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_DEFERRAL" 2>/dev/null ||
+	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_INVERTED" 2>/dev/null; then
 	cat <<'JSON'
 {"decision":"block","reason":"Per CLAUDE.md MANDATORY Pre-Commit Gate: don't ask whether to run /precheck — run it. The checklist that /precheck presents is the approval gate; the start of /precheck is unilateral. Continue this turn by invoking /precheck now."}
 JSON

--- a/tests/regression/test_precheck_asking_detector.sh
+++ b/tests/regression/test_precheck_asking_detector.sh
@@ -87,6 +87,12 @@ assert_blocks "let_me_know_when" "Let me know when I should run precheck."
 assert_blocks "do_you_want" "Do you want me to run /precheck?"
 assert_blocks "may_i_run" "May I run /precheck?"
 
+# Inverted phrasings — issue #545. Trigger word follows "precheck" instead
+# of preceding it. Caught by PATTERN_INVERTED.
+assert_blocks "inverted_is_precheck" "Is /precheck something I should run?"
+assert_blocks "inverted_appropriate" "Would /precheck be appropriate here?"
+assert_blocks "inverted_precheck_first" "Precheck — should I do that now?"
+
 # ---------------------------------------------------------------------------
 # Negative cases — hook MUST NOT block
 # ---------------------------------------------------------------------------
@@ -113,6 +119,13 @@ assert_passes "checklist_text" "Validation green, trivy 0, reviewer clean. Ready
 # Distance test: trigger word and "precheck" >40 chars apart.
 assert_passes "distant_words" \
 	"Should we, given everything that has happened in this very long sentence with lots of detail, also do a precheck?"
+
+# Issue #545 false-positive guard: a past-tense precheck mention followed by
+# a separate question about the *next* step must not block. The
+# sentence-terminating period severs precheck from "should" so PATTERN_INVERTED
+# declines to fire. CRITICAL — narrow PATTERN_INVERTED if this regresses.
+assert_passes "negative_past_tense_with_question" \
+	"/precheck completed. Should I commit now?"
 
 # ---------------------------------------------------------------------------
 # Disable env var


### PR DESCRIPTION
## Summary

Add a third regex alternation to `scripts/precheck-asking-detector.sh` covering inverted forms ("Is /precheck something I should run?", "Would /precheck be appropriate here?", etc.). Includes a false-positive guard for "/precheck completed. Should I commit now?" to avoid blocking valid post-precheck phrasing.

## Linked Issues

Closes #545

## Reviewer pass

CLEAN

## Wave bus

Results: `/tmp/wavemachine/Wave-Engineering-claudecode-workflow/wave-1/flight-1/issue-545/results.md`