### PR TITLE
feat(wave-watcher): standalone daemon aggregating active wave-pattern state

### DIFF
--- a/config/statusline-command.sh
+++ b/config/statusline-command.sh
@@ -111,6 +111,28 @@ if [ -n "$project_root" ] && [ -f "$project_root/.claude/status/state.json" ]; t
 	fi
 fi
 
+# --- wave-watcher indicator ---
+# wave-watcher writes a one-line digest to /tmp/wave-watcher-statusline.txt
+# at every poll. We surface a single-glyph view here so the statusline
+# reflects health across ALL local wave-pattern projects, not just this one.
+# Silent skip when the file is missing (daemon not running or surface off).
+ww_str=""
+ww_file="/tmp/wave-watcher-statusline.txt"
+if [ -f "$ww_file" ]; then
+	ww_line=$(head -1 "$ww_file" 2>/dev/null)
+	# ww_line shape: "wave-watcher: V ok=N blocked=M unhealthy=K (T total)"
+	ww_glyph=""
+	case "$ww_line" in
+	*": V "*) ww_glyph="$(printf '%b' "${c_green}")V$(printf '%b' "${c_reset}")" ;;
+	*": ! "*) ww_glyph="$(printf '%b' "${c_yellow}")!$(printf '%b' "${c_reset}")" ;;
+	*": X "*) ww_glyph="$(printf '%b' "${c_red}")X$(printf '%b' "${c_reset}")" ;;
+	*": O "*) ww_glyph="$(printf '%b' "${c_yellow}")O$(printf '%b' "${c_reset}")" ;;
+	esac
+	if [ -n "$ww_glyph" ]; then
+		ww_str="${ww_glyph} "
+	fi
+fi
+
 # --- Agent display string ---
 agent_str=""
 if [ -n "$dev_name" ]; then
@@ -120,8 +142,9 @@ if [ -n "$dev_name" ]; then
 	fi
 fi
 
-# === LINE 1: [indicators] [wavemachine] [pwd] [dev-name] [dev-avatar] ===
+# === LINE 1: [indicators] [wave-watcher] [wavemachine] [pwd] [dev-name] [dev-avatar] ===
 printf "%s" "$indicators_str"
+printf "%s" "$ww_str"
 printf "%s" "$wave_str"
 printf '%b' "${c_blue}${short_cwd}${c_reset}"
 printf "%s" "$agent_str"

--- a/scripts/ci/wave-watcher-smoke.sh
+++ b/scripts/ci/wave-watcher-smoke.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Smoke test for wave-watcher.
+#
+# Builds (or trusts an existing) wave-watcher, points it at a fixture tree
+# with three .claude/status/state.json files, and curls its endpoints to
+# verify aggregation works end-to-end. Exits 0 on success, non-zero on any
+# probe failure.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+WW_DIR="${REPO_DIR}/scripts/wave-watcher"
+PORT="${WAVE_WATCHER_SMOKE_PORT:-37777}"
+TMPROOT="$(mktemp -d -t ww-smoke-XXXXXX)"
+trap 'cleanup' EXIT
+
+cleanup() {
+	if [[ -n "${DAEMON_PID:-}" ]] && kill -0 "${DAEMON_PID}" 2>/dev/null; then
+		kill -TERM "${DAEMON_PID}" 2>/dev/null || true
+		sleep 0.2
+		kill -KILL "${DAEMON_PID}" 2>/dev/null || true
+	fi
+	rm -rf "${TMPROOT}"
+}
+
+info() { echo "  [+] $*"; }
+fail() {
+	echo "  [!] $*" >&2
+	exit 1
+}
+
+# Build three fixture projects with three different shapes.
+mkdir -p "${TMPROOT}/projects/p1/.claude/status" \
+	"${TMPROOT}/projects/p2/.claude/status" \
+	"${TMPROOT}/projects/p3/.sdlc/waves" \
+	"${TMPROOT}/projects/p1/.git" \
+	"${TMPROOT}/projects/p2/.git" \
+	"${TMPROOT}/projects/p3/.git"
+
+cat >"${TMPROOT}/projects/p1/.claude/status/state.json" <<'JSON'
+{"schema_version":3,"current_wave":"1a","current_action":{"action":"flight-1","label":"Flight 1","detail":""},"waves":{"1a":{"status":"in_progress","mr_urls":{}}},"issues":{},"deferrals":[]}
+JSON
+cat >"${TMPROOT}/projects/p2/.claude/status/state.json" <<'JSON'
+{"schema_version":3,"current_wave":"2a","current_action":{"action":"idle","label":"idle","detail":""},"waves":{"2a":{"status":"completed","mr_urls":{}}},"issues":{},"deferrals":[{"issue":99,"status":"pending"}]}
+JSON
+cat >"${TMPROOT}/projects/p3/.sdlc/waves/state.json" <<'JSON'
+{"schema_version":3,"current_wave":"3a","current_action":{"action":"idle","label":"idle","detail":""},"waves":{"3a":{"status":"pending","mr_urls":{}}},"issues":{},"deferrals":[]}
+JSON
+echo '[remote "origin"]
+	url = https://github.com/x/y.git' >"${TMPROOT}/projects/p1/.git/config"
+echo '[remote "origin"]
+	url = git@gitlab.com:a/b.git' >"${TMPROOT}/projects/p2/.git/config"
+echo '[remote "origin"]
+	url = https://github.com/c/d.git' >"${TMPROOT}/projects/p3/.git/config"
+
+cat >"${TMPROOT}/config.json" <<JSON
+{"scan_roots":["${TMPROOT}/projects"],"poll_interval_ms":500,"port":${PORT},"surfaces":["statusline"],"max_depth":4}
+JSON
+
+# Pick the runtime: prefer a built binary if present, else run TS via bun.
+if [[ -x "${WW_DIR}/dist/wave-watcher" ]]; then
+	RUN=("${WW_DIR}/dist/wave-watcher" run)
+elif command -v bun >/dev/null 2>&1; then
+	RUN=(bun "${WW_DIR}/launcher.ts" run)
+else
+	fail "neither dist/wave-watcher nor bun is available"
+fi
+
+info "starting wave-watcher (${RUN[*]})"
+WAVE_WATCHER_CONFIG="${TMPROOT}/config.json" \
+	WAVE_WATCHER_STATE_DIR="${TMPROOT}/state-dir" \
+	"${RUN[@]}" >"${TMPROOT}/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+# Wait for /health to come up.
+deadline=$((SECONDS + 10))
+until curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; do
+	if [[ $SECONDS -ge $deadline ]]; then
+		echo "daemon log:"
+		cat "${TMPROOT}/daemon.log" >&2
+		fail "wave-watcher did not become healthy within 10s"
+	fi
+	sleep 0.2
+done
+info "daemon healthy at :${PORT}"
+
+# Wait for an aggregation cycle.
+sleep 1
+
+# Probe /api/projects.
+PROJECTS_JSON="$(curl -sf "http://127.0.0.1:${PORT}/api/projects")"
+COUNT="$(echo "${PROJECTS_JSON}" | jq -r '.projects | length')"
+if [[ "${COUNT}" != "3" ]]; then
+	fail "expected 3 projects, got ${COUNT}: ${PROJECTS_JSON}"
+fi
+info "/api/projects reports 3 projects"
+
+# Probe /statusline.
+STATUSLINE="$(curl -sf "http://127.0.0.1:${PORT}/statusline")"
+if [[ -z "${STATUSLINE}" ]]; then
+	fail "/statusline returned empty"
+fi
+info "/statusline returned: $(echo "${STATUSLINE}" | cat -v)"
+
+# Probe /events — pull a single chunk.
+EVENTS="$(curl -sN --max-time 2 "http://127.0.0.1:${PORT}/events" || true)"
+if ! echo "${EVENTS}" | grep -q "event: snapshot"; then
+	fail "/events did not emit initial snapshot frame"
+fi
+info "/events emitted snapshot frame"
+
+# Probe statusline file written by the surface.
+STATUSLINE_FILE="${TMPDIR:-/tmp}/wave-watcher-statusline.txt"
+if [[ -f "${STATUSLINE_FILE}" ]]; then
+	info "statusline file: $(cat "${STATUSLINE_FILE}")"
+fi
+
+info "all probes succeeded"

