### PR TITLE
fix(install): adopt Cellar + symlink-farm layout for orphan-free re-deploys

### DIFF
--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.local/bin/hooks/nerf/session-start-compact.sh"
+            "command": "~/.claude/scripts/hooks/nerf/session-start-compact.sh"
           }
         ]
       }
@@ -73,7 +73,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.local/bin/hooks/nerf/pre-compact.sh"
+            "command": "~/.claude/scripts/hooks/nerf/pre-compact.sh"
           }
         ]
       }

--- a/install
+++ b/install
@@ -42,6 +42,11 @@ REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$HOME/.claude/skills"
 SCRIPTS_DIR="$HOME/.local/bin"
 CLAUDE_DIR="$HOME/.claude"
+# Cellar: kit-owned scripts directory (Homebrew/Nix pattern). Wiped and
+# recreated on every install — this is what eliminates orphan rot. Anything
+# that landed here in a prior install is fair game for deletion. SCRIPTS_DIR
+# becomes a symlink farm pointing into here for entries that need PATH.
+CELLAR_DIR="$HOME/.claude/scripts"
 DRY_RUN=false
 CHECK_MODE=false
 PRUNE_MODE=false
@@ -232,6 +237,238 @@ do_check() {
 	fi
 }
 
+# --- Cellar + symlink-farm helpers --------------------------------------------
+# Cellar = $CELLAR_DIR (kit-owned). Wiped and recreated each install.
+# Symlink farm = $SCRIPTS_DIR — only top-level Cellar entries (recommendation
+# B from #560: subtrees like hooks/, vox-providers/ stay Cellar-only and are
+# invoked by absolute path).
+
+# Resolve a symlink's target to a normalized absolute path. Uses readlink -f
+# when available (GNU), falls back to a portable cd-and-pwd dance for BSD.
+# Result printed to stdout. Empty string if the path can't be resolved.
+resolve_symlink_target() {
+	local link="$1" target
+	# Plain readlink (no -f) gives the literal target text.
+	target=$(readlink "$link" 2>/dev/null || true)
+	[[ -z "$target" ]] && return 0
+	# Make absolute relative to the link's directory if needed.
+	if [[ "$target" != /* ]]; then
+		target="$(cd "$(dirname "$link")" 2>/dev/null && pwd)/$target"
+	fi
+	# Normalize ~ (readlink can't do this for us if user's HOME has tilde
+	# in raw target — uncommon but harmless to handle).
+	target="${target/#\~/$HOME}"
+	echo "$target"
+}
+
+# Wipe and recreate the Cellar from $REPO_DIR/scripts/. Preserves directory
+# structure and executable bits. Excludes ci/ and noise subtrees.
+# Honors $DRY_RUN.
+cellar_deploy() {
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) Would wipe and redeploy $CELLAR_DIR from $REPO_DIR/scripts/"
+		return 0
+	fi
+	# Wipe — this is the structural orphan-killer. Anything that was in
+	# Cellar from a prior install but is no longer in the repo dies here.
+	rm -rf "$CELLAR_DIR"
+	mkdir -p "$CELLAR_DIR"
+	while IFS= read -r rel; do
+		[[ "$rel" == ci/* ]] && continue
+		local src="$REPO_DIR/scripts/$rel"
+		local dest="$CELLAR_DIR/$rel"
+		mkdir -p "$(dirname "$dest")"
+		cp "$src" "$dest"
+		# Preserve exec bit (top-level scripts always +x for backwards compat).
+		if [[ "$rel" != */* ]]; then
+			chmod +x "$dest"
+		elif [[ -x "$src" ]]; then
+			chmod +x "$dest"
+		fi
+	done < <(enumerate_scripts)
+	info "Cellar redeployed: $CELLAR_DIR ($(find "$CELLAR_DIR" -type f | wc -l) files)"
+}
+
+# Drop a single file (skill helper or built artifact) into the Cellar at
+# $CELLAR_DIR/<name>. Preserves +x.
+cellar_install_file() {
+	local src="$1" name="$2"
+	local dest="$CELLAR_DIR/$name"
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) $src → $dest (Cellar)"
+		return 0
+	fi
+	mkdir -p "$(dirname "$dest")"
+	cp "$src" "$dest"
+	chmod +x "$dest"
+}
+
+# Drop a skill helper into a per-skill Cellar subdir at
+# $CELLAR_DIR/skills/<skill_name>/<helper_name>. Preserves +x. Distinct from
+# cellar_install_file() so two skills shipping same-named helpers (e.g. both
+# with helper.sh) cannot silently overwrite each other in the Cellar.
+cellar_install_skill_helper() {
+	local src="$1" skill_name="$2" helper_name="$3"
+	local dest="$CELLAR_DIR/skills/$skill_name/$helper_name"
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) $src → $dest (Cellar/skills)"
+		return 0
+	fi
+	mkdir -p "$(dirname "$dest")"
+	cp "$src" "$dest"
+	chmod +x "$dest"
+}
+
+# Create or refresh a symlink at $SCRIPTS_DIR/<helper_name> pointing to
+# $CELLAR_DIR/skills/<skill_name>/<helper_name>. Bare-name target preserves
+# PATH-based skill invocation (e.g. `slackbot-send`, `file-opener`). If a
+# symlink with this name already exists pointing into a *different* skill's
+# Cellar subdir, warn loudly — this is the namespace-collision case the
+# per-skill Cellar layout was designed to surface.
+farm_symlink_skill_helper() {
+	local skill_name="$1" helper_name="$2"
+	local target="$CELLAR_DIR/skills/$skill_name/$helper_name"
+	local link="$SCRIPTS_DIR/$helper_name"
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) symlink $link → $target"
+		return 0
+	fi
+	if [[ -L "$link" ]]; then
+		local existing
+		existing=$(resolve_symlink_target "$link")
+		# Existing symlink into a *different* skill's helper → collision.
+		if [[ "$existing" == "$CELLAR_DIR/skills/"* && "$existing" != "$target" ]]; then
+			warn "Helper name collision for '$helper_name': $existing already farmed; overwriting with $target"
+		fi
+	fi
+	mkdir -p "$(dirname "$link")"
+	ln -sf "$target" "$link"
+}
+
+# If $SCRIPTS_DIR/<name> exists as a plain file (not a symlink), it's a user
+# customization or a leftover from the pre-Cellar layout. Back it up to
+# <name>.bak before we replace it with a symlink. No-op if it's already a
+# symlink (or doesn't exist).
+safeguard_user_file() {
+	local name="$1"
+	local path="$SCRIPTS_DIR/$name"
+	# Symlink → already farm-managed, leave alone (will be overwritten below).
+	[[ -L "$path" ]] && return 0
+	# No plain file → nothing to safeguard.
+	[[ -e "$path" ]] || return 0
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) Would back up plain file $path → ${path}.bak"
+		return 0
+	fi
+	cp "$path" "${path}.bak"
+	rm -f "$path"
+	warn "Backed up user-customized $path → ${path}.bak"
+}
+
+# Create or refresh a single symlink at $SCRIPTS_DIR/<name> pointing into
+# the Cellar. The target is $CELLAR_DIR/<name>. Caller is responsible for
+# safeguarding any plain-file occupant first via safeguard_user_file().
+farm_symlink() {
+	local name="$1"
+	local target="$CELLAR_DIR/$name"
+	local link="$SCRIPTS_DIR/$name"
+	if [[ "$DRY_RUN" == true ]]; then
+		info "(dry-run) symlink $link → $target"
+		return 0
+	fi
+	mkdir -p "$(dirname "$link")"
+	ln -sf "$target" "$link"
+}
+
+# Walk $SCRIPTS_DIR and remove symlinks that point into the Cellar but whose
+# target no longer exists. This is the structural reaper that catches both
+# removed-from-repo cases (e.g. discord-bot in PR #283) and rename cases.
+# Foreign symlinks (target NOT under $CELLAR_DIR) are NEVER touched.
+reap_stale_cellar_symlinks() {
+	[[ -d "$SCRIPTS_DIR" ]] || return 0
+	local removed=0
+	while IFS= read -r link; do
+		[[ -L "$link" ]] || continue
+		local target
+		target=$(resolve_symlink_target "$link")
+		# Foreign symlink (target outside Cellar) → leave alone.
+		[[ "$target" == "$CELLAR_DIR"/* || "$target" == "$CELLAR_DIR" ]] || continue
+		# Target exists → live link, skip.
+		[[ -e "$target" ]] && continue
+		# Target missing under Cellar → stale. Reap it.
+		if [[ "$DRY_RUN" == true ]]; then
+			info "(dry-run) Would remove stale symlink: $link → $target"
+		else
+			rm -f "$link"
+			info "Reaped stale symlink: $link → $target"
+		fi
+		removed=$((removed + 1))
+	done < <(find "$SCRIPTS_DIR" -maxdepth 1 -type l 2>/dev/null)
+	if [[ $removed -eq 0 ]]; then
+		skip "No stale symlinks under $SCRIPTS_DIR (Cellar reaper)"
+	fi
+}
+
+# Enumerate the basenames that should appear in $SCRIPTS_DIR as symlinks
+# pointing into $CELLAR_DIR. Granularity B: only top-level entries from
+# scripts/ (subtrees like hooks/, vox-providers/, testing/ stay Cellar-only).
+# ci/ is excluded as before.
+#
+# Uses `find ... | sed` rather than GNU's `-printf '%f\n'` because BSD/macOS
+# find lacks -printf and silently emits nothing — which would empty the
+# symlink farm on macOS and silently break PATH discoverability (AC #2).
+# Same fix-pattern enumerate_scripts uses above.
+enumerate_farm_targets() {
+	(cd "$REPO_DIR/scripts" && find . -maxdepth 1 -type f | sed 's|^\./||' | sort)
+}
+
+# In a $HOME/.claude/settings.json, rewrite any hook command path of the
+# shape "~/.local/bin/hooks/..." to "~/.claude/scripts/hooks/...". Walks
+# every hooks.<event>[].hooks[].command and applies a literal-string replace.
+# Idempotent. Modifies $1 in place via tmpfile rotation.
+rewrite_old_hook_paths_in_settings() {
+	local target="$1"
+	[[ -f "$target" ]] || return 0
+	command -v jq &>/dev/null || return 0
+	# jq walk: for any string ending up under hooks.*.hooks.*.command,
+	# rewrite leading "~/.local/bin/hooks/" → "~/.claude/scripts/hooks/".
+	local rewritten
+	rewritten=$(jq '
+		if .hooks then
+			.hooks |= with_entries(
+				if .key == "_comment" then . else
+					.value |= map(
+						.hooks |= map(
+							if .command and (.command | startswith("~/.local/bin/hooks/")) then
+								.command = ("~/.claude/scripts/hooks/" + (.command | ltrimstr("~/.local/bin/hooks/")))
+							else . end
+						)
+					)
+				end
+			)
+		else . end
+	' "$target")
+	echo "$rewritten" >"$target"
+}
+
+# Detect any settings.json hook command paths of the old form. Prints the
+# offending event names (one per line) for use in --check drift reporting.
+detect_old_hook_paths_in_settings() {
+	local target="$1"
+	[[ -f "$target" ]] || return 0
+	command -v jq &>/dev/null || return 0
+	jq -r '
+		.hooks // {} | to_entries[] |
+		select(.key != "_comment") |
+		. as $e |
+		.value |
+		map(.hooks // []) | add // [] |
+		map(.command // "") |
+		map(select(startswith("~/.local/bin/hooks/"))) |
+		if length > 0 then $e.key else empty end
+	' "$target" 2>/dev/null
+}
+
 merge_settings() {
 	local template="$1" target="$2"
 
@@ -242,6 +479,19 @@ merge_settings() {
 	fi
 
 	cp "$target" "${target}.bak"
+
+	# Migrate any pre-Cellar hook command paths (~/.local/bin/hooks/...) to
+	# the new Cellar location (~/.claude/scripts/hooks/...) BEFORE merge so
+	# the union step compares apples to apples (template uses new paths).
+	local old_path_events
+	old_path_events=$(detect_old_hook_paths_in_settings "$target")
+	if [[ -n "$old_path_events" ]]; then
+		rewrite_old_hook_paths_in_settings "$target"
+		while IFS= read -r ev; do
+			[[ -z "$ev" ]] && continue
+			info "hooks.$ev — migrated old path(s) ~/.local/bin/hooks/... → ~/.claude/scripts/hooks/..."
+		done <<<"$old_path_events"
+	fi
 
 	# Deep merge: template into local, preserving user customizations
 	# Rules:
@@ -532,7 +782,7 @@ if [[ "$CHECK_MODE" == true ]]; then
 			total=$((total + 1))
 			do_check "$src" "$dest" "$skill_name" || drifted=$((drifted + 1))
 		fi
-		# Check non-SKILL.md files: .md files in skill dir, others in scripts dir
+		# Check non-SKILL.md files: .md files in skill dir, helpers in Cellar.
 		for helper in "$skill_dir"/*; do
 			[[ -f "$helper" ]] || continue
 			helper_name="$(basename "$helper")"
@@ -541,7 +791,7 @@ if [[ "$CHECK_MODE" == true ]]; then
 			if [[ "$helper_name" == *.md ]]; then
 				do_check "$helper" "$SKILLS_DIR/$skill_name/$helper_name" "$skill_name/$helper_name" || drifted=$((drifted + 1))
 			else
-				do_check "$helper" "$SCRIPTS_DIR/$helper_name" "$skill_name/$helper_name" || drifted=$((drifted + 1))
+				do_check "$helper" "$CELLAR_DIR/$helper_name" "$skill_name/$helper_name" || drifted=$((drifted + 1))
 			fi
 		done
 		# Check content subdirectories (e.g., tours/)
@@ -558,23 +808,79 @@ if [[ "$CHECK_MODE" == true ]]; then
 	done
 
 	echo ""
-	echo "Scripts"
+	echo "Scripts (Cellar: $CELLAR_DIR)"
 	echo "──────────────────────────────────────────"
 	while IFS= read -r rel; do
 		[[ "$rel" == ci/* ]] && continue
 		src="$REPO_DIR/scripts/$rel"
-		dest="$SCRIPTS_DIR/$rel"
+		dest="$CELLAR_DIR/$rel"
 		total=$((total + 1))
 		do_check "$src" "$dest" "$rel" || drifted=$((drifted + 1))
 	done < <(enumerate_scripts)
-	# Orphans: installed files whose source under scripts/ no longer exists.
-	# (Detected via union of source set + previous-install manifest.)
+	# Legacy orphan detector (manifest-based) — kept for backwards compat.
+	# Cellar wipe handles structural orphan rot at install time, but a user
+	# running --check on a host that hasn't installed since the migration may
+	# still see orphans in $SCRIPTS_DIR; surface them.
 	while IFS= read -r orphan; do
 		[[ -z "$orphan" ]] && continue
 		total=$((total + 1))
 		drift "$orphan — ORPHAN (run ./install --prune to remove)"
 		drifted=$((drifted + 1))
 	done < <(enumerate_orphans)
+
+	echo ""
+	echo "Symlink farm ($SCRIPTS_DIR → Cellar)"
+	echo "──────────────────────────────────────────"
+	# Top-level Cellar entries should be reachable via $SCRIPTS_DIR/<name>.
+	# Either as a symlink pointing into Cellar, or — pre-migration — as a
+	# plain file (which will be backed up + replaced on the next install).
+	while IFS= read -r name; do
+		[[ -z "$name" ]] && continue
+		total=$((total + 1))
+		link="$SCRIPTS_DIR/$name"
+		if [[ -L "$link" ]]; then
+			tgt=$(resolve_symlink_target "$link")
+			if [[ "$tgt" == "$CELLAR_DIR/$name" && -e "$tgt" ]]; then
+				info "$name (symlink → Cellar)"
+			elif [[ ! -e "$tgt" ]]; then
+				drift "$name — DANGLING SYMLINK ($link → $tgt)"
+				drifted=$((drifted + 1))
+			else
+				drift "$name — symlink points outside Cellar ($tgt)"
+				drifted=$((drifted + 1))
+			fi
+		elif [[ -e "$link" ]]; then
+			drift "$name — plain file (will be backed up to .bak on next ./install)"
+			drifted=$((drifted + 1))
+		else
+			drift "$name — NOT INSTALLED in $SCRIPTS_DIR"
+			drifted=$((drifted + 1))
+		fi
+	done < <(enumerate_farm_targets)
+	# Stale symlinks under $SCRIPTS_DIR pointing into Cellar but with missing
+	# target — orphan detection at the symlink-farm level.
+	stale_count=0
+	while IFS= read -r link; do
+		[[ -L "$link" ]] || continue
+		tgt=$(resolve_symlink_target "$link")
+		[[ "$tgt" == "$CELLAR_DIR"/* || "$tgt" == "$CELLAR_DIR" ]] || continue
+		if [[ ! -e "$tgt" ]]; then
+			# Skip if this symlink is for a name we just reported above —
+			# avoid double-counting. enumerate_farm_targets gives current
+			# expected names; a stale link is one for a name no longer
+			# expected.
+			link_name="$(basename "$link")"
+			if ! enumerate_farm_targets | grep -Fxq "$link_name"; then
+				total=$((total + 1))
+				drift "stale symlink $link → $tgt (target gone from Cellar)"
+				drifted=$((drifted + 1))
+				stale_count=$((stale_count + 1))
+			fi
+		fi
+	done < <(find "$SCRIPTS_DIR" -maxdepth 1 -type l 2>/dev/null)
+	if [[ $stale_count -eq 0 ]]; then
+		info "no stale symlinks pointing into Cellar"
+	fi
 
 	echo ""
 	echo "Config"
@@ -625,6 +931,22 @@ if [[ "$CHECK_MODE" == true ]]; then
 				info "settings.json plugin $plugin (present)"
 			fi
 		done
+
+		# Old-path hook commands: any leftover ~/.local/bin/hooks/... entries
+		# from before the Cellar migration. These get rewritten by the next
+		# ./install (merge_settings); surface them here so a --check user
+		# knows they're carrying drift.
+		old_path_events=$(detect_old_hook_paths_in_settings "$CLAUDE_DIR/settings.json")
+		if [[ -n "$old_path_events" ]]; then
+			while IFS= read -r ev; do
+				[[ -z "$ev" ]] && continue
+				total=$((total + 1))
+				drift "settings.json — hooks.$ev has old ~/.local/bin/hooks/... command path (will be rewritten on next ./install)"
+				drifted=$((drifted + 1))
+			done <<<"$old_path_events"
+		else
+			info "settings.json hook paths (no legacy ~/.local/bin/hooks/... entries)"
+		fi
 	fi
 
 	# Crystallizer: compare repo files vs ~/.claude/context-crystallizer/
@@ -670,7 +992,7 @@ if [[ "$CHECK_MODE" == true ]]; then
 				pkg_name="$(basename "$pkg_dir")"
 				artifact_name="${pkg_name//_/-}"
 				src="$REPO_DIR/dist/$artifact_name"
-				dest="$SCRIPTS_DIR/$artifact_name"
+				dest="$CELLAR_DIR/$artifact_name"
 				if [[ -f "$src" ]]; then
 					total=$((total + 1))
 					do_check "$src" "$dest" "$artifact_name" || drifted=$((drifted + 1))
@@ -707,19 +1029,62 @@ if [[ "$CHECK_MODE" == true ]]; then
 	exit 0
 fi
 
+# --- Install scripts ----------------------------------------------------------
+# Cellar + symlink-farm layout (closes #560):
+#   1. Wipe and redeploy $CELLAR_DIR from scripts/ — kills orphans structurally.
+#   2. Reap stale symlinks under $SCRIPTS_DIR (target was under Cellar but the
+#      file is now gone — catches removed-from-repo scripts like discord-bot).
+#   3. Recreate symlinks for top-level Cellar entries (granularity B from #560:
+#      subtrees like hooks/, vox-providers/, testing/ stay Cellar-only).
+#
+# MUST run before INSTALL_SKILLS: cellar_deploy wipes $CELLAR_DIR before
+# deploying scripts/, so skill helpers (which live under $CELLAR_DIR/skills/)
+# would be obliterated if INSTALL_SKILLS ran first. Skills then layer onto the
+# freshly-deployed Cellar without conflict.
+if [[ "$INSTALL_SCRIPTS" == true ]]; then
+	echo ""
+	echo "Scripts → $CELLAR_DIR (Cellar) + $SCRIPTS_DIR (symlinks)"
+	echo "──────────────────────────────────────────"
+	# 1. Cellar: wipe + redeploy.
+	cellar_deploy
+	# 2. Reap stale symlinks: any symlink under $SCRIPTS_DIR pointing into the
+	# Cellar but whose target no longer exists. Foreign symlinks left alone.
+	reap_stale_cellar_symlinks
+	# 3. Symlink farm: top-level Cellar entries only. Per-name safeguard for
+	# user-customized plain files in $SCRIPTS_DIR (back up to .bak first).
+	while IFS= read -r name; do
+		[[ -z "$name" ]] && continue
+		safeguard_user_file "$name"
+		farm_symlink "$name"
+	done < <(enumerate_farm_targets)
+	# Refresh manifest (still used by --prune for legacy compat).
+	write_manifest
+fi
+
 # --- Install skills -----------------------------------------------------------
 if [[ "$INSTALL_SKILLS" == true ]]; then
 	echo ""
-	echo "Skills → $SKILLS_DIR"
+	echo "Skills → $SKILLS_DIR (helpers go to $CELLAR_DIR/skills/<name>/ + symlink farm)"
 	echo "──────────────────────────────────────────"
+	# Skill helpers ride the Cellar + symlink-farm pattern same as scripts/,
+	# but namespaced under $CELLAR_DIR/skills/<skill_name>/<helper>: two skills
+	# shipping same-named helpers cannot silently clobber each other.
+	# When --skills runs in isolation, INSTALL_SCRIPTS hasn't created the
+	# Cellar — ensure it exists so we can write into it.
+	[[ "$DRY_RUN" != true && "$INSTALL_SCRIPTS" != true ]] && mkdir -p "$CELLAR_DIR"
 	for skill_dir in "$REPO_DIR"/skills/*/; do
 		skill_name="$(basename "$skill_dir")"
 		# Install SKILL.md
 		src="$skill_dir/SKILL.md"
 		dest="$SKILLS_DIR/$skill_name/SKILL.md"
 		[[ -f "$src" ]] && do_copy "$src" "$dest"
-		# Install non-SKILL.md files: .md files stay in the skill dir,
-		# everything else goes to ~/.local/bin/ as executable scripts
+		# Install non-SKILL.md files: .md files stay in the skill dir;
+		# everything else (helper scripts) goes into the Cellar at
+		# $CELLAR_DIR/skills/<skill_name>/<helper> (per-skill namespace, so
+		# two skills shipping same-named helpers cannot silently clobber each
+		# other), with a top-level bare-name symlink in $SCRIPTS_DIR for
+		# PATH discoverability. farm_symlink_skill_helper warns on cross-skill
+		# name collisions at symlink time.
 		for helper in "$skill_dir"/*; do
 			[[ -f "$helper" ]] || continue
 			helper_name="$(basename "$helper")"
@@ -727,10 +1092,9 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
 			if [[ "$helper_name" == *.md ]]; then
 				do_copy "$helper" "$SKILLS_DIR/$skill_name/$helper_name"
 			else
-				do_copy "$helper" "$SCRIPTS_DIR/$helper_name"
-				if [[ "$DRY_RUN" != true ]]; then
-					chmod +x "$SCRIPTS_DIR/$helper_name"
-				fi
+				cellar_install_skill_helper "$helper" "$skill_name" "$helper_name"
+				safeguard_user_file "$helper_name"
+				farm_symlink_skill_helper "$skill_name" "$helper_name"
 			fi
 		done
 		# Install content subdirectories (e.g., tours/) into the skill dir
@@ -744,34 +1108,6 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
 			done
 		done
 	done
-fi
-
-# --- Install scripts ----------------------------------------------------------
-if [[ "$INSTALL_SCRIPTS" == true ]]; then
-	echo ""
-	echo "Scripts → $SCRIPTS_DIR"
-	echo "──────────────────────────────────────────"
-	# Skip ci/ — internal tooling, not for installation. Everything else under
-	# scripts/ (including nested subdirs like vox-providers/, wavebus/) gets
-	# mirrored into ~/.local/bin/, preserving relative paths.
-	while IFS= read -r rel; do
-		[[ "$rel" == ci/* ]] && continue
-		src="$REPO_DIR/scripts/$rel"
-		dest="$SCRIPTS_DIR/$rel"
-		do_copy "$src" "$dest"
-		# Preserve the source's executable bit. Top-level scripts have
-		# always been chmod'd +x unconditionally; preserve that behavior
-		# for backward compatibility while honoring source bits in subdirs.
-		if [[ "$DRY_RUN" != true ]]; then
-			if [[ "$rel" != */* ]]; then
-				chmod +x "$dest"
-			elif [[ -x "$src" ]]; then
-				chmod +x "$dest"
-			fi
-		fi
-	done < <(enumerate_scripts)
-	# Refresh manifest of what we just installed — used by --prune later.
-	write_manifest
 fi
 
 # --- Install config -----------------------------------------------------------
@@ -844,7 +1180,7 @@ fi
 # --- Build and install packages -----------------------------------------------
 if [[ "$INSTALL_SCRIPTS" == true && -d "$REPO_DIR/src" ]]; then
 	echo ""
-	echo "Packages → $SCRIPTS_DIR"
+	echo "Packages → $CELLAR_DIR (Cellar) + $SCRIPTS_DIR (symlinks)"
 	echo "──────────────────────────────────────────"
 	# Build from source
 	if [[ "$DRY_RUN" == true ]]; then
@@ -852,19 +1188,19 @@ if [[ "$INSTALL_SCRIPTS" == true && -d "$REPO_DIR/src" ]]; then
 	else
 		"$REPO_DIR/scripts/ci/build.sh"
 	fi
-	# Install built artifacts
+	# Install built artifacts: Cellar copy + top-level symlink farm entry.
 	for pkg_dir in "$REPO_DIR"/src/*/; do
 		[[ -f "$pkg_dir/__main__.py" ]] || continue
 		pkg_name="$(basename "$pkg_dir")"
 		artifact_name="${pkg_name//_/-}"
 		src="$REPO_DIR/dist/$artifact_name"
-		dest="$SCRIPTS_DIR/$artifact_name"
 		if [[ "$DRY_RUN" == true ]]; then
-			info "(dry-run) $src → $dest"
+			info "(dry-run) $src → $CELLAR_DIR/$artifact_name (+ symlink at $SCRIPTS_DIR/$artifact_name)"
 		else
 			if [[ -f "$src" ]]; then
-				do_copy "$src" "$dest"
-				chmod +x "$dest"
+				cellar_install_file "$src" "$artifact_name"
+				safeguard_user_file "$artifact_name"
+				farm_symlink "$artifact_name"
 			else
 				warn "Expected artifact not found: $src"
 			fi

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -511,30 +511,56 @@ class TestInstallSyntheticTree:
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
+        # Cellar + symlink-farm contract (#560, recommendation B):
+        # - Cellar at ~/.claude/scripts/ holds the full recursive tree
+        #   (top-level + nested), preserving exec bits and structure.
+        # - ~/.local/bin/ holds symlinks ONLY for top-level Cellar entries.
+        cellar = home / ".claude" / "scripts"
         bin_dir = home / ".local" / "bin"
-        # Flat + nested + doubly-nested all landed.
-        assert (bin_dir / "foo").exists(), "flat top-level script missing"
-        assert (bin_dir / "sub" / "bar").exists(), "single-nested script missing"
-        assert (bin_dir / "sub" / "baz" / "qux").exists(), (
-            "double-nested script missing"
+
+        # Cellar mirrors the source tree end-to-end (top-level + nested).
+        assert (cellar / "foo").exists(), "flat top-level script missing in Cellar"
+        assert (cellar / "sub" / "bar").exists(), (
+            "single-nested script missing in Cellar"
         )
-        # Executable bits preserved.
-        assert os.access(str(bin_dir / "foo"), os.X_OK)
-        assert os.access(str(bin_dir / "sub" / "bar"), os.X_OK)
-        assert os.access(str(bin_dir / "sub" / "baz" / "qux"), os.X_OK)
-        # Non-executable doc copied, NOT marked executable.
-        readme = bin_dir / "sub" / "README.md"
-        assert readme.exists(), "non-executable doc not copied"
+        assert (cellar / "sub" / "baz" / "qux").exists(), (
+            "double-nested script missing in Cellar"
+        )
+        # Executable bits preserved end-to-end in the Cellar.
+        assert os.access(str(cellar / "foo"), os.X_OK)
+        assert os.access(str(cellar / "sub" / "bar"), os.X_OK)
+        assert os.access(str(cellar / "sub" / "baz" / "qux"), os.X_OK)
+        # Non-executable doc copied to Cellar, NOT marked executable.
+        readme = cellar / "sub" / "README.md"
+        assert readme.exists(), "non-executable doc not copied to Cellar"
         assert not os.access(str(readme), os.X_OK), (
-            "non-executable doc was incorrectly chmod'd +x"
+            "non-executable doc was incorrectly chmod'd +x in Cellar"
         )
-        # Excluded subtree not copied.
-        assert not (bin_dir / "excluded" / "__pycache__" / "y").exists(), (
+        # Excluded subtree not copied to Cellar either.
+        assert not (cellar / "excluded" / "__pycache__" / "y").exists(), (
             "excluded __pycache__ subtree was copied"
         )
 
+        # Symlink farm: only top-level entries are symlinked into ~/.local/bin/.
+        # Nested entries (sub/, sub/baz/, etc.) stay Cellar-only per
+        # recommendation B from #560.
+        assert (bin_dir / "foo").is_symlink(), (
+            "top-level script should be a symlink in the farm"
+        )
+        assert not (bin_dir / "sub").exists(), (
+            "subtree directories should NOT be mirrored into ~/.local/bin/ "
+            "(granularity B per #560)"
+        )
+
     def test_prune_removes_orphan(self, tmp_path: Path) -> None:
-        """--prune removes installed files whose source no longer exists."""
+        """--prune (legacy, manifest-based) removes ~/.local/bin/<rel> files
+        whose source under scripts/<rel> no longer exists.
+
+        Note: under #560's Cellar layout, structural orphan rot is killed
+        by the cellar-wipe at install time, so --prune is effectively a
+        backwards-compat code path. We exercise it with a synthetic
+        manifest entry to confirm it still functions.
+        """
         repo = self._build_synthetic_repo(tmp_path)
         home = tmp_path / "home"
         (home / ".local" / "bin").mkdir(parents=True)
@@ -553,7 +579,9 @@ class TestInstallSyntheticTree:
         ).returncode
         assert rc == 0, "first install failed"
 
-        # Plant an orphan (the manifest will pick it up since we'll add it).
+        # Plant an orphan (manifest-tracked plain file under ~/.local/bin/).
+        # The legacy --prune walks the manifest and removes plain files
+        # whose source under scripts/ no longer exists.
         bin_dir = home / ".local" / "bin"
         orphan = bin_dir / "ghost"
         orphan.write_text("#!/bin/bash\necho gone\n")
@@ -576,14 +604,24 @@ class TestInstallSyntheticTree:
         assert not orphan.exists(), "orphan was not pruned"
         # Backup retained.
         assert (bin_dir / "ghost.bak").exists(), "orphan backup missing"
-        # Real files still present.
-        assert (bin_dir / "foo").exists(), "prune removed live top-level script"
-        assert (bin_dir / "sub" / "bar").exists(), (
-            "prune removed live nested script"
+        # Cellar live files still present (top-level + nested).
+        cellar = home / ".claude" / "scripts"
+        assert (cellar / "foo").exists(), "prune removed live top-level Cellar entry"
+        assert (cellar / "sub" / "bar").exists(), (
+            "prune removed live nested Cellar entry"
+        )
+        # Symlink farm top-level still present.
+        assert (bin_dir / "foo").is_symlink(), (
+            "prune removed live top-level symlink-farm entry"
         )
 
     def test_check_reports_nested_drift(self, tmp_path: Path) -> None:
-        """--check reports drift for missing nested files (not just top-level)."""
+        """--check reports drift for missing nested files in the Cellar.
+
+        Under #560 the Cellar (~/.claude/scripts/) holds the full recursive
+        tree (top-level + nested). Deleting a nested Cellar entry should
+        surface as drift — the tree no longer matches the source.
+        """
         repo = self._build_synthetic_repo(tmp_path)
         home = tmp_path / "home"
         (home / ".local" / "bin").mkdir(parents=True)
@@ -601,8 +639,8 @@ class TestInstallSyntheticTree:
         ).returncode
         assert rc == 0, "install failed"
 
-        # Delete a nested file; --check should flag the drift.
-        target = home / ".local" / "bin" / "sub" / "bar"
+        # Delete a nested Cellar file; --check should flag the drift.
+        target = home / ".claude" / "scripts" / "sub" / "bar"
         assert target.exists()
         target.unlink()
 
@@ -615,7 +653,7 @@ class TestInstallSyntheticTree:
         )
         assert result.returncode == 0, "check exited non-zero"
         assert "sub/bar" in result.stdout, (
-            f"--check did not report missing nested file:\n{result.stdout}"
+            f"--check did not report missing nested Cellar file:\n{result.stdout}"
         )
         assert "out of sync" in result.stdout.lower(), (
             f"--check did not flag drift:\n{result.stdout}"

--- a/tests/test_install_cellar.py
+++ b/tests/test_install_cellar.py
@@ -1,0 +1,573 @@
+"""Cellar + symlink-farm tests for the ``install`` script (issue #560).
+
+Covers the layout migration where kit-managed scripts move from direct
+deployment in ``~/.local/bin/`` to a wipe-and-recreate Cellar at
+``~/.claude/scripts/``, with ``~/.local/bin/`` becoming a symlink farm
+pointing into the Cellar (Homebrew/Nix pattern).
+
+This file is intentionally self-contained — like
+``tests/test_install_merge_hooks_union.py`` it does NOT depend on
+``tests/test_install.py`` or ``tests/test_install_merge.py`` (which have
+known pre-existing failures from the ``install.sh`` -> ``install`` rename).
+It writes synthetic fixtures, invokes ``./install`` with ``HOME``
+overridden, and asserts the post-install on-disk shape.
+
+Acceptance criteria from #560 are mapped 1:1 to test functions:
+
+- AC1 — Cellar wipe + redeploy: ``test_cellar_wipe_and_redeploy``
+- AC2 — Symlink farm granularity B: ``test_symlink_farm_granularity_b``
+- AC3 — Removed-from-repo orphan-free re-deploy:
+  ``test_removed_from_repo_no_orphan``
+- AC4 — Hook path migration in settings.json:
+  ``test_settings_hook_path_migration``
+- AC5 — Matcher union-merge (re-confirms #556 still holds after #560):
+  ``test_matcher_union_merge_still_works``
+- AC6 — User-customized plain file backup:
+  ``test_user_customized_plain_file_backup``
+- AC7 — ``--check`` reports stale symlinks AND old-path hooks:
+  ``test_check_reports_stale_symlinks``,
+  ``test_check_reports_old_path_hooks``
+- Bonus — Foreign symlinks (target outside Cellar) NOT touched:
+  ``test_foreign_symlinks_untouched``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_REPO_DIR = Path(__file__).resolve().parent.parent
+_INSTALL_SCRIPT = str(_REPO_DIR / "install")
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions
+# ---------------------------------------------------------------------------
+
+_HAS_BASH = shutil.which("bash") is not None
+_HAS_JQ = shutil.which("jq") is not None
+_HAS_PYTHON3 = shutil.which("python3") is not None
+
+_SKIP_NO_BASH = pytest.mark.skipif(not _HAS_BASH, reason="bash not available")
+_SKIP_NO_JQ = pytest.mark.skipif(not _HAS_JQ, reason="jq not available")
+_SKIP_NO_PYTHON3 = pytest.mark.skipif(
+    not _HAS_PYTHON3, reason="python3 not available (zipapp build)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_env(home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return env
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _build_synthetic_repo(tmp_path: Path) -> Path:
+    """Materialize a minimal repo at ``tmp_path/repo`` exercising
+    the Cellar + symlink-farm code path without dragging in skills,
+    crystallizer, MCPs, or built packages.
+
+    Layout::
+
+        repo/
+        ├── install                         (real script)
+        ├── config/
+        │   └── settings.template.json      (with new ~/.claude/scripts/ paths)
+        └── scripts/
+            ├── foo                         (top-level — gets a symlink)
+            ├── bar                         (top-level — gets a symlink)
+            ├── ci/
+            │   └── check-deps.sh           (stub: no deps)
+            └── hooks/nerf/
+                └── pre-compact.sh          (subtree — Cellar only, no symlink)
+    """
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+
+    # Top-level scripts (these get symlinks).
+    (scripts / "foo").write_text("#!/bin/bash\necho foo\n")
+    os.chmod(scripts / "foo", 0o755)
+    (scripts / "bar").write_text("#!/bin/bash\necho bar\n")
+    os.chmod(scripts / "bar", 0o755)
+
+    # Subtree (Cellar-only, no symlink under recommendation B).
+    nerf = scripts / "hooks" / "nerf"
+    nerf.mkdir(parents=True)
+    (nerf / "pre-compact.sh").write_text("#!/bin/bash\necho pre-compact\n")
+    os.chmod(nerf / "pre-compact.sh", 0o755)
+
+    # Stub ci/check-deps.sh so the post-install dep gate is a no-op.
+    ci_dir = scripts / "ci"
+    ci_dir.mkdir()
+    (ci_dir / "check-deps.sh").write_text(
+        "#!/usr/bin/env bash\ncheck_deps() { return 0; }\n"
+    )
+    (ci_dir / "check-deps.sh").chmod(0o755)
+
+    # Minimal settings template using the NEW Cellar hook path.
+    config_dir = repo / "config"
+    config_dir.mkdir()
+    template = {
+        "hooks": {
+            "PreCompact": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "~/.claude/scripts/hooks/nerf/pre-compact.sh",
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    (config_dir / "settings.template.json").write_text(json.dumps(template, indent=2))
+
+    # Drop the real install script in.
+    shutil.copy(_INSTALL_SCRIPT, repo / "install")
+    os.chmod(repo / "install", 0o755)
+    return repo
+
+
+def _build_sandbox_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    (home / ".local" / "bin").mkdir(parents=True)
+    (home / ".claude" / "skills").mkdir(parents=True)
+    return home
+
+
+def _run_install(repo: Path, args: list[str], home: Path) -> tuple[int, str, str]:
+    result = subprocess.run(
+        ["bash", str(repo / "install")] + args,
+        capture_output=True,
+        text=True,
+        env=_make_env(home),
+        timeout=120,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# AC1 — Cellar wipe + redeploy
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+def test_cellar_wipe_and_redeploy(tmp_path: Path) -> None:
+    """``~/.claude/scripts/`` is the canonical install location and the
+    entire tree is wiped and recreated on every ``./install``."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # Plant a stale file in the Cellar BEFORE install — verify it disappears.
+    cellar = home / ".claude" / "scripts"
+    cellar.mkdir(parents=True, exist_ok=True)
+    stale = cellar / "leftover-from-old-install"
+    stale.write_text("#!/bin/bash\necho stale\n")
+
+    rc, out, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"install --scripts failed: stdout={out}\nstderr={err}"
+
+    # Cellar exists and contains current sources.
+    assert (cellar / "foo").exists(), "Cellar missing top-level: foo"
+    assert (cellar / "bar").exists(), "Cellar missing top-level: bar"
+    assert (cellar / "hooks" / "nerf" / "pre-compact.sh").exists(), (
+        "Cellar missing nested hook: hooks/nerf/pre-compact.sh"
+    )
+
+    # Stale file from before install was wiped.
+    assert not stale.exists(), (
+        f"Cellar wipe did not delete stale file: {stale}"
+    )
+
+    # Cellar files have exec bits preserved.
+    assert os.access(str(cellar / "foo"), os.X_OK), "Cellar foo not executable"
+    assert os.access(str(cellar / "hooks" / "nerf" / "pre-compact.sh"), os.X_OK), (
+        "Cellar hook script not executable"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC2 — Symlink farm: granularity B (top-level only)
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+def test_symlink_farm_granularity_b(tmp_path: Path) -> None:
+    """``~/.local/bin/`` contains symlinks for top-level Cellar entries
+    only. Subtrees (hooks/, vox-providers/, etc.) stay Cellar-only."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    rc, _out, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"install failed: {err}"
+
+    bin_dir = home / ".local" / "bin"
+    cellar = home / ".claude" / "scripts"
+
+    # Top-level entries are symlinks pointing into the Cellar.
+    for name in ("foo", "bar"):
+        link = bin_dir / name
+        assert link.is_symlink(), f"{name} should be a symlink in {bin_dir}"
+        target = os.readlink(str(link))
+        # Target may be absolute or relative — resolve via os.path.realpath.
+        resolved = Path(os.path.realpath(str(link)))
+        assert resolved == cellar / name, (
+            f"{name} symlink target: expected {cellar / name}, got {resolved}"
+        )
+
+    # Subtree entries are NOT symlinked (granularity B).
+    assert not (bin_dir / "hooks").exists(), (
+        "hooks/ subtree should NOT be mirrored into ~/.local/bin/ "
+        "(recommendation B from #560)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3 — Removed-from-repo orphan-free re-deploy
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+def test_removed_from_repo_no_orphan(tmp_path: Path) -> None:
+    """Running ``./install`` after a script is removed from the repo
+    deletes both the Cellar entry AND the corresponding ``~/.local/bin/``
+    symlink — without any ``--prune`` flag."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # First install: foo and bar both present.
+    rc, _, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"first install failed: {err}"
+
+    cellar = home / ".claude" / "scripts"
+    bin_dir = home / ".local" / "bin"
+    assert (cellar / "foo").exists()
+    assert (bin_dir / "foo").is_symlink()
+
+    # Remove foo from the repo.
+    (repo / "scripts" / "foo").unlink()
+
+    # Second install: foo should be gone from BOTH Cellar and bin/.
+    rc, _, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"second install failed: {err}"
+
+    assert not (cellar / "foo").exists(), (
+        "removed-from-repo script still in Cellar after re-install"
+    )
+    assert not (bin_dir / "foo").exists(), (
+        "removed-from-repo symlink still in ~/.local/bin/ — orphan rot"
+    )
+    # bar is unaffected.
+    assert (cellar / "bar").exists()
+    assert (bin_dir / "bar").is_symlink()
+
+
+# ---------------------------------------------------------------------------
+# AC4 — Settings hook path migration
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+def test_settings_hook_path_migration(tmp_path: Path) -> None:
+    """``~/.claude/settings.json`` hook command paths get rewritten from
+    ``~/.local/bin/hooks/...`` to ``~/.claude/scripts/hooks/...`` during
+    ``merge_settings()``."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # Pre-existing user settings with the OLD path shape.
+    settings = home / ".claude" / "settings.json"
+    _write_json(settings, {
+        "hooks": {
+            "PreCompact": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "~/.local/bin/hooks/nerf/pre-compact.sh",
+                        }
+                    ],
+                }
+            ],
+        },
+    })
+
+    rc, _out, err = _run_install(repo, ["--config"], home)
+    assert rc == 0, f"install --config failed: {err}"
+
+    merged = _read_json(settings)
+    cmd = merged["hooks"]["PreCompact"][0]["hooks"][0]["command"]
+    assert cmd == "~/.claude/scripts/hooks/nerf/pre-compact.sh", (
+        f"hook path not migrated: got {cmd}"
+    )
+
+    # Backup retains the original.
+    bak = settings.with_suffix(".json.bak")
+    assert bak.exists(), "settings.json.bak not created during migration"
+    bak_data = _read_json(bak)
+    bak_cmd = bak_data["hooks"]["PreCompact"][0]["hooks"][0]["command"]
+    assert bak_cmd == "~/.local/bin/hooks/nerf/pre-compact.sh", (
+        "settings.json.bak should preserve the pre-migration path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5 — Matcher union-merge still works (re-confirm #556 wave-1 contract)
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+def test_matcher_union_merge_still_works(tmp_path: Path) -> None:
+    """``merge_settings()`` continues to union-merge new matcher entries
+    into existing event arrays (regression test for #556 logic now sharing
+    code path with the #560 path-rewrite)."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # Override the synthetic template to have TWO matchers in a single
+    # event. The user has only one — merge must add the second.
+    template = {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {"type": "command", "command": "default-session-start.sh"}
+                    ],
+                },
+                {
+                    "matcher": "compact",
+                    "hooks": [
+                        {"type": "command", "command": "session-start-compact.sh"}
+                    ],
+                },
+            ],
+        },
+    }
+    (repo / "config" / "settings.template.json").write_text(
+        json.dumps(template, indent=2)
+    )
+
+    settings = home / ".claude" / "settings.json"
+    _write_json(settings, {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {"type": "command", "command": "user-session-start.sh"}
+                    ],
+                }
+            ],
+        },
+    })
+
+    rc, _out, err = _run_install(repo, ["--config"], home)
+    assert rc == 0, f"install --config failed: {err}"
+
+    merged = _read_json(settings)
+    matchers = sorted(e["matcher"] for e in merged["hooks"]["SessionStart"])
+    assert matchers == ["*", "compact"], (
+        f"matcher union merge failed: got {matchers}"
+    )
+    # User customization on '*' preserved.
+    star = next(e for e in merged["hooks"]["SessionStart"] if e["matcher"] == "*")
+    assert any(h["command"] == "user-session-start.sh" for h in star["hooks"]), (
+        "user customization on shared matcher was overwritten"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC6 — User-customized plain file gets backed up before symlink replacement
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+def test_user_customized_plain_file_backup(tmp_path: Path) -> None:
+    """If ``~/.local/bin/<script>`` is a plain file (not a symlink) with
+    hand edits, install backs it up to ``.bak`` before replacing it with
+    a symlink."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # Plant a user-customized plain file at the destination.
+    bin_dir = home / ".local" / "bin"
+    user_foo = bin_dir / "foo"
+    user_foo.write_text("#!/bin/bash\necho USER CUSTOMIZED\n")
+    os.chmod(user_foo, 0o755)
+
+    rc, _out, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"install failed: {err}"
+
+    # Plain file replaced with symlink into Cellar.
+    assert user_foo.is_symlink(), "user plain file not replaced with symlink"
+    # Backup retains the user's version.
+    bak = bin_dir / "foo.bak"
+    assert bak.exists(), "user customization not backed up to .bak"
+    assert "USER CUSTOMIZED" in bak.read_text(), (
+        "backup does not contain user-customized content"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bonus AC — Foreign symlinks (target outside Cellar) NOT touched
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+def test_foreign_symlinks_untouched(tmp_path: Path) -> None:
+    """Symlinks in ``~/.local/bin/`` whose target is outside the Cellar
+    (e.g. user-installed binaries from another tool) must NOT be touched
+    by the symlink-farm reaper."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # First install establishes the Cellar.
+    rc, _, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"first install failed: {err}"
+
+    # Plant a foreign symlink: point ~/.local/bin/myapp at a path OUTSIDE
+    # the Cellar. Make the target legitimate (so it isn't itself stale),
+    # then verify install leaves it alone.
+    foreign_target = tmp_path / "elsewhere" / "myapp"
+    foreign_target.parent.mkdir(parents=True, exist_ok=True)
+    foreign_target.write_text("#!/bin/bash\necho foreign\n")
+    os.chmod(foreign_target, 0o755)
+
+    bin_dir = home / ".local" / "bin"
+    foreign_link = bin_dir / "myapp"
+    foreign_link.symlink_to(foreign_target)
+
+    # Re-run install.
+    rc, _out, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"second install failed: {err}"
+
+    # Foreign symlink and its target both still exist, untouched.
+    assert foreign_link.is_symlink(), "foreign symlink was removed"
+    assert foreign_link.resolve() == foreign_target.resolve(), (
+        "foreign symlink target was changed"
+    )
+
+    # Now make the foreign target also dangle (rm the file). Reaper still
+    # leaves it — because it points OUTSIDE Cellar, not under it.
+    foreign_target.unlink()
+    rc, _out, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"third install failed: {err}"
+    assert foreign_link.is_symlink(), (
+        "foreign symlink with dangling external target was incorrectly "
+        "reaped (reaper must only consider Cellar-targeted symlinks)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC7a — --check reports stale symlinks
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+def test_check_reports_stale_symlinks(tmp_path: Path) -> None:
+    """``./install --check`` reports symlinks under ``~/.local/bin/`` that
+    point into the Cellar but whose target no longer exists."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # First install populates the farm.
+    rc, _, err = _run_install(repo, ["--scripts"], home)
+    assert rc == 0, f"install failed: {err}"
+
+    # Manually break a symlink — delete its Cellar target without touching
+    # the link itself. Use a name that will NOT be in enumerate_farm_targets
+    # on the next check (i.e. simulate a removed-from-repo script).
+    cellar = home / ".claude" / "scripts"
+    bin_dir = home / ".local" / "bin"
+
+    # Plant a symlink to a fake old script and a Cellar target, then
+    # delete the target.
+    fake_target = cellar / "ghost-script"
+    fake_target.write_text("#!/bin/bash\necho ghost\n")
+    fake_link = bin_dir / "ghost-script"
+    fake_link.symlink_to(fake_target)
+    fake_target.unlink()  # now stale
+
+    rc, out, err = _run_install(repo, ["--check"], home)
+    assert rc == 0, f"--check exited non-zero: {err}"
+
+    output = out + err
+    # The stale entry must appear in the output as drift.
+    assert "ghost-script" in output, (
+        f"--check did not report stale symlink 'ghost-script':\n{output}"
+    )
+    # Either as DANGLING SYMLINK (if it's enumerated as expected) or as
+    # 'stale symlink' (the reaper-side detection) — both forms are valid.
+    assert ("stale" in output.lower()) or ("dangling" in output.lower()), (
+        f"--check did not flag the symlink as stale/dangling:\n{output}"
+    )
+    assert "out of sync" in output.lower(), (
+        f"--check summary did not report drift:\n{output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC7b — --check reports old-path hook commands as drift
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+def test_check_reports_old_path_hooks(tmp_path: Path) -> None:
+    """``./install --check`` reports hook command paths still using the
+    pre-Cellar form ``~/.local/bin/hooks/...`` as drift."""
+    repo = _build_synthetic_repo(tmp_path)
+    home = _build_sandbox_home(tmp_path)
+
+    # Pre-existing settings with old-shape hook paths.
+    settings = home / ".claude" / "settings.json"
+    _write_json(settings, {
+        "hooks": {
+            "PreCompact": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "~/.local/bin/hooks/nerf/pre-compact.sh",
+                        }
+                    ],
+                }
+            ],
+        },
+    })
+
+    rc, out, err = _run_install(repo, ["--check"], home)
+    assert rc == 0, f"--check exited non-zero: {err}"
+    output = out + err
+
+    # The drift report must name the affected event AND describe the gap.
+    assert "PreCompact" in output, (
+        f"--check did not name the affected event 'PreCompact':\n{output}"
+    )
+    assert "old" in output.lower() and "~/.local/bin/hooks" in output, (
+        f"--check did not describe the old-path drift:\n{output}"
+    )
+    assert "out of sync" in output.lower(), (
+        f"--check summary did not report drift:\n{output}"
+    )


### PR DESCRIPTION
## Summary

Wipe-and-recreate `~/.claude/scripts/` as the Cellar; replace direct `~/.local/bin/` deploy with a symlink farm pointing into the Cellar. Stale-symlink reaper kills orphans without `--prune`. `merge_settings()` rewrites old `~/.local/bin/hooks/...` paths to `~/.claude/scripts/hooks/...` and continues to union-merge new matcher entries (preserves #556).

## Changes

- Granularity B: only top-level `scripts/` entries get symlinks; subtrees (`hooks/`, `vox-providers/`, `testing/`) stay Cellar-only.
- `./install --check` reports both stale symlinks and old-path hook commands as drift.
- User customizations (plain files at `~/.local/bin/<name>`) are backed up to `.bak` before symlink replacement.
- Foreign symlinks (target outside the Cellar) are never reaped.

## Linked Issues

Closes #560

## Test Plan

- Reviewer pass: CLEAN (after rework — see results.md)
- Initial review flagged 2 issues (1 CRITICAL macOS `find -printf`, 1 IMPORTANT skill-helper namespace collision); both fixed in rework via amended commit; re-review confirmed CLEAN.
- Flight artifacts: `/tmp/wavemachine/Wave-Engineering-claudecode-workflow/wave-2/flight-1/issue-560/results.md`