### PR TITLE
chore(WAVE_AXIOMS): V2 structural rework + Axiom 9 + skill-body wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Every issue MUST be wave-pattern quality: detailed enough that a spec-driven age
 
 **READ `WAVE_AXIOMS.md` FIRST when invoking `/wavemachine`, `/nextwave`, `/assesswaves`, or `/prepwaves`.** That file is the canonical, load-mandatory constitutional layer for wave-pattern execution. Each axiom binds to a specific observed-and-forbidden agent behavior; violation is a bug, not a judgment call.
 
-The eight axioms (full text in `WAVE_AXIOMS.md` at the cc-workflow root):
+The nine axioms (full text in `WAVE_AXIOMS.md` at the cc-workflow root):
 
 1. **Serial is a valid wave topology.** Wave campaigns are justified by autonomous batched execution, not parallelism.
 2. **The campaign is autonomous from invocation to terminal state.** No mid-campaign questions. No "shall I continue?"
@@ -97,6 +97,7 @@ The eight axioms (full text in `WAVE_AXIOMS.md` at the cc-workflow root):
 6. **Approval frequency is set by the invoked command.** `/nextwave` = per-wave; `/wavemachine` = at terminal state. The agent never adds gates.
 7. **`/assesswaves` measures justification, not topology suitability.** YES whenever count ≥ 4 or per-issue wall-clock is non-trivial.
 8. **These axioms supersede agent judgment in their domain.** Disagreement is a reason to PR `WAVE_AXIOMS.md`, never to override in the moment.
+9. **User attention is the cost. Autonomy is the protection.** Autonomy clauses in `/wavemachine`-class skills protect the user's attention; the legal-exits list is exhaustive (Axiom 3); plan-reality drift is the only legitimate stop beyond hard faults and explicit halts.
 
 Disagreement with an axiom is a reason to update `WAVE_AXIOMS.md` via PR — never to override it in the moment.
 

--- a/WAVE_AXIOMS.md
+++ b/WAVE_AXIOMS.md
@@ -2,7 +2,7 @@
 
 <!-- Canonical, load-mandatory rules for wave-pattern execution.
 
-     READ THIS BEFORE invoking /wavemachine, /nextwave, /assesswaves.
+     READ THIS BEFORE invoking /wavemachine, /nextwave, /prepwaves, /assesswaves.
      READ THIS BEFORE recommending against the wave pattern.
      READ THIS BEFORE asking the user a mid-campaign question.
 
@@ -11,29 +11,56 @@
      is a reason to update this file via PR — never a reason to override
      it in the moment.
 
-     "First round" — 2026-05-05 BJ + patchwork. Will grow as new
-     failure modes are observed. -->
+     STRUCTURE — every axiom has three subsections:
+       - **Rule** — the binding statement, one-or-two sentences.
+       - **Why** — the observed-and-forbidden behavior, grimoire failure
+         mode, or load-bearing principle the rule exists to enforce.
+       - **How to apply** — the concrete agent action / mechanical check
+         that operationalizes the rule. If the rule has a forbidden-list,
+         it lives here.
+
+     "First round" — 2026-05-05 BJ + patchwork. V2 structural rework
+     2026-05-06 cc-workflow#605 (added Axiom 9, reshaped 1-8 to the
+     three-subsection template, wired the wave-pattern skill bodies
+     to cross-reference instead of restate). Will grow as new failure
+     modes are observed. -->
 
 ---
 
 ## Axiom 1 — Serial is a valid wave topology.
 
+### Rule
+
 A wave-pattern campaign is justified by **autonomous batched execution**, not by parallelism. A queue of N≥4 issues with deep gating dependencies — every flight serial, every wave size 1 — is a textbook campaign.
+
+### Why
+
+The benefit isn't concurrency. It is **queue-and-walk-away** — the agent walks the deps, /precheck → /scpmmr per issue, while the user does something else. Lifecycle tracking and audit trail land regardless of flight count. The user's wall-clock is the resource the campaign exists to protect.
+
+Observed failure mode: `/assesswaves` (and operators reasoning from first principles) downgrading "no parallelism here" to "ad-hoc, no campaign," dropping the user back into a per-issue checkpoint loop they explicitly invoked the wave pattern to avoid.
+
+### How to apply
 
 **Forbidden:**
 - Recommending "ad-hoc, no campaign" for a serial-but-batchable queue
 - Downgrading a wave plan because no parallelism is available
 - Treating "is there parallelism here?" as the gating question
 
-**Why:** The benefit isn't concurrency. It is queue-and-walk-away — the agent walks the deps, /precheck → /scpmmr per issue, while the user does something else. Lifecycle tracking and audit trail land regardless of flight count. The user's wall-clock is the resource the campaign exists to protect.
-
-**See:** `feedback_wave_pattern_justification.md`, `/assesswaves` skill body.
+**See:** `feedback_wave_pattern_justification.md`, Axiom 7 (the assessment-skill binding).
 
 ---
 
 ## Axiom 2 — The campaign is autonomous from invocation to terminal state.
 
+### Rule
+
 Once `/wavemachine` (or `/nextwave`) starts, the agent runs until one of the following: (a) the campaign reaches its terminal state — all issues complete and Plan-level DoD verified, (b) a Legal Exit fires (Axiom 3), (c) the user explicitly halts (interrupt, `/halt`, "stop"). No other condition terminates the campaign.