--- a/scripts/wave-watcher/aggregator.test.ts
+++ b/scripts/wave-watcher/aggregator.test.ts
@@ -1,0 +1,245 @@
+// Aggregator tests: pollOnce diff, transition listeners, hashRoot stable.
+//
+// Uses real scanner + reader against an on-disk fixture tree to exercise
+// the integration end-to-end. Mocks are limited to *not* mocking — we
+// just write JSON to a tmpdir and let the real code path read it.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Aggregator, diff, hashRoot } from "./aggregator";
+import type { AggregatedState, Transition, WaveWatcherConfig } from "./types";
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "ww-agg-"));
+});
+
+afterEach(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+function makeFixture(name: string, state: object) {
+	const root = join(scratch, name);
+	const dir = join(root, ".claude", "status");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "state.json"), JSON.stringify(state));
+	mkdirSync(join(root, ".git"), { recursive: true });
+	writeFileSync(
+		join(root, ".git", "config"),
+		"[remote \"origin\"]\n\turl = https://github.com/x/y.git\n",
+	);
+	return root;
+}
+
+const cfg = (overrides: Partial<WaveWatcherConfig> = {}): WaveWatcherConfig => ({
+	scan_roots: [scratch],
+	poll_interval_ms: 50,
+	port: 0,
+	max_depth: 4,
+	surfaces: [],
+	...overrides,
+});
+
+describe("hashRoot", () => {
+	test("is stable and 16 chars", () => {
+		const a = hashRoot("/tmp/foo");
+		const b = hashRoot("/tmp/foo");
+		expect(a).toBe(b);
+		expect(a).toHaveLength(16);
+		expect(hashRoot("/tmp/bar")).not.toBe(a);
+	});
+});
+
+describe("diff", () => {
+	const base: AggregatedState = {
+		root: "/x",
+		platform: "github",
+		current_wave: "1a",
+		current_action: { action: "idle", label: "idle", detail: "" },
+		waves: [{ id: "1a", status: "pending", mr_urls: {} }],
+		issues: [],
+		deferrals: [],
+		gauges: {},
+		last_updated: null,
+		last_mtime: 0,
+		health: "ok",
+		error: null,
+	};
+
+	test("emits action-change on action transition", () => {
+		const next = { ...base, current_action: { action: "planning", label: "p", detail: "" } };
+		const ts = diff(base, next, "now");
+		expect(ts.find((t) => t.kind === "action-change")).toBeDefined();
+	});
+
+	test("emits flight-start when entering a flight action", () => {
+		const next = { ...base, current_action: { action: "flight-1", label: "f", detail: "" } };
+		const ts = diff(base, next, "now");
+		expect(ts.find((t) => t.kind === "flight-start")).toBeDefined();
+		expect(ts.find((t) => t.kind === "action-change")).toBeDefined();
+	});
+
+	test("emits wave-completion when a wave moves to completed", () => {
+		const next = {
+			...base,
+			waves: [{ id: "1a", status: "completed", mr_urls: {} }],
+		};
+		const ts = diff(base, next, "now");
+		const wc = ts.find((t) => t.kind === "wave-completion");
+		expect(wc).toBeDefined();
+		if (wc?.kind === "wave-completion") expect(wc.wave_id).toBe("1a");
+	});
+
+	test("emits health-degrade on ok → blocked", () => {
+		const next = { ...base, health: "blocked" as const };
+		const ts = diff(base, next, "now");
+		const hd = ts.find((t) => t.kind === "health-degrade");
+		expect(hd).toBeDefined();
+	});
+
+	test("does not emit health-degrade for blocked → blocked (no change)", () => {
+		const prev = { ...base, health: "blocked" as const };
+		const ts = diff(prev, prev, "now");
+		expect(ts.find((t) => t.kind === "health-degrade")).toBeUndefined();
+	});
+});
+
+describe("Aggregator.pollOnce", () => {
+	test("populates state on first poll without emitting transitions", async () => {
+		makeFixture("p1", {
+			schema_version: 3,
+			current_wave: "1a",
+			current_action: { action: "idle", label: "idle", detail: "" },
+			waves: { "1a": { status: "pending", mr_urls: {} } },
+			issues: {},
+			deferrals: [],
+		});
+		const agg = new Aggregator(cfg());
+		const events: Transition[] = [];
+		agg.on((t) => events.push(t));
+		const ts = await agg.pollOnce();
+		expect(ts).toEqual([]);
+		expect(events).toEqual([]);
+		expect(agg.getAll()).toHaveLength(1);
+	});
+
+	test("detects wave-completion across two polls", async () => {
+		const root = makeFixture("p1", {
+			schema_version: 3,
+			current_wave: "1a",
+			current_action: { action: "idle", label: "idle", detail: "" },
+			waves: { "1a": { status: "in_progress", mr_urls: {} } },
+			issues: {},
+			deferrals: [],
+		});
+		const agg = new Aggregator(cfg());
+		const events: Transition[] = [];
+		agg.on((t) => events.push(t));
+		await agg.pollOnce();
+		// Mutate state.json — wave moves to completed.
+		writeFileSync(
+			join(root, ".claude", "status", "state.json"),
+			JSON.stringify({
+				schema_version: 3,
+				current_wave: "1a",
+				current_action: { action: "idle", label: "idle", detail: "" },
+				waves: { "1a": { status: "completed", mr_urls: {} } },
+				issues: {},
+				deferrals: [],
+			}),
+		);
+		const ts = await agg.pollOnce();
+		expect(ts.find((t) => t.kind === "wave-completion")).toBeDefined();
+		expect(events.find((t) => t.kind === "wave-completion")).toBeDefined();
+	});
+
+	test("detects health-degrade ok → blocked across polls", async () => {
+		const root = makeFixture("p1", {
+			schema_version: 3,
+			current_wave: "1a",
+			current_action: { action: "idle", label: "idle", detail: "" },
+			waves: { "1a": { status: "pending", mr_urls: {} } },
+			issues: {},
+			deferrals: [],
+		});
+		const agg = new Aggregator(cfg());
+		await agg.pollOnce(); // ok
+		// Inject a pending deferral → blocked.
+		writeFileSync(
+			join(root, ".claude", "status", "state.json"),
+			JSON.stringify({
+				schema_version: 3,
+				current_wave: "1a",
+				current_action: { action: "idle", label: "idle", detail: "" },
+				waves: { "1a": { status: "pending", mr_urls: {} } },
+				issues: {},
+				deferrals: [{ issue: 99, status: "pending" }],
+			}),
+		);
+		const ts = await agg.pollOnce();
+		const hd = ts.find((t) => t.kind === "health-degrade");
+		expect(hd).toBeDefined();
+		if (hd?.kind === "health-degrade") {
+			expect(hd.from).toBe("ok");
+			expect(hd.to).toBe("blocked");
+		}
+	});
+
+	test("get(rootHash) returns the project keyed by hashRoot", async () => {
+		const root = makeFixture("p1", {
+			schema_version: 3,
+			current_wave: null,
+			waves: {},
+			issues: {},
+		});
+		const agg = new Aggregator(cfg());
+		await agg.pollOnce();
+		const found = agg.get(hashRoot(root));
+		expect(found?.root).toBe(root);
+		expect(agg.get("nonsense")).toBeNull();
+	});
+
+	test("onPoll fires every poll, even when no transitions", async () => {
+		makeFixture("p1", {
+			schema_version: 3,
+			waves: { "1a": { status: "in_progress", mr_urls: {} } },
+		});
+		const agg = new Aggregator(cfg());
+		const polls: number[] = [];
+		agg.onPoll((s) => polls.push(s.length));
+		await agg.pollOnce();
+		await agg.pollOnce();
+		expect(polls).toEqual([1, 1]);
+	});
+
+	test("listener exception does not crash the poll loop", async () => {
+		makeFixture("p1", {
+			schema_version: 3,
+			waves: { "1a": { status: "in_progress", mr_urls: {} } },
+		});
+		const agg = new Aggregator(cfg());
+		await agg.pollOnce();
+		agg.on(() => {
+			throw new Error("boom");
+		});
+		// Mutate the state to provoke a transition.
+		writeFileSync(
+			join(scratch, "p1", ".claude", "status", "state.json"),
+			JSON.stringify({
+				schema_version: 3,
+				waves: { "1a": { status: "completed", mr_urls: {} } },
+			}),
+		);
+		// Should not throw.
+		const ts = await agg.pollOnce();
+		expect(ts.length).toBeGreaterThan(0);
+	});
+});

--- a/scripts/wave-watcher/aggregator.ts
+++ b/scripts/wave-watcher/aggregator.ts
@@ -1,0 +1,203 @@
+// Aggregator: in-memory map { project_root: AggregatedState }, polled at
+// `poll_interval_ms`. Detects transitions (wave-completion / flight-start /
+// action-change / health-degrade) by diffing successive snapshots.
+//
+// Single-instance per process; the launcher owns the lifecycle.
+
+import { scanProjects } from "./scanner";
+import { readState } from "./reader";
+import type {
+	AggregatedState,
+	Health,
+	Transition,
+	WaveWatcherConfig,
+} from "./types";
+
+export type TransitionListener = (t: Transition) => void;
+export type PollListener = (states: AggregatedState[]) => void;
+
+export class Aggregator {
+	private state = new Map<string, AggregatedState>();
+	private listeners = new Set<TransitionListener>();
+	private pollListeners = new Set<PollListener>();
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private startedAt = Date.now();
+	private lastPollAt = 0;
+
+	constructor(private config: WaveWatcherConfig) {}
+
+	on(listener: TransitionListener): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	onPoll(listener: PollListener): () => void {
+		this.pollListeners.add(listener);
+		return () => this.pollListeners.delete(listener);
+	}
+
+	getAll(): AggregatedState[] {
+		return [...this.state.values()].sort(
+			(a, b) => b.last_mtime - a.last_mtime,
+		);
+	}
+
+	get(rootHash: string): AggregatedState | null {
+		for (const s of this.state.values()) {
+			if (hashRoot(s.root) === rootHash) return s;
+		}
+		return null;
+	}
+
+	uptimeSeconds(): number {
+		return Math.floor((Date.now() - this.startedAt) / 1000);
+	}
+
+	lastPoll(): number {
+		return this.lastPollAt;
+	}
+
+	/** Run one poll pass. Public so tests can drive it deterministically. */
+	async pollOnce(): Promise<Transition[]> {
+		const matches = await scanProjects(
+			this.config.scan_roots,
+			this.config.max_depth,
+		);
+		const next = new Map<string, AggregatedState>();
+		const transitions: Transition[] = [];
+		const now = new Date().toISOString();
+
+		for (const m of matches) {
+			const agg = await readState(m);
+			next.set(m.root, agg);
+			const prev = this.state.get(m.root);
+			if (prev) {
+				transitions.push(...diff(prev, agg, now));
+			}
+		}
+
+		// Handle disappearance: a project that was being tracked is gone.
+		// We don't emit a transition for it, just drop it from state.
+
+		this.state = next;
+		this.lastPollAt = Date.now();
+		for (const t of transitions) {
+			for (const l of this.listeners) {
+				try {
+					l(t);
+				} catch (err) {
+					process.stderr.write(
+						`wave-watcher: transition listener threw: ${(err as Error).message}\n`,
+					);
+				}
+			}
+		}
+		const snapshot = this.getAll();
+		for (const l of this.pollListeners) {
+			try {
+				l(snapshot);
+			} catch (err) {
+				process.stderr.write(
+					`wave-watcher: poll listener threw: ${(err as Error).message}\n`,
+				);
+			}
+		}
+		return transitions;
+	}
+
+	start(): void {
+		if (this.timer) return;
+		// Kick off an immediate poll so the dashboard isn't empty for
+		// poll_interval_ms after start.
+		void this.pollOnce();
+		this.timer = setInterval(() => {
+			void this.pollOnce();
+		}, this.config.poll_interval_ms);
+	}
+
+	stop(): void {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+	}
+}
+
+export function diff(
+	prev: AggregatedState,
+	next: AggregatedState,
+	at: string,
+): Transition[] {
+	const out: Transition[] = [];
+
+	if (prev.current_action.action !== next.current_action.action) {
+		out.push({
+			kind: "action-change",
+			project: next.root,
+			from: prev.current_action.action,
+			to: next.current_action.action,
+			at,
+		});
+		// Treat any move into a *flight* action as flight-start.
+		if (
+			next.current_action.action.toLowerCase().includes("flight") &&
+			!prev.current_action.action.toLowerCase().includes("flight")
+		) {
+			out.push({
+				kind: "flight-start",
+				project: next.root,
+				wave_id: next.current_wave ?? "",
+				at,
+			});
+		}
+	}
+
+	const prevWaves = new Map(prev.waves.map((w) => [w.id, w.status]));
+	for (const w of next.waves) {
+		const prior = prevWaves.get(w.id);
+		if (prior !== "completed" && w.status === "completed") {
+			out.push({
+				kind: "wave-completion",
+				project: next.root,
+				wave_id: w.id,
+				at,
+			});
+		}
+	}
+
+	if (
+		healthRank(next.health) > healthRank(prev.health) &&
+		prev.health !== "unknown"
+	) {
+		out.push({
+			kind: "health-degrade",
+			project: next.root,
+			from: prev.health,
+			to: next.health,
+			at,
+		});
+	}
+
+	return out;
+}
+
+function healthRank(h: Health): number {
+	switch (h) {
+		case "ok":
+			return 0;
+		case "unknown":
+			return 1;
+		case "blocked":
+			return 2;
+		case "unhealthy":
+			return 3;
+	}
+}
+
+export function hashRoot(root: string): string {
+	// Stable, short, filename-safe. We're not using crypto for security,
+	// just to map root paths to URL slugs.
+	const hasher = new Bun.CryptoHasher("sha256");
+	hasher.update(root);
+	return hasher.digest("hex").slice(0, 16);
+}

--- a/scripts/wave-watcher/build.sh
+++ b/scripts/wave-watcher/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build wave-watcher into a single standalone binary.
+# Usage: build.sh [bun-target]
+#   With no argument: builds for the host platform.
+#   With a target argument (used by release CI matrix): builds that target.
+#
+# Mirrors mcp-server-sdlc's build.sh shape so the same release pipeline can
+# pick this up: outputs into dist/wave-watcher-<suffix>.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+mkdir -p dist
+
+TARGETS=("${1:-}")
+if [[ -z "${1:-}" ]]; then
+	TARGETS=("$(bun --version >/dev/null && echo bun)") # placeholder; bun build w/o --target uses host
+fi
+
+for TARGET in "${TARGETS[@]}"; do
+	if [[ "$TARGET" == "bun" ]]; then
+		bun build --compile launcher.ts --outfile "dist/wave-watcher"
+		echo "Built dist/wave-watcher (host)"
+	else
+		SUFFIX="${TARGET#bun-}"
+		bun build --compile --target="$TARGET" launcher.ts --outfile "dist/wave-watcher-${SUFFIX}"
+		echo "Built dist/wave-watcher-${SUFFIX}"
+	fi
+done

