### PR TITLE
chore(logging): add logrotate policy for ~/.claude/logs/mcp.jsonl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,8 @@ On session start, run `/engage` to detect platform, resolve identity, load conte
 
 If the session was started with `--channels`, a Discord watcher will push notifications. See `docs/discord-watcher.md` for the addressing convention, signature format, and echo-filter rules.
 
+The MCP fleet writes a unified structured-event log to `~/.claude/logs/mcp.jsonl`. Rotation policy and operational commands: `docs/operations/log-rotation.md`.
+
 ---
 
 ## MANDATORY: Post-Compaction Rules Confirmation

--- a/assets/logrotate/cc-mcp-logs
+++ b/assets/logrotate/cc-mcp-logs
@@ -1,0 +1,27 @@
+# /etc/logrotate.d/cc-mcp-logs — MCP fleet structured-log rotation policy
+#
+# Rotates the unified Claude Code MCP log aggregator at
+# ~/.claude/logs/mcp.jsonl when it reaches 100 MB OR daily, whichever
+# comes first. Keeps 14 rotations, gzip-compressed except for the most
+# recent (delaycompress) so a live grep/tail of the previous rotation
+# stays human-readable for debugging.
+#
+# Templated: the {{HOME}} marker is replaced with the installing user's
+# home directory at install time by `install --with-logrotate`.
+#
+# copytruncate is load-bearing — MCP servers do not handle SIGHUP, so a
+# rename-and-reopen rotation would orphan the original file descriptor
+# and silently drop subsequent log writes. With copytruncate, the log
+# file's inode is preserved; a small write window during the copy may
+# duplicate or interleave but cannot lose entries.
+
+{{HOME}}/.claude/logs/mcp.jsonl {
+    size 100M
+    daily
+    rotate 14
+    compress
+    delaycompress
+    copytruncate
+    missingok
+    notifempty
+}

