### PR TITLE
docs: add quick-reference cheat sheet — skill + MCP tool map

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo packages the custom skills, utility scripts, and project instructions 
 | [Getting Started](docs/getting-started.md) | 15-minute walkthrough of your first session |
 | [Concepts](docs/concepts.md) | How the pieces fit together |
 | [Skill Reference](docs/skill-reference.md) | Detailed docs for every skill |
+| [Cheat Sheet](docs/cheatsheet.md) | One-page skill + MCP tool quick reference |
 | [KAHUNA Guide](docs/kahuna-guide.md) | Run `/wavemachine` autonomously on multi-issue epics |
 | [Discord Setup](docs/discord-config.md) | Bot token, watcher, inter-agent messaging |
 | [Statusline Indicators](docs/statusline-indicators.md) | Per-session indicator interface for skills and scripts |

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1,0 +1,81 @@
+# Cheat Sheet
+
+Quick reference for all skills and the MCP tools they route to.
+
+## Shipping
+
+| Command | Purpose | MCP Tool |
+|---------|---------|----------|
+| `/precheck` | Pre-commit gate — verify, review, checklist | `ibm`, `spec_validate_structure` |
+| `/scp` | Stage, commit, push, create PR | `pr_list`, `pr_create` |
+| `/scpmr` | scp + stop before merge | `pr_list`, `pr_create` |
+| `/scpmmr` | scp + merge (full pipeline) | `pr_create`, `pr_wait_ci`, `pr_merge` |
+| `/mmr` | Merge existing PR/MR | `pr_status`, `pr_diff`, `pr_wait_ci`, `pr_merge` |
+| `/review` | Code review (branch/staged/file/PR) | — (sub-agent) |
+| `/jfail` | CI failure analysis | `ci_run_logs`, `ci_failed_jobs` |
+
+## Wave Pattern
+
+| Command | Purpose | MCP Tool |
+|---------|---------|----------|
+| `/assesswaves` | Triage wave suitability | `spec_validate_structure`, `wave_topology` |
+| `/prepwaves` | Validate specs, compute waves, persist plan | `epic_sub_issues`, `wave_compute`, `wave_init` |
+| `/nextwave` | Execute one wave (flights) | `wave_next_pending`, `wave_flight`, `wave_flight_done` |
+| `/wavemachine` | Autopilot loop across all waves | `wave_health_check`, `wave_next_pending` |
+| `/wave` | Show wave status | `wave_show` |
+
+## SDLC Stages
+
+| Command | Purpose | MCP Tool |
+|---------|---------|----------|
+| `/ddd` | Domain discovery (event storming) | `ddd_locate_sketchbook`, `ddd_verify_committed` |
+| `/devspec` | Interactive Dev Spec creation | `devspec_locate`, `devspec_finalize` |
+| `/dod` | Definition of Done verification | `dod_load_manifest`, `dod_verify_deliverable` |
+| `/sdlc` | Work item creation, ibm check | `work_item`, `ibm` |
+
+## Work Tracking
+
+| Command | Purpose | MCP Tool |
+|---------|---------|----------|
+| `/issue` | Create structured issues | `work_item` |
+| `/ibm` | Issue→Branch→PR compliance | `ibm` |
+
+## Ops & Troubleshooting
+
+| Command | Purpose | MCP Tool |
+|---------|---------|----------|
+| `/nerf` | Context budget (darts, modes) | `nerf_status`, `nerf_darts`, `nerf_mode` |
+| `/wtf` | Start troubleshooting session | `wtf_freshell` |
+| `/wtf now` | Record manual journal entry | `wtf_now` |
+| `/wtf happened` | Get incident timeline | `wtf_happened` |
+| `/wtf imout` | Suspend recording | `wtf_imout` |
+| `/disc` | Discord (send, read, list, create) | `disc_send`, `disc_read`, `disc_list` |
+
+## Session & UI
+
+| Command | Purpose | MCP Tool |
+|---------|---------|----------|
+| `/engage` | Load rules, restore context | — |
+| `/name` | Report/pick session identity | — |
+| `/ccfold` | Merge upstream CLAUDE.md template | — |
+| `/ccwork` | Onboarding hub (tours, labs, setup) | — |
+| `/man` | Skill usage display | — |
+| `/vox` | Voice announcements (TTS) | — (script) |
+| `/view` | Open file in GUI viewer | — (script) |
+| `/edit` | Open file in GUI editor | — (script) |
+| `/ping` | Post to Slack | — (script) |
+| `/pong` | Read Slack | — (script) |
+
+## CLI Tools
+
+| Command | Purpose |
+|---------|---------|
+| `campaign-status` | SDLC stage tracking + HTML dashboard |
+| `wave-status` | Wave execution lifecycle tracking |
+| `vox` | TTS from shell scripts |
+| `discord-bot` | Discord REST client |
+| `file-opener` | Cross-platform file/URL opener |
+
+---
+
+*Full docs: [Skill Reference](skill-reference.md) · [Tool-Skill Map](tool-skill-map.md)*

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -957,6 +957,7 @@ campaign-status dashboard-url --branch feature/42-work
 
 ## See Also
 
+- [Cheat Sheet](cheatsheet.md) -- one-page skill + MCP tool quick reference
 - [Getting Started](getting-started.md) -- hands-on walkthrough of your first session
 - [Concepts](concepts.md) -- how the pieces fit together
 - [Troubleshooting](troubleshooting.md) -- common failure modes and fixes


### PR DESCRIPTION
## Summary

Single-page quick-reference with every skill grouped by function, showing the MCP tools each routes to.

## Changes

- `docs/cheatsheet.md` — grouped tables: Shipping, Wave Pattern, SDLC Stages, Work Tracking, Ops, Session & UI, CLI Tools
- `README.md` — added cheat sheet to documentation table
- `docs/skill-reference.md` — added cheat sheet to See Also section

## Linked Issues

Closes #650

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (150 regressions)
- [x] trivy: 0 HIGH/CRITICAL
- [x] All 34 skills accounted for in the cheatsheet
- [x] Links from README and skill-reference resolve