### PR TITLE
fix(wave-status): make all mutating commands survive dashboard-regen crash

### DIFF
--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 
 from wave_status import deferrals
@@ -101,10 +102,15 @@ def _safe_regenerate_dashboard(root: Path) -> None:
     try:
         _regenerate_dashboard(root)
     except Exception as exc:  # noqa: BLE001 — best-effort; envelope must print
+        # The mutation already persisted; a derived-view refresh failure must
+        # not fail the command. Emit the full traceback (not just the message)
+        # so a render bug like #<this issue> is diagnosable from the warning
+        # even though the exit code stays 0.
         print(
             f"warning: dashboard regeneration failed: {exc}",
             file=sys.stderr,
         )
+        traceback.print_exc(file=sys.stderr)
 
 
 def _print_envelope(state: dict) -> None:
@@ -143,7 +149,7 @@ def _cmd_init(args: argparse.Namespace) -> None:
         extend_state(plan_data, root)
     else:
         init_state(plan_data, root, force=args.force)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_flight_plan(args: argparse.Namespace) -> None:
@@ -152,21 +158,21 @@ def _cmd_flight_plan(args: argparse.Namespace) -> None:
     raw = _read_json_source(args.file)
     flights_data = json.loads(raw)
     store_flight_plan(flights_data, root)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_preflight(args: argparse.Namespace) -> None:
     """Handle ``preflight``."""
     root = get_project_root()
     preflight(root)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_planning(args: argparse.Namespace) -> None:
     """Handle ``planning``."""
     root = get_project_root()
     planning(root)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_flight(args: argparse.Namespace) -> None:
@@ -189,14 +195,14 @@ def _cmd_review(args: argparse.Namespace) -> None:
     """Handle ``review``."""
     root = get_project_root()
     review(root)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_complete(args: argparse.Namespace) -> None:
     """Handle ``complete``."""
     root = get_project_root()
     complete(root)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_waiting(args: argparse.Namespace) -> None:
@@ -213,7 +219,7 @@ def _cmd_waiting_ci(args: argparse.Namespace) -> None:
     root = get_project_root()
     detail = args.detail if args.detail else ""
     waiting_ci(root, detail=detail)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_close_issue(args: argparse.Namespace) -> None:
@@ -241,7 +247,7 @@ def _cmd_defer(args: argparse.Namespace) -> None:
         raise ValueError("no active wave — all waves are complete")
     deferrals.defer(state_data, args.desc, args.risk, state_data["current_wave"])
     save_json(d / "state.json", state_data)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_defer_accept(args: argparse.Namespace) -> None:
@@ -251,14 +257,14 @@ def _cmd_defer_accept(args: argparse.Namespace) -> None:
     state_data = load_state(d / "state.json")
     deferrals.accept(state_data, args.index)
     save_json(d / "state.json", state_data)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_set_current(args: argparse.Namespace) -> None:
     """Handle ``set-current <wave-id>``."""
     root = get_project_root()
     set_current_wave(args.wave_id, root)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_set_kahuna_branch(args: argparse.Namespace) -> None:
@@ -266,14 +272,14 @@ def _cmd_set_kahuna_branch(args: argparse.Namespace) -> None:
     root = get_project_root()
     branch = args.branch.strip() if args.branch else ""
     set_kahuna_branch(branch or None, root)
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_wavemachine_start(args: argparse.Namespace) -> None:
     """Handle ``wavemachine-start [--launcher <tag>]``."""
     root = get_project_root()
     wavemachine_start(root, launcher=args.launcher or "")
-    _regenerate_dashboard(root)
+    _safe_regenerate_dashboard(root)
 
 
 def _cmd_wavemachine_stop(args: argparse.Namespace) -> None:

--- a/tests/test_wave_status_cli_envelope.py
+++ b/tests/test_wave_status_cli_envelope.py
@@ -253,3 +253,85 @@ class TestEnvelopeSurvivesRegen:
         assert env_payload["state"]["current_action"]["action"] == "in-flight"
         # Failure surfaced as a best-effort stderr warning.
         assert "synthetic regen failure" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Regression: non-enveloped mutations (init, complete, ...) must ALSO survive