--- a/scripts/wave-watcher/config.test.ts
+++ b/scripts/wave-watcher/config.test.ts
@@ -1,0 +1,80 @@
+// Config loader tests: defaults + override + tilde expansion.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expandHome, loadConfig } from "./config";
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "ww-config-"));
+});
+
+afterEach(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("expandHome", () => {
+	test("replaces leading ~ with $HOME", () => {
+		const out = expandHome("~/foo/bar");
+		expect(out).not.toContain("~");
+		expect(out.endsWith("foo/bar")).toBe(true);
+	});
+
+	test("leaves absolute paths alone", () => {
+		expect(expandHome("/absolute/path")).toBe("/absolute/path");
+	});
+});
+
+describe("loadConfig", () => {
+	test("returns defaults when file is missing", async () => {
+		const path = join(scratch, "missing.json");
+		const cfg = await loadConfig(path);
+		expect(cfg.port).toBe(7777);
+		expect(cfg.poll_interval_ms).toBe(5000);
+		expect(cfg.max_depth).toBe(4);
+		expect(cfg.surfaces).toEqual([]);
+		// scan_roots should have ~ expanded.
+		for (const r of cfg.scan_roots) {
+			expect(r.startsWith("~")).toBe(false);
+		}
+	});
+
+	test("merges user overrides over defaults", async () => {
+		const path = join(scratch, "config.json");
+		writeFileSync(
+			path,
+			JSON.stringify({
+				port: 9999,
+				poll_interval_ms: 1500,
+				surfaces: ["discord"],
+			}),
+		);
+		const cfg = await loadConfig(path);
+		expect(cfg.port).toBe(9999);
+		expect(cfg.poll_interval_ms).toBe(1500);
+		expect(cfg.surfaces).toEqual(["discord"]);
+		// max_depth was not overridden, stays at default.
+		expect(cfg.max_depth).toBe(4);
+	});
+
+	test("malformed JSON falls back to defaults (does not throw)", async () => {
+		const path = join(scratch, "bad.json");
+		writeFileSync(path, "{this is not json");
+		const cfg = await loadConfig(path);
+		expect(cfg.port).toBe(7777);
+	});
+
+	test("scan_roots from config are also tilde-expanded", async () => {
+		const path = join(scratch, "config.json");
+		writeFileSync(
+			path,
+			JSON.stringify({ scan_roots: ["~/projects", "/abs"] }),
+		);
+		const cfg = await loadConfig(path);
+		expect(cfg.scan_roots[0]?.startsWith("~")).toBe(false);
+		expect(cfg.scan_roots[1]).toBe("/abs");
+	});
+});

--- a/scripts/wave-watcher/config.ts
+++ b/scripts/wave-watcher/config.ts
@@ -1,0 +1,59 @@
+// Configuration loader.
+//
+// Reads ~/.config/wave-watcher.json (overridable via WAVE_WATCHER_CONFIG env)
+// and merges over DEFAULT_CONFIG. Missing or invalid file → defaults silently
+// (the daemon must run on a fresh machine without ceremony).
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG, type WaveWatcherConfig } from "./types";
+
+export function configPath(): string {
+	if (process.env.WAVE_WATCHER_CONFIG) {
+		return process.env.WAVE_WATCHER_CONFIG;
+	}
+	return join(homedir(), ".config", "wave-watcher.json");
+}
+
+export function expandHome(p: string): string {
+	if (p.startsWith("~")) {
+		return join(homedir(), p.slice(1).replace(/^[/\\]/, ""));
+	}
+	return p;
+}
+
+export async function loadConfig(
+	path: string = configPath(),
+): Promise<WaveWatcherConfig> {
+	const file = Bun.file(path);
+	if (!(await file.exists())) {
+		return {
+			...DEFAULT_CONFIG,
+			scan_roots: DEFAULT_CONFIG.scan_roots.map(expandHome),
+		};
+	}
+	let parsed: Partial<WaveWatcherConfig> = {};
+	try {
+		parsed = (await file.json()) as Partial<WaveWatcherConfig>;
+	} catch (err) {
+		// Malformed JSON: fall back to defaults rather than crash. A daemon
+		// that won't start because someone left a trailing comma in their
+		// config is a worse failure than running with defaults.
+		process.stderr.write(
+			`wave-watcher: config at ${path} is invalid JSON (${(err as Error).message}); using defaults\n`,
+		);
+		return {
+			...DEFAULT_CONFIG,
+			scan_roots: DEFAULT_CONFIG.scan_roots.map(expandHome),
+		};
+	}
+	const merged: WaveWatcherConfig = {
+		...DEFAULT_CONFIG,
+		...parsed,
+	};
+	merged.scan_roots = (merged.scan_roots ?? DEFAULT_CONFIG.scan_roots).map(
+		expandHome,
+	);
+	merged.surfaces = merged.surfaces ?? [];
+	return merged;
+}

--- a/scripts/wave-watcher/install-remote.sh
+++ b/scripts/wave-watcher/install-remote.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Install wave-watcher binary using the ETXTBSY-safe download-temp-then-mv-f
+# pattern from mcp-server-sdlc CHANGELOG v1.0.1. The daemon may be running
+# (systemd-supervised) when this runs; rename(2) unlinks the old inode but
+# keeps the running process's text segment alive, so the in-flight binary
+# is not corrupted.
+#
+# Usage:
+#   ./install-remote.sh                  # install latest release
+#   WAVE_WATCHER_VERSION=v0.1.0 ./install-remote.sh
+#   ./install-remote.sh --local <path>   # install a locally-built binary
+
+set -euo pipefail
+
+REPO="Wave-Engineering/claudecode-workflow"
+BINARY_NAME="wave-watcher"
+INSTALL_DIR="${HOME}/.local/bin"
+SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+
+LOCAL_PATH=""
+for arg in "$@"; do
+	case "$arg" in
+	--local)
+		shift || true
+		LOCAL_PATH="${1:-}"
+		shift || true
+		;;
+	--help | -h)
+		echo "Usage: install-remote.sh [--local <path>]"
+		echo "  --local <path>  Install a locally-built binary instead of downloading"
+		echo "  WAVE_WATCHER_VERSION=...  Override release tag"
+		exit 0
+		;;
+	esac
+done
+
+mkdir -p "${INSTALL_DIR}"
+
+if [[ -n "${LOCAL_PATH}" ]]; then
+	if [[ ! -f "${LOCAL_PATH}" ]]; then
+		echo "wave-watcher: local path does not exist: ${LOCAL_PATH}" >&2
+		exit 1
+	fi
+	TMP="${INSTALL_DIR}/${BINARY_NAME}.tmp.$$"
+	trap 'rm -f "${TMP}"' EXIT
+	cp -f "${LOCAL_PATH}" "${TMP}"
+	chmod +x "${TMP}"
+	mv -f "${TMP}" "${INSTALL_DIR}/${BINARY_NAME}"
+	trap - EXIT
+	echo "wave-watcher: installed local build to ${INSTALL_DIR}/${BINARY_NAME}"
+else
+	OS="$(uname -s)"
+	ARCH="$(uname -m)"
+	case "${OS}-${ARCH}" in
+	Linux-x86_64) PLATFORM="linux-x64" ;;
+	Darwin-x86_64) PLATFORM="darwin-x64" ;;
+	Darwin-arm64) PLATFORM="darwin-arm64" ;;
+	*)
+		echo "wave-watcher: unsupported platform: ${OS}-${ARCH}" >&2
+		exit 1
+		;;
+	esac
+
+	TAG="${WAVE_WATCHER_VERSION:-}"
+	if [[ -z "${TAG}" ]]; then
+		TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
+			grep '"tag_name"' | head -1 | sed 's/.*"tag_name": "\(.*\)".*/\1/')
+	fi
+	if [[ -z "${TAG}" ]]; then
+		echo "wave-watcher: could not determine release tag (set WAVE_WATCHER_VERSION)" >&2
+		exit 1
+	fi
+	URL="https://github.com/${REPO}/releases/download/${TAG}/${BINARY_NAME}-${PLATFORM}"
+	echo "wave-watcher: downloading ${URL}"
+	TMP="${INSTALL_DIR}/${BINARY_NAME}.tmp.$$"
+	trap 'rm -f "${TMP}"' EXIT
+	curl -fsSL --progress-bar "${URL}" -o "${TMP}"
+	chmod +x "${TMP}"
+	mv -f "${TMP}" "${INSTALL_DIR}/${BINARY_NAME}"
+	trap - EXIT
+	echo "wave-watcher: installed ${TAG} to ${INSTALL_DIR}/${BINARY_NAME}"
+fi
+
+# Install systemd user unit if systemd is present.
+SYSTEMD_UNIT_SRC="$(dirname "$0")/systemd/wave-watcher.service"
+if [[ -f "${SYSTEMD_UNIT_SRC}" ]] && command -v systemctl >/dev/null 2>&1; then
+	mkdir -p "${SYSTEMD_USER_DIR}"
+	cp -f "${SYSTEMD_UNIT_SRC}" "${SYSTEMD_USER_DIR}/wave-watcher.service"
+	systemctl --user daemon-reload || true
+	echo "wave-watcher: systemd user unit installed at ${SYSTEMD_USER_DIR}/wave-watcher.service"
+	echo "  enable + start: systemctl --user enable --now wave-watcher"
+fi
+
+case ":${PATH}:" in
+*":${INSTALL_DIR}:"*) ;;
+*)
+	echo ""
+	echo "wave-watcher: ${INSTALL_DIR} is not on PATH; add it to your shell profile."
+	;;
+esac

