### PR TITLE
chore(wavebus): formalize CHANGELOG fragment aggregation

### DIFF
--- a/scripts/wavebus/changelog-aggregate
+++ b/scripts/wavebus/changelog-aggregate
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# wavebus: aggregate per-issue CHANGELOG fragments into the target repo's
+# CHANGELOG.md under "## Unreleased".
+#
+# Usage: changelog-aggregate <wave-root> <target-repo-path> [<wave-id>]
+#
+# Scans <wave-root>/flight-*/issue-*/CHANGELOG.fragment.md in deterministic
+# order (numeric flight then numeric issue). Each fragment is a markdown
+# document with H3 category headings (### Breaking, ### Features, ### Fixes,
+# ### Docs, ### Chore) followed by bullet lines (lines starting with "- ").
+#
+# Lines outside a recognized category heading are ignored (so fragments may
+# carry an H2 of their own or arbitrary prose; only category-bullets are
+# merged). Within each category, identical bullets are deduplicated (first
+# occurrence wins). Categories are emitted in the canonical order:
+#
+#     Breaking, Features, Fixes, Docs, Chore
+#
+# The merged content is written under "## Unreleased" in
+# <target-repo-path>/CHANGELOG.md, creating that heading at the top of the
+# file (after any leading H1/intro) if absent. If the heading already exists,
+# its existing body is replaced wholesale by the freshly-aggregated content.
+#
+# Empty fragment dir (no fragments anywhere under <wave-root>) -> no-op,
+# exit 0, CHANGELOG.md untouched.
+#
+# Exit codes:
+#   0  success (including no-op when zero fragments)
+#   1  usage error
+#   2  wave-root missing or not a directory
+#   3  target-repo-path missing or not a directory
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+	echo "usage: changelog-aggregate <wave-root> <target-repo-path> [<wave-id>]" >&2
+	exit 1
+fi
+
+wave_root="$1"
+target_repo="$2"
+# wave_id is currently unused by the merge logic; accepted for forward-compat
+# (callers may want to stamp the section heading with the wave id later).
+wave_id="${3:-}"
+: "$wave_id" # silence shellcheck SC2034 — accepted but unused
+
+if [[ ! -d "$wave_root" ]]; then
+	echo "error: wave-root is not a directory: $wave_root" >&2
+	exit 2
+fi
+
+if [[ ! -d "$target_repo" ]]; then
+	echo "error: target-repo-path is not a directory: $target_repo" >&2
+	exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Discover fragments in deterministic order: numeric flight, then numeric
+# issue. Globbing alone gives lexical order which would mis-order flight-10
+# vs flight-2; sort by the numeric component instead.
+# ---------------------------------------------------------------------------
+
+mapfile -t fragments < <(
+	find "$wave_root" -path "*/flight-*/issue-*/CHANGELOG.fragment.md" -type f 2>/dev/null |
+		while IFS= read -r path; do
+			flight=""
+			issue=""
+			# Walk path components; pull out the numeric ids from flight-N
+			# and issue-N segments. POSIX-portable bash extraction (no gawk
+			# match-with-array required, so this works on mawk too).
+			IFS='/' read -r -a parts <<<"$path"
+			for part in "${parts[@]}"; do
+				if [[ "$part" =~ ^flight-([0-9]+)$ ]]; then
+					flight="${BASH_REMATCH[1]}"
+				elif [[ "$part" =~ ^issue-([0-9]+)$ ]]; then
+					issue="${BASH_REMATCH[1]}"
+				fi
+			done
+			printf '%010d\t%010d\t%s\n' "$flight" "$issue" "$path"
+		done |
+		sort -k1,1n -k2,2n |
+		cut -f3-
+)
+
+if [[ ${#fragments[@]} -eq 0 ]]; then
+	# No-op: no fragments anywhere under wave-root.
+	echo "changelog-aggregate: no fragments found under $wave_root (no-op)"
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Parse each fragment, accumulating bullets per category. We use one tmpfile
+# per canonical category so dedup can be done with awk '!seen[$0]++' at the
+# end. Categories are case-insensitive on the heading match but emitted with
+# canonical capitalization.
+# ---------------------------------------------------------------------------
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+# Canonical order and display names.
+declare -a CATEGORIES=("Breaking" "Features" "Fixes" "Docs" "Chore")
+
+# Initialize per-category tmpfiles.
+for cat in "${CATEGORIES[@]}"; do
+	: >"$work_dir/$cat"
+done
+
+# Map a heading text (lowercased) to a canonical category, or empty if not
+# recognized.
+canonical_category() {
+	local raw="$1"
+	# Strip leading/trailing whitespace and trailing punctuation.
+	raw="${raw#"${raw%%[![:space:]]*}"}"
+	raw="${raw%"${raw##*[![:space:]]}"}"
+	local lower
+	lower="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+	case "$lower" in
+	breaking | "breaking changes" | "breaking change") echo "Breaking" ;;
+	features | feature | added | new) echo "Features" ;;
+	fixes | fixed | "bug fixes" | bugfix | bugfixes) echo "Fixes" ;;
+	docs | documentation) echo "Docs" ;;
+	chore | chores | maintenance) echo "Chore" ;;
+	*) echo "" ;;
+	esac
+}
+
+for frag in "${fragments[@]}"; do
+	current=""
+	# shellcheck disable=SC2094 # reading line-by-line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# H3 heading -> category switch.
+		if [[ "$line" =~ ^###[[:space:]]+(.+)$ ]]; then
+			heading="${BASH_REMATCH[1]}"
+			current="$(canonical_category "$heading")"
+			continue
+		fi
+		# Any other heading resets current (so an H2 in a fragment won't
+		# accidentally absorb bullets into the previous H3's category).
+		if [[ "$line" =~ ^#{1,2}[[:space:]] ]]; then
+			current=""
+			continue
+		fi
+		# Bullet under a recognized category.
+		if [[ -n "$current" && "$line" =~ ^-[[:space:]] ]]; then
+			printf '%s\n' "$line" >>"$work_dir/$current"
+		fi
+	done <"$frag"
+done
+
+# Dedupe each category (first occurrence wins, preserving order).
+for cat in "${CATEGORIES[@]}"; do
+	if [[ -s "$work_dir/$cat" ]]; then
+		awk '!seen[$0]++' "$work_dir/$cat" >"$work_dir/$cat.dedup"
+		mv "$work_dir/$cat.dedup" "$work_dir/$cat"
+	fi
+done
+
+# If, after parsing, every category is empty (fragments existed but contained
+# no recognizable bullets), treat as no-op too.
+any_content=0
+for cat in "${CATEGORIES[@]}"; do
+	if [[ -s "$work_dir/$cat" ]]; then
+		any_content=1
+		break
+	fi
+done
+if [[ $any_content -eq 0 ]]; then
+	echo "changelog-aggregate: fragments found but no recognized category bullets (no-op)"
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build the new "## Unreleased" body.
+# ---------------------------------------------------------------------------
+
+new_section="$work_dir/unreleased.md"
+{
+	echo "## Unreleased"
+	echo ""
+	for cat in "${CATEGORIES[@]}"; do
+		if [[ -s "$work_dir/$cat" ]]; then
+			echo "### $cat"
+			echo ""
+			cat "$work_dir/$cat"
+			echo ""
+		fi
+	done
+} >"$new_section"
+
+# ---------------------------------------------------------------------------
+# Splice into target CHANGELOG.md.
+# ---------------------------------------------------------------------------
+
+changelog="$target_repo/CHANGELOG.md"
+
+if [[ ! -f "$changelog" ]]; then
+	# Brand-new CHANGELOG.md: just emit the section.
+	{
+		echo "# Changelog"
+		echo ""
+		cat "$new_section"
+	} >"$changelog"
+	echo "changelog-aggregate: wrote $(wc -l <"$new_section") lines under '## Unreleased' (new CHANGELOG.md at $changelog)"
+	exit 0
+fi
+
+# Existing CHANGELOG.md. Look for an existing "## Unreleased" heading. If
+# present, replace from that line up to (but not including) the next H2 (or
+# EOF) with the freshly built section. If absent, insert the new section
+# after the file's leading H1 + blank-line block (if any), else at the top.
+
+if grep -q -E '^## Unreleased[[:space:]]*$' "$changelog"; then
+	# Replace existing block.
+	awk -v new_section_path="$new_section" '
+		BEGIN { state = "before" }
+		state == "before" {
+			if ($0 ~ /^## Unreleased[[:space:]]*$/) {
+				# Emit the new section in place of this line + everything until next H2/EOF.
+				while ((getline line < new_section_path) > 0) print line;
+				close(new_section_path);
+				state = "skip"
+				next
+			}
+			print
+			next
+		}
+		state == "skip" {
+			# We are skipping the old Unreleased body. Stop skipping when we hit the next H2.
+			if ($0 ~ /^## /) { print; state = "after"; next }
+			next
+		}
+		state == "after" { print }
+	' "$changelog" >"$work_dir/changelog.new"
+else
+	# Insert new section. Strategy: place it after the first H1+blank-line
+	# (typical CHANGELOG.md preamble) if present, else at the top.
+	awk -v new_section_path="$new_section" '
+		BEGIN { inserted = 0; saw_h1 = 0; just_after_h1 = 0 }
+		!inserted {
+			if (!saw_h1 && $0 ~ /^# /) {
+				print
+				saw_h1 = 1
+				just_after_h1 = 1
+				next
+			}
+			if (just_after_h1) {
+				# The blank line directly after the H1 is the natural splice point.
+				if ($0 == "") {
+					print
+					while ((getline line < new_section_path) > 0) print line;
+					close(new_section_path);
+					inserted = 1
+					next
+				}
+				# H1 not followed by blank line -> splice now anyway.
+				while ((getline line < new_section_path) > 0) print line;
+				close(new_section_path);
+				inserted = 1
+				print
+				next
+			}
+			# No H1 yet -> splice at the very top before printing the first line.
+			while ((getline line < new_section_path) > 0) print line;
+			close(new_section_path);
+			inserted = 1
+			print
+			next
+		}
+		{ print }
+		END {
+			if (!inserted) {
+				while ((getline line < new_section_path) > 0) print line;
+				close(new_section_path);
+			}
+		}
+	' "$changelog" >"$work_dir/changelog.new"
+fi
+
+mv "$work_dir/changelog.new" "$changelog"
+echo "changelog-aggregate: merged ${#fragments[@]} fragments into $changelog"

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -26,7 +26,7 @@ CC sub-agents do not have the `Agent`/`Task` tool. Only the top-level session ca
 - Spec: `spec_validate_structure`, `spec_get`, `spec_acceptance_criteria`
 - Commutativity + merge (used by Prime post-flight): `commutativity_verify`, `pr_create`, `pr_wait_ci`, `pr_merge`
 - CI trust (auto mode): `wave_ci_trust_level`
-- Bus primitives (bash): `scripts/wavebus/wave-init`, `scripts/wavebus/flight-finalize`, `scripts/wavebus/wave-cleanup`
+- Bus primitives (bash): `scripts/wavebus/wave-init`, `scripts/wavebus/flight-finalize`, `scripts/wavebus/wave-cleanup`, `scripts/wavebus/changelog-aggregate`
 - Notifications: `mcp__disc-server__disc_send` — post wave status to `#wave-status` (`1487386934094462986`)
 - Observability: `mcp-log` — emit lifecycle events to `~/.claude/logs/mcp.jsonl` for temporal correlation against sdlc-server `tool_call` events. See `docs/mcp-logging-standard.md`.
 
@@ -362,8 +362,9 @@ After every flight has merged:
    >    - `SPEC CURRENT` → note in report; move on.
    >    - `SPEC STALE` → mechanical fix: update the issue with corrected paths/names; list changes in the report.
    >    - `SPEC BROKEN` → leave the issue alone; flag for user attention in the report.
-   > 4. `wave_complete()` (marks the current wave complete — takes no args; the server uses the active wave from state).
-   > 5. Write `<wave-root>/merge-report.md` (issues closed, PR URLs, flight breakdown, drift findings, deferred items, next-wave preview).
+   > 4. **CHANGELOG aggregation (mechanical — no gate).** Run `scripts/wavebus/changelog-aggregate <wave-root> <target-repo-path> wave-<N>` to merge per-issue `CHANGELOG.fragment.md` files into the target repo's `CHANGELOG.md` under `## Unreleased`. If the aggregator wrote to `CHANGELOG.md`, commit on a fresh `chore/wave-<N>-changelog` branch in the target repo, push, open a PR (`pr_create`) targeting `<kahuna_branch>` if set else `main`, wait for CI (`pr_wait_ci`), then `pr_merge`. No human gate — content was already approved at each flight's Step 3d gate; this step is purely mechanical aggregation. If the aggregator reports `no fragments found`, skip the commit/PR step entirely (no-op).
+   > 5. `wave_complete()` (marks the current wave complete — takes no args; the server uses the active wave from state).
+   > 6. Write `<wave-root>/merge-report.md` (issues closed, PR URLs, flight breakdown, drift findings, CHANGELOG aggregation result + PR URL if applicable, deferred items, next-wave preview).
    >
    > Final message — exactly one line:
    >
@@ -378,7 +379,7 @@ After every flight has merged:
 
 ## Step 5 — Cleanup
 
-- **Success path** (Prime(post-wave) returned `PASS`): call `scripts/wavebus/wave-cleanup <wave-root>`. Report "bus cleaned" in the final summary. Then remove any worktrees the wave created — both same-repo (CC `isolation: "worktree"`) and cross-repo (orchestrator-created).
+- **Success path** (Prime(post-wave) returned `PASS`): call `scripts/wavebus/wave-cleanup <wave-root>`. This rm -rf's the wave subtree, including every per-issue `CHANGELOG.fragment.md` written by the flights — Prime(post-wave) Step 4 already merged their content into the target repo's `CHANGELOG.md` under `## Unreleased` and opened the chore PR, so the fragments are intentionally ephemeral and disappear with the bus. Report "bus cleaned" in the final summary. Then remove any worktrees the wave created — both same-repo (CC `isolation: "worktree"`) and cross-repo (orchestrator-created).
 
   **Worktree-removal contract.** CC's worktree-isolation mechanism (and Flight sub-agents in general) leaves a git lock file on each Flight's worktree (`lock reason: "claude agent <id> (pid ...)"`). A single `git worktree remove --force` is NOT enough — git refuses to remove a locked working tree. The cleanup MUST unlock first (no-op if unlocked) and then force-remove:
 
@@ -433,6 +434,8 @@ This prompt is what each Flight sub-agent receives. Preserve the SPEC EXECUTOR b
 > - CI/CD: no more than 5 lines in any `run:`/`script:` block — extract shell scripts to `scripts/ci/`. No hardcoded secrets.
 > - Tests exercise REAL code paths. Mocks only for true external boundaries (network/fs/APIs). Every new function needs coverage. Assert meaningful outcomes. >2 mocks in one test = wrong approach.
 > - Report: what was implemented, files, test results, review findings, AC status, concerns. Do NOT report success on failing tests or unmet AC.
+>
+> **CHANGELOG fragment rule.** Do NOT edit `CHANGELOG.md` directly. If the issue introduces a user-visible change worth a changelog entry, write `CHANGELOG.fragment.md` in your issue dir at `<wave-root>/flight-<M>/issue-<X>/CHANGELOG.fragment.md`. The fragment is a markdown document with H3 category headings (`### Breaking`, `### Features`, `### Fixes`, `### Docs`, `### Chore`) followed by bullet lines. Prime(post-wave) aggregates every fragment in the wave into the target repo's `CHANGELOG.md` under `## Unreleased` (deterministic order: numeric flight, then numeric issue; identical bullets deduplicated). This unblocks `flight_partition` parallelism for waves whose stories all touch `CHANGELOG.md` — see `pattern_changelog_fragment_aggregation.md`.
 >
 > **After implementation, run the mechanical half of `/precheck` in the worktree:**
 >

--- a/tests/test_changelog_aggregate.py
+++ b/tests/test_changelog_aggregate.py
@@ -1,0 +1,262 @@
+"""Tests for scripts/wavebus/changelog-aggregate.
+
+Exercises the real bash script via subprocess.run() against a tmp-dir wave
+root and a tmp-dir target repo. No mocking of the script under test.
+
+Pattern mirrors tests/test_wavebus_scripts.py — keep the same shape so the
+two test files read consistently.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "wavebus" / "changelog-aggregate"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(argv: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def _seed_fragment(
+    wave_root: Path,
+    flight: int,
+    issue: int,
+    body: str,
+) -> Path:
+    issue_dir = wave_root / f"flight-{flight}" / f"issue-{issue}"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    frag = issue_dir / "CHANGELOG.fragment.md"
+    frag.write_text(body)
+    return frag
+
+
+@pytest.fixture()
+def wave_root(tmp_path: Path) -> Path:
+    root = tmp_path / "wave-1"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture()
+def target_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_usage_error_no_args() -> None:
+    result = _run([str(SCRIPT)])
+    assert result.returncode == 1, result.stderr
+    assert "usage:" in result.stderr
+
+
+def test_usage_error_too_many_args(tmp_path: Path) -> None:
+    result = _run([str(SCRIPT), str(tmp_path), str(tmp_path), "wave-1", "extra"])
+    assert result.returncode == 1, result.stderr
+
+
+def test_rejects_missing_wave_root(target_repo: Path, tmp_path: Path) -> None:
+    bogus = tmp_path / "does-not-exist"
+    result = _run([str(SCRIPT), str(bogus), str(target_repo)])
+    assert result.returncode == 2, result.stderr
+
+
+def test_rejects_missing_target_repo(wave_root: Path, tmp_path: Path) -> None:
+    bogus = tmp_path / "no-such-repo"
+    result = _run([str(SCRIPT), str(wave_root), str(bogus)])
+    assert result.returncode == 3, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Empty / no-op cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_wave_root_is_noop(wave_root: Path, target_repo: Path) -> None:
+    """No fragments anywhere -> exit 0, no CHANGELOG.md created."""
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo)])
+    assert result.returncode == 0, result.stderr
+    assert not (target_repo / "CHANGELOG.md").exists()
+    assert "no fragments" in result.stdout.lower()
+
+
+def test_fragments_with_no_recognized_categories_is_noop(
+    wave_root: Path, target_repo: Path
+) -> None:
+    """Fragments exist but contain no recognized H3 category bullets -> no-op."""
+    _seed_fragment(
+        wave_root,
+        1,
+        100,
+        "## Just an H2\n\nSome prose, no category headings.\n",
+    )
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo)])
+    assert result.returncode == 0, result.stderr
+    assert not (target_repo / "CHANGELOG.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Basic merge: 3 fragments, 2 categories, deterministic order
+# ---------------------------------------------------------------------------
+
+
+def test_basic_merge_three_fragments_two_categories(
+    wave_root: Path, target_repo: Path
+) -> None:
+    _seed_fragment(
+        wave_root,
+        1,
+        101,
+        "### Features\n- Added A (#101)\n\n### Fixes\n- Fixed X (#101)\n",
+    )
+    _seed_fragment(
+        wave_root,
+        1,
+        102,
+        "### Features\n- Added B (#102)\n",
+    )
+    _seed_fragment(
+        wave_root,
+        2,
+        103,
+        "### Fixes\n- Fixed Y (#103)\n",
+    )
+
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo)])
+    assert result.returncode == 0, result.stderr
+
+    content = (target_repo / "CHANGELOG.md").read_text()
+    # Heading present
+    assert "## Unreleased" in content
+    # Both categories present in canonical order
+    feat_idx = content.index("### Features")
+    fix_idx = content.index("### Fixes")
+    assert feat_idx < fix_idx, "Features should come before Fixes"
+    # Numeric flight / issue ordering preserved within Features:
+    # flight-1/issue-101 (Added A) before flight-1/issue-102 (Added B)
+    a_idx = content.index("Added A (#101)")
+    b_idx = content.index("Added B (#102)")
+    assert a_idx < b_idx
+    # And X (flight 1) before Y (flight 2) within Fixes
+    x_idx = content.index("Fixed X (#101)")
+    y_idx = content.index("Fixed Y (#103)")
+    assert x_idx < y_idx
+
+
+# ---------------------------------------------------------------------------
+# Dedup: identical bullet across fragments collapses to one line
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_bullet_collapses_to_one_line(
+    wave_root: Path, target_repo: Path
+) -> None:
+    _seed_fragment(wave_root, 1, 200, "### Features\n- Same bullet\n")
+    _seed_fragment(wave_root, 1, 201, "### Features\n- Same bullet\n")
+    _seed_fragment(wave_root, 2, 202, "### Features\n- Same bullet\n")
+
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo)])
+    assert result.returncode == 0, result.stderr
+
+    content = (target_repo / "CHANGELOG.md").read_text()
+    occurrences = content.count("- Same bullet")
+    assert occurrences == 1, f"expected one occurrence, got {occurrences}"
+
+
+# ---------------------------------------------------------------------------
+# Splice into an existing CHANGELOG.md
+# ---------------------------------------------------------------------------
+
+
+def test_splice_replaces_existing_unreleased_block(
+    wave_root: Path, target_repo: Path
+) -> None:
+    _seed_fragment(wave_root, 1, 300, "### Features\n- New entry\n")
+
+    (target_repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## Unreleased\n\n"
+        "### Fixes\n\n"
+        "- Stale entry that should disappear\n\n"
+        "## v1.0.0\n\n"
+        "- Initial release\n"
+    )
+
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo)])
+    assert result.returncode == 0, result.stderr
+
+    content = (target_repo / "CHANGELOG.md").read_text()
+    assert "Stale entry that should disappear" not in content
+    assert "New entry" in content
+    # Earlier release section preserved
+    assert "## v1.0.0" in content
+    assert "Initial release" in content
+    # Unreleased still appears exactly once
+    assert content.count("## Unreleased") == 1
+
+
+def test_splice_inserts_when_unreleased_absent(
+    wave_root: Path, target_repo: Path
+) -> None:
+    _seed_fragment(wave_root, 1, 400, "### Features\n- Brand new entry\n")
+
+    (target_repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## v1.0.0\n\n- Initial release\n"
+    )
+
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo)])
+    assert result.returncode == 0, result.stderr
+
+    content = (target_repo / "CHANGELOG.md").read_text()
+    assert "## Unreleased" in content
+    assert "Brand new entry" in content
+    # Unreleased should land before the prior release
+    assert content.index("## Unreleased") < content.index("## v1.0.0")
+    # H1 still at the top
+    assert content.startswith("# Changelog")
+
+
+# ---------------------------------------------------------------------------
+# Numeric flight ordering: flight-2 before flight-10
+# ---------------------------------------------------------------------------
+
+
+def test_flight_ordering_is_numeric_not_lexical(
+    wave_root: Path, target_repo: Path
+) -> None:
+    _seed_fragment(wave_root, 2, 500, "### Features\n- From flight 2\n")
+    _seed_fragment(wave_root, 10, 501, "### Features\n- From flight 10\n")
+
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo)])
+    assert result.returncode == 0, result.stderr
+
+    content = (target_repo / "CHANGELOG.md").read_text()
+    # flight 2 must precede flight 10 even though "10" sorts before "2" lexically
+    assert content.index("From flight 2") < content.index("From flight 10")
+
+
+# ---------------------------------------------------------------------------
+# Wave-id arg accepted (forward-compat) but ignored
+# ---------------------------------------------------------------------------
+
+
+def test_wave_id_arg_accepted(wave_root: Path, target_repo: Path) -> None:
+    _seed_fragment(wave_root, 1, 600, "### Features\n- With wave id\n")
+    result = _run([str(SCRIPT), str(wave_root), str(target_repo), "wave-1"])
+    assert result.returncode == 0, result.stderr
+    assert "With wave id" in (target_repo / "CHANGELOG.md").read_text()


### PR DESCRIPTION
## Summary

Formalizes the CHANGELOG fragment aggregation pattern: Flights write per-issue `CHANGELOG.fragment.md` files; Prime(post-wave) aggregates them into a single CHANGELOG commit. Unblocks `flight_partition` parallelism for append-only files.

## Linked Issues

Closes #524

## Reviewer pass

CLEAN

## Flight artifacts

- Results: `/tmp/wavemachine/Wave-Engineering-claudecode-workflow/wave-1/flight-3/issue-524/results.md`
- Wave 1, Flight 3 (single-issue flight)