### PR TITLE
feat(orchestrator): long-session drift mitigation for /wavemachine campaigns

### DIFF
--- a/scripts/wavemachine/drift-instrumentation.sh
+++ b/scripts/wavemachine/drift-instrumentation.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# drift-instrumentation.sh — emit per-wave drift-signal events for /wavemachine campaigns.
+#
+# Long /wavemachine campaigns (5+ waves) drift in agent behavior: late-campaign
+# waves get sloppier checklist treatment, more cross-talk with the user, more
+# "is this still right?" pauses. The longer the session, the further the
+# Orchestrator agent has drifted from its constitutional rules (CLAUDE.md,
+# WAVE_AXIOMS, the skill body it started with). Issue cc-workflow#601 ("Bug C"
+# from Plan #581 campaign A debrief) tracks the rework.
+#
+# This helper standardizes the three per-wave drift-signal events the
+# wavemachine SKILL body emits at each `wave_complete` boundary. Events are
+# written via the standard `mcp-log` CLI to ~/.claude/logs/mcp.jsonl so the
+# fleet logfile aggregator (and any post-campaign report) can detect monotonic
+# trends across a campaign's waves.
+#
+# Usage:
+#   drift-instrumentation.sh emit-wave-drift \
+#       --plan <plan_id> \
+#       --wave <wave_id> \
+#       --message-length-main <int> \
+#       --stop-hook-blocks <int> \
+#       --concerns-posts <int>
+#
+#   drift-instrumentation.sh self-test
+#       Emit one synthetic event per signal (sample values) to stdout in
+#       compact JSON form for testing the instrumentation surface without
+#       touching the real fleet logfile. Exit 0 on success; exit 1 on any
+#       formatting failure.
+#
+#   drift-instrumentation.sh report <jsonl-path>
+#       Read a fleet logfile (or test-harness file) and aggregate the three
+#       drift signals into a per-wave trend table. Used for post-campaign
+#       reports — answers "did the late-wave drift signals flatten?".
+#
+# Events emitted (one mcp-log line per signal):
+#   - wave_message_length_main  plan=<id> wave=<id> chars=<int>
+#   - wave_stop_hook_blocks     plan=<id> wave=<id> count=<int>
+#   - wave_concerns_posts       plan=<id> wave=<id> count=<int>
+#
+# Exit codes:
+#   0  success
+#   1  usage error or self-test failure
+#   2  mcp-log not on PATH (degrades to stderr warning + exit non-zero)
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  drift-instrumentation.sh emit-wave-drift \
+      --plan <plan_id> --wave <wave_id> \
+      --message-length-main <int> \
+      --stop-hook-blocks <int> \
+      --concerns-posts <int>
+
+  drift-instrumentation.sh self-test
+      Emit one synthetic event per signal to stdout (compact JSON) and verify
+      formatting without touching the fleet logfile.
+
+  drift-instrumentation.sh report <jsonl-path>
+      Aggregate drift events from a fleet logfile or test harness file into a
+      per-wave trend table.
+
+Events emitted:
+  wave_message_length_main  plan=<id> wave=<id> chars=<int>
+  wave_stop_hook_blocks     plan=<id> wave=<id> count=<int>
+  wave_concerns_posts       plan=<id> wave=<id> count=<int>
+EOF
+}
+
+die() {
+	echo "drift-instrumentation: $*" >&2
+	exit 1
+}
+
+require_mcp_log() {
+	if ! command -v mcp-log >/dev/null 2>&1; then
+		echo "drift-instrumentation: mcp-log not on PATH; cannot emit events" >&2
+		exit 2
+	fi
+}
+
+cmd_emit_wave_drift() {
+	local plan="" wave="" msg_len="" stop_blocks="" concerns=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--plan)
+			plan="$2"
+			shift 2
+			;;
+		--wave)
+			wave="$2"
+			shift 2
+			;;
+		--message-length-main)
+			msg_len="$2"
+			shift 2
+			;;
+		--stop-hook-blocks)
+			stop_blocks="$2"
+			shift 2
+			;;
+		--concerns-posts)
+			concerns="$2"
+			shift 2
+			;;
+		*)
+			die "unknown flag: $1"
+			;;
+		esac
+	done
+
+	[[ -n "$plan" ]] || die "--plan required"
+	[[ -n "$wave" ]] || die "--wave required"
+	[[ -n "$msg_len" ]] || die "--message-length-main required"
+	[[ -n "$stop_blocks" ]] || die "--stop-hook-blocks required"
+	[[ -n "$concerns" ]] || die "--concerns-posts required"
+
+	# Validate integer-ness of the three numeric fields. Refuse anything else
+	# so emit-time bugs surface immediately rather than dribbling malformed
+	# events into the fleet logfile.
+	for v in "$msg_len" "$stop_blocks" "$concerns"; do
+		[[ "$v" =~ ^[0-9]+$ ]] || die "expected non-negative integer, got '$v'"
+	done
+
+	require_mcp_log
+
+	# Three events per wave — one per signal. Emitting them as separate
+	# events (rather than one combined event with three fields) keeps the
+	# schema consistent with other lifecycle events that follow the
+	# event=<one-thing> convention, and makes per-signal trend filtering
+	# trivial (one jq select per signal).
+	mcp-log wave_message_length_main \
+		plan="$plan" wave="$wave" chars="$msg_len"
+	mcp-log wave_stop_hook_blocks \
+		plan="$plan" wave="$wave" count="$stop_blocks"
+	mcp-log wave_concerns_posts \
+		plan="$plan" wave="$wave" count="$concerns"
+}
+
+cmd_self_test() {
+	# Synthesize one event per signal and emit to stdout (NOT mcp-log) so
+	# the test harness can validate the format without polluting the fleet
+	# logfile. Each line is a compact JSON object in the same shape mcp-log
+	# would produce.
+	local ts
+	ts="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+
+	for tuple in \
+		"wave_message_length_main:chars:8421" \
+		"wave_stop_hook_blocks:count:3" \
+		"wave_concerns_posts:count:1"; do
+		local event="${tuple%%:*}"
+		local rest="${tuple#*:}"
+		local field="${rest%%:*}"
+		local value="${rest#*:}"
+
+		jq -nc \
+			--arg ts "$ts" \
+			--arg event "$event" \
+			--arg field "$field" \
+			--argjson value "$value" \
+			'{ts: $ts, server: "wave", level: "info", event: $event, plan: 581, wave: "3a", ($field): $value}'
+	done
+}
+
+cmd_report() {
+	[[ $# -eq 1 ]] || die "report requires <jsonl-path>"
+	local path="$1"
+	[[ -f "$path" ]] || die "file not found: $path"
+
+	# Aggregate by (plan, wave). Output is a tab-separated table:
+	#   plan  wave  message_length_main  stop_hook_blocks  concerns_posts
+	# Sorted by plan then wave so monotonic trends are visible at a glance.
+	# All three signals must be present for a wave to show up — a partial
+	# row is a sign the emitter crashed mid-wave.
+	jq -rs '
+		map(select(.event | test("^wave_(message_length_main|stop_hook_blocks|concerns_posts)$"))) |
+		group_by([.plan, .wave]) |
+		map({
+			plan: .[0].plan,
+			wave: .[0].wave,
+			message_length_main: (map(select(.event == "wave_message_length_main")) | first | .chars // null),
+			stop_hook_blocks:    (map(select(.event == "wave_stop_hook_blocks"))    | first | .count // null),
+			concerns_posts:      (map(select(.event == "wave_concerns_posts"))      | first | .count // null)
+		}) |
+		sort_by([.plan, .wave]) |
+		(["plan", "wave", "message_length_main", "stop_hook_blocks", "concerns_posts"] | @tsv),
+		(.[] | [.plan, .wave, .message_length_main, .stop_hook_blocks, .concerns_posts] | @tsv)
+	' "$path"
+}
+
+if [[ $# -lt 1 ]]; then
+	usage >&2
+	exit 1
+fi
+
+subcommand="$1"
+shift
+
+case "$subcommand" in
+emit-wave-drift)
+	cmd_emit_wave_drift "$@"
+	;;
+self-test)
+	cmd_self_test
+	;;
+report)
+	cmd_report "$@"
+	;;
+-h | --help)
+	usage
+	;;
+*)
+	usage >&2
+	exit 1
+	;;
+esac

--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -32,6 +32,7 @@ This skill is bound by WAVE_AXIOMS 2, 3, 4, 5, 6, 8, 9 — see `WAVE_AXIOMS.md` 
 - The `Agent` tool — invoked AT THE GATE only, for the `feature-dev:code-reviewer` trust signal (one of four concurrent signals). The loop body itself never spawns Agents — `/nextwave auto` owns wave-internal Agent spawning.
 - The `Bash` tool — invoked AT THE GATE for the `trivy fs` dependency scan trust signal.
 - The Skill tool — invokes `/nextwave auto` per iteration (the one place wave work is delegated)
+- `scripts/wavemachine/drift-instrumentation.sh` — emits the three per-wave drift-signal events (`wave_message_length_main`, `wave_stop_hook_blocks`, `wave_concerns_posts`) to the fleet logfile so post-campaign analysis can detect monotonic drift trends. See "Periodic Re-Grounding (drift mitigation)" below for the wiring.
 - `ScheduleWakeup` — OPTIONAL, fallback-only, used when a merge-queue idle is detected (not the primary execution model)
 
 **Not used in the loop body:** wave-internal `Agent` spawning is owned by `/nextwave` — the loop body itself never spawns sub-agents per iteration. The single exception is the gate's `feature-dev:code-reviewer` Agent at Plan completion (one of four concurrent trust signals — see "Trust-Score Gate and Auto-Merge"). Background Agent invocation is NEVER used anywhere in this skill; the loop and the gate both run synchronously in the top-level session.
@@ -158,8 +159,10 @@ loop:
                     this transition MUST be a single tool-use boundary with
                     NO narrative text between the OK return and the next
                     iteration's `wave_health_check` call. Treat the post-OK
-                    side effects (status-panel regen, discord-status-post)
-                    and `wave_health_check` as ONE tool-use block; the
+                    side effects (status-panel regen, discord-status-post,
+                    drift-instrumentation emit, system-reminder re-grounding
+                    — see "Periodic Re-Grounding (drift mitigation)") and
+                    `wave_health_check` as ONE tool-use block; the
                     immediately following assistant message MUST be that
                     tool-use block — not prose, not "wave N complete,
                     starting wave N+1", not anything narrative.
@@ -187,7 +190,7 @@ This section binds the OK-path of step 4 to a structural rule: **the wave-to-wav
 **The contract — what the assistant message immediately after `/nextwave auto` returns OK must look like:**
 
 - It MUST be a tool-use block. The first (and ideally only) substantive content is tool calls.
-- The tool calls in that block are: (a) `generate-status-panel` (fire-and-forget Bash), (b) `discord-status-post` (fire-and-forget Bash), (c) `wave_health_check()` for the *next* iteration. Issuing all three in the same tool-use block is the canonical shape — it is one assistant message, three concurrent tool calls, no prose.
+- The tool calls in that block are: (a) `generate-status-panel` (fire-and-forget Bash), (b) `discord-status-post` (fire-and-forget Bash), (c) `scripts/wavemachine/drift-instrumentation.sh emit-wave-drift ...` (fire-and-forget Bash; see "Periodic Re-Grounding (drift mitigation)" below for the flag set), (d) `wave_health_check()` for the *next* iteration. Issuing all in the same tool-use block is the canonical shape — one assistant message, concurrent tool calls, no prose. The system-reminder re-grounding payload (also documented in "Periodic Re-Grounding") is appended in the same boundary as out-of-band content, NOT as in-turn narrative.
 - It MUST NOT contain narrative text such as "wave N complete", "starting wave N+1", "all flights merged", "loop iteration K finished", or any other status narration. Narration is what the Discord embed and status panel are for; the assistant turn is for tool calls.
 
 **If `wave_health_check` returns HEALTHY in the same tool-use block, the next assistant message proceeds to the loop's `wave_next_pending` step — also as a tool call, not prose.** Likewise, the message that calls `wave_next_pending` MUST also call `/nextwave auto` (via the Skill tool) when the result is non-null, in the same or the immediately following tool-use block. The whole iteration body is one chain of tool-use boundaries; narration belongs at terminal exits only (clean completion, abort, gate-blocked).
@@ -195,6 +198,90 @@ This section binds the OK-path of step 4 to a structural rule: **the wave-to-wav
 **Why this is structural, not advisory.** The Stop hook with `decision:block` (config/settings.template.json, see "Pre-Flight Checks" cross-ref to `lesson_stop_hook_with_block.md`) prevents the agent from *ending the turn* while `wavemachine_active=true`, but the inter-wave stall manifests as an in-turn prose emission — the agent does not end the turn, it just emits a narrator paragraph that costs wall-clock. The Stop hook is the safety net for premature termination; this section is the contract that prevents the in-turn narration the Stop hook cannot catch.
 
 **Regression check.** `tests/regression/test_wavemachine_handoff_no_narrator.sh` is a doc-shape test asserting (a) this section exists and uses "single tool-use boundary" wording, (b) the loop body's OK-path defers to this section rather than enumerating side effects in narration-friendly prose, (c) Non-Negotiables forbid inter-wave narration. If a future edit silently weakens any of these, the test fails before merge.
+
+## Periodic Re-Grounding (drift mitigation)
+
+Long /wavemachine campaigns (5+ waves, multi-hour wall-clock) drift in agent behavior: late-campaign waves get sloppier checklist treatment, more cross-talk with the user, more "is this still right?" pauses. The longer the session runs, the further the Orchestrator has drifted from its constitutional rules — `CLAUDE.md`, `WAVE_AXIOMS.md`, and the skill body it started with. This is "Bug C" from the Plan #581 campaign A debrief, and `cc-workflow#601` is the rework.
+
+Re-grounding is the structural counter-pressure. At each `wave_complete` boundary, the loop emits a system-reminder payload that re-loads the constitutional layer into the Orchestrator's working context, alongside two pieces of drift telemetry. The mechanism is the lightest of the three options the issue evaluated (per-wave system-reminder injection vs mandatory `/engage` between waves vs compact-on-N-waves heuristic). The two heavyweight options are documented as rejected alternatives below — they remain available if instrumentation shows the lightweight option is insufficient.
+
+### Mechanism — per-wave system-reminder injection
+
+At each `wave_complete` boundary inside the Wave-to-Wave Handoff block (i.e. in the same single tool-use boundary that fires status-panel regen + discord-status-post + the next iteration's `wave_health_check`), append a system-reminder payload with the following content:
+
+```
+[wavemachine re-grounding — wave <N> of <total>]
+
+Constitutional layer (single source of truth):
+  WAVE_AXIOMS.md — 9 axioms binding wave-pattern execution.
+  Axiom 9 in particular: "User attention is the cost. Autonomy is the
+  protection." The autonomy contract on this loop exists to protect the
+  user's wall-clock; every "shall I continue?" the agent invents costs
+  the human a context-switch they did not ask to pay. The decisions are
+  already made — the approved Plan, the approved Dev Spec, the approved
+  phases-waves.json. Re-asking re-litigates settled questions.
+
+  Axiom 3: closed-list legal exits — plan-reality drift, hard fault,
+  explicit user halt. No others. Unease that doesn't match an exit goes
+  through the Concerns Channel (Axiom 4), not through a stop.
+
+Loop contract (this skill body):
+  Wave-to-Wave Handoff is a single tool-use boundary — no narrator gap,
+  no prose between waves. The next assistant message is a tool-use
+  block, not status narration.
+
+Plan summary at this boundary:
+  Plan #<plan_id>, kahuna branch <kahuna_branch>.
+  Waves remaining: <count of pending waves>.
+  Next wave: <id> — <one-line summary from phases-waves.json>.
+```
+
+The `<total>`, `<plan_id>`, `<kahuna_branch>`, and pending-wave summary are filled from `wave_show()` output; the WAVE_AXIOMS reference is fixed text (the file is the canonical source — restating axiom prose here would re-introduce the cross-skill-rot pattern Axiom 8 + cc-workflow#605 corrected). This re-loads the constitutional layer into context exactly when drift accumulation is observable but before the next wave's first sub-agent dispatch.
+
+The re-grounding payload is a system-reminder (not narrative prose), which means it does NOT violate the Wave-to-Wave Handoff "no narrator gap" contract — system-reminders are out-of-band, not in-turn assistant text.
+
+### Instrumentation — drift signals per wave
+
+`scripts/wavemachine/drift-instrumentation.sh emit-wave-drift` emits three events to the fleet logfile (`~/.claude/logs/mcp.jsonl`) at each `wave_complete` boundary:
+
+- **`wave_message_length_main`** — the cumulative character count of Orchestrator (top-level session) assistant messages over the wave just completed. Drift signal: monotonically increasing per-wave totals indicate the Orchestrator emitting more narrative prose / cross-talk per wave as the campaign progresses.
+- **`wave_stop_hook_blocks`** — the number of Stop-hook `decision: block` events fired during the wave. Drift signal: late-wave increases indicate the agent is more frequently trying to end its turn while `wavemachine_active=true`, which the Stop hook catches but the count of which is the leading indicator.
+- **`wave_concerns_posts`** — the number of `[concern]` comments posted via the Concerns Channel (Axiom 4) during the wave. Drift signal: increases are NOT necessarily bad — the Concerns Channel exists precisely so unease has a legitimate outlet — but a sudden spike late in the campaign is evidence the agent is hitting more "this feels wrong" moments without a Legal Exit firing, which is itself drift.
+
+The helper accepts the three counts as flags so the loop body's measurement step (count assistant messages, count Stop-hook events from the session log, count `[concern]` comments via `gh issue view`) is decoupled from the emit step. See the script's `--help` for the exact invocation; the `report` subcommand aggregates a fleet logfile into a per-wave trend table for post-campaign analysis.
+
+`scripts/wavemachine/drift-instrumentation.sh self-test` emits one synthetic event per signal to stdout in compact JSON form, for verifying the instrumentation surface end-to-end without polluting the real fleet logfile. This is the test path used by `tests/test_drift_instrumentation_skill.py` to validate the script ships and its output shape matches the schema.
+
+### Wiring — where the calls fire in the loop body
+
+At the OK-path of step 4 in the loop (the Wave-to-Wave Handoff block), the single tool-use boundary that fires `generate-status-panel` + `discord-status-post` + the next iteration's `wave_health_check` ALSO fires:
+
+- `scripts/wavemachine/drift-instrumentation.sh emit-wave-drift --plan <plan_id> --wave <N> --message-length-main <chars> --stop-hook-blocks <count> --concerns-posts <count>` (Bash, fire-and-forget; failure logged, not gating)
+- The system-reminder injection described above
+
+Both are added to the same tool-use block as the existing handoff calls — they do NOT add a narrator gap because they are tool calls, not assistant prose. Per Axiom 6 ("approval frequency is set by the invoked command — the agent does not add gates"), the re-grounding mechanism is mechanical and unconditional; it does not gate on user approval, and it fires at every `wave_complete` boundary regardless of campaign length. Late-wave drift is the primary target, but the cost of re-grounding at wave 1 is negligible.
+
+### Rejected alternatives
+
+- **Mandatory `/engage` between waves.** Reloads CLAUDE.md and the project rules from scratch. Maximally re-grounding, but heavyweight: each `/engage` is a context-eating sub-skill invocation that re-reads memory files, MEMORY.md indexes, and identity caches. Net cost is several thousand tokens per wave. Not justified by current evidence — the system-reminder option lands the load-bearing constitutional content (WAVE_AXIOMS.md reference + the loop contract) at a fraction of the cost. If instrumentation shows drift signals are still trending up after the lightweight option is wired, this becomes the next escalation rung.
+- **Compact-on-N-waves heuristic.** Invoke `/compact` at wave N (e.g. N=3 or N=5) to clear conversation rot, then resume. Drastic — `/compact` rewrites the entire conversation history into a summary, which carries the risk of dropping load-bearing details (per-issue commit SHAs, partial decisions, Concerns Channel posts). Also fights against the Stop hook's `decision:block` contract, since `/compact` ends the agent's turn explicitly. Last-resort option; not the default mechanism.
+
+The lightweight option's main risk is that the system-reminder is not strong enough — drift signals continue trending up despite the per-wave re-grounding. If that turns up in practice (instrumentation will surface it), the escalation path is well-defined: tighten the payload first, then escalate to mandatory `/engage` if necessary, then to compaction as last resort.
+
+### Empirical baseline
+
+A fully empirical comparison ("run the same 6-wave plan with and without mitigation, observe drift signals flatten") cannot be performed inside a single Flight context — Flights cannot run live `/wavemachine` campaigns. The Flight ships:
+
+1. The instrumentation surface (`drift-instrumentation.sh`, the three named events, the report subcommand).
+2. The mitigation mechanism documented and wired into this skill body.
+3. The script's `self-test` invocation as a synthetic harness, executable end-to-end inside CI.
+4. A test (`tests/test_drift_instrumentation_skill.py`) asserting the wiring is in place — script exists, executable, self-test exits clean, the SKILL.md reference is present.
+
+The full A/B empirical comparison is tracked as a follow-up empirical-comparison issue (filed at the same level as the original cc-workflow#601). The first natural campaign of ≥5 waves run after this lands provides the post-mitigation data; the pre-mitigation baseline is the existing campaign A trace (Plan #581) referenced in the issue body.
+
+### Cross-reference
+
+WAVE_AXIOMS Axiom 9 (user attention as cost), Axiom 5 (cost-asymmetry), Axiom 4 (Concerns Channel), Axiom 6 (gate-frequency contract). cc-workflow#601 (this issue), cc-workflow#600 (Bug B — narrator gap), `decision_skills_ownership.md`, `feedback_user_attention_is_the_cost.md`.
 
 ## Trust-Score Gate and Auto-Merge
 
@@ -432,7 +519,8 @@ The closed-list discipline above is the operational binding of WAVE_AXIOMS Axiom
 - **NEVER run the loop in a background sub-agent.** No background Agent invocation, ever — not with the `run_in_background` parameter, not shelled out, not via any other escape hatch. The loop is top-level, period. (The gate's `feature-dev:code-reviewer` Agent runs *synchronously* at the top level — not in the background.)
 - **NEVER spawn Flights or Prime directly.** `/nextwave auto` owns the Orchestrator/Prime/Flight protocol for each wave — `/wavemachine` only delegates wave work to it.
 - **Circuit breaker before every iteration.** `wave_health_check` is called at the TOP of each loop iteration, not just the first.
-- **Wave-to-wave handoff is a single tool-use boundary — no narrator gap.** When `/nextwave auto` returns OK, the immediately following assistant message MUST be a tool-use block (status-panel regen + discord-status-post + next iteration's `wave_health_check`), NOT narrative text. Prose like "Wave N complete, starting wave N+1" between waves is forbidden — it costs wall-clock and is the specific failure mode this rule (cc-workflow#600 / Plan #581 campaign A "Bug B") exists to prevent. See "Wave-to-Wave Handoff" above. Stop hook with `decision:block` (config/settings.template.json) is the structural safety net for *premature termination*; this rule is the contract preventing the *in-turn narration* the Stop hook cannot catch.
+- **Wave-to-wave handoff is a single tool-use boundary — no narrator gap.** When `/nextwave auto` returns OK, the immediately following assistant message MUST be a tool-use block (status-panel regen + discord-status-post + drift-instrumentation emit + next iteration's `wave_health_check`), NOT narrative text. Prose like "Wave N complete, starting wave N+1" between waves is forbidden — it costs wall-clock and is the specific failure mode this rule (cc-workflow#600 / Plan #581 campaign A "Bug B") exists to prevent. See "Wave-to-Wave Handoff" above. Stop hook with `decision:block` (config/settings.template.json) is the structural safety net for *premature termination*; this rule is the contract preventing the *in-turn narration* the Stop hook cannot catch.
+- **Re-grounding fires every wave-to-wave handoff.** The drift-instrumentation emit AND the system-reminder re-grounding payload (referencing `WAVE_AXIOMS.md`, with explicit citation of Axiom 9 — user attention as cost) are unconditional at every `wave_complete` boundary. They are not gated on user approval, campaign length, or drift-signal threshold. Per Axiom 6, the agent does not add gates the user did not invoke; per Axiom 9, the cost of re-grounding at wave 1 is dominated by the cost of NOT re-grounding at wave 6. This is the cc-workflow#601 contract; weakening it requires a tracked rework. See "Periodic Re-Grounding (drift mitigation)".
 - **Leave the bus alone on abort.** On any non-happy exit, the in-flight wave's bus tree stays on disk for forensics. `wave-cleanup` runs only on PASS, inside `/nextwave auto`.
 - **Block on green CI.** `/nextwave auto` handles the per-wave CI gate; `/wavemachine` does not merge wave PRs directly and does not fast-path around it. The kahuna→main MR is the *only* PR `/wavemachine` merges, and only after the four-signal gate passes all-green.
 - **`skip_train` is platform-asymmetric.** On GitHub it bypasses the merge queue (the gate has earned that bypass). On GitLab it is a no-op — the merge train is a project-level merge method with no per-MR client bypass. The flag is passed unconditionally; the adapter handles the platform difference; the all-green path emits a warning notification on GitLab so operators know the kahuna→main MR is correctly waiting on the train rather than stuck. See "Platform note: `skip_train` semantics".

--- a/tests/test_drift_instrumentation_skill.py
+++ b/tests/test_drift_instrumentation_skill.py
@@ -1,0 +1,312 @@
+"""Tests for cc-workflow#601 — long-session drift mitigation in /wavemachine.
+
+Validates two surfaces:
+
+1. The instrumentation script ``scripts/wavemachine/drift-instrumentation.sh``
+   exists, is executable, and its self-test subcommand produces three
+   well-formed JSON-line events with the canonical event names.
+2. The wavemachine SKILL.md documents the mitigation mechanism, names the
+   three drift-signal events, references WAVE_AXIOMS.md (and Axiom 9
+   specifically), wires the emit call into the Wave-to-Wave Handoff
+   tool-use boundary, and lists the rejected alternatives.
+
+These tests assert content of live files — no mocks. The script is invoked
+as a real subprocess; the SKILL.md is read from disk. The shape mirrors
+``tests/test_wavemachine_skill.py`` and ``tests/test_nextwave_skill.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths and fixtures
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PATH = _ROOT / "skills" / "wavemachine" / "SKILL.md"
+SCRIPT_PATH = _ROOT / "scripts" / "wavemachine" / "drift-instrumentation.sh"
+
+# The three canonical event names emitted per wave by the instrumentation.
+# These names are the contract — changing them breaks the report subcommand
+# and any downstream aggregator.
+DRIFT_EVENTS = (
+    "wave_message_length_main",
+    "wave_stop_hook_blocks",
+    "wave_concerns_posts",
+)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Script exists, executable, self-test produces canonical events
+# ---------------------------------------------------------------------------
+
+
+class TestAC1_ScriptShape:
+    """The drift-instrumentation script must exist, be executable, and
+    expose the three subcommands the SKILL body and post-campaign report
+    pipeline rely on (emit-wave-drift, self-test, report)."""
+
+    def test_script_exists(self) -> None:
+        assert SCRIPT_PATH.exists(), (
+            f"drift-instrumentation script not found at {SCRIPT_PATH}"
+        )
+
+    def test_script_is_executable(self) -> None:
+        mode = SCRIPT_PATH.stat().st_mode
+        assert mode & stat.S_IXUSR, (
+            f"drift-instrumentation script is not executable: {SCRIPT_PATH}"
+        )
+
+    def test_script_help_lists_subcommands(self) -> None:
+        result = subprocess.run(
+            [str(SCRIPT_PATH), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        # Help is allowed on either stdout (--help) or stderr (usage error
+        # path); union the streams for the assertion. Bash scripts often
+        # mix the two.
+        out = result.stdout + result.stderr
+        for sub in ("emit-wave-drift", "self-test", "report"):
+            assert sub in out, f"--help missing '{sub}' subcommand: {out!r}"
+
+    def test_self_test_emits_three_canonical_events(self) -> None:
+        """The self-test subcommand emits exactly three JSON lines, one per
+        canonical event, in the documented order (message-length, stop-hook,
+        concerns)."""
+        result = subprocess.run(
+            [str(SCRIPT_PATH), "self-test"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        lines = [ln for ln in result.stdout.strip().splitlines() if ln]
+        assert len(lines) == 3, (
+            f"expected 3 lines, got {len(lines)}: {lines}"
+        )
+        events_seen = []
+        for line in lines:
+            obj = json.loads(line)
+            # Schema baseline — every event has these fields.
+            for required in ("ts", "server", "level", "event"):
+                assert required in obj, (
+                    f"event missing '{required}': {obj}"
+                )
+            assert obj["server"] == "wave", (
+                f"event server should be 'wave', got {obj['server']!r}"
+            )
+            events_seen.append(obj["event"])
+        assert events_seen == list(DRIFT_EVENTS), (
+            f"self-test event order/names wrong. "
+            f"expected {list(DRIFT_EVENTS)}, got {events_seen}"
+        )
+
+    def test_self_test_does_not_touch_real_logfile(self, tmp_path) -> None:
+        """The self-test subcommand emits to stdout, NOT to the fleet
+        logfile. Verify by overriding LOG_FILE to a tmp path and confirming
+        nothing is written there."""
+        log_file = tmp_path / "mcp.jsonl"
+        env = {**os.environ, "LOG_FILE": str(log_file)}
+        subprocess.run(
+            [str(SCRIPT_PATH), "self-test"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        assert not log_file.exists(), (
+            f"self-test wrote to LOG_FILE={log_file}, should be stdout-only"
+        )
+
+    def test_emit_wave_drift_rejects_non_integer(self) -> None:
+        """Validation: the emit subcommand refuses non-integer counts so
+        malformed events never reach the fleet logfile."""
+        result = subprocess.run(
+            [
+                str(SCRIPT_PATH), "emit-wave-drift",
+                "--plan", "581",
+                "--wave", "3a",
+                "--message-length-main", "not-a-number",
+                "--stop-hook-blocks", "0",
+                "--concerns-posts", "0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode != 0, (
+            "emit-wave-drift accepted non-integer message-length-main"
+        )
+        assert "integer" in (result.stdout + result.stderr).lower(), (
+            "error message should mention the integer requirement"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Report subcommand aggregates correctly
+# ---------------------------------------------------------------------------
+
+
+class TestAC2_ReportSubcommand:
+    """The report subcommand reads a fleet logfile (or test-harness file)
+    and aggregates the three drift signals into a per-wave trend table."""
+
+    def test_report_on_self_test_output(self, tmp_path) -> None:
+        # Produce a synthetic fleet logfile via self-test.
+        log_file = tmp_path / "harness.jsonl"
+        with log_file.open("w") as f:
+            result = subprocess.run(
+                [str(SCRIPT_PATH), "self-test"],
+                stdout=f,
+                stderr=subprocess.PIPE,
+                timeout=10,
+                check=True,
+            )
+
+        # Report against it.
+        result = subprocess.run(
+            [str(SCRIPT_PATH), "report", str(log_file)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        out = result.stdout
+        # Header row + at least one data row.
+        lines = [ln for ln in out.splitlines() if ln]
+        assert len(lines) >= 2, f"report output too short: {out!r}"
+        header = lines[0].split("\t")
+        assert header == [
+            "plan", "wave", "message_length_main",
+            "stop_hook_blocks", "concerns_posts"
+        ], f"unexpected header: {header}"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: SKILL.md documents the mitigation mechanism
+# ---------------------------------------------------------------------------
+
+
+class TestAC3_SkillDocumentation:
+    """The SKILL body must document the chosen mitigation mechanism, name
+    the three drift-signal events, reference WAVE_AXIOMS.md (and Axiom 9
+    specifically), and document the rejected alternatives."""
+
+    def test_section_heading_present(self, skill_text: str) -> None:
+        assert re.search(
+            r"^## Periodic Re-Grounding \(drift mitigation\)\s*$",
+            skill_text,
+            re.MULTILINE,
+        ), "SKILL.md must contain '## Periodic Re-Grounding (drift mitigation)' section"
+
+    def test_section_names_three_events(self, skill_text: str) -> None:
+        for event in DRIFT_EVENTS:
+            assert event in skill_text, (
+                f"SKILL.md missing reference to drift event '{event}'"
+            )
+
+    def test_section_references_wave_axioms(self, skill_text: str) -> None:
+        # WAVE_AXIOMS.md must be named in the section. Per cc-workflow#605
+        # it is the canonical source — we cite it, we don't restate it.
+        section = _section(skill_text, "Periodic Re-Grounding (drift mitigation)")
+        assert "WAVE_AXIOMS.md" in section, (
+            "Re-grounding section must cite WAVE_AXIOMS.md as canonical source"
+        )
+
+    def test_section_cites_axiom_9(self, skill_text: str) -> None:
+        section = _section(skill_text, "Periodic Re-Grounding (drift mitigation)")
+        assert "Axiom 9" in section, (
+            "Re-grounding section must cite Axiom 9 specifically — "
+            "the user-attention-cost / autonomy contract is the load-bearing "
+            "axiom this drift work serves"
+        )
+
+    def test_section_documents_rejected_alternatives(
+        self, skill_text: str
+    ) -> None:
+        """Per the Notes for the Flight, the rejected alternatives must be
+        documented so future readers (and follow-up work) know the design
+        tradeoffs were considered."""
+        section = _section(skill_text, "Periodic Re-Grounding (drift mitigation)")
+        assert "Rejected alternatives" in section or \
+               "rejected alternatives" in section, (
+            "Re-grounding section must include a 'Rejected alternatives' subsection"
+        )
+        # Both heavyweight options must be named so the escalation path
+        # is explicit.
+        for option in ("/engage", "/compact"):
+            assert option in section, (
+                f"Rejected alternatives must mention {option}"
+            )
+
+    def test_script_path_referenced_in_skill(self, skill_text: str) -> None:
+        assert "scripts/wavemachine/drift-instrumentation.sh" in skill_text, (
+            "SKILL.md must reference scripts/wavemachine/drift-instrumentation.sh "
+            "so the wiring is explicit"
+        )
+
+    def test_handoff_block_mentions_drift_emit(self, skill_text: str) -> None:
+        """The Wave-to-Wave Handoff section must list the drift-instrumentation
+        emit as one of the calls in the canonical single tool-use boundary.
+        Without this, drift events fire at unspecified times and the
+        regression test for the no-narrator-gap contract would still pass
+        even if the wiring were silently dropped."""
+        handoff = _section(skill_text, "Wave-to-Wave Handoff")
+        assert "drift-instrumentation" in handoff, (
+            "Wave-to-Wave Handoff section must reference drift-instrumentation "
+            "in the canonical tool-use block enumeration"
+        )
+
+    def test_non_negotiable_lists_regrounding(self, skill_text: str) -> None:
+        """The Non-Negotiables section must include the re-grounding
+        contract — without it, the mechanism is documentation, not policy."""
+        non_neg = _section(skill_text, "Non-Negotiables")
+        assert (
+            "re-grounding" in non_neg.lower()
+            or "Re-grounding" in non_neg
+            or "re-ground" in non_neg.lower()
+        ), (
+            "Non-Negotiables must include the re-grounding-fires-every-handoff rule"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section helper (mirrors test_wavemachine_skill.py for consistency)
+# ---------------------------------------------------------------------------
+
+
+def _section(text: str, header_substr: str) -> str:
+    """Return the slice of ``text`` from the header containing
+    ``header_substr`` to the next sibling/parent header."""
+    lines = text.splitlines(keepends=True)
+    start = None
+    for i, line in enumerate(lines):
+        if header_substr in line and (
+            line.startswith("## ") or line.startswith("### ")
+        ):
+            start = i
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## "):
+            end = j
+            break
+    return "".join(lines[start:end])


### PR DESCRIPTION
Implements long-session drift mitigation per cc-workflow#601.

Adds per-wave drift instrumentation (`wave_message_length_main`, `wave_stop_hook_blocks`, `wave_concerns_posts` events) and one mitigation mechanism (per-wave system-reminder injection citing WAVE_AXIOMS, especially Axiom 9 — "User attention is the cost. Autonomy is the protection.").

Closes #601

Wave 3a / Flight 2 of Plan #607 (Beta). Sequenced after cc#605 due to shared edit on `skills/wavemachine/SKILL.md`. Worktree was rebased onto kahuna's post-#605 tip; references new Axiom 9 in re-grounding payload.