--- a/scripts/wave-watcher/launcher.test.ts
+++ b/scripts/wave-watcher/launcher.test.ts
@@ -1,0 +1,91 @@
+// Launcher tests: pidfile read/write, idempotency, pidIsAlive.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	clearPidFile,
+	pidIsAlive,
+	readPidFile,
+	writePidFile,
+} from "./launcher";
+
+let scratch: string;
+let pidPath: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "ww-launcher-"));
+	pidPath = join(scratch, "wave-watcher.pid");
+});
+
+afterEach(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("pidfile primitives", () => {
+	test("readPidFile returns null when file is missing", () => {
+		expect(readPidFile(pidPath)).toBeNull();
+	});
+
+	test("writePidFile + readPidFile roundtrip", () => {
+		writePidFile(12345, pidPath);
+		expect(readFileSync(pidPath, "utf-8").trim()).toBe("12345");
+		expect(readPidFile(pidPath)).toBe(12345);
+	});
+
+	test("readPidFile returns null on corrupt content", () => {
+		writeFileSync(pidPath, "not a pid", "utf-8");
+		expect(readPidFile(pidPath)).toBeNull();
+	});
+
+	test("readPidFile returns null on negative/zero pid", () => {
+		writeFileSync(pidPath, "-5", "utf-8");
+		expect(readPidFile(pidPath)).toBeNull();
+		writeFileSync(pidPath, "0", "utf-8");
+		expect(readPidFile(pidPath)).toBeNull();
+	});
+
+	test("clearPidFile removes the file silently when present", () => {
+		writePidFile(1, pidPath);
+		expect(existsSync(pidPath)).toBe(true);
+		clearPidFile(pidPath);
+		expect(existsSync(pidPath)).toBe(false);
+	});
+
+	test("clearPidFile is a no-op when file is missing (no throw)", () => {
+		clearPidFile(pidPath);
+		expect(existsSync(pidPath)).toBe(false);
+	});
+});
+
+describe("pidIsAlive", () => {
+	test("returns true for our own pid", () => {
+		expect(pidIsAlive(process.pid)).toBe(true);
+	});
+
+	test("returns false for a definitely-dead pid", () => {
+		// 2^31 - 1 is the upper bound of Linux pids by default; this is
+		// virtually guaranteed to be unallocated.
+		expect(pidIsAlive(2_147_483_646)).toBe(false);
+	});
+});
+
+describe("idempotency-shape contract", () => {
+	test("a stale pidfile pointing to a dead pid is treated as not-running", () => {
+		writePidFile(2_147_483_646, pidPath);
+		expect(readPidFile(pidPath)).toBe(2_147_483_646);
+		expect(pidIsAlive(readPidFile(pidPath)!)).toBe(false);
+	});
+
+	test("a live pid in the pidfile is treated as running", () => {
+		writePidFile(process.pid, pidPath);
+		expect(pidIsAlive(readPidFile(pidPath)!)).toBe(true);
+	});
+});

--- a/scripts/wave-watcher/launcher.ts
+++ b/scripts/wave-watcher/launcher.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env bun
+// Launcher / lifecycle manager for wave-watcher.
+//
+// Subcommands:
+//   start   — daemonize (setsid + fork), pid in ~/.local/state/wave-watcher.pid
+//   stop    — SIGTERM, escalate SIGKILL after 5s
+//   status  — print state, port, projects, last poll
+//   run     — run in foreground (used by daemonized child + systemd unit)
+//
+// Idempotency: `start` checks the pidfile + signal-0 liveness; if the daemon
+// is already running it prints status and exits 0.
+
+import { spawn } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Aggregator } from "./aggregator";
+import { loadConfig } from "./config";
+import { createServer } from "./server";
+import { makeDiscordHandler } from "./surfaces/discord";
+import { writeStatusline } from "./surfaces/statusline";
+import { makeVoxHandler } from "./surfaces/vox";
+
+export const PID_PATH = join(
+	process.env.WAVE_WATCHER_STATE_DIR || join(homedir(), ".local", "state"),
+	"wave-watcher.pid",
+);
+
+export function pidIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+export function readPidFile(path: string = PID_PATH): number | null {
+	if (!existsSync(path)) return null;
+	try {
+		const raw = readFileSync(path, "utf-8").trim();
+		const n = Number.parseInt(raw, 10);
+		if (!Number.isFinite(n) || n <= 0) return null;
+		return n;
+	} catch {
+		return null;
+	}
+}
+
+export function writePidFile(pid: number, path: string = PID_PATH): void {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, String(pid), "utf-8");
+}
+
+export function clearPidFile(path: string = PID_PATH): void {
+	try {
+		unlinkSync(path);
+	} catch {
+		// ignore
+	}
+}
+
+export interface StartResult {
+	status: "started" | "already-running";
+	pid: number;
+}
+
+/** Daemonize via setsid + detached spawn. The child re-execs `run`. */
+export function daemonize(): StartResult {
+	const existing = readPidFile();
+	if (existing && pidIsAlive(existing)) {
+		return { status: "already-running", pid: existing };
+	}
+	if (existing) clearPidFile();
+
+	// Re-exec ourselves under `setsid` with the `run` subcommand. This both
+	// detaches the child from the controlling terminal and makes it the
+	// session leader so closing the parent's terminal doesn't SIGHUP it.
+	const exe = process.execPath;
+	const script = process.argv[1] ?? "";
+	const child = spawn("setsid", [exe, script, "run"], {
+		stdio: ["ignore", "ignore", "ignore"],
+		detached: true,
+		env: process.env,
+	});
+	child.unref();
+	if (typeof child.pid !== "number") {
+		throw new Error("daemonize: spawn returned no pid");
+	}
+	writePidFile(child.pid);
+	return { status: "started", pid: child.pid };
+}
+
+export async function stopDaemon(timeoutMs = 5000): Promise<{
+	stopped: boolean;
+	used_kill: boolean;
+}> {
+	const pid = readPidFile();
+	if (!pid) return { stopped: false, used_kill: false };
+	if (!pidIsAlive(pid)) {
+		clearPidFile();
+		return { stopped: true, used_kill: false };
+	}
+	try {
+		process.kill(pid, "SIGTERM");
+	} catch {
+		// already gone
+	}
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!pidIsAlive(pid)) {
+			clearPidFile();
+			return { stopped: true, used_kill: false };
+		}
+		await new Promise((r) => setTimeout(r, 100));
+	}
+	try {
+		process.kill(pid, "SIGKILL");
+	} catch {
+		// ignore
+	}
+	await new Promise((r) => setTimeout(r, 200));
+	clearPidFile();
+	return { stopped: true, used_kill: true };
+}
+
+export async function runForeground(): Promise<void> {
+	const config = await loadConfig();
+	const agg = new Aggregator(config);
+	const server = createServer(agg, { port: config.port });
+
+	// Wire active surfaces.
+	const discord = makeDiscordHandler(config);
+	if (discord) agg.on(discord);
+	const vox = makeVoxHandler(config);
+	if (vox) agg.on(vox);
+	if (config.surfaces.includes("statusline")) {
+		// Re-emit the statusline file on every successful poll. The file
+		// must reflect "last known truth" continuously, not only at
+		// transition moments.
+		agg.onPoll((states) => void writeStatusline(states));
+	}
+
+	agg.start();
+	process.stderr.write(
+		`wave-watcher: serving on http://${server.hostname}:${server.port} pid=${process.pid}\n`,
+	);
+
+	const shutdown = (sig: string) => {
+		process.stderr.write(`wave-watcher: ${sig} — shutting down\n`);
+		agg.stop();
+		server.stop(true);
+		clearPidFile();
+		process.exit(0);
+	};
+	process.on("SIGTERM", () => shutdown("SIGTERM"));
+	process.on("SIGINT", () => shutdown("SIGINT"));
+
+	// Update pidfile to *our* pid (the daemonized child); when invoked
+	// via `run` directly (e.g. systemd), the parent never wrote one.
+	writePidFile(process.pid);
+}
+
+export interface StatusReport {
+	running: boolean;
+	pid: number | null;
+	port: number;
+	projects: number;
+	last_poll: number;
+}
+
+export async function statusReport(): Promise<StatusReport> {
+	const config = await loadConfig();
+	const pid = readPidFile();
+	const running = pid !== null && pidIsAlive(pid);
+	let projects = 0;
+	let lastPoll = 0;
+	if (running) {
+		try {
+			const res = await fetch(`http://127.0.0.1:${config.port}/api/projects`);
+			if (res.ok) {
+				const body = (await res.json()) as { projects: unknown[] };
+				projects = body.projects.length;
+			}
+			const h = await fetch(`http://127.0.0.1:${config.port}/health`);
+			if (h.ok) {
+				const hb = (await h.json()) as { last_poll_ms?: number };
+				lastPoll = hb.last_poll_ms ?? 0;
+			}
+		} catch {
+			// daemon claims to be alive but can't be queried — surface that
+			// via running:false in the caller's eyes. We'll keep running:true
+			// here because the pid IS alive; the HTTP failure may be transient.
+		}
+	}
+	return {
+		running,
+		pid: pid ?? null,
+		port: config.port,
+		projects,
+		last_poll: lastPoll,
+	};
+}
+
+async function main(argv: string[]): Promise<number> {
+	const cmd = argv[2] ?? "status";
+	switch (cmd) {
+		case "start": {
+			const r = daemonize();
+			if (r.status === "already-running") {
+				process.stdout.write(`wave-watcher already running pid=${r.pid}\n`);
+				return 0;
+			}
+			process.stdout.write(`wave-watcher started pid=${r.pid}\n`);
+			return 0;
+		}
+		case "stop": {
+			const r = await stopDaemon();
+			if (!r.stopped) {
+				process.stdout.write("wave-watcher not running\n");
+				return 0;
+			}
+			process.stdout.write(
+				`wave-watcher stopped${r.used_kill ? " (SIGKILL)" : ""}\n`,
+			);
+			return 0;
+		}
+		case "status": {
+			const r = await statusReport();
+			process.stdout.write(JSON.stringify(r, null, 2) + "\n");
+			return r.running ? 0 : 1;
+		}
+		case "run": {
+			await runForeground();
+			// runForeground returns once setup completes, but the process
+			// must stay alive — Bun.serve and the polling interval timer
+			// hold the loop open, but only as long as someone is awaiting.
+			// Park here until a SIGTERM/SIGINT handler calls process.exit.
+			await new Promise<never>(() => {
+				/* never resolves */
+			});
+			return 0;
+		}
+		case "--help":
+		case "-h":
+		case "help": {
+			process.stdout.write(
+				"usage: wave-watcher {start|stop|status|run}\n" +
+					"  start  — daemonize and write pidfile\n" +
+					"  stop   — SIGTERM (escalate SIGKILL after 5s)\n" +
+					"  status — print pid/port/projects/last_poll JSON\n" +
+					"  run    — run in foreground (used by daemonized child + systemd)\n",
+			);
+			return 0;
+		}
+		default:
+			process.stderr.write(`unknown subcommand: ${cmd}\n`);
+			return 2;
+	}
+}
+
+if (import.meta.main) {
+	main(process.argv).then(
+		(code) => process.exit(code),
+		(err) => {
+			process.stderr.write(`wave-watcher: ${err?.stack ?? err}\n`);
+			process.exit(1);
+		},
+	);
+}

--- a/scripts/wave-watcher/package.json
+++ b/scripts/wave-watcher/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "wave-watcher",
+  "version": "0.1.0",
+  "description": "Standalone daemon aggregating active wave-pattern state from local projects",
+  "type": "module",
+  "scripts": {
+    "start": "bun launcher.ts run",
+    "dev": "bun --watch launcher.ts run",
+    "lint": "bunx tsc --noEmit",
+    "test": "bun test",
+    "build": "./build.sh"
+  },
+  "license": "MIT",
+  "author": "Wave Engineering",
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  }
+}

--- a/scripts/wave-watcher/reader.test.ts
+++ b/scripts/wave-watcher/reader.test.ts
@@ -1,0 +1,155 @@
+// Reader tests: schema_version 3 parse + missing phases-waves.json
+// graceful + health derivation.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readState } from "./reader";
+import type { ProjectMatch } from "./types";
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "ww-reader-"));
+});
+
+afterEach(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+function writeState(content: object, options: { withPhases?: boolean } = {}) {
+	const dir = join(scratch, ".claude", "status");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "state.json"), JSON.stringify(content));
+	if (options.withPhases) {
+		writeFileSync(
+			join(dir, "phases-waves.json"),
+			JSON.stringify({ phases: [] }),
+		);
+	}
+	return {
+		root: scratch,
+		platform: "github" as const,
+		last_mtime: Date.now(),
+		state_path: join(dir, "state.json"),
+		phases_path: options.withPhases ? join(dir, "phases-waves.json") : null,
+	} satisfies ProjectMatch;
+}
+
+describe("readState", () => {
+	test("parses a v3 state.json into AggregatedState", async () => {
+		const match = writeState({
+			schema_version: 3,
+			current_wave: "1a",
+			current_action: { action: "planning", label: "Planning", detail: "" },
+			waves: {
+				"1a": { status: "in_progress", mr_urls: { "owner/repo#1": "https://x" } },
+				"1b": { status: "pending", mr_urls: {} },
+			},
+			issues: {
+				"123": { status: "open" },
+				"124": { status: "closed" },
+			},
+			deferrals: [],
+			gauges: { quality: 0.9 },
+			last_updated: "2026-05-06T18:00:00Z",
+		});
+		const agg = await readState(match);
+		expect(agg.current_wave).toBe("1a");
+		expect(agg.current_action.action).toBe("planning");
+		expect(agg.waves).toHaveLength(2);
+		const wa = agg.waves.find((w) => w.id === "1a");
+		expect(wa?.status).toBe("in_progress");
+		expect(wa?.mr_urls).toEqual({ "owner/repo#1": "https://x" });
+		expect(agg.issues).toHaveLength(2);
+		expect(agg.gauges).toEqual({ quality: 0.9 });
+		expect(agg.last_updated).toBe("2026-05-06T18:00:00Z");
+		expect(agg.health).toBe("ok");
+		expect(agg.error).toBeNull();
+	});
+
+	test("treats unreadable JSON as unhealthy + error set", async () => {
+		const dir = join(scratch, ".claude", "status");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "state.json"), "not json {{{");
+		const match: ProjectMatch = {
+			root: scratch,
+			platform: "github",
+			last_mtime: Date.now(),
+			state_path: join(dir, "state.json"),
+			phases_path: null,
+		};
+		const agg = await readState(match);
+		expect(agg.health).toBe("unhealthy");
+		expect(agg.error).toContain("state.json unreadable");
+	});
+
+	test("missing phases-waves.json does not block parsing of state.json", async () => {
+		const match = writeState(
+			{
+				schema_version: 3,
+				current_wave: "1a",
+				waves: { "1a": { status: "completed", mr_urls: {} } },
+				issues: {},
+				deferrals: [],
+			},
+			{ withPhases: false },
+		);
+		expect(match.phases_path).toBeNull();
+		const agg = await readState(match);
+		expect(agg.error).toBeNull();
+		expect(agg.waves[0]?.status).toBe("completed");
+	});
+
+	test("health: pending deferrals → blocked", async () => {
+		const match = writeState({
+			schema_version: 3,
+			current_wave: "1a",
+			waves: {},
+			issues: {},
+			deferrals: [{ issue: 99, status: "pending" }],
+		});
+		const agg = await readState(match);
+		expect(agg.health).toBe("blocked");
+	});
+
+	test("health: failed wave → blocked", async () => {
+		const match = writeState({
+			schema_version: 3,
+			current_wave: "1a",
+			waves: { "1a": { status: "failed", mr_urls: {} } },
+			issues: {},
+			deferrals: [],
+		});
+		const agg = await readState(match);
+		expect(agg.health).toBe("blocked");
+	});
+
+	test("health: schema_version > 3 → unhealthy", async () => {
+		const match = writeState({
+			schema_version: 99,
+			current_wave: "1a",
+			waves: {},
+			issues: {},
+			deferrals: [],
+		});
+		const agg = await readState(match);
+		expect(agg.health).toBe("unhealthy");
+	});
+
+	test("missing optional fields default cleanly", async () => {
+		const match = writeState({ schema_version: 3 });
+		const agg = await readState(match);
+		expect(agg.waves).toEqual([]);
+		expect(agg.issues).toEqual([]);
+		expect(agg.deferrals).toEqual([]);
+		expect(agg.gauges).toEqual({});
+		expect(agg.current_action.action).toBe("idle");
+	});
+});