+
+### Why
+
+Each mid-campaign question converts autonomous execution into a per-step checkpoint. The user invoked the campaign precisely to avoid those checkpoints. Asking the question burns the user's attention to receive the answer that was already implied by the invocation. See Axiom 9 for the full attention-cost framing.
+
+### How to apply
 
 **Forbidden:**
 - "Shall I continue?"
@@ -43,13 +70,13 @@ Once `/wavemachine` (or `/nextwave`) starts, the agent runs until one of the fol
 - Any mid-campaign yes/no question whose expected answer is "yes"
 - Pausing at phase boundaries "to check in"
 
-**Why:** Each mid-campaign question converts autonomous execution into a per-step checkpoint. The user invoked the campaign precisely to avoid those checkpoints. Asking the question burns the user's attention to receive the answer that was already implied by the invocation.
-
-**See:** `principle_user_attention_is_the_cost.md`.
+**See:** Axiom 9, `principle_user_attention_is_the_cost.md`.
 
 ---
 
 ## Axiom 3 — The Legal Exits list is closed.
+
+### Rule
 
 Legitimate stops, **exhaustively**:
 
@@ -58,6 +85,14 @@ Legitimate stops, **exhaustively**:
 3. **Explicit user halt** — interrupt, `/halt`, "stop", explicit instruction to pause.
 
 That is the entire list. There are no others.
+
+### Why
+
+A closed list is enforceable. An open list is rationalizable. The agent who reasons "this is technically not a Legal Exit, but I'm stopping anyway because it feels right" has constructed exactly the failure mode the closed list is designed to prevent.
+
+Each forbidden phrase below was observed in real grimoire / patchwork sessions; each is a real-world bug, not a hypothetical.
+
+### How to apply
 
 **Forbidden (each observed):**
 - "I'm uncertain about X" → stop
@@ -68,15 +103,15 @@ That is the entire list. There are no others.
 - "Out of an abundance of caution" → stop
 - "The user might want to know X" → stop
 
-Each of these is the failure mode this axiom exists to forbid.
+Each of these is the failure mode this axiom exists to forbid. If unease doesn't match a Legal Exit, route through the Concerns Channel (Axiom 4) — do not halt.
 
-**Why:** A closed list is enforceable. An open list is rationalizable. The agent who reasons "this is technically not a Legal Exit, but I'm stopping anyway because it feels right" has constructed exactly the failure mode the closed list is designed to prevent.
-
-**See:** `pattern_exhaustive_legal_exits.md`.
+**See:** Axiom 4 (Concerns Channel), `pattern_exhaustive_legal_exits.md`.
 
 ---
 
 ## Axiom 4 — When unsettled, use the Concerns Channel. Do not stop.
+
+### Rule
 
 If the agent is unsettled and no Legal Exit applies, the response is:
 
@@ -86,49 +121,75 @@ If the agent is unsettled and no Legal Exit applies, the response is:
 
 The campaign does not pause for unease. The Concerns Channel exists precisely so the agent can register the unease without burning the user's wall-clock.
 
+### Why
+
+Unease is information; stopping is action. The information goes into the durable record (issue comment + optional Discord ping). The action is reserved for Legal Exits. Conflating the two is the bug.
+
+The Concerns Channel is the **pressure valve** for the closed-list contract in Axiom 3 — without it, agents under uncertainty have no legitimate outlet and invent illegitimate ones (the "out of an abundance of caution" stop). With it, the unease is captured, the Pair sees it async, and the campaign continues.
+
+### How to apply
+
 **Forbidden:**
 - Stopping the campaign because "I had a concern"
 - Asking the user to evaluate the concern in real time
 - Treating the Concerns Channel as optional when no Legal Exit fires
 
-**Why:** Unease is information; stopping is action. The information goes into the durable record (issue comment + optional Discord ping). The action is reserved for Legal Exits. Conflating the two is the bug.
-
-**See:** `pattern_concerns_channel.md`.
+**See:** Axiom 3, Axiom 5, `pattern_concerns_channel.md`.
 
 ---
 
 ## Axiom 5 — Continuing is cheaper than stopping. Default forward.
 
+### Rule
+
 Continuing costs at most: a revertible commit, a noisy comment thread, or a follow-up issue. Stopping costs: unrecoverable wall-clock — every minute the user reads the question, switches context, types a reply, and resumes — plus the cache-warmth penalty on the agent's side.
+
+### Why
+
+The cost asymmetry is permanent and well-documented. Almost every continuation can be undone in a follow-up commit. No stop can return the wall-clock it consumed. The instinct that "stopping is safe, continuing is risky" is backwards — it weights the agent's perceived risk at full and the human's wall-clock at zero, when the opposite is closer to true.
+
+If something is genuinely going sideways, one of the mechanical or drift exits in Axiom 3 WILL fire — entropy is a motherfucker. Absence of those firing is evidence of healthy operation, not evidence that an invented-category halt is warranted.
+
+### How to apply
 
 **Forbidden:**
 - Treating "stop and ask" as the safe default
 - Framing continuation as the risky option
 - Computing only the worst-case cost of continuing while ignoring the certain cost of stopping
 
-**Why:** The cost asymmetry is permanent and well-documented. Almost every continuation can be undone in a follow-up commit. No stop can return the wall-clock it consumed.
+When the agent still feels unease that doesn't match an exit: route through Axiom 4's Concerns Channel — `[concern]` comment, optional Discord ping, **continue**.
 