+# a dashboard-regen crash with exit 0. #495 hardened the envelope-printing
+# commands but left init/complete/planning/etc. calling the raw regen, so a
+# render crash ('str' object has no attribute 'get') surfaced as a non-zero
+# exit AFTER the state had already persisted — sdlc-server's wave_init /
+# wave_complete wrappers (which key on exit code) then reported ok:false on
+# full success, risking a retry into a wave-ID collision.
+# ---------------------------------------------------------------------------
+
+class TestNonEnvelopeMutationsSurviveRegen:
+    """Mutations that don't print an envelope (their MCP wrappers key on the
+    CLI exit code) must still exit 0 when the best-effort dashboard regen
+    crashes — the state mutation already persisted."""
+
+    @staticmethod
+    def _run_with_regen_boom(repo: Path, args: list[str]):
+        import os
+        import subprocess
+        import sys
+
+        inject_dir = repo / "_inject"
+        if not inject_dir.exists():
+            inject_dir.mkdir()
+            (inject_dir / "sitecustomize.py").write_text(
+                "import wave_status.dashboard.generator as _g\n"
+                "def _boom(*a, **kw):\n"
+                "    raise RuntimeError('synthetic regen failure')\n"
+                "_g.generate_dashboard = _boom\n",
+                encoding="utf-8",
+            )
+        env = os.environ.copy()
+        src_dir = str(Path(__file__).resolve().parent.parent / "src")
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = os.pathsep.join(
+            p for p in [str(inject_dir), src_dir, existing] if p
+        )
+        return subprocess.run(
+            [sys.executable, "-m", "wave_status", *args],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_complete_exits_zero_when_regen_raises(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        repo = temp_git_repo
+        _bootstrap_through_flight_started(repo, run_cli)
+
+        result = self._run_with_regen_boom(repo, ["complete"])
+
+        assert result.returncode == 0, (
+            f"complete must exit 0 despite a regen crash (state persisted); "
+            f"got rc={result.returncode}, stderr={result.stderr!r}"
+        )
+        assert "synthetic regen failure" in result.stderr
+        # The mutation landed: the wave is marked completed on disk.
+        state = json.loads(
+            (repo / ".claude" / "status" / "state.json").read_text(encoding="utf-8")
+        )
+        assert state["waves"]["wave-1"]["status"] == "completed"
+
+    def test_init_exits_zero_when_regen_raises(
+        self, temp_git_repo: Path
+    ) -> None:
+        repo = temp_git_repo
+        _write_plan(repo)
+
+        result = self._run_with_regen_boom(repo, ["init", "plan.json"])
+
+        assert result.returncode == 0, (
+            f"init must exit 0 despite a regen crash (plan persisted); "
+            f"got rc={result.returncode}, stderr={result.stderr!r}"
+        )
+        assert "synthetic regen failure" in result.stderr
+        # The plan persisted despite the regen crash.
+        assert (repo / ".claude" / "status" / "state.json").exists()
+        assert (repo / ".claude" / "status" / "phases-waves.json").exists()


### PR DESCRIPTION
## Summary

`wave-status` mutating subcommands (`init`, `complete`, `planning`, `review`, `flight-plan`, `preflight`, `waiting-ci`, `defer`, `defer-accept`, `set-current`, `set-kahuna-branch`, `wavemachine-start`) called the **raw** `_regenerate_dashboard()` as a post-persist step. When that best-effort derived-view refresh crashes, the command exits non-zero **after the state already persisted**. sdlc-server's `wave_init`/`wave_complete` wrappers use `execSync` (keying on exit code), so they reported `ok:false` on full success — risking an agent retry into a wave-ID collision.

## Changes

- Every mutating `_cmd_*` handler now uses `_safe_regenerate_dashboard()` (catch → stderr → exit 0), completing #495 uniformly. The 6 envelope-printing mutations already did; this covers the remaining ~12.
- `_safe_regenerate_dashboard()` now prints the full traceback to stderr (not just the message) so the underlying render crash stays diagnosable while the exit code stays 0.

## Linked Issues

Closes #661

## Test Plan

- New `TestNonEnvelopeMutationsSurviveRegen`: injects a synthetic `generate_dashboard` crash; asserts `init` and `complete` exit 0 with the mutation persisted (they previously exited non-zero).
- `tests/test_wave_status_cli_envelope.py` → 10 pass; wave_status suite → 373 pass; `ruff` clean.
- Code review: no findings. trivy: 0 HIGH/CRITICAL.

Note: 128 pre-existing full-suite failures in `test_install_merge`/`test_issue_skill` are unrelated (verified failing on clean main).

## Follow-up

The underlying `'str' object has no attribute 'get'` render crash is not reproducible from current `src` (all dashboard `.get` sites are `isinstance`-guarded). Awaiting deep-thought's live traceback (now emitted to stderr) to fix the actual render site separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)