--- a/scripts/wave-watcher/reader.ts
+++ b/scripts/wave-watcher/reader.ts
@@ -1,0 +1,121 @@
+// State reader: parses `.claude/status/state.json` (or `.sdlc/waves/state.json`)
+// and the optional sibling `phases-waves.json` directly. Does NOT shell out
+// to wave_show — wave-watcher must work even when sdlc-server is offline.
+//
+// Schema reference: cc-workflow `src/wave_status/state.py` — schema_version 3.
+// Earlier versions are tolerated (degraded view) but never modified by us.
+
+import { stat } from "node:fs/promises";
+import type {
+	AggregatedState,
+	Deferral,
+	Gauges,
+	Health,
+	IssueStatus,
+	Platform,
+	ProjectMatch,
+	WaveStatus,
+} from "./types";
+
+interface RawState {
+	schema_version?: number;
+	current_wave?: string | null;
+	current_action?: { action?: string; label?: string; detail?: string };
+	waves?: Record<string, { status?: string; mr_urls?: Record<string, string> }>;
+	issues?: Record<string, { status?: string }>;
+	deferrals?: Deferral[];
+	gauges?: Gauges;
+	last_updated?: string;
+	wavemachine_active?: boolean;
+}
+
+export async function readState(
+	match: ProjectMatch,
+): Promise<AggregatedState> {
+	const base: AggregatedState = {
+		root: match.root,
+		platform: match.platform,
+		current_wave: null,
+		current_action: { action: "idle", label: "idle", detail: "" },
+		waves: [],
+		issues: [],
+		deferrals: [],
+		gauges: {},
+		last_updated: null,
+		last_mtime: match.last_mtime,
+		health: "unknown",
+		error: null,
+	};
+
+	let raw: RawState;
+	try {
+		raw = (await Bun.file(match.state_path).json()) as RawState;
+	} catch (err) {
+		base.error = `state.json unreadable: ${(err as Error).message}`;
+		base.health = "unhealthy";
+		return base;
+	}
+
+	// Refresh mtime — match.last_mtime is from scan time, but the file
+	// could have rotated since. We want the freshness badge to reflect
+	// "what we just read", not "what we found".
+	try {
+		const s = await stat(match.state_path);
+		base.last_mtime = s.mtimeMs;
+	} catch {
+		// keep scan-time mtime
+	}
+
+	base.current_wave = raw.current_wave ?? null;
+	if (raw.current_action) {
+		base.current_action = {
+			action: raw.current_action.action ?? "idle",
+			label: raw.current_action.label ?? "idle",
+			detail: raw.current_action.detail ?? "",
+		};
+	}
+
+	const waves: WaveStatus[] = [];
+	for (const [id, w] of Object.entries(raw.waves ?? {})) {
+		waves.push({
+			id,
+			status: w.status ?? "unknown",
+			mr_urls: w.mr_urls ?? {},
+		});
+	}
+	base.waves = waves;
+
+	const issues: IssueStatus[] = [];
+	for (const [key, i] of Object.entries(raw.issues ?? {})) {
+		issues.push({ key, status: i.status ?? "open" });
+	}
+	base.issues = issues;
+
+	base.deferrals = Array.isArray(raw.deferrals) ? raw.deferrals : [];
+	base.gauges = raw.gauges ?? {};
+	base.last_updated = raw.last_updated ?? null;
+
+	base.health = computeHealth(raw, base);
+
+	return base;
+}
+
+function computeHealth(raw: RawState, agg: AggregatedState): Health {
+	if (raw.schema_version && raw.schema_version > 3) return "unhealthy";
+	const pendingDeferrals = agg.deferrals.filter(
+		(d) => d.status === "pending",
+	).length;
+	if (pendingDeferrals > 0) return "blocked";
+	const failed = agg.waves.filter(
+		(w) => w.status === "failed" || w.status === "blocked",
+	).length;
+	if (failed > 0) return "blocked";
+	const action = agg.current_action.action.toLowerCase();
+	if (action.includes("error") || action.includes("fail")) return "unhealthy";
+	if (action === "idle" || action === "complete") return "ok";
+	return "ok";
+}
+
+export function platformFromAggregated(agg: AggregatedState): Platform {
+	return agg.platform;
+}