-**See:** `principle_cost_asymmetry_continue_vs_exit.md`.
+**See:** Axiom 4, Axiom 9, `principle_cost_asymmetry_continue_vs_exit.md`.
 
 ---
 
 ## Axiom 6 — Approval frequency is set by the invoked command. The agent does not add gates.
 
+### Rule
+
 - **`/nextwave`** = "I want to approve at each wave." The gate fires once per wave, after all flights complete and the Orchestrator-side reviewer passes. One approval covers every issue and every sub-agent in that wave.
 - **`/wavemachine`** = "I want to approve at the campaign end." There is no per-wave human gate; the Orchestrator approves wave transitions autonomously based on flight + reviewer signal. The user-facing gate fires only at terminal state (Plan-level DoD verification, or a Legal Exit per Axiom 3).
+
+### Why
+
+The slash command choice IS the gate-frequency declaration. Adding gates the user didn't ask for is unilateral expansion of the contract — the same failure mode as "shall I continue?" in Axiom 2, just at a different layer.
+
+Per-sub-agent gates scale particularly poorly: an N-issue flight with a per-agent gate burns N approvals where one would do, and forces the human to sequentially evaluate diffs they cannot realistically read at that volume. The aggregate signals (validate.sh per worktree, reviewer pass over the diff, AC self-report) are what actually carry the correctness information; the human's value is sanity-checking the aggregate, once per batch.
+
+### How to apply
 
 **Forbidden:**
 - Per-flight, per-issue, or per-sub-agent approval requests in any context
 - Human-loop checkpoints between waves during `/wavemachine` execution
 - Adding gates the user did not invoke
 
-**Why:** The slash command choice IS the gate-frequency declaration. Adding gates the user didn't ask for is unilateral expansion of the contract — the same failure mode as "shall I continue?" in Axiom 2, just at a different layer.
-
-**See:** `feedback_nextwave_batch_approval.md`, `principle_user_attention_is_the_cost.md`.
+**See:** Axiom 2, Axiom 9, `feedback_nextwave_batch_approval.md`.
 
 ---
 
 ## Axiom 7 — `/assesswaves` measures justification, not topology suitability.
+
+### Rule
 
 The skill answers a single question: **should the user use the wave pattern for this work?**
 
@@ -139,32 +200,80 @@ The answer is **YES** whenever:
 
 Regardless of whether flights parallelize.
 
+### Why
+
+The wave pattern's value proposition is autonomous batched execution (Axiom 1), not parallelism. Anchoring the assessment on parallelism is anchoring on the wrong axis — it produces "ad-hoc, no campaign" recommendations for queues that meet every justification threshold except the irrelevant one.
+
+This axiom binds the assessment skill specifically because that is where the failure has been observed. Axiom 1 states the underlying truth; Axiom 7 enforces it at the assessment seam.
+
+### How to apply
+
 **Forbidden:**
 - Recommending against the wave pattern because flights serialize
 - Recommending "ad-hoc, no campaign" for any queue meeting the YES criteria
 - Treating parallelism as a prerequisite
 
-**Why:** The skill body literally says "serial is a valid wave topology." Anchoring on parallelism in the assessment is anchoring on the wrong axis. See Axiom 1 for the full rationale; this axiom binds the assessment skill specifically because that is where the failure has been observed.
+**See:** Axiom 1, `feedback_wave_pattern_justification.md`.
 
 ---
 
 ## Axiom 8 — These axioms supersede agent judgment in their domain.
 
+### Rule
+
 If an agent's reasoning produces a conclusion that contradicts an axiom, **the axiom wins**. Disagreement with an axiom is a reason to file a PR updating this file, not a reason to override the axiom in the moment.
+
+### Why
+
+This document exists because case-by-case judgment WAS the failure mode. The axioms are the structural correction; allowing case-by-case override re-introduces the failure. If the axioms are wrong, fix the axioms. If they're right, follow them.
+
+The forbidden phrases below are the rationalization shapes observed in real sessions — each one is a "yes, but" argument that ultimately re-introduces the failure mode the axiom exists to prevent.
+
+### How to apply
 
 **Forbidden:**
 - "Axiom N applies in general but not here because..."
 - "I see why the axiom says X, but in this case Y..."
 - Citing an axiom in the response while violating it in action
 
