### PR TITLE
fix(install): correct --check path for skill helpers in Cellar

### DIFF
--- a/install
+++ b/install
@@ -814,7 +814,7 @@ if [[ "$CHECK_MODE" == true ]]; then
 			if [[ "$helper_name" == *.md ]]; then
 				do_check "$helper" "$SKILLS_DIR/$skill_name/$helper_name" "$skill_name/$helper_name" || drifted=$((drifted + 1))
 			else
-				do_check "$helper" "$CELLAR_DIR/$helper_name" "$skill_name/$helper_name" || drifted=$((drifted + 1))
+				do_check "$helper" "$CELLAR_DIR/skills/$skill_name/$helper_name" "$skill_name/$helper_name" || drifted=$((drifted + 1))
 			fi
 		done
 		# Check content subdirectories (e.g., tours/)


### PR DESCRIPTION
## Summary

Fixes false-positive "NOT INSTALLED" reports for skill helpers (`job-fetch`, `slackbot-send`, `file-opener`) in `./install --check`.

## Changes

- Fixed check-mode path from `$CELLAR_DIR/$helper_name` to `$CELLAR_DIR/skills/$skill_name/$helper_name` to match where `cellar_install_skill_helper()` actually deploys

## Linked Issues

Closes #657

## Test Plan

- Ran `./install` then `./install --check` — all three helpers now report "in sync" instead of "NOT INSTALLED"