--- a/docs/operations/log-rotation.md
+++ b/docs/operations/log-rotation.md
@@ -1,0 +1,167 @@
+# MCP Log Rotation
+
+The Claude Code kit's MCP fleet writes a unified structured-event log to
+`~/.claude/logs/mcp.jsonl`. At ~12 events/sec sustained, the file accrues
+roughly 290k events / day and grows on the order of 50 MB / day. Without
+rotation, the aggregator reaches multi-GB sizes within weeks — slow to
+grep, slow to tail, and an eventual disk-fill risk on developer machines.
+
+The kit ships a `logrotate(8)` policy that lands at
+`/etc/logrotate.d/cc-mcp-logs` during install. This doc describes the
+policy, the operational commands, and the macOS escape hatch.
+
+## Scope and platform
+
+**Linux only.** `logrotate` is in every standard Linux distro and the kit
+relies on the system-wide `cron.daily` (or systemd timer) hook to invoke
+it. The `install --with-logrotate` flag is a no-op on macOS / non-Linux
+hosts — the installer detects `uname` and skips the step with a notice.
+
+**macOS users:** macOS ships `newsyslog(8)` instead of `logrotate`. The
+cc-workflow kit does not currently include a `newsyslog` config; the
+recommended workaround is one of:
+
+- Manual rotation: `mv ~/.claude/logs/mcp.jsonl{,.$(date +%Y%m%d)} &&
+  : > ~/.claude/logs/mcp.jsonl` on a personal cron / launchd schedule.
+- Native `newsyslog` config under `/etc/newsyslog.d/cc-mcp-logs.conf`
+  with `B` (binary mode, do not insert "logfile turned over" markers)
+  and a size threshold. PRs adding this template welcomed.
+
+If macOS support becomes load-bearing, a separate issue should track it.
+
+## Policy
+
+```
+~/.claude/logs/mcp.jsonl {
+    size 100M
+    daily
+    rotate 14
+    compress
+    delaycompress
+    copytruncate
+    missingok
+    notifempty
+}
+```
+
+| Directive       | Effect                                                                                |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `size 100M`     | Rotate when file exceeds 100 MB, regardless of cadence.                               |
+| `daily`         | Also rotate every day at the system's `cron.daily` time, even if under the size cap. |
+| `rotate 14`     | Keep 14 historical files; the 15th oldest is unlinked.                                |
+| `compress`      | Gzip rotated files (`.1.gz`, `.2.gz`, ...).                                           |
+| `delaycompress` | Skip compressing the most-recent rotation (so `.1` stays plaintext for grep/tail).   |
+| `copytruncate`  | Copy contents to the rotated path, then truncate the live file in place.              |
+| `missingok`     | Do not error if the log file does not exist yet (fresh installs).                     |
+| `notifempty`    | Do not rotate an empty file.                                                          |
+
+### Why `copytruncate` (load-bearing)
+
+The conventional `logrotate` workflow is rename-and-reopen:
+
+1. `mv mcp.jsonl mcp.jsonl.1`
+2. Send SIGHUP (or equivalent) to the writing process so it reopens its
+   log file descriptor at the original path.
+
+The kit's MCP servers do **not** handle SIGHUP. They open their log
+once at startup and hold the file descriptor for the lifetime of the
+process. A rename-and-reopen rotation would orphan the file descriptor —
+the OS would keep `mcp.jsonl.1` open under the writing process while the
+new `mcp.jsonl` sat on disk receiving zero events. Silent log loss.
+
+`copytruncate` solves this by preserving the inode: the rotation runs
+`cp mcp.jsonl mcp.jsonl.1; : > mcp.jsonl`. The MCP server's open file
+descriptor still points at the same inode, which has been truncated to
+zero. Subsequent writes append to the (now empty) file. There is a small
+window during the copy where new events may write into both the source
+(before truncate) and the rotated copy (since the copy started); these
+are duplicates, not losses, and the timestamp ordering is preserved.
+
+For comparison, the alternative — adding SIGHUP handling to every MCP
+server — is a fleet-wide refactor of process lifecycle code. Not worth
+it for a log rotation policy.
+
+## Install / uninstall
+
+```bash
+# Install (interactive prompt)
+./install
+
+# Install non-interactively
+./install --with-logrotate
+
+# Skip rotation install (still installs the rest of the kit)
+./install --without-logrotate
+
+# Check whether rotation is in place
+./install --check
+```
+
+`./install --with-logrotate` does the following:
+
+1. Detects platform; bails out cleanly on non-Linux.
+2. Renders `assets/logrotate/cc-mcp-logs` with the current user's home.
+3. Drops it to `/etc/logrotate.d/cc-mcp-logs` via `sudo install -m 0644`.
+4. Runs `sudo logrotate -d /etc/logrotate.d/cc-mcp-logs` for syntax /
+   target validation, surfaces stderr.
+
+## Operational commands
+
+```bash
+# Validate config without rotating (dry-run, prints what would happen)
+sudo logrotate -d /etc/logrotate.d/cc-mcp-logs
+
+# Force-rotate now, ignoring size and cadence thresholds
+sudo logrotate -f /etc/logrotate.d/cc-mcp-logs
+
+# Inspect last rotation time
+ls -lh ~/.claude/logs/mcp.jsonl*
+
+# Tail the most-recent rotation (uncompressed thanks to delaycompress)
+tail -F ~/.claude/logs/mcp.jsonl.1
+```
+
+## Disabling temporarily
+
+For short-term high-volume debugging where you want every event in
+one file:
+
+```bash
+# Move the config aside; logrotate will skip it
+sudo mv /etc/logrotate.d/cc-mcp-logs{,.disabled}
+
+# ...debug session here...
+
+# Re-enable
+sudo mv /etc/logrotate.d/cc-mcp-logs{.disabled,}
+```
+
+Or comment out the entire stanza in place. The kit's `--check` mode
+reports the config as missing while it is `.disabled`.
+
+## Removing the policy
+
+```bash
+sudo rm /etc/logrotate.d/cc-mcp-logs
+```
+
+Existing `.gz` archives under `~/.claude/logs/` are unaffected. To
+reclaim disk space:
+
+```bash
+rm ~/.claude/logs/mcp.jsonl.*.gz
+```
+
+## Verification on a Linux test box
+
+The full operator-side verification list (per cc-workflow#540):
+
+1. `./install --with-logrotate` succeeds on a fresh checkout.
+2. `sudo logrotate -d /etc/logrotate.d/cc-mcp-logs` reports no errors.
+3. `sudo logrotate -f /etc/logrotate.d/cc-mcp-logs` produces
+   `mcp.jsonl.1` (uncompressed); MCP servers continue writing to
+   `mcp.jsonl` without restart; no log lines lost.
+4. After a second forced run: `mcp.jsonl.1.gz` exists and `mcp.jsonl.1`
+   is the most-recent rotation (delaycompress confirmed).
+5. `./install --check` reports the rotation config as present and
+   surfaces the last-rotation mtime.

--- a/install
+++ b/install
@@ -5,17 +5,20 @@
 # into the correct locations on the local machine.
 #
 # Usage:
-#   ./install                 Install everything
-#   ./install --dry-run       Show what would be done without doing it
-#   ./install --check         Show drift between repo and installed versions
-#   ./install --skills        Install skills only
-#   ./install --scripts       Install scripts only (also builds packages from src/)
-#   ./install --config        Install config files only (smart-merges settings.json)
-#   ./install --mcps          Install MCP servers only (via mcps.json manifest)
-#   ./install --crystallizer  Install context-crystallizer only
-#   ./install --no-mcps       Install everything except MCP servers
-#   ./install --prune         Remove installed files whose source no longer exists
-#   ./install --yes           Non-interactive (assume yes for --prune confirmations)
+#   ./install                    Install everything
+#   ./install --dry-run          Show what would be done without doing it
+#   ./install --check            Show drift between repo and installed versions
+#   ./install --skills           Install skills only
+#   ./install --scripts          Install scripts only (also builds packages from src/)
+#   ./install --config           Install config files only (smart-merges settings.json)
+#   ./install --mcps             Install MCP servers only (via mcps.json manifest)
+#   ./install --crystallizer     Install context-crystallizer only
+#   ./install --no-mcps          Install everything except MCP servers
+#   ./install --with-logrotate   Install logrotate policy for ~/.claude/logs/mcp.jsonl
+#                                  (Linux only; no-op elsewhere). Implies non-interactive.
+#   ./install --without-logrotate Skip logrotate install (suppresses the prompt).
+#   ./install --prune            Remove installed files whose source no longer exists
+#   ./install --yes              Non-interactive (assume yes for --prune confirmations)
 #
 # Recursion: scripts/ is walked recursively. Files at scripts/<sub>/path are
 # mirrored to ~/.local/bin/<sub>/path with executable bit preserved. Excluded
@@ -48,6 +51,8 @@ INSTALL_SCRIPTS=true
 INSTALL_CONFIG=true
 INSTALL_MCPS=true
 INSTALL_CRYSTALLIZER=true
+# Logrotate is a tri-state: "prompt" by default, forced on/off by flag.
+LOGROTATE_MODE=prompt
 
 # Subtree names excluded from the recursive scripts/ walk.
 SCRIPTS_EXCLUDE_NAMES=(tests fixtures __pycache__ .pytest_cache)
@@ -100,6 +105,14 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--no-mcps)
 		INSTALL_MCPS=false