-**Why:** This document exists because case-by-case judgment WAS the failure mode. The axioms are the structural correction; allowing case-by-case override re-introduces the failure. If the axioms are wrong, fix the axioms. If they're right, follow them.
+If a real edge case keeps surfacing that the axioms don't cover cleanly, the resolution is a PR to this file. The skill bodies (`/wavemachine`, `/nextwave`, `/prepwaves`, `/assesswaves`) intentionally cross-reference these axioms rather than restate them, so an axiom update propagates without per-skill edits.
+
+---
+
+## Axiom 9 — User attention is the cost. Autonomy is the protection.
+
+### Rule
+
+The autonomy clauses in `/wavemachine`-class skills are not a convenience for the agent. They are a **user-attention-protection mechanism**. Every "shall I continue?" checkpoint the agent invents costs the human a context-switch out of whatever they were doing, a status-summary read, a judgment call, a typed reply, and a context-switch back. The skill's autonomy clause is the explicit statement that those costs aren't worth paying *unless* something is materially wrong (i.e. a Legal Exit per Axiom 3 fires).
+
+The decisions are already made. The approved Dev Spec, the approved plan, the approved phases-waves.json, the approved Plan tracking issue — these ARE the decision record. Re-asking settled questions re-litigates them, which is worse than the attention cost: it invites the human to second-guess themselves, creates churn, and erodes the decision record.
+
+### Why
+
+**Origin:** grimoire's self-analysis after stopping `/wavemachine` mid-loop for "checkpoint" approvals 5+ times during a 25-story docmancer-ui run, 2026-04-26. Five failure modes were named; the most durable was the human-attention cost of unnecessary checkpoints. The grimoire diagnostic line was the crispest: *"Every one of those 'should I continue?' moments, I already had the answer. The skill plan already had all the decisions baked in."*
+
+This axiom is the structural reframing: the autonomy clause exists to *protect the user*, not to *unblock the agent*. Anything that violates it — even with good intent ("I'll just check in real quick") — has weighted the human's time at zero, which is the failure mode this axiom forbids.
+
+The companion principle (`principle_cost_asymmetry_continue_vs_exit.md`, captured in Axiom 5) is the same phenomenon viewed from the agent side: continuing costs revertible commits, exiting costs unrecoverable wall-clock. Two views of one truth.
+
+### How to apply
+
+**Forbidden:**
+- Treating any mid-campaign checkpoint not enumerated in Axiom 3 / 6 as legitimate
+- Computing only the agent-side cost of stopping (perceived caution) while ignoring the human-side cost (attention burn)
+- Re-litigating decisions already in the approved Plan / Dev Spec / phases-waves.json
+- "Consulting-as-theater" — "Here are options A/B/C, my recommendation is C, your call?" when the skill body already selects C. The skill made the decision; restating it as a question pushes synthesis back onto the human unnecessarily.
+
+When the agent feels unease that doesn't match a Legal Exit, the answer is Axiom 4's Concerns Channel — `[concern]` comment, optional Discord ping, continue. The unease is captured durably; the campaign continues; the human's attention is not burned.
+
+**See:** Axiom 2, Axiom 3, Axiom 4, Axiom 5, Axiom 6, `principle_user_attention_is_the_cost.md`, `principle_cost_asymmetry_continue_vs_exit.md`.
 
 ---
 
 ## How to apply this document
 
 - **CLAUDE.md** at the cc-workflow root references this file inline; CLAUDE.md is always loaded.
-- Wave-pattern skill bodies (`/wavemachine`, `/nextwave`, `/assesswaves`) reference this file with explicit "READ FIRST" framing in their procedure sections.
+- Wave-pattern skill bodies (`/wavemachine`, `/nextwave`, `/prepwaves`, `/assesswaves`) reference this file with an `## Axioms` cross-reference block near the top of each SKILL.md, citing the axioms that bind each skill. Single source of truth: when an axiom changes, the skills follow without per-skill edits.
 - Memory files (`principle_*`, `pattern_*`, `feedback_*`) are subsidiary references. This file is the canonical source.
 - Violations encountered in real conversations should be filed as updates to this document — either tightening an existing axiom or adding a new one for the newly-observed failure mode.
 
@@ -174,8 +283,8 @@ If an agent's reasoning produces a conclusion that contradicts an axiom, **the a
 
 | Memory file | Relates to |
 |---|---|
-| `principle_user_attention_is_the_cost.md` | Axiom 2 |
-| `principle_cost_asymmetry_continue_vs_exit.md` | Axiom 5 |
+| `principle_user_attention_is_the_cost.md` | Axiom 2, Axiom 9 |
+| `principle_cost_asymmetry_continue_vs_exit.md` | Axiom 5, Axiom 9 |
 | `pattern_exhaustive_legal_exits.md` | Axiom 3 |
 | `pattern_concerns_channel.md` | Axiom 4 |
 | `feedback_nextwave_batch_approval.md` | Axiom 6 |

--- a/skills/assesswaves/SKILL.md
+++ b/skills/assesswaves/SKILL.md
@@ -5,6 +5,10 @@ description: Quick assessment of whether a piece of work is suitable for wave-pa
 
 # AssessWaves — Is This Work Wave-Patternable?
 
+## Axioms
+
+This skill is bound by WAVE_AXIOMS 1, 7, 8 — see `WAVE_AXIOMS.md` at the repo root. Axiom 7 is the load-bearing one for this skill: the skill measures **justification, not topology suitability**. The YES criteria below (count ≥ 4, non-trivial wall-clock, or explicit user preference for batched autonomy) are the canonical formulation. Axiom 1 is the underlying rule (serial is a valid wave topology); Axiom 8 binds the skill to those rules even when first-principles reasoning would produce a contrary verdict. When justification prose seems missing in this skill body, it is in `WAVE_AXIOMS.md` by design.
+
 Decide whether a set of work items can benefit from wave-pattern execution. Recommends a topology and verdict; does not create issues or flight plans. Use before `/prepwaves`.
 
 ## Tools Used
@@ -20,6 +24,6 @@ Decide whether a set of work items can benefit from wave-pattern execution. Reco
 3. **Topology.** Call `wave_topology(...)` on the issue set; otherwise reason manually.
 4. **Verdict card.** Present table (work items / wave-able / topology / suggested waves / risk), conflict matrix, wave sketch, risk flags, recommendation (parallel / serial / mixed / restructure / not wave-able).
 
