### PR TITLE
fix(skills): add multi-Phase guard to /prepwaves, fix upshift prompt (#659)

### DIFF
--- a/skills/devspec/SKILL.md
+++ b/skills/devspec/SKILL.md
@@ -564,7 +564,7 @@ Plan issue #<plan_id> updated: Phases checklist backfilled.
 
 Also post this summary as a plain comment (not a `[ledger]` entry) on the Plan issue so the Pair has a single place to read the backlog state.
 
-Confirm to the user: "Backlog populated. N Story issues created. `phases-waves.json` written with plan_id=<plan_id> and per-Story depends_on. Dev Spec and Plan issue updated with Story references. Run `/prepwaves` to plan execution."
+Confirm to the user: "Backlog populated. N Story issues created. `phases-waves.json` written with plan_id=<plan_id> and per-Story depends_on. Dev Spec and Plan issue updated with Story references. Run `/nextwave` to begin execution." (Do NOT recommend `/prepwaves` — upshift already wrote the complete multi-Phase topology to `phases-waves.json`; running `/prepwaves` on top of it would be redundant or destructive.)
 
 <!-- END TEMPLATE: devspec-upshift -->
 

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -18,6 +18,11 @@ Analyze one or more Plan tracking issues, validate their sub-issue specs, comput
 
 ## Procedure
 
+0. **Multi-Phase guard.** Before any work, check if `.claude/status/phases-waves.json` already exists in the project. If it does, read it and inspect `phases.length`:
+   - If `phases.length > 1` (multi-Phase topology already written by `/devspec upshift`): **STOP.** Report to the user: "`phases-waves.json` already contains a multi-Phase topology (N phases, M waves, K stories). This was written by `/devspec upshift` — `/prepwaves` persist is unnecessary. Run `/nextwave` to begin execution, or delete `phases-waves.json` to re-plan from scratch."
+   - If `phases.length === 1` and the plan's `plan_id` matches one of the user's input Plan refs: this is a re-run of a single-Phase prep. Proceed normally (wave_init's extend/idempotent path handles it).
+   - If the file does not exist: proceed normally (fresh prep).
+
 1. **Inputs.** Plan tracking-issue numbers passed by the user (`/prepwaves #2` or `/prepwaves #2 #3 ...`). Each Plan becomes one Phase in `phases-waves.json`.
 2. **Pre-flight readiness table.** For each Plan:
    a. Call `epic_sub_issues(N)` inline to get the list of sub-issue numbers (must complete before spawning validators — you need the list first).


### PR DESCRIPTION
## Summary

`/prepwaves` assumed 1 Phase per Plan and would overwrite multi-Phase `phases-waves.json` written by `/devspec upshift`. This adds a Step 0 guard and fixes the upshift closing prompt.

## Changes

- Add Step 0 to `/prepwaves` — detects existing multi-Phase `phases-waves.json` and stops with actionable message
- Update `/devspec upshift` closing prompt to recommend `/nextwave` instead of `/prepwaves`

## Linked Issues

Closes #659
Cross-ref: mcp-server-sdlc#435

## Test Plan

- `scripts/ci/validate.sh` — 150/150 pass
- Manual: verified guard logic covers all three states (multi-phase stop, single-phase re-run, fresh prep)