### PR TITLE
fix(wave-status): preserve cross-repo issue refs in state.json keys

### DIFF
--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -248,10 +248,27 @@ def _plan_default_repo(plan_data: dict) -> str | None:
 
 
 def _issue_repo(plan_data: dict, issue: dict) -> str | None:
-    """Resolve the effective repo for *issue* — per-issue overrides plan-level."""
+    """Resolve the effective repo for *issue*.
+
+    Resolution order:
+
+    1. Per-issue ``repo`` override — wins.
+    2. Per-issue qualified ``ref`` field (e.g. ``owner/name#N``) — when no
+       per-issue ``repo`` is set, parse the repo prefix off the ref so a
+       cross-repo plan written from a different orchestrator repo doesn't
+       silently substitute the orchestrator slug into ``state.json`` keys
+       (issue #521).
+    3. Plan-level default ``repo``.
+    4. ``None``.
+    """
     per_issue = issue.get("repo")
     if isinstance(per_issue, str) and per_issue:
         return per_issue
+    ref = issue.get("ref")
+    if isinstance(ref, str) and "#" in ref:
+        repo_part, _, _ = ref.rpartition("#")
+        if repo_part:
+            return repo_part
     return _plan_default_repo(plan_data)
 
 
@@ -297,7 +314,20 @@ def _all_issue_refs(plan_data: dict, default_repo: str | None = None) -> set[str
     for phase in plan_data.get("phases", []):
         for wave in phase.get("waves", []):
             for issue in wave.get("issues", []):
-                repo = issue.get("repo") if isinstance(issue.get("repo"), str) and issue.get("repo") else plan_default
+                # Per-issue repo wins; then a qualified ``ref`` field; then
+                # the plan-level default.  Mirrors ``_issue_repo()`` so
+                # collision detection sees the same key shape ``init`` and
+                # ``extend_init`` actually write.
+                per_issue_repo = issue.get("repo")
+                if isinstance(per_issue_repo, str) and per_issue_repo:
+                    repo = per_issue_repo
+                else:
+                    ref = issue.get("ref")
+                    if isinstance(ref, str) and "#" in ref:
+                        repo_part, _, _ = ref.rpartition("#")
+                        repo = repo_part or plan_default
+                    else:
+                        repo = plan_default
                 refs.add(_compose_issue_key(issue["number"], repo))
     return refs
 

--- a/tests/test_wave_status.py
+++ b/tests/test_wave_status.py
@@ -1022,6 +1022,81 @@ class TestCrossRepoPlanRoundTrip:
             "Wave-Engineering/mcp-server-sdlc",
         ]
 
+    def test_init_preserves_cross_repo_refs(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """Issue #521 regression: ``state.json`` ``issues`` dict keys must
+        match the qualified ``ref`` from phases-waves.json verbatim — even
+        when the orchestrator git repo (current working directory) is a
+        DIFFERENT repo from the issues' target repos.
+
+        Before #521: an issue with ``ref="Wave-Engineering/mcp-server-sdlc#362"``
+        but no per-issue ``repo`` override would resolve through the plan-level
+        default (or — worst case — the orchestrator slug), and the state.json
+        key got built as ``Wave-Engineering/<orchestrator>#362``.
+
+        After #521: the qualified ``ref`` field, when present, is the source
+        of truth for the repo prefix and state.json keys round-trip the
+        original ``ref`` exactly.
+        """
+        repo = temp_git_repo
+        cross_repo_plan: dict = {
+            "project": "test-cross-repo-refs",
+            "base_branch": "main",
+            "master_issue": 499,
+            # Plan-level repo simulates the ORCHESTRATOR repo (cc-workflow),
+            # NOT the target repo of the issues.  Without the #521 fix this
+            # is what state.json keys would silently get prefixed with.
+            "repo": "Wave-Engineering/claudecode-workflow",
+            "phases": [
+                {
+                    "name": "Cross-Repo Phase",
+                    "cross_repo": True,
+                    "target_repos": ["Wave-Engineering/mcp-server-sdlc"],
+                    "waves": [
+                        {
+                            "id": "wave-1",
+                            "name": "Wave 1",
+                            "issues": [
+                                {
+                                    "number": 362,
+                                    "ref": "Wave-Engineering/mcp-server-sdlc#362",
+                                    "title": "Cross-repo issue 362",
+                                    "deps": [],
+                                },
+                                {
+                                    "number": 367,
+                                    "ref": "Wave-Engineering/mcp-server-sdlc#367",
+                                    "title": "Cross-repo issue 367",
+                                    "deps": [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+        _write_plan(repo, cross_repo_plan)
+
+        rc, _, err = run_cli(["init", "--force", "plan.json"], repo)
+        assert rc == 0, f"init failed: {err}"
+
+        state_path = repo / ".claude" / "status" / "state.json"
+        state_data = json.loads(state_path.read_text(encoding="utf-8"))
+        issue_keys = set(state_data["issues"].keys())
+
+        # Keys must match the original ref values verbatim.
+        assert issue_keys == {
+            "Wave-Engineering/mcp-server-sdlc#362",
+            "Wave-Engineering/mcp-server-sdlc#367",
+        }, f"unexpected issue keys: {issue_keys}"
+
+        # And specifically: NO key may carry the orchestrator slug.
+        for key in issue_keys:
+            assert "claudecode-workflow" not in key, (
+                f"orchestrator slug leaked into state.json key: {key}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # No external dependencies test [CT-01]


### PR DESCRIPTION
## Summary

When `phases-waves.json` declares an issue with a qualified ref (`owner/repo#N`) and the issue has no per-issue repo override, `state.json`'s issues-dict keys were getting the orchestrator repo slug substituted in. `_issue_repo()` now extracts the repo from the qualified ref so `state.json` keys match `phases-waves.json` refs verbatim.

## Linked Issues

Closes #521

## Reviewer Pass

CLEAN — no high-severity findings.

## Wave Bus

Results: `/tmp/wavemachine/Wave-Engineering-claudecode-workflow/wave-1/flight-2/issue-521/results.md`