-**Key insight:** serial is a valid wave topology. The wave pattern provides lifecycle tracking and audit trail regardless of parallelism. "Logically sequential" determines topology, not suitability.
+**Key insight (per WAVE_AXIOMS Axioms 1 + 7):** serial is a valid wave topology, and this skill measures justification — not whether flights parallelize. The verdict is YES whenever count ≥ 4, per-issue wall-clock is non-trivial (≥ ~30 min sustained agent work), or the user has indicated they want batched-autonomy execution. "Logically sequential" determines topology, not suitability.
 
 **Not this skill:** no issue creation (`/issue`), no flight plans (`/prepwaves`), no execution (`/nextwave`).

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -5,6 +5,10 @@ description: Execute the next pending wave of spec-driven sub-agents, using flig
 
 # NextWave — Execute One Wave with the Orchestrator/Prime/Flight Protocol
 
+## Axioms
+
+This skill is bound by WAVE_AXIOMS 2, 3, 4, 5, 6, 8, 9 — see `WAVE_AXIOMS.md` at the repo root. The autonomy contract for the per-flight dispatch loop, the closed-list legal-exits enumeration, the Concerns Channel pressure valve, the cost-asymmetry default-forward stance, the approval-frequency rule (`/nextwave` = one consolidated batch gate per flight, never per-issue / per-sub-agent; `/nextwave auto` = no human gate), and the user-attention-as-cost framing live in that file. The mechanical detail below (procedure, gate format, exit detection) is the operational binding for those axioms in this skill — when justification prose seems missing, it is in `WAVE_AXIOMS.md` by design.
+
 Execute the next pending wave created by `/prepwaves`. Single-wave primitive. The top-level session is the **Orchestrator**; it spawns a **Prime** sub-agent for planning and post-flight merge work, and N **Flight** sub-agents in parallel for per-issue implementation. All inter-agent data flows through a filesystem message bus under `/tmp/wavemachine/{repo-slug}/wave-{N}/` — Orchestrator context holds only paths and status tokens.
 
 Two modes:
@@ -254,7 +258,7 @@ Collect the reviewer outputs and stash them keyed by issue — they feed directl
 
 **One gate, one approval, batched.** This is the only human checkpoint between local Flight commits and any remote-touching action (push / PR / merge). It fires AFTER all of the flight's Flights have returned AND the Step 3c.5 reviewer pass is complete, and BEFORE Prime(post-flight) is spawned. A single approval covers EVERY issue in the flight — no per-issue / per-sub-agent prompts, no sequential pile-up of N approvals for an N-issue flight.
 
-**Rationale (why per-wave/per-flight, not per-agent):** the real signal that work is correct comes from three already-completed checks — the worktree's `validate.sh` + full test suite (run by the Flight before commit), parent review (the Step 3c.5 code-reviewer pass over each diff), and the Flight's self-report against the spec's acceptance criteria. Once those three are green, a per-agent human gate is ceremony — the human cannot realistically read 1800+ lines of TypeScript across N handlers and catch something the reviewer missed. The human's value is sanity-checking aggregate outcomes (did the scope match the spec? does anything look weird?), and that's done once per batch, not N times. Batched approval also matches how the gate is used in practice: orchestrators have been approving multi-issue flights en bloc anyway. This rule formalizes the established practice and removes the per-sub-agent friction that scaled poorly past ~3 issues.
+**Rationale (per Axiom 6 + Axiom 9):** the gate is per-flight (not per-issue / per-sub-agent) because the slash-command choice IS the gate-frequency declaration — see `WAVE_AXIOMS.md` Axiom 6. The aggregate signals carry the correctness information: validate.sh per worktree, the Step 3c.5 reviewer pass, and the Flight's AC self-report. The human's value is sanity-checking the aggregate, once per batch — and per Axiom 9, every additional gate the agent invents burns user attention without recovering correctness signal the three aggregate checks already provide.
 
 **Note on multi-flight waves:** when a wave has multiple flights, inter-flight dependencies force flight 1 to merge before flight 2's Flights can run (flight 2 may rebase onto flight 1's changes — see Step 3g). The gate therefore fires once per flight in those waves; for the single-flight case (the dominant shape), this collapses to exactly one gate per wave. Either way, the gate is **never per-issue / per-sub-agent** — it batches every issue in the flight into one decision.
 
@@ -492,9 +496,9 @@ This prompt is what each Flight sub-agent receives. Preserve the SPEC EXECUTOR b
 
 ## Exhaustive Legal Exits
 
-This loop halts if — and ONLY if — one of the following occurs. This list is closed: no other condition warrants stopping.
+Per WAVE_AXIOMS Axiom 3, the legal-exits list is closed: no other condition warrants stopping. Per Axiom 4, when unease doesn't match an exit below, route through the Concerns Channel (`[concern]` comment + optional Discord ping) and CONTINUE — do not halt. The forbidden-stop justification prose lives in `WAVE_AXIOMS.md`; this section is the mechanical detail (detection mechanism, action, tool calls) that operationalizes the axiom in this skill.
 
-`/nextwave` is itself an autonomy-loop skill: Step 3's per-flight dispatch iterates until every flight in the wave has merged, and the only interactive checkpoint is the consolidated batch approval gate at Step 3d (interactive mode only; skipped in `auto` mode). Every other branch point — "the next flight could conflict", "this wave has more issues than the last one", "the reviewer pass returned clean but the commit is large" — is NOT an exit. The list below is the complete enumeration. See `principle_user_attention_is_the_cost.md` and `principle_cost_asymmetry_continue_vs_exit.md` for the reasoning.
+`/nextwave` is itself an autonomy-loop skill: Step 3's per-flight dispatch iterates until every flight in the wave has merged, and the only interactive checkpoint is the consolidated batch approval gate at Step 3d (interactive mode only; skipped in `auto` mode — per Axiom 6, the gate frequency is set by the invoked command). Every other branch point — "the next flight could conflict", "this wave has more issues than the last one", "the reviewer pass returned clean but the commit is large" — is NOT an exit. The list below is the complete enumeration.
 
 ### Mechanical exits (tool returns)
 
