### PR TITLE
fix(wave-status): tolerate legacy flight-envelope shape in renderers + CLI

### DIFF
--- a/src/wave_status/dashboard/execution_grid.py
+++ b/src/wave_status/dashboard/execution_grid.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import html as _html
 
 from wave_status.dashboard.theme import PHASE_COLORS
+from wave_status.state import wave_flight_list
 
 
 def _status_badge(status: str, data_wave: str = "", data_issue: str = "") -> str:
@@ -44,7 +45,7 @@ def _render_flight_badges(wave_id: str, flights_data: dict) -> str:
 
     Returns an empty string if no flight plan exists for *wave_id*.
     """
-    wave_flights = flights_data.get("flights", {}).get(wave_id, [])
+    wave_flights = wave_flight_list(flights_data, wave_id)
     if not wave_flights:
         return ""
 

--- a/src/wave_status/dashboard/gauge_cards.py
+++ b/src/wave_status/dashboard/gauge_cards.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import html as _html
 
-from wave_status.state import current_phase_info
+from wave_status.state import current_phase_info, wave_flight_list
 
 
 def _flight_info(state_data: dict, flights_data: dict) -> dict:
@@ -24,7 +24,7 @@ def _flight_info(state_data: dict, flights_data: dict) -> dict:
         }
     """
     current_wave = state_data.get("current_wave") or ""
-    wave_flights = flights_data.get("flights", {}).get(current_wave, [])
+    wave_flights = wave_flight_list(flights_data, current_wave)
 
     if not wave_flights:
         return {"value": "\u2014", "pct": 0.0, "has_flights": False}

--- a/src/wave_status/dashboard/kahuna_section.py
+++ b/src/wave_status/dashboard/kahuna_section.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import html as _html
 
+from wave_status.state import wave_flight_list
+
 
 # Maximum number of history rows rendered before the table collapses.  The
 # spec calls for "last 10 entries" (devspec §5.2.5).