--- a/scripts/wave-watcher/scanner.test.ts
+++ b/scripts/wave-watcher/scanner.test.ts
@@ -1,0 +1,131 @@
+// Scanner tests: discovery + depth limit + symlink/dot-dir avoidance.
+//
+// Real fs (mkdtempSync) — these tests exercise the real walker, not a
+// mocked one. The wave-watcher scanner is a thin wrapper over readdir/stat;
+// stubbing those would test nothing.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanProjects } from "./scanner";
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "ww-scanner-"));
+});
+
+afterEach(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+function makeProject(root: string, useSdlc = false): string {
+	mkdirSync(root, { recursive: true });
+	const statusDir = useSdlc
+		? join(root, ".sdlc", "waves")
+		: join(root, ".claude", "status");
+	mkdirSync(statusDir, { recursive: true });
+	writeFileSync(
+		join(statusDir, "state.json"),
+		JSON.stringify({ schema_version: 3, current_wave: "1a", waves: {} }),
+	);
+	mkdirSync(join(root, ".git"), { recursive: true });
+	writeFileSync(
+		join(root, ".git", "config"),
+		"[remote \"origin\"]\n\turl = https://github.com/foo/bar.git\n",
+	);
+	return root;
+}
+
+describe("scanProjects", () => {
+	test("finds a project at the scan root itself (depth 0)", async () => {
+		makeProject(scratch);
+		const out = await scanProjects([scratch], 4);
+		expect(out).toHaveLength(1);
+		expect(out[0]?.root).toBe(scratch);
+		expect(out[0]?.platform).toBe("github");
+	});
+
+	test("finds projects nested 2 deep", async () => {
+		makeProject(join(scratch, "owner1", "repo1"));
+		makeProject(join(scratch, "owner2", "repo2"));
+		const out = await scanProjects([scratch], 4);
+		const roots = out.map((m) => m.root).sort();
+		expect(roots).toEqual([
+			join(scratch, "owner1", "repo1"),
+			join(scratch, "owner2", "repo2"),
+		]);
+	});
+
+	test("respects max depth — projects deeper than limit are not found", async () => {
+		// scratch/a/b/c/d/repo — that's 5 levels deep
+		const deep = join(scratch, "a", "b", "c", "d", "repo");
+		makeProject(deep);
+		const found = await scanProjects([scratch], 3);
+		expect(found).toHaveLength(0);
+		const found4 = await scanProjects([scratch], 4);
+		// At depth 4 we still don't reach a 5-deep path; sanity check.
+		expect(found4).toHaveLength(0);
+		const found5 = await scanProjects([scratch], 5);
+		expect(found5).toHaveLength(1);
+	});
+
+	test("does not descend into a project once found (no .git/modules false-positives)", async () => {
+		const proj = join(scratch, "owner", "repo");
+		makeProject(proj);
+		// Plant a fake nested project (e.g. a submodule's status dir).
+		const nested = join(proj, "submodules", "nested");
+		makeProject(nested);
+		const out = await scanProjects([scratch], 6);
+		expect(out.map((m) => m.root)).toEqual([proj]);
+	});
+
+	test("skips dot-dirs and node_modules", async () => {
+		makeProject(join(scratch, "real"));
+		makeProject(join(scratch, ".hidden", "repo"));
+		makeProject(join(scratch, "node_modules", "evil"));
+		const out = await scanProjects([scratch], 4);
+		expect(out.map((m) => m.root)).toEqual([join(scratch, "real")]);
+	});
+
+	test("supports both .claude/status and .sdlc/waves layouts", async () => {
+		makeProject(join(scratch, "claude-style"), false);
+		makeProject(join(scratch, "sdlc-style"), true);
+		const out = await scanProjects([scratch], 4);
+		expect(out).toHaveLength(2);
+	});
+
+	test("detects gitlab platform", async () => {
+		const root = join(scratch, "gl");
+		makeProject(root);
+		writeFileSync(
+			join(root, ".git", "config"),
+			"[remote \"origin\"]\n\turl = git@gitlab.com:foo/bar.git\n",
+		);
+		const out = await scanProjects([scratch], 4);
+		expect(out[0]?.platform).toBe("gitlab");
+	});
+
+	test("returns last_mtime from the actual file", async () => {
+		const root = join(scratch, "p");
+		makeProject(root);
+		const out = await scanProjects([scratch], 4);
+		expect(out[0]?.last_mtime).toBeGreaterThan(0);
+		expect(typeof out[0]?.last_mtime).toBe("number");
+	});
+
+	test("non-existent scan root is silently skipped", async () => {
+		const out = await scanProjects(
+			[join(scratch, "nope"), scratch],
+			4,
+		);
+		// scratch alone — empty — so 0 projects, but no throw.
+		expect(out).toHaveLength(0);
+	});
+});

--- a/scripts/wave-watcher/scanner.ts
+++ b/scripts/wave-watcher/scanner.ts
@@ -1,0 +1,128 @@
+// Project discovery: walk scan_roots looking for `.claude/status/state.json`
+// or `.sdlc/waves/state.json` markers. Depth-limited; symlinks not followed
+// (cycle protection).
+//
+// Each match → ProjectMatch{root, platform, last_mtime, state_path, phases_path?}.
+
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { Platform, ProjectMatch } from "./types";
+
+const STATE_RELATIVE = [
+	[".claude", "status", "state.json"],
+	[".sdlc", "waves", "state.json"],
+] as const;
+
+const PHASES_RELATIVE = [
+	[".claude", "status", "phases-waves.json"],
+	[".sdlc", "waves", "phases-waves.json"],
+] as const;
+
+async function tryStat(path: string) {
+	try {
+		return await stat(path);
+	} catch {
+		return null;
+	}
+}
+
+async function detectPlatform(repoRoot: string): Promise<Platform> {
+	// Cheap inference from .git/config — no shell-out. We don't fail if
+	// .git is missing (could be a worktree pointing elsewhere); caller
+	// gets `unknown` and the UI can degrade.
+	const gitConfig = Bun.file(join(repoRoot, ".git", "config"));
+	if (await gitConfig.exists()) {
+		try {
+			const text = await gitConfig.text();
+			if (/gitlab\.com|gitlab\.[a-z0-9.-]+/i.test(text)) return "gitlab";
+			if (/github\.com/i.test(text)) return "github";
+		} catch {
+			// ignore — fall through to unknown
+		}
+	}
+	return "unknown";
+}
+
+async function findMarker(
+	dir: string,
+): Promise<{ statePath: string; phasesPath: string | null; mtime: number } | null> {
+	for (let i = 0; i < STATE_RELATIVE.length; i++) {
+		const p = STATE_RELATIVE[i];
+		if (!p) continue;
+		const candidate = join(dir, ...p);
+		const s = await tryStat(candidate);
+		if (s && s.isFile()) {
+			const phasesParts = PHASES_RELATIVE[i];
+			const phasesPath = phasesParts ? join(dir, ...phasesParts) : null;
+			let phasesExists: string | null = null;
+			if (phasesPath) {
+				const ps = await tryStat(phasesPath);
+				if (ps && ps.isFile()) phasesExists = phasesPath;
+			}
+			return {
+				statePath: candidate,
+				phasesPath: phasesExists,
+				mtime: s.mtimeMs,
+			};
+		}
+	}
+	return null;
+}
+
+async function walk(
+	dir: string,
+	depth: number,
+	maxDepth: number,
+	out: ProjectMatch[],
+	visited: Set<string>,
+): Promise<void> {
+	if (depth > maxDepth) return;
+	if (visited.has(dir)) return;
+	visited.add(dir);
+
+	// Check this dir for a marker first.
+	const marker = await findMarker(dir);
+	if (marker) {
+		out.push({
+			root: dir,
+			platform: await detectPlatform(dir),
+			last_mtime: marker.mtime,
+			state_path: marker.statePath,
+			phases_path: marker.phasesPath,
+		});
+		// Don't descend into a project once found — projects don't nest
+		// for our purposes, and skipping prevents .git/modules false-positives.
+		return;
+	}
+
+	if (depth === maxDepth) return;
+
+	let entries;
+	try {
+		entries = await readdir(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		// Skip dot-dirs except known safe ones; .git, node_modules, etc. are
+		// noise and can contain symlink loops.
+		if (entry.name.startsWith(".")) continue;
+		if (entry.name === "node_modules") continue;
+		await walk(join(dir, entry.name), depth + 1, maxDepth, out, visited);
+	}
+}
+
+export async function scanProjects(
+	roots: string[],
+	maxDepth = 4,
+): Promise<ProjectMatch[]> {
+	const out: ProjectMatch[] = [];
+	const visited = new Set<string>();
+	for (const root of roots) {
+		const s = await tryStat(root);
+		if (!s || !s.isDirectory()) continue;
+		await walk(root, 0, maxDepth, out, visited);
+	}
+	return out;
+}

--- a/scripts/wave-watcher/server.test.ts
+++ b/scripts/wave-watcher/server.test.ts
@@ -1,0 +1,217 @@
+// Server tests: /api/projects, /events, /statusline, /health, /api/project/:hash.
+//
+// Boots a real Bun.serve on an ephemeral port (port: 0) so the route
+// behavior — including SSE — is exercised. No mocks of Bun.serve.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Aggregator, hashRoot } from "./aggregator";
+import { createServer, renderDashboard, statuslineFor, worstHealth } from "./server";
+import type { AggregatedState, WaveWatcherConfig } from "./types";
+
+let scratch: string;
+let server: ReturnType<typeof createServer> | null = null;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "ww-server-"));
+});
+
+afterEach(() => {
+	if (server) {
+		server.stop(true);
+		server = null;
+	}
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+function makeFixture(name: string, state: object) {
+	const root = join(scratch, name);
+	const dir = join(root, ".claude", "status");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "state.json"), JSON.stringify(state));
+	return root;
+}
+
+const cfg: WaveWatcherConfig = {
+	scan_roots: [],
+	poll_interval_ms: 1000,
+	port: 0,
+	max_depth: 4,
+	surfaces: [],
+};
+
+async function bootWithFixture(name = "p1"): Promise<{
+	agg: Aggregator;
+	root: string;
+	url: string;
+}> {
+	const root = makeFixture(name, {
+		schema_version: 3,
+		current_wave: "1a",
+		current_action: { action: "idle", label: "idle", detail: "" },
+		waves: { "1a": { status: "in_progress", mr_urls: {} } },
+		issues: {},
+		deferrals: [],
+	});
+	const agg = new Aggregator({ ...cfg, scan_roots: [scratch] });
+	await agg.pollOnce();
+	server = createServer(agg, { port: 0 });
+	const url = `http://${server.hostname}:${server.port}`;
+	return { agg, root, url };
+}
+
+describe("statuslineFor + worstHealth", () => {
+	const mk = (h: AggregatedState["health"]): AggregatedState =>
+		({
+			root: "/x",
+			platform: "github",
+			current_wave: null,
+			current_action: { action: "idle", label: "idle", detail: "" },
+			waves: [],
+			issues: [],
+			deferrals: [],
+			gauges: {},
+			last_updated: null,
+			last_mtime: 0,
+			health: h,
+			error: null,
+		}) satisfies AggregatedState;
+
+	test("empty list → yellow O", () => {
+		expect(statuslineFor([])).toContain("O");
+	});
+
+	test("all ok → green V", () => {
+		const s = statuslineFor([mk("ok"), mk("ok")]);
+		expect(s).toContain("V");
+		expect(s).toContain("\x1b[32m");
+	});
+
+	test("any unhealthy → red X", () => {
+		expect(statuslineFor([mk("ok"), mk("unhealthy")])).toContain("X");
+		expect(statuslineFor([mk("ok"), mk("blocked")])).toContain("X");
+	});
+
+	test("worstHealth ranks unhealthy > blocked > unknown > ok", () => {
+		expect(worstHealth([mk("ok"), mk("blocked")])).toBe("blocked");
+		expect(worstHealth([mk("blocked"), mk("unhealthy")])).toBe("unhealthy");
+		expect(worstHealth([mk("ok"), mk("ok")])).toBe("ok");
+	});
+});
+
+describe("renderDashboard", () => {
+	test("escapes HTML in project root paths", () => {
+		const html = renderDashboard([
+			{
+				root: "/x<script>",
+				platform: "github",
+				current_wave: null,
+				current_action: { action: "idle", label: "idle", detail: "" },
+				waves: [],
+				issues: [],
+				deferrals: [],
+				gauges: {},
+				last_updated: null,
+				last_mtime: Date.now(),
+				health: "ok",
+				error: null,
+			},
+		]);
+		// User input is escaped; the literal "<script>" from /x<script>
+		// must not appear inside the project-root cell.
+		expect(html).toContain("&lt;script&gt;");
+		expect(html).toContain("/x&lt;script&gt;");
+		// And it must not be rendered as a real tag in that context.
+		expect(html).not.toContain("/x<script>");
+	});
+
+	test("emits empty-state message when no projects", () => {
+		const html = renderDashboard([]);
+		expect(html).toContain("No active wave-pattern projects");
+	});
+});
+
+describe("HTTP routes", () => {
+	test("/health returns ok + uptime", async () => {
+		const { url } = await bootWithFixture();
+		const res = await fetch(`${url}/health`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { ok: boolean; uptime_s: number };
+		expect(body.ok).toBe(true);
+		expect(body.uptime_s).toBeGreaterThanOrEqual(0);
+	});
+
+	test("/api/projects returns aggregated state", async () => {
+		const { root, url } = await bootWithFixture("apiproj");
+		const res = await fetch(`${url}/api/projects`);
+		const body = (await res.json()) as { projects: AggregatedState[] };
+		expect(body.projects).toHaveLength(1);
+		expect(body.projects[0]?.root).toBe(root);
+		expect(body.projects[0]?.waves[0]?.status).toBe("in_progress");
+	});
+
+	test("/api/project/:hash returns the matching project", async () => {
+		const { root, url } = await bootWithFixture();
+		const h = hashRoot(root);
+		const res = await fetch(`${url}/api/project/${h}`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as AggregatedState;
+		expect(body.root).toBe(root);
+	});
+
+	test("/api/project/:hash 404s for unknown hash", async () => {
+		const { url } = await bootWithFixture();
+		const res = await fetch(`${url}/api/project/deadbeef`);
+		expect(res.status).toBe(404);
+	});
+
+	test("/statusline returns ANSI-coloured glyph", async () => {
+		const { url } = await bootWithFixture();
+		const res = await fetch(`${url}/statusline`);
+		const text = await res.text();
+		expect(text).toMatch(/[VXO]/);
+		expect(text).toContain("\x1b[");
+	});
+
+	test("/ returns HTML", async () => {
+		const { url } = await bootWithFixture();
+		const res = await fetch(`${url}/`);
+		expect(res.headers.get("content-type")).toContain("text/html");
+		const text = await res.text();
+		expect(text).toContain("wave-watcher");
+	});
+
+	test("/events streams SSE and emits initial snapshot frame", async () => {
+		const { url } = await bootWithFixture();
+		const ctrl = new AbortController();
+		const res = await fetch(`${url}/events`, { signal: ctrl.signal });
+		expect(res.headers.get("content-type")).toContain("text/event-stream");
+		const reader = res.body!.getReader();
+		const dec = new TextDecoder();
+		let buf = "";
+		// Read until we have at least the "snapshot" event.
+		const deadline = Date.now() + 2000;
+		while (Date.now() < deadline) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			buf += dec.decode(value);
+			if (buf.includes("event: snapshot")) break;
+		}
+		ctrl.abort();
+		expect(buf).toContain("event: snapshot");
+		expect(buf).toContain("projects");
+	});
+
+	test("unknown path 404s", async () => {
+		const { url } = await bootWithFixture();
+		const res = await fetch(`${url}/nope`);
+		expect(res.status).toBe(404);
+	});
+});

--- a/scripts/wave-watcher/server.ts
+++ b/scripts/wave-watcher/server.ts
@@ -1,0 +1,253 @@
+// HTTP/SSE server. Bun.serve on localhost:7777 by default.
+//
+// Routes:
+//   GET /              — HTML dashboard
+//   GET /events        — Server-Sent Events stream of transitions
+//   GET /api/projects  — Aggregated state JSON
+//   GET /api/project/:root_hash — Per-project drilldown
+//   GET /statusline    — Single-glyph status with ANSI color
+//   GET /health        — {ok, uptime_s}
+
+import { Aggregator } from "./aggregator";
+import type { AggregatedState, Health, Transition } from "./types";
+
+export interface ServerOptions {
+	port: number;
+	host?: string;
+}
+
+export function createServer(
+	agg: Aggregator,
+	opts: ServerOptions,
+) {
+	const sseClients = new Set<WritableStreamDefaultWriter<Uint8Array>>();
+	const encoder = new TextEncoder();
+
+	agg.on((t) => {
+		const payload = encoder.encode(`data: ${JSON.stringify(t)}\n\n`);
+		for (const client of sseClients) {
+			void client.write(payload).catch(() => {
+				sseClients.delete(client);
+			});
+		}
+	});
+
+	return Bun.serve({
+		port: opts.port,
+		hostname: opts.host ?? "127.0.0.1",
+		async fetch(req) {
+			const url = new URL(req.url);
+			if (url.pathname === "/health") {
+				return Response.json({
+					ok: true,
+					uptime_s: agg.uptimeSeconds(),
+					last_poll_ms: agg.lastPoll(),
+				});
+			}
+			if (url.pathname === "/api/projects") {
+				return Response.json({ projects: agg.getAll() });
+			}
+			if (url.pathname.startsWith("/api/project/")) {
+				const id = url.pathname.slice("/api/project/".length);
+				const state = agg.get(id);
+				if (!state) {
+					return Response.json({ error: "not found" }, { status: 404 });
+				}
+				return Response.json(state);
+			}
+			if (url.pathname === "/statusline") {
+				return new Response(statuslineFor(agg.getAll()), {
+					headers: { "content-type": "text/plain; charset=utf-8" },
+				});
+			}
+			if (url.pathname === "/events") {
+				const { readable, writable } = new TransformStream<
+					Uint8Array,
+					Uint8Array
+				>();
+				const writer = writable.getWriter();
+				sseClients.add(writer);
+				// Initial comment to flush headers immediately.
+				void writer.write(encoder.encode(": hello\n\n"));
+				// Send a snapshot frame so clients connecting mid-flight
+				// don't sit empty until the next transition.
+				void writer.write(
+					encoder.encode(
+						`event: snapshot\ndata: ${JSON.stringify({ projects: agg.getAll() })}\n\n`,
+					),
+				);
+				req.signal.addEventListener("abort", () => {
+					sseClients.delete(writer);
+					void writer.close().catch(() => {});
+				});
+				return new Response(readable, {
+					headers: {
+						"content-type": "text/event-stream",
+						"cache-control": "no-cache",
+						connection: "keep-alive",
+					},
+				});
+			}
+			if (url.pathname === "/" || url.pathname === "/index.html") {
+				return new Response(renderDashboard(agg.getAll()), {
+					headers: { "content-type": "text/html; charset=utf-8" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		},
+	});
+}
+
+const COLOR = {
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+	red: "\x1b[31m",
+	reset: "\x1b[0m",
+} as const;
+
+export function statuslineFor(states: AggregatedState[]): string {
+	if (states.length === 0) return `${COLOR.yellow}O${COLOR.reset}`;
+	const worst = worstHealth(states);
+	switch (worst) {
+		case "ok":
+			return `${COLOR.green}V${COLOR.reset}`;
+		case "blocked":
+		case "unhealthy":
+			return `${COLOR.red}X${COLOR.reset}`;
+		case "unknown":
+		default:
+			return `${COLOR.yellow}O${COLOR.reset}`;
+	}
+}
+
+export function worstHealth(states: AggregatedState[]): Health {
+	let worst: Health = "ok";
+	const rank: Record<Health, number> = {
+		ok: 0,
+		unknown: 1,
+		blocked: 2,
+		unhealthy: 3,
+	};
+	for (const s of states) {
+		if (rank[s.health] > rank[worst]) worst = s.health;
+	}
+	return worst;
+}
+
+const TRANSITION_KINDS: Transition["kind"][] = [
+	"wave-completion",
+	"flight-start",
+	"action-change",
+	"health-degrade",
+];
+
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function freshnessBadge(mtime: number): string {
+	const ageS = Math.max(0, Math.floor((Date.now() - mtime) / 1000));
+	let cls = "fresh";
+	if (ageS > 300) cls = "stale";
+	else if (ageS > 60) cls = "warm";
+	const label = ageS < 60 ? `${ageS}s` : ageS < 3600 ? `${Math.floor(ageS / 60)}m` : `${Math.floor(ageS / 3600)}h`;
+	return `<span class="badge ${cls}">${label}</span>`;
+}
+
+export function renderDashboard(states: AggregatedState[]): string {
+	const rows = states
+		.map((s) => {
+			const wavesSummary = s.waves
+				.slice(0, 5)
+				.map(
+					(w) =>
+						`<code class="wave wave-${escapeHtml(w.status)}">${escapeHtml(w.id)}:${escapeHtml(w.status)}</code>`,
+				)
+				.join(" ");
+			return `
+<tr class="health-${escapeHtml(s.health)}" data-root="${escapeHtml(s.root)}">
+  <td>${freshnessBadge(s.last_mtime)}</td>
+  <td><code>${escapeHtml(s.root)}</code></td>
+  <td>${escapeHtml(s.platform)}</td>
+  <td>${escapeHtml(s.current_wave ?? "—")}</td>
+  <td>${escapeHtml(s.current_action.label || s.current_action.action)}</td>
+  <td><span class="health">${escapeHtml(s.health)}</span></td>
+  <td>${wavesSummary || "—"}</td>
+</tr>`;
+		})
+		.join("");
+
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>wave-watcher</title>
+<meta http-equiv="refresh" content="10">
+<style>
+  body { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; margin: 1em; background: #0e1116; color: #e6edf3; }
+  h1 { font-size: 1.1em; margin: 0 0 1em 0; }
+  table { border-collapse: collapse; width: 100%; font-size: 13px; }
+  th, td { padding: 6px 10px; text-align: left; border-bottom: 1px solid #21262d; vertical-align: top; }
+  th { background: #161b22; cursor: pointer; user-select: none; }
+  tr.health-ok { }
+  tr.health-blocked { background: rgba(187, 128, 9, 0.10); }
+  tr.health-unhealthy { background: rgba(248, 81, 73, 0.12); }
+  tr.health-unknown { color: #8b949e; }
+  code { font-family: inherit; }
+  code.wave { padding: 1px 4px; border: 1px solid #30363d; border-radius: 3px; margin-right: 2px; }
+  code.wave-completed { color: #3fb950; border-color: #2ea043; }
+  code.wave-pending { color: #8b949e; }
+  code.wave-active, code.wave-in_progress { color: #58a6ff; border-color: #1f6feb; }
+  code.wave-failed, code.wave-blocked { color: #f85149; border-color: #f85149; }
+  .badge { padding: 1px 6px; border-radius: 8px; font-size: 11px; }
+  .badge.fresh { background: #1f6feb33; color: #58a6ff; }
+  .badge.warm { background: #bb800933; color: #d29922; }
+  .badge.stale { background: #f8514933; color: #f85149; }
+  .health { text-transform: uppercase; font-weight: 600; font-size: 11px; }
+  .empty { color: #8b949e; padding: 2em; text-align: center; }
+  #log { margin-top: 1em; max-height: 200px; overflow-y: auto; background: #161b22; padding: 8px; font-size: 11px; }
+  #log .entry { padding: 2px 0; }
+</style>
+</head>
+<body>
+<h1>wave-watcher — ${states.length} project(s) — kinds: ${TRANSITION_KINDS.join(", ")}</h1>
+${
+	states.length === 0
+		? `<div class="empty">No active wave-pattern projects discovered. Configure scan roots in <code>~/.config/wave-watcher.json</code>.</div>`
+		: `<table>
+<thead>
+  <tr>
+    <th>fresh</th><th>root</th><th>platform</th><th>wave</th><th>action</th><th>health</th><th>waves</th>
+  </tr>
+</thead>
+<tbody>${rows}</tbody>
+</table>`
+}
+<div id="log"><strong>events</strong></div>
+<script>
+(function() {
+  var log = document.getElementById('log');
+  function append(kind, payload) {
+    var div = document.createElement('div');
+    div.className = 'entry';
+    div.textContent = '[' + new Date().toLocaleTimeString() + '] ' + kind + ' ' + JSON.stringify(payload);
+    log.appendChild(div);
+    log.scrollTop = log.scrollHeight;
+  }
+  try {
+    var es = new EventSource('/events');
+    es.onmessage = function(e) {
+      try { var t = JSON.parse(e.data); append(t.kind || 'event', t); } catch(_){}
+    };
+    es.addEventListener('snapshot', function() { /* noop — page refreshes itself */ });
+  } catch (e) { /* SSE unsupported — meta refresh covers it */ }
+})();
+</script>
+</body>
+</html>`;
+}

--- a/scripts/wave-watcher/surfaces/discord.test.ts
+++ b/scripts/wave-watcher/surfaces/discord.test.ts
@@ -1,0 +1,160 @@
+// Discord surface tests: posts on unhealthy/blocked transitions, no-ops on
+// other kinds, swallows post failures.
+
+import { describe, expect, test } from "bun:test";
+import {
+	formatDiscordMessage,
+	makeDiscordHandler,
+	shouldNotifyDiscord,
+} from "./discord";
+import type { DiscordPoster } from "./discord";
+import type { Transition, WaveWatcherConfig } from "../types";
+
+const cfg = (overrides: Partial<WaveWatcherConfig> = {}): WaveWatcherConfig => ({
+	scan_roots: [],
+	poll_interval_ms: 1000,
+	port: 7777,
+	max_depth: 4,
+	surfaces: ["discord"],
+	discord_webhook: "https://example.invalid/webhook",
+	...overrides,
+});
+
+class CapturePoster implements DiscordPoster {
+	posts: { content: string }[] = [];
+	failNext = false;
+	async post(payload: { content: string }) {
+		if (this.failNext) {
+			this.failNext = false;
+			return false;
+		}
+		this.posts.push(payload);
+		return true;
+	}
+}
+
+describe("shouldNotifyDiscord", () => {
+	test("yes for health-degrade → blocked", () => {
+		expect(
+			shouldNotifyDiscord({
+				kind: "health-degrade",
+				project: "/x",
+				from: "ok",
+				to: "blocked",
+				at: "now",
+			}),
+		).toBe(true);
+	});
+
+	test("yes for health-degrade → unhealthy", () => {
+		expect(
+			shouldNotifyDiscord({
+				kind: "health-degrade",
+				project: "/x",
+				from: "ok",
+				to: "unhealthy",
+				at: "now",
+			}),
+		).toBe(true);
+	});
+
+	test("no for action-change", () => {
+		expect(
+			shouldNotifyDiscord({
+				kind: "action-change",
+				project: "/x",
+				from: "idle",
+				to: "planning",
+				at: "now",
+			}),
+		).toBe(false);
+	});
+
+	test("no for wave-completion", () => {
+		expect(
+			shouldNotifyDiscord({
+				kind: "wave-completion",
+				project: "/x",
+				wave_id: "1a",
+				at: "now",
+			}),
+		).toBe(false);
+	});
+});
+
+describe("formatDiscordMessage", () => {
+	test("includes project, transition, and timestamp", () => {
+		const msg = formatDiscordMessage({
+			kind: "health-degrade",
+			project: "/repo",
+			from: "ok",
+			to: "blocked",
+			at: "2026-05-06T18:00:00Z",
+		});
+		expect(msg).toContain("/repo");
+		expect(msg).toContain("blocked");
+		expect(msg).toContain("2026-05-06T18:00:00Z");
+	});
+});
+
+describe("makeDiscordHandler", () => {
+	test("returns null when surface not enabled", () => {
+		expect(makeDiscordHandler(cfg({ surfaces: [] }))).toBeNull();
+	});
+
+	test("returns null when webhook missing and no poster", () => {
+		expect(
+			makeDiscordHandler({
+				...cfg(),
+				discord_webhook: undefined,
+			}),
+		).toBeNull();
+	});
+
+	test("posts on health-degrade to blocked", async () => {
+		const poster = new CapturePoster();
+		const h = makeDiscordHandler(cfg(), poster);
+		expect(h).not.toBeNull();
+		const t: Transition = {
+			kind: "health-degrade",
+			project: "/x",
+			from: "ok",
+			to: "blocked",
+			at: "now",
+		};
+		h!(t);
+		// post() is async — yield once to let the floating promise resolve.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(poster.posts).toHaveLength(1);
+		expect(poster.posts[0]?.content).toContain("blocked");
+	});
+
+	test("does not post on wave-completion", async () => {
+		const poster = new CapturePoster();
+		const h = makeDiscordHandler(cfg(), poster);
+		h!({
+			kind: "wave-completion",
+			project: "/x",
+			wave_id: "1a",
+			at: "now",
+		});
+		await Promise.resolve();
+		expect(poster.posts).toHaveLength(0);
+	});
+
+	test("post failure is swallowed (handler does not throw)", () => {
+		const poster = new CapturePoster();
+		poster.failNext = true;
+		const h = makeDiscordHandler(cfg(), poster);
+		expect(() =>
+			h!({
+				kind: "health-degrade",
+				project: "/x",
+				from: "ok",
+				to: "unhealthy",
+				at: "now",
+			}),
+		).not.toThrow();
+	});
+});

--- a/scripts/wave-watcher/surfaces/discord.ts
+++ b/scripts/wave-watcher/surfaces/discord.ts
@@ -1,0 +1,81 @@
+// Discord surface: posts a message to a webhook URL when a project becomes
+// unhealthy or blocked. Opt-in via `surfaces: ["discord"]` in config and
+// `discord_webhook` URL.
+//
+// We deliberately keep this dumb and dependency-free (POST to a webhook URL
+// the user supplies). Failures are logged-and-swallowed — a busted webhook
+// must never take down the daemon.
+
+import type { Transition, WaveWatcherConfig } from "../types";
+
+export interface DiscordPoster {
+	post(payload: { content: string }): Promise<boolean>;
+}
+
+export class WebhookDiscordPoster implements DiscordPoster {
+	constructor(private url: string) {}
+	async post(payload: { content: string }): Promise<boolean> {
+		try {
+			const res = await fetch(this.url, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(payload),
+			});
+			if (!res.ok) {
+				process.stderr.write(
+					`wave-watcher: discord post failed ${res.status} ${res.statusText}\n`,
+				);
+				return false;
+			}
+			return true;
+		} catch (err) {
+			process.stderr.write(
+				`wave-watcher: discord post threw: ${(err as Error).message}\n`,
+			);
+			return false;
+		}
+	}
+}
+
+export function shouldNotifyDiscord(t: Transition): boolean {
+	if (t.kind === "health-degrade") {
+		return t.to === "blocked" || t.to === "unhealthy";
+	}
+	return false;
+}
+
+export function formatDiscordMessage(t: Transition): string {
+	if (t.kind === "health-degrade") {
+		return `:warning: \`${t.project}\` health: ${t.from} → **${t.to}** at ${t.at}`;
+	}
+	if (t.kind === "wave-completion") {
+		return `:white_check_mark: \`${t.project}\` wave **${t.wave_id}** completed at ${t.at}`;
+	}
+	if (t.kind === "flight-start") {
+		return `:airplane: \`${t.project}\` flight start (wave ${t.wave_id}) at ${t.at}`;
+	}
+	return `:bell: \`${t.project}\` action ${t.from} → ${t.to} at ${t.at}`;
+}
+
+export function makeDiscordHandler(
+	config: WaveWatcherConfig,
+	poster?: DiscordPoster,
+): ((t: Transition) => void) | null {
+	if (!config.surfaces.includes("discord")) return null;
+	if (!config.discord_webhook && !poster) {
+		process.stderr.write(
+			"wave-watcher: discord surface enabled but no discord_webhook configured\n",
+		);
+		return null;
+	}
+	const sender =
+		poster ??
+		(config.discord_webhook
+			? new WebhookDiscordPoster(config.discord_webhook)
+			: null);
+	if (!sender) return null;
+	return (t: Transition) => {
+		if (!shouldNotifyDiscord(t)) return;
+		void sender.post({ content: formatDiscordMessage(t) });
+	};
+}

--- a/scripts/wave-watcher/surfaces/statusline.test.ts
+++ b/scripts/wave-watcher/surfaces/statusline.test.ts
@@ -1,0 +1,74 @@
+// Statusline surface tests.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { statuslineLine, writeStatusline } from "./statusline";
+import type { AggregatedState } from "../types";
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "ww-sl-"));
+});
+
+afterEach(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+const mk = (h: AggregatedState["health"]): AggregatedState =>
+	({
+		root: "/x",
+		platform: "github",
+		current_wave: null,
+		current_action: { action: "idle", label: "idle", detail: "" },
+		waves: [],
+		issues: [],
+		deferrals: [],
+		gauges: {},
+		last_updated: null,
+		last_mtime: 0,
+		health: h,
+		error: null,
+	}) satisfies AggregatedState;
+
+describe("statuslineLine", () => {
+	test("0 projects → idle marker", () => {
+		expect(statuslineLine([])).toBe("wave-watcher: 0 projects");
+	});
+
+	test("ok counts only", () => {
+		const line = statuslineLine([mk("ok"), mk("ok")]);
+		expect(line).toContain("V");
+		expect(line).toContain("ok=2");
+		expect(line).toContain("blocked=0");
+	});
+
+	test("any unhealthy → X glyph", () => {
+		const line = statuslineLine([mk("ok"), mk("unhealthy")]);
+		expect(line).toContain("X");
+		expect(line).toContain("unhealthy=1");
+	});
+
+	test("blocked-without-unhealthy → ! glyph", () => {
+		const line = statuslineLine([mk("ok"), mk("blocked")]);
+		expect(line).toContain("!");
+	});
+});
+
+describe("writeStatusline", () => {
+	test("writes the line atomically (no .tmp left behind)", async () => {
+		const path = join(scratch, "sl.txt");
+		await writeStatusline([mk("ok")], path);
+		const text = readFileSync(path, "utf-8");
+		expect(text).toContain("V");
+		// Tmp file should be cleaned up by the rename.
+		const list = await Bun.file(`${path}.tmp.${process.pid}`).exists();
+		expect(list).toBe(false);
+	});
+});

--- a/scripts/wave-watcher/surfaces/statusline.ts
+++ b/scripts/wave-watcher/surfaces/statusline.ts
@@ -1,0 +1,39 @@
+// Statusline surface: writes a one-line digest of project health to a
+// well-known file (`/tmp/wave-watcher-statusline.txt`) that
+// `config/statusline-command.sh` can read on every prompt redraw.
+//
+// The file is written atomically (tmp + rename) so a half-written file is
+// never observed by the statusline reader.
+
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import type { AggregatedState } from "../types";
+
+export const STATUSLINE_PATH = join(tmpdir(), "wave-watcher-statusline.txt");
+
+export function statuslineLine(states: AggregatedState[]): string {
+	if (states.length === 0) return "wave-watcher: 0 projects";
+	let ok = 0,
+		blocked = 0,
+		unhealthy = 0;
+	for (const s of states) {
+		if (s.health === "ok") ok++;
+		else if (s.health === "blocked") blocked++;
+		else if (s.health === "unhealthy") unhealthy++;
+	}
+	const glyph =
+		unhealthy > 0 ? "X" : blocked > 0 ? "!" : ok > 0 ? "V" : "O";
+	return `wave-watcher: ${glyph} ok=${ok} blocked=${blocked} unhealthy=${unhealthy} (${states.length} total)`;
+}
+
+export async function writeStatusline(
+	states: AggregatedState[],
+	path: string = STATUSLINE_PATH,
+): Promise<void> {
+	const dir = dirname(path);
+	await mkdir(dir, { recursive: true });
+	const tmp = `${path}.tmp.${process.pid}`;
+	await writeFile(tmp, statuslineLine(states) + "\n", "utf-8");
+	await rename(tmp, path);
+}

--- a/scripts/wave-watcher/surfaces/vox.test.ts
+++ b/scripts/wave-watcher/surfaces/vox.test.ts
@@ -1,0 +1,75 @@
+// Vox surface tests: announces on wave-completion only.
+
+import { describe, expect, test } from "bun:test";
+import { makeVoxHandler, shouldAnnounceVox } from "./vox";
+import type { Transition, WaveWatcherConfig } from "../types";
+
+const cfg = (overrides: Partial<WaveWatcherConfig> = {}): WaveWatcherConfig => ({
+	scan_roots: [],
+	poll_interval_ms: 1000,
+	port: 7777,
+	max_depth: 4,
+	surfaces: ["vox"],
+	vox_command: "echo",
+	...overrides,
+});
+
+describe("shouldAnnounceVox", () => {
+	test("yes only for wave-completion", () => {
+		expect(
+			shouldAnnounceVox({
+				kind: "wave-completion",
+				project: "/x",
+				wave_id: "1a",
+				at: "now",
+			}),
+		).toBe(true);
+		expect(
+			shouldAnnounceVox({
+				kind: "health-degrade",
+				project: "/x",
+				from: "ok",
+				to: "blocked",
+				at: "now",
+			}),
+		).toBe(false);
+	});
+});
+
+describe("makeVoxHandler", () => {
+	test("returns null when surface not enabled", () => {
+		expect(makeVoxHandler(cfg({ surfaces: [] }))).toBeNull();
+	});
+
+	test("invokes spawn on wave-completion", () => {
+		const calls: { cmd: string; args: string[] }[] = [];
+		const h = makeVoxHandler(cfg(), (cmd, args) => {
+			calls.push({ cmd, args });
+		});
+		const t: Transition = {
+			kind: "wave-completion",
+			project: "/x",
+			wave_id: "1a",
+			at: "now",
+		};
+		h!(t);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.cmd).toBe("echo");
+		expect(calls[0]?.args[0]).toContain("1a");
+	});
+
+	test("does not invoke spawn for non-completion transitions", () => {
+		const calls: unknown[] = [];
+		const h = makeVoxHandler(cfg(), () => {
+			calls.push(1);
+		});
+		h!({
+			kind: "action-change",
+			project: "/x",
+			from: "idle",
+			to: "planning",
+			at: "now",
+		});
+		expect(calls).toHaveLength(0);
+	});
+});

--- a/scripts/wave-watcher/surfaces/vox.ts
+++ b/scripts/wave-watcher/surfaces/vox.ts
@@ -1,0 +1,45 @@
+// Vox surface: speaks an announcement on wave completion via the project's
+// existing `vox` CLI (or a configured equivalent). Opt-in via
+// `surfaces: ["vox"]`.
+//
+// We never block on the vox subprocess — fire-and-forget with a logged-and-
+// swallowed failure is the right shape for an active surface.
+
+import { spawn } from "node:child_process";
+import type { Transition, WaveWatcherConfig } from "../types";
+
+export type SpawnFn = (cmd: string, args: string[]) => void;
+
+export function defaultSpawn(cmd: string, args: string[]): void {
+	try {
+		const p = spawn(cmd, args, { stdio: "ignore", detached: true });
+		p.on("error", (err) => {
+			process.stderr.write(
+				`wave-watcher: vox spawn failed: ${err.message}\n`,
+			);
+		});
+		p.unref();
+	} catch (err) {
+		process.stderr.write(
+			`wave-watcher: vox spawn threw: ${(err as Error).message}\n`,
+		);
+	}
+}
+
+export function shouldAnnounceVox(t: Transition): boolean {
+	return t.kind === "wave-completion";
+}
+
+export function makeVoxHandler(
+	config: WaveWatcherConfig,
+	spawnFn: SpawnFn = defaultSpawn,
+): ((t: Transition) => void) | null {
+	if (!config.surfaces.includes("vox")) return null;
+	const cmd = config.vox_command || "vox";
+	return (t: Transition) => {
+		if (!shouldAnnounceVox(t)) return;
+		if (t.kind === "wave-completion") {
+			spawnFn(cmd, [`Wave ${t.wave_id} complete`]);
+		}
+	};
+}

--- a/scripts/wave-watcher/systemd/wave-watcher.service
+++ b/scripts/wave-watcher/systemd/wave-watcher.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=wave-watcher: aggregate wave-pattern state across local projects
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/wave-watcher run
+Restart=on-failure
+RestartSec=2
+# We bind to 127.0.0.1 only — no need for capabilities. Keep stdout+stderr
+# on the journal; do not redirect to a file. The daemon writes its own pid
+# (pidfile is informational; systemd manages lifecycle).
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/wave-watcher/tsconfig.json
+++ b/scripts/wave-watcher/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "allowJs": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/wave-watcher/types.ts
+++ b/scripts/wave-watcher/types.ts
@@ -1,0 +1,104 @@
+// Shared types for wave-watcher.
+//
+// The reader treats schema_version 3 as canonical. Unknown fields are
+// preserved in the raw state but ignored at the typed surface.
+
+export type Platform = "github" | "gitlab" | "unknown";
+
+export type Health = "ok" | "blocked" | "unhealthy" | "unknown";
+
+export interface ProjectMatch {
+	root: string;
+	platform: Platform;
+	last_mtime: number; // ms since epoch
+	state_path: string;
+	phases_path: string | null;
+}
+
+export interface WaveStatus {
+	id: string;
+	status: string;
+	mr_urls: Record<string, string>;
+}
+
+export interface IssueStatus {
+	key: string;
+	status: string;
+}
+
+export interface CurrentAction {
+	action: string;
+	label: string;
+	detail: string;
+}
+
+export interface Deferral {
+	issue?: string | number;
+	status?: string;
+	[k: string]: unknown;
+}
+
+export interface Gauges {
+	[name: string]: number | string | boolean | null;
+}
+
+export interface AggregatedState {
+	root: string;
+	platform: Platform;
+	current_wave: string | null;
+	current_action: CurrentAction;
+	waves: WaveStatus[];
+	issues: IssueStatus[];
+	deferrals: Deferral[];
+	gauges: Gauges;
+	last_updated: string | null;
+	last_mtime: number;
+	health: Health;
+	error: string | null;
+}
+
+export interface WaveWatcherConfig {
+	scan_roots: string[];
+	poll_interval_ms: number;
+	port: number;
+	max_depth: number;
+	surfaces: string[];
+	discord_webhook?: string;
+	vox_command?: string;
+}
+
+export const DEFAULT_CONFIG: WaveWatcherConfig = {
+	scan_roots: ["~/sandbox/github", "~/sandbox/gitlab"],
+	poll_interval_ms: 5000,
+	port: 7777,
+	max_depth: 4,
+	surfaces: [],
+};
+
+export type Transition =
+	| {
+			kind: "wave-completion";
+			project: string;
+			wave_id: string;
+			at: string;
+	  }
+	| {
+			kind: "flight-start";
+			project: string;
+			wave_id: string;
+			at: string;
+	  }
+	| {
+			kind: "action-change";
+			project: string;
+			from: string;
+			to: string;
+			at: string;
+	  }
+	| {
+			kind: "health-degrade";
+			project: string;
+			from: Health;
+			to: Health;
+			at: string;
+	  };


### PR DESCRIPTION
Implements wave-watcher daemon per cc-workflow#578.

Standalone aggregator scanning .claude/status/ across the fleet. Lives in scripts/wave-watcher/ (in-tree per Prime's design-intent override of the spec's "new repo" framing — wave is scoped to claudecode-workflow).

Closes #578

Wave 4a / Flight 1 of Plan #607 (Beta).