+		shift
+		;;
+	--with-logrotate)
+		LOGROTATE_MODE=on
+		shift
+		;;
+	--without-logrotate)
+		LOGROTATE_MODE=off
 		shift
 		;;
 	--prune)
@@ -342,6 +355,103 @@ merge_settings() {
 	fi
 }
 
+# --- Logrotate helpers --------------------------------------------------------
+# Constants for the logrotate policy. Source template lives under
+# assets/logrotate/cc-mcp-logs and contains a {{HOME}} marker that must be
+# rendered to the installing user's home before dropping into /etc.
+LOGROTATE_SRC="$REPO_DIR/assets/logrotate/cc-mcp-logs"
+LOGROTATE_DEST="/etc/logrotate.d/cc-mcp-logs"
+LOGROTATE_LOGS_DIR="$HOME/.claude/logs"
+
+# True iff this host has a logrotate(8) we can drive. Linux + logrotate on PATH.
+logrotate_supported() {
+	[[ "$(uname -s)" == "Linux" ]] && command -v logrotate &>/dev/null
+}
+
+# Render the templated config to stdout: substitute {{HOME}} with $HOME.
+render_logrotate_template() {
+	# Use a literal sed delimiter that cannot appear in a Linux home path.
+	# Any character is fine; we use '|' since absolute paths contain '/'.
+	sed "s|{{HOME}}|$HOME|g" "$LOGROTATE_SRC"
+}
+
+# Install the rendered config to /etc/logrotate.d/cc-mcp-logs and run a
+# dry-run validation. Returns non-zero on failure.
+install_logrotate_config() {
+	local tmp
+	tmp="$(mktemp)"
+	render_logrotate_template >"$tmp"
+
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) Would install logrotate config to $LOGROTATE_DEST"
+		info "(dry-run) Would run: sudo logrotate -d $LOGROTATE_DEST"
+		rm -f "$tmp"
+		return 0
+	fi
+
+	if sudo install -m 0644 "$tmp" "$LOGROTATE_DEST"; then
+		info "Installed $LOGROTATE_DEST"
+	else
+		warn "Failed to install $LOGROTATE_DEST (sudo install)"
+		rm -f "$tmp"
+		return 1
+	fi
+	rm -f "$tmp"
+
+	# Dry-run validation: logrotate -d prints what it would do without rotating.
+	if sudo logrotate -d "$LOGROTATE_DEST" >/dev/null 2>&1; then
+		ok "logrotate -d validation passed"
+	else
+		warn "logrotate -d reported errors — re-run manually to diagnose:"
+		warn "  sudo logrotate -d $LOGROTATE_DEST"
+		return 1
+	fi
+}
+
+# Report logrotate status for --check mode.
+# Returns 0 if all-in-sync, 1 if any drift.
+check_logrotate_status() {
+	if ! logrotate_supported; then
+		info "logrotate (skipped — non-Linux or logrotate not installed)"
+		return 0
+	fi
+	local d=0
+	if [[ ! -f "$LOGROTATE_DEST" ]]; then
+		drift "logrotate config $LOGROTATE_DEST — NOT INSTALLED"
+		return 1
+	fi
+	# Compare installed vs rendered template; report drift if differs.
+	local rendered
+	rendered="$(mktemp)"
+	render_logrotate_template >"$rendered"
+	if ! sudo diff -q "$rendered" "$LOGROTATE_DEST" &>/dev/null; then
+		drift "logrotate config $LOGROTATE_DEST — DIFFERS from repo template"
+		d=1
+	else
+		info "logrotate config $LOGROTATE_DEST (in sync)"
+	fi
+	rm -f "$rendered"
+	# Last-rotation mtime: any mcp.jsonl.1 / mcp.jsonl.1.gz / mcp.jsonl.N[.gz]
+	# under the logs dir indicates the rotation has fired at least once.
+	if [[ -d "$LOGROTATE_LOGS_DIR" ]]; then
+		local newest
+		newest=$(find "$LOGROTATE_LOGS_DIR" -maxdepth 1 \
+			\( -name 'mcp.jsonl.[0-9]*' -o -name 'mcp.jsonl.[0-9]*.gz' \) \
+			-type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1)
+		if [[ -n "$newest" ]]; then
+			local newest_path newest_mtime
+			newest_path="${newest#* }"
+			newest_mtime=$(stat -c '%y' "$newest_path" 2>/dev/null || echo 'unknown')
+			info "last rotation: $newest_path ($newest_mtime)"
+		else
+			info "no rotated files yet under $LOGROTATE_LOGS_DIR — rotation has not fired"
+		fi
+	else
+		info "$LOGROTATE_LOGS_DIR does not exist yet — no rotation history"
+	fi
+	return $d
+}
+
 # --- Prune mode ---------------------------------------------------------------
 # Walk previously-installed files (manifest + current source set), remove the
 # ones whose source under scripts/ no longer exists. Backed-up to <file>.bak