@@ -36,7 +38,7 @@ def _flight_counts(flights_data: dict, current_wave: str | None) -> tuple[int, i
     """
     if current_wave is None:
         return (0, 0)
-    wave_flights = flights_data.get("flights", {}).get(current_wave, [])
+    wave_flights = wave_flight_list(flights_data, current_wave)
     merged = 0
     pending = 0
     for fl in wave_flights:

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -651,6 +651,31 @@ def extend_state(plan_data: dict, root: Path) -> None:
     save_json(state_path, existing_state)
 
 
+def wave_flight_list(flights_data: dict, wave_id: str) -> list[dict]:
+    """Return the flat list of flight dicts for *wave_id*, shape-tolerant [#663].
+
+    ``flights.json`` stores per-wave flight data as ``flights[<wave_id>]``. The
+    canonical shape written by :func:`store_flight_plan` is a flat list of
+    flight dicts (``[{"issues": [...], "status": "..."}]``). A legacy
+    flight-partition writer persisted a nested *envelope* for some waves
+    instead (``{"flights": [...], "strategy": "safe", "conflict_count": 1}``).
+
+    Consumers that iterate the per-wave value directly crash on the envelope
+    shape — iterating a dict yields its keys (strings), so the subsequent
+    ``flight.get(...)`` raises ``'str' object has no attribute 'get'``. This
+    helper accepts either shape, unwraps the envelope, and drops any non-dict
+    element so a single legacy-shaped wave can never crash a renderer or the
+    CLI summary. Returns ``[]`` for a missing wave or any unexpected type.
+    """
+    raw = flights_data.get("flights", {}).get(wave_id, [])
+    if isinstance(raw, dict):
+        # Legacy envelope — the real list lives under the "flights" key.
+        raw = raw.get("flights", [])
+    if not isinstance(raw, list):
+        return []
+    return [flight for flight in raw if isinstance(flight, dict)]
+
+
 def store_flight_plan(flights_data: list, root: Path) -> None:
     """Store *flights_data* keyed by the current wave ID in ``flights.json`` [R-04].
 
@@ -841,7 +866,9 @@ def flight(n: int, root: Path) -> dict:
         )
 
     flights = load_json(d / "flights.json")
-    wave_flights = flights.get("flights", {}).get(current_wave, [])
+    # Shape-tolerant read (#663): normalize legacy envelope → flat list. The
+    # write-back below then persists the flat shape, self-healing the drift.
+    wave_flights = wave_flight_list(flights, current_wave)
 
     if n < 1 or n > len(wave_flights):
         raise ValueError(
@@ -895,7 +922,9 @@ def flight_done(n: int, root: Path) -> dict:
         )
 
     flights = load_json(d / "flights.json")
-    wave_flights = flights.get("flights", {}).get(current_wave, [])
+    # Shape-tolerant read (#663): normalize legacy envelope → flat list. The
+    # write-back below then persists the flat shape, self-healing the drift.
+    wave_flights = wave_flight_list(flights, current_wave)
 
     if n < 1 or n > len(wave_flights):
         raise ValueError(
@@ -1124,7 +1153,7 @@ def show(root: Path) -> dict:
     waves_in_current_phase = phase_info["waves_in_phase"]
 
     # Flight info.
-    wave_flights = flights_data.get("flights", {}).get(current_wave or "", [])
+    wave_flights = wave_flight_list(flights_data, current_wave or "")
     total_flights = len(wave_flights)
     running_flight = None
     for fi, fl in enumerate(wave_flights):

--- a/tests/test_flights_envelope_shape.py
+++ b/tests/test_flights_envelope_shape.py
@@ -1,0 +1,117 @@
+"""Regression tests for the legacy flight-envelope shape [#663].
+
+``flights.json`` stores per-wave flight data as ``flights[<wave_id>]``. The
+canonical shape is a flat list of flight dicts; a legacy flight-partition
+writer persisted a nested envelope (``{"flights": [...], "strategy": ...}``)
+for some waves. Renderers that iterate the per-wave value directly crashed on
+the envelope shape with ``'str' object has no attribute 'get'`` (iterating a
+dict yields its string keys).
+
+``state.wave_flight_list`` normalizes both shapes; these tests pin that the
+helper and all four consumers (three dashboard renderers + the CLI summary)
+tolerate the envelope shape and agree with the flat-list shape.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wave_status.dashboard import execution_grid, gauge_cards, kahuna_section
+from wave_status.state import (
+    flight,
+    load_json,
+    save_json,
+    status_dir,
+    wave_flight_list,
+)
+
+_FLIGHT = {"issues": [20], "status": "completed"}
+
+# Same wave expressed both ways.
+_FLAT = {"flights": {"wave-x": [_FLIGHT]}}
+_ENVELOPE = {
+    "flights": {"wave-x": {"flights": [_FLIGHT], "strategy": "safe", "conflict_count": 1}}
+}
+
+
+class TestWaveFlightList:
+    def test_flat_list_passthrough(self) -> None:
+        assert wave_flight_list(_FLAT, "wave-x") == [_FLIGHT]
+
+    def test_envelope_unwrapped(self) -> None:
+        assert wave_flight_list(_ENVELOPE, "wave-x") == [_FLIGHT]
+
+    def test_missing_wave_returns_empty(self) -> None:
+        assert wave_flight_list(_FLAT, "nope") == []
+
+    def test_non_dict_elements_dropped(self) -> None:
+        data = {"flights": {"wave-x": ["junk", _FLIGHT, 7]}}
+        assert wave_flight_list(data, "wave-x") == [_FLIGHT]
+
+    def test_garbage_value_returns_empty(self) -> None:
+        assert wave_flight_list({"flights": {"wave-x": "nonsense"}}, "wave-x") == []
+        assert wave_flight_list({}, "wave-x") == []
+
+
+class TestRenderersTolerateEnvelope:
+    """Each consumer must produce the SAME result for the envelope shape as
+    for the flat list — and must not raise ``'str' object has no attribute
+    'get'`` on the envelope."""
+
+    def test_execution_grid_badges(self) -> None:
+        flat = execution_grid._render_flight_badges("wave-x", _FLAT)
+        env = execution_grid._render_flight_badges("wave-x", _ENVELOPE)
+        assert flat == env
+        assert flat  # non-empty — the flight rendered
+
+    def test_gauge_cards_flight_info(self) -> None:
+        state = {"current_wave": "wave-x"}
+        flat = gauge_cards._flight_info(state, _FLAT)
+        env = gauge_cards._flight_info(state, _ENVELOPE)
+        assert flat == env
+        assert env["has_flights"] is True
+
+    def test_kahuna_flight_counts(self) -> None:
+        flat = kahuna_section._flight_counts(_FLAT, "wave-x")
+        env = kahuna_section._flight_counts(_ENVELOPE, "wave-x")
+        assert flat == env == (1, 0)
+
+
+class TestWriteSideSelfHeals:
+    """``flight`` / ``flight_done`` read the per-wave value to validate and
+    mutate it. On the envelope shape they previously crashed; now they read
+    via ``wave_flight_list`` and write the flat list back — self-healing the
+    drift so the legacy envelope never persists past the next flight op."""
+
+    def test_flight_tolerates_and_heals_envelope(self, temp_git_repo) -> None:
+        repo = temp_git_repo
+        d = status_dir(repo)
+        d.mkdir(parents=True, exist_ok=True)
+        save_json(d / "state.json", {"current_wave": "wave-x", "waves": {}})
+        # Envelope-shaped wave (legacy drift) with one pending flight.
+        save_json(
+            d / "flights.json",
+            {
+                "flights": {
+                    "wave-x": {
+                        "flights": [{"issues": [20], "status": "pending"}],
+                        "strategy": "safe",
+                        "conflict_count": 1,
+                    }
+                }
+            },
+        )
+
+        # Previously raised on the envelope shape; must now succeed.
+        result = flight(1, repo)
+        assert result["current_action"]["action"] == "in-flight"
+
+        # Self-heal: the persisted shape is now the flat list, and the flight
+        # is marked running.
+        healed = load_json(d / "flights.json")
+        assert healed["flights"]["wave-x"] == [
+            {"issues": [20], "status": "running"}
+        ]


### PR DESCRIPTION
## Summary

`flights.json` stores per-wave flight data as `flights[<wave_id>]`. The canonical shape (`store_flight_plan`) is a flat list of flight dicts, but a legacy flight-partition writer persisted a nested envelope (`{"flights":[...], "strategy":..., "conflict_count":...}`) for some waves. **Six** consumers iterated the per-wave value directly and crashed on the envelope shape with `'str' object has no attribute 'get'` (iterating a dict yields its string keys).

This is the render-side root cause behind #661, which made the dashboard regen non-fatal to the *mutation*; this closes the render side so the dashboard actually generates and the write-side ops don't crash.

## Changes

- Add `state.wave_flight_list(flights_data, wave_id)` — shape-tolerant: unwraps the `{"flights":[...]}` envelope and drops non-dict elements.
- Apply it at all six sites: `execution_grid._render_flight_badges`, `gauge_cards._flight_info`, `kahuna_section._flight_counts`, `state.show`, `state.flight`, `state.flight_done`.
- Because `flight`/`flight_done` write the value back, normalizing on read **self-heals** the drift — the flat shape persists on the next flight op.
- Helper lives in `state.py` (data layer owns `flights.json`); dashboard modules import it — no circular dependency.

## Linked Issues

Closes #663

## Test Plan

- New `tests/test_flights_envelope_shape.py`: normalizer edge cases (flat/envelope/missing/garbage/non-dict), flat-vs-envelope render equivalence for all three renderers, and a `flight()` self-heal test (9 pass).
- `test_execution_grid` + `test_gauge_cards` + `test_kahuna_section` + `test_sdlc_dashboard` → 200 pass; flight tests → 114 pass; `ruff` clean.
- Code review: 1 critical fixed (`flight`/`flight_done`). trivy: 0 HIGH/CRITICAL.

Note: pre-existing `test_discord_bot_help`/`test_install_merge`/`test_issue_skill` failures on main are unrelated (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)