### PR TITLE
docs(onboarding): cross-reference seed-ai-dev.md in orientation materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo packages the custom skills, utility scripts, and project instructions 
 | [Discord Setup](docs/discord-config.md) | Bot token, watcher, inter-agent messaging |
 | [Statusline Indicators](docs/statusline-indicators.md) | Per-session indicator interface for skills and scripts |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues and fixes |
+| [New Agent Orientation](docs/seed-ai-dev.md) | Day-1 context for AI agents joining the fleet |
 
 ## Install via Claude Code
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,8 @@ This guide walks you through your first 15 minutes with the ccwork kit -- from v
 
 **Prerequisites:** You have already cloned the repo and run `./install.sh`. If not, see the [Quick Start](../README.md#quick-start) in the README.
 
+> **AI agent?** If you're a Claude Code agent being dropped into this org for the first time, start with [New Agent Orientation](seed-ai-dev.md) instead — it covers the context you need in a single read.
+
 ---
 
 ## Step 1: Verify Your Install

--- a/skills/ccwork/tours/orientation.md
+++ b/skills/ccwork/tours/orientation.md
@@ -156,6 +156,7 @@ Narration: "That's the orientation. Here's where to go from here:"
 - **Learn the foundations** — `/ccwork tour foundations` covers the session lifecycle skills in depth
 - **Read the docs** — [Getting Started](../../../docs/getting-started.md) for the hands-on walkthrough, [Concepts](../../../docs/concepts.md) for architecture
 - **Run a lab** — `/ccwork lab` to see available hands-on exercises (requires the ccwork-lab repo)
-- **Explore skills** — run any `/command` to see what it does
+- **Explore skills** — run `/man <skill>` to see detailed usage for any skill
+- **AI agent onboarding** — if you're a new agent joining the fleet, read [New Agent Orientation](../../../docs/seed-ai-dev.md) for day-1 context
 
 Narration: "That's it. You know what's installed, how the loop works, and where the docs live. Ready when you are."


### PR DESCRIPTION
## Summary

Links the new agent orientation doc (`seed-ai-dev.md`) from three discovery points so new AI agents find it naturally.

## Changes

- **README.md** — added "New Agent Orientation" row to docs table
- **docs/getting-started.md** — added blockquote callout directing AI agents to `seed-ai-dev.md`
- **skills/ccwork/tours/orientation.md** — added agent onboarding bullet + fixed `/command` → `/man <skill>` in "What's Next"

## Linked Issues

Closes #651

## Test Plan

- Verified all relative links resolve to existing files
- Docs-only change — no runtime behavior affected