@@ -569,6 +679,15 @@ if [[ "$CHECK_MODE" == true ]]; then
 		fi
 	fi
 
+	# Logrotate
+	echo ""
+	echo "Logrotate"
+	echo "──────────────────────────────────────────"
+	total=$((total + 1))
+	if ! check_logrotate_status; then
+		drifted=$((drifted + 1))
+	fi
+
 	# External dependencies
 	# shellcheck source=scripts/ci/check-deps.sh
 	source "$REPO_DIR/scripts/ci/check-deps.sh"
@@ -781,6 +900,52 @@ if [[ "$INSTALL_MCPS" == true && -f "$REPO_DIR/mcps.json" ]]; then
 				echo ""
 			fi
 		done
+	fi
+fi
+
+# --- Install logrotate policy -------------------------------------------------
+# Only fires on Linux with logrotate(8) on PATH. macOS and other platforms
+# print a single notice and skip — no error, no prompt. The mode is set by
+# --with-logrotate / --without-logrotate; absent either flag the user is
+# prompted (unless --yes was passed, which is taken as consent).
+if [[ "$INSTALL_CONFIG" == true || "$LOGROTATE_MODE" != "prompt" ]]; then
+	echo ""
+	echo "Logrotate (~/.claude/logs/mcp.jsonl)"
+	echo "──────────────────────────────────────────"
+	if ! logrotate_supported; then
+		skip "Skipping — logrotate(8) is Linux-only and not present here ($(uname -s))."
+		skip "macOS users: see docs/operations/log-rotation.md for newsyslog guidance."
+	else
+		do_logrotate=false
+		case "$LOGROTATE_MODE" in
+		on)
+			do_logrotate=true
+			;;
+		off)
+			skip "Skipping — --without-logrotate."
+			;;
+		prompt)
+			if [[ "$ASSUME_YES" == true ]]; then
+				do_logrotate=true
+				info "--yes given — installing logrotate policy."
+			elif [[ "$DRY_RUN" == true ]]; then
+				info "(dry-run) Would prompt to install logrotate policy."
+			elif [[ -t 0 ]]; then
+				read -r -p "Install logrotate policy for ~/.claude/logs/mcp.jsonl? [Y/n] " reply || reply=""
+				case "$reply" in
+				n | N | no | NO) skip "Skipped by user." ;;
+				*) do_logrotate=true ;;
+				esac
+			else
+				# Non-interactive (no tty) and no flag — default to skip with a notice.
+				skip "Non-interactive shell and no --with-logrotate / --without-logrotate flag — skipping."
+				info "Re-run with ./install --with-logrotate to enable rotation."
+			fi
+			;;
+		esac
+		if [[ "$do_logrotate" == true ]]; then
+			install_logrotate_config || warn "logrotate install reported issues — see above."
+		fi
 	fi
 fi
 


### PR DESCRIPTION
## Summary

Add `assets/logrotate/cc-mcp-logs` with size 100M / daily / rotate 14 / copytruncate. Install via the new `--with-logrotate` flag in install (or interactive prompt). `--check` reports rotation status. Documented in `docs/operations/log-rotation.md` and cross-referenced from CLAUDE.md. Linux-only; macOS path documented separately.

## Linked Issues

Closes #540

## Reviewer Pass

CLEAN — no high-severity findings.

## Wave Bus

Results: `/tmp/wavemachine/Wave-Engineering-claudecode-workflow/wave-1/flight-2/issue-540/results.md`