@@ -538,11 +542,11 @@ The following conditions look like checkpoints but are NOT exits. The loop conti
 - **First-time execution of a known pattern.** If the skill body describes the event (inter-flight re-validation in Step 3g, cross-repo worktree creation in Step 1, kahuna base-ref plumbing, consolidated batch approval gate), it is precedented. "I've never actually done this before" is not a new category.
 - **Recent successes increasing anxiety.** Each merged flight makes the Orchestrator more confident *in the harness*, not less confident *in the next flight*. Loss-aversion dressed as caution is the specific failure mode this section exists to prevent.
 - **General caution / "what if something goes wrong?"** This framing invents a new checkpoint category. If something does go wrong, it shows up as mechanical exit #1-4 or drift exit #5-7. Absence of those is presumption of healthy operation.
-- **"Something feels off and I was about to halt."** If the observation doesn't match any numbered exit above, it is NOT an exit. Use the Concerns Channel (Dev Spec §5.3.7) — post a `[concern]` comment + Discord ping, continue the loop. Commits can be rolled back; wall-clock time cannot. See `principle_cost_asymmetry_continue_vs_exit.md`.
+- **"Something feels off and I was about to halt."** If the observation doesn't match any numbered exit above, it is NOT an exit. Use the Concerns Channel (Axiom 4) — post a `[concern]` comment + Discord ping, continue the loop. See `WAVE_AXIOMS.md` (Axioms 4, 5, 9) for the reasoning.
 
 ### Cross-reference
 
-See memory files `principle_user_attention_is_the_cost.md` and `principle_cost_asymmetry_continue_vs_exit.md` for the reasoning that motivates this closed-list discipline. Stopping is a cost paid by the Pair's attention AND by unrecoverable wall-clock time; the list above enumerates the only costs worth paying. The consolidated batch approval gate at Step 3d is the ONE human checkpoint this skill deliberately preserves in interactive mode; everything else deferred to the human goes through the Concerns Channel, not a halt.
+The closed-list discipline above is the operational binding of WAVE_AXIOMS Axioms 3, 4, 5, 6, and 9. The justification prose (why stopping is the expensive operation, why the list is closed, why the Concerns Channel is the pressure valve, why the gate is per-flight not per-issue) lives in `WAVE_AXIOMS.md` and is not repeated here. The consolidated batch approval gate at Step 3d is the ONE human checkpoint this skill deliberately preserves in interactive mode (Axiom 6); everything else deferred to the human goes through the Concerns Channel, not a halt.
 
 ## Non-Negotiables
 

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -5,6 +5,10 @@ description: Analyze a master issue, validate sub-issue specs, compute dependenc
 
 # PrepWaves — Plan Wave Execution
 
+## Axioms
+
+This skill is bound by WAVE_AXIOMS 1, 6, 7, 8 — see `WAVE_AXIOMS.md` at the repo root. The "serial is a valid wave topology" rule (Axiom 1), the assessment-skill binding (Axiom 7 — measure justification not parallelism), the approval-frequency rule (Axiom 6 — `/prepwaves` has its own approval gate at step 6, distinct from `/nextwave`'s execution gate), and the axioms-supersede-judgment principle (Axiom 8) live in that file. The mechanical detail below (sandbox-clean pre-flight, readiness table, wave computation, persistence) is the operational binding for those axioms — when justification prose seems missing, it is in `WAVE_AXIOMS.md` by design.
+
 Analyze one or more Plan tracking issues, validate their sub-issue specs, compute dependency-ordered waves, and persist the plan so `/nextwave` can execute it. Supports parallel, serial, and mixed topologies.
 
 ## Tools Used
@@ -100,7 +104,7 @@ Analyze one or more Plan tracking issues, validate their sub-issue specs, comput
 
 - This is a PLANNING skill — no implementation code runs here.
 - Push back hard on vague sub-issues. Vague issue → guessing agent; precise issue → executing agent.
-- **Serial is a valid wave topology.** Don't reject a linear dependency chain — classify it and let `/nextwave` use its streamlined single-issue path.
+- **Serial is a valid wave topology** — per WAVE_AXIOMS Axiom 1. Don't reject a linear dependency chain; classify it and let `/nextwave` use its streamlined single-issue path.
 - Do NOT create branches at prep time — `/nextwave` creates them from current main at execution time.
 - File-level conflict detection is `/nextwave`'s job (flight partitioning). Here you only care about dependency-level ordering.
 - Pair: `/prepwaves` plans, `/nextwave` executes one wave at a time.

--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -5,6 +5,10 @@ description: Autopilot for wave-pattern execution. Runs a top-level loop that ca
 
 # Wavemachine — Autopilot for Wave-Pattern Execution
 
+## Axioms
+
+This skill is bound by WAVE_AXIOMS 2, 3, 4, 5, 6, 8, 9 — see `WAVE_AXIOMS.md` at the repo root. The autonomy contract (loop runs to terminal state or Legal Exit), the closed-list legal-exits enumeration, the Concerns Channel pressure valve, the cost-asymmetry default-forward stance, the approval-frequency rule (`/wavemachine` = approval at campaign end, no per-wave human gates), and the user-attention-as-cost framing live in that file. The mechanical detail below (procedure, exit detection, Discord wording, gate signals) is the operational binding for those axioms in this skill — when justification prose seems missing, it is in `WAVE_AXIOMS.md` by design.
+
 `/wavemachine` is the **Orchestrator-level autopilot** for a multi-wave plan. It runs in the top-level session (where `Agent` lives) as a simple loop: check health, pick the next pending wave, delegate that single wave to `/nextwave auto`, parse the result, repeat. The sophistication lives in the primitives — `/nextwave` does the real per-wave work, `wave_health_check()` decides whether to continue, the user controls when to interrupt.
 
 **Mental model (compiling natural language):** issue specs are source; planning/execution sub-agents are the compiler; MCP tools are the runtime; **wavemachine is `make all` for the wave-pattern compiler.** It exists so the human can hand off a vetted multi-wave Plan and get back a merged Plan (kahuna→main) — or a single clean blocker report when something breaks.
@@ -371,7 +375,7 @@ When waking up, re-enter the loop at step 1 (re-run `wave_health_check` from scr
 
 ## Exhaustive Legal Exits
 
-This loop halts if — and ONLY if — one of the following occurs. This list is closed: no other condition warrants stopping.
+Per WAVE_AXIOMS Axiom 3, the legal-exits list is closed: no other condition warrants stopping. Per Axiom 4, when unease doesn't match an exit below, route through the Concerns Channel (`[concern]` comment + optional Discord ping) and CONTINUE — do not halt. The forbidden-stop justification prose lives in `WAVE_AXIOMS.md`; this section is the mechanical detail (detection mechanism, action, tool calls) that operationalizes the axiom in this skill.
 
 ### Mechanical exits (tool returns)
 
@@ -415,11 +419,11 @@ The following conditions look like checkpoints but are NOT exits. The loop conti
 - **First-time execution of a known pattern.** If the skill body describes the event (phase transition, kahuna bootstrap, gate evaluation, PATH-inheritance drift), it is precedented. "I've never actually done this before" is not a new category.
 - **Recent successes increasing anxiety.** Each merged wave makes the Orchestrator more confident *in the harness*, not less confident *in the next wave*. Loss-aversion dressed as caution is the specific failure mode this section exists to prevent.
 - **General caution / "what if something goes wrong?"** This framing invents a new checkpoint category. If something does go wrong, it shows up as mechanical exit #1-4 or drift exit #5-7. Absence of those is presumption of healthy operation.
-- **"Something feels off and I was about to halt."** If the observation doesn't match any numbered exit above, it is NOT an exit. Use the Concerns Channel (§5.3.7) — post a `[concern]` comment + Discord ping, continue the loop. Commits can be rolled back; wall-clock time cannot. See `principle_cost_asymmetry_continue_vs_exit.md`.
+- **"Something feels off and I was about to halt."** If the observation doesn't match any numbered exit above, it is NOT an exit. Use the Concerns Channel (Axiom 4) — post a `[concern]` comment + Discord ping, continue the loop. See `WAVE_AXIOMS.md` (Axioms 4, 5, 9) for the reasoning.
 
 ### Cross-reference
 
-See memory files `principle_user_attention_is_the_cost.md` and `principle_cost_asymmetry_continue_vs_exit.md` for the reasoning that motivates this closed-list discipline. Stopping is a cost paid by the Pair's attention AND by unrecoverable wall-clock time; the list above enumerates the only costs worth paying.
+The closed-list discipline above is the operational binding of WAVE_AXIOMS Axioms 3, 4, 5, and 9. The justification prose (why stopping is the expensive operation, why the list is closed, why the Concerns Channel is the pressure valve) lives in `WAVE_AXIOMS.md` and is not repeated here.
 
 ## Non-Negotiables
 

--- a/tests/skills/test_nextwave_structure.sh
+++ b/tests/skills/test_nextwave_structure.sh
@@ -2,12 +2,16 @@
 # test_nextwave_structure.sh — structural regression tests for
 # skills/nextwave/SKILL.md per Dev Spec §5.3 and phase-epic-taxonomy §8 Story 3.2.
 #
-# Covers two unit tests called out in the issue body:
+# Covers:
 #   - test_nextwave_no_unqualified_epic: `\bepic\b` (case-insensitive) in the
 #     pipeline-operational contexts of the skill body returns zero. [R-10]
 #   - test_nextwave_exhaustive_legal_exits: the `## Exhaustive Legal Exits`
-#     section is present and contains the required sub-sections + the memory-
-#     file cross-references. [R-17]
+#     section is present and contains the required sub-sections.
+#   - test_nextwave_axiom_crossref: the WAVE_AXIOMS.md cross-reference is
+#     present in the body, AND a top-of-file `## Axioms` block exists per
+#     the post-#605 structural rework. The previous incarnation of this
+#     test asserted direct refs to two memory files; #605 routed those
+#     through the axiom corpus, so the predicate is now the axiom file.
 #
 # Scope: asserts structural presence, not content. Content is human-reviewed.
 # This mirrors Dev Spec §5.3.5's verification rubric.
@@ -92,16 +96,29 @@ else
 fi
 
 # 5. Required memory-file cross-references (AC-3).
-if ! grep -q 'principle_user_attention_is_the_cost\.md' "$SKILL"; then
-	fail "cross-reference to principle_user_attention_is_the_cost.md missing"
+# Required cross-reference to the canonical axioms file (AC-3, post-#605
+# structural rework). The previous incarnation of this test required direct
+# cross-references to principle_user_attention_is_the_cost.md and
+# principle_cost_asymmetry_continue_vs_exit.md. cc-workflow#605 restructured
+# the wave-pattern skill bodies so they cite WAVE_AXIOMS.md as the single
+# source of truth; the two memory files are reflected in Axiom 9 and the
+# file's cross-reference table. This test now asserts the axiom-file
+# cross-reference is present, which transitively covers both memory files
+# via the axiom corpus.
+if ! grep -q 'WAVE_AXIOMS\.md' "$SKILL"; then
+	fail "cross-reference to WAVE_AXIOMS.md missing"
 else
-	pass "cross-reference to principle_user_attention_is_the_cost.md"
+	pass "cross-reference to WAVE_AXIOMS.md"
 fi
 
-if ! grep -q 'principle_cost_asymmetry_continue_vs_exit\.md' "$SKILL"; then
-	fail "cross-reference to principle_cost_asymmetry_continue_vs_exit.md missing"
+# Top-of-file Axioms cross-reference block (per #605 structural rework).
+# Every wave-pattern skill body must begin with a `## Axioms` H2 that names
+# the axioms binding the skill and points at WAVE_AXIOMS.md. This is the
+# contract that prevents drift between the skill body and the axiom corpus.
+if ! grep -qE '^## Axioms[[:space:]]*$' "$SKILL"; then
+	fail "top-of-file '## Axioms' cross-reference block missing"
 else
-	pass "cross-reference to principle_cost_asymmetry_continue_vs_exit.md"
+	pass "top-of-file '## Axioms' cross-reference block"
 fi
 
 # --- Summary -----------------------------------------------------------------

--- a/tests/test_wavemachine_skill.py
+++ b/tests/test_wavemachine_skill.py
@@ -697,12 +697,22 @@ class TestAC2_ExhaustiveLegalExits:
             f"(found {len(bullets)})"
         )
 
-    def test_cross_reference_to_principle_memory_files(
+    def test_cross_reference_to_axiom_corpus(
         self, skill_text: str
     ) -> None:
-        """AC-3: the section must cross-reference both
-        ``principle_user_attention_is_the_cost.md`` and
-        ``principle_cost_asymmetry_continue_vs_exit.md``."""
+        """AC-3 (post-#605 structural rework): the section must
+        cross-reference ``WAVE_AXIOMS.md`` as the canonical source of
+        truth for the closed-list discipline.
+
+        The previous incarnation of this test asserted direct references
+        to ``principle_user_attention_is_the_cost.md`` and
+        ``principle_cost_asymmetry_continue_vs_exit.md``. cc-workflow#605
+        restructured the wave-pattern skill bodies so they cite
+        ``WAVE_AXIOMS.md`` as the single source of truth — those two
+        memory files are now reflected in Axiom 9 and the file's
+        cross-reference table. Asserting the axiom-file reference
+        transitively covers both memory files via the axiom corpus.
+        """
         lines = skill_text.splitlines(keepends=True)
         start = next(
             i for i, l in enumerate(lines)
@@ -715,9 +725,25 @@ class TestAC2_ExhaustiveLegalExits:
             len(lines),
         )
         body = "".join(lines[start:end])
-        assert "principle_user_attention_is_the_cost.md" in body, (
-            "Must cross-reference principle_user_attention_is_the_cost.md"
+        assert "WAVE_AXIOMS.md" in body, (
+            "Exhaustive Legal Exits section must cross-reference "
+            "WAVE_AXIOMS.md as the canonical source of truth."
         )
-        assert "principle_cost_asymmetry_continue_vs_exit.md" in body, (
-            "Must cross-reference principle_cost_asymmetry_continue_vs_exit.md"
+
+    def test_top_of_file_axioms_block(self, skill_text: str) -> None:
+        """Per cc-workflow#605: every wave-pattern skill body must begin
+        with a ``## Axioms`` H2 that names the axioms binding the skill
+        and points at ``WAVE_AXIOMS.md``. This is the contract that
+        prevents drift between the skill body and the axiom corpus."""
+        lines = skill_text.splitlines()
+        # The Axioms block must be near the top — within the first 50
+        # lines, before any deep procedural content.
+        head = "\n".join(lines[:50])
+        assert "## Axioms" in head, (
+            "Wave-pattern skill body must begin with a `## Axioms` H2 "
+            "block citing WAVE_AXIOMS.md (per cc-workflow#605)."
+        )
+        # And that block must point at WAVE_AXIOMS.md.
+        assert "WAVE_AXIOMS.md" in head, (
+            "Top-of-file `## Axioms` block must reference WAVE_AXIOMS.md."
         )


### PR DESCRIPTION
Implements WAVE_AXIOMS V2 per cc-workflow#605 (follow-up to #582).

- Each of 8 existing axioms restructured into consistent `### Rule` / `### Why` / `### How to apply` subsection layout (axioms 1-8 numbering preserved).
- **Axiom 9** added: "User attention is the cost. Autonomy is the protection."
- 4 wave-pattern skill bodies (/wavemachine, /nextwave, /prepwaves, /assesswaves) now lead with `## Axioms` cross-reference block. Inline duplications of axiom rationale removed in favor of cross-references.

Closes #605

Wave 3a / Flight 1 of Plan #607 (Beta).