### PR TITLE
fix(status-panel): tolerate v3 plan schema in generate-status-panel

### DIFF
--- a/scripts/generate-status-panel
+++ b/scripts/generate-status-panel
@@ -126,6 +126,23 @@ def compute_stats(phases: list, state: dict) -> dict:
     }
 
 
+def wave_flight_list(flights: dict, wave_id: str) -> list[dict]:
+    """Return the flat list of flight dicts for *wave_id*, shape-tolerant.
+
+    Mirrors ``wave_status.state.wave_flight_list`` (#663): tolerates both the
+    canonical flat list and the legacy ``{"flights": [...], ...}`` envelope, and
+    drops any non-dict element. Inlined because this script is standalone
+    (stdlib only) and does not import the ``wave_status`` package. (See #665
+    follow-up to dedup this renderer against the package.)
+    """
+    raw = flights.get("flights", {}).get(wave_id, [])
+    if isinstance(raw, dict):
+        raw = raw.get("flights", [])
+    if not isinstance(raw, list):
+        return []
+    return [f for f in raw if isinstance(f, dict)]
+
+
 def render_phase_html(phase: dict, state: dict, flights: dict) -> str:
     phase_waves = phase["waves"]
     completed = sum(
@@ -140,7 +157,7 @@ def render_phase_html(phase: dict, state: dict, flights: dict) -> str:
     lines.append(f'<div class="phase {phase_status}">')
     lines.append(f'  <div class="phase-header">')
     lines.append(
-        f'    <h2>{html.escape(phase["name"])}'
+        f'    <h2>{html.escape(phase.get("name") or phase.get("title", ""))}'
         f' <span class="phase-progress">{completed}/{total} waves</span></h2>'
     )
     lines.append(f"  </div>")
@@ -162,7 +179,7 @@ def render_phase_html(phase: dict, state: dict, flights: dict) -> str:
             f"</div>"
         )
 
-        wave_flights = flights.get("flights", {}).get(wave_id, [])
+        wave_flights = wave_flight_list(flights, wave_id)
         if wave_flights:
             lines.append('    <div class="flights">')
             for i, flight in enumerate(wave_flights):
@@ -188,7 +205,10 @@ def render_phase_html(phase: dict, state: dict, flights: dict) -> str:
             issue_state = state.get("issues", {}).get(str(num), {})
             ist = issue_state.get("status", "pending")
             ic = status_class(ist)
-            dep_str = ", ".join(f"#{d}" for d in issue.get("deps", [])) or "none"
+            # v3 schema uses `depends_on`; older plans used `deps`. Two-key
+            # fallback so the Deps column renders on both (#665).
+            issue_deps = issue.get("deps") or issue.get("depends_on", [])
+            dep_str = ", ".join(f"#{d}" for d in issue_deps) or "none"
             mr_str = mr_urls.get(str(num), "")
 
             lines.append(

--- a/tests/test_status_panel_schema.py
+++ b/tests/test_status_panel_schema.py
@@ -1,0 +1,101 @@
+"""Regression tests for scripts/generate-status-panel schema tolerance [#665].
+
+The standalone status-panel script duplicates the wave_status dashboard
+renderer and had drifted: it assumed phase ``name`` (the v3 schema uses
+``title``) and iterated the per-wave flight value directly (crashing on the
+legacy envelope shape, same family as #663). Both made the panel crash on any
+real plan. These tests run the real script against a ``title``-schema plan with
+an envelope-shaped flights wave and assert it renders.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "generate-status-panel"
+
+# v3 plan: phases use `title`/`phase_id`, NOT `name`.
+_PHASES = {
+    "plan_id": 1,
+    "project": "org/repo",
+    "base_branch": "main",
+    "phases": [
+        {
+            "phase_id": "P1",
+            "title": "Phase 1: Tier 1 Runtime",
+            "epic_ref": "#1",
+            "waves": [
+                {
+                    "id": "wave-1",
+                    "issues": [
+                        {"number": 1, "ref": "org/repo#1", "title": "S1",
+                         "branch": "feature/1-s1", "depends_on": []},
+                        # Uses `depends_on` (v3), not `deps`; 99 appears nowhere
+                        # else so the rendered "#99" can only come from the deps
+                        # column — proving the depends_on fallback works (#665).
+                        {"number": 2, "ref": "org/repo#2", "title": "S2",
+                         "branch": "feature/2-s2", "depends_on": [99]},
+                    ],
+                },
+            ],
+        },
+    ],
+}
+_STATE = {
+    "current_wave": "wave-1",
+    "waves": {"wave-1": {"status": "pending"}},
+    "issues": {},
+    "deferrals": [],
+}
+# wave-1 uses the legacy ENVELOPE shape (the #663 drift) — the script must
+# tolerate it without crashing on `'str' object has no attribute 'get'`.
+_FLIGHTS = {
+    "flights": {
+        "wave-1": {
+            "flights": [{"issues": [1], "status": "running"}],
+            "strategy": "safe",
+            "conflict_count": 1,
+        }
+    }
+}
+
+
+def _write_status(tmp_path: Path) -> Path:
+    status = tmp_path / ".claude" / "status"
+    status.mkdir(parents=True)
+    (status / "phases-waves.json").write_text(json.dumps(_PHASES), encoding="utf-8")
+    (status / "state.json").write_text(json.dumps(_STATE), encoding="utf-8")
+    (status / "flights.json").write_text(json.dumps(_FLIGHTS), encoding="utf-8")
+    return status
+
+
+def test_panel_renders_on_title_schema_and_envelope_flights(tmp_path: Path) -> None:
+    status = _write_status(tmp_path)
+    out = tmp_path / "panel.html"
+
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT),
+         "--status-dir", str(status), "--output", str(out)],
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"panel generation failed: rc={result.returncode}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "KeyError" not in result.stderr
+    assert "has no attribute" not in result.stderr  # envelope crash guard
+    html = out.read_text(encoding="utf-8")
+    assert html, "panel HTML is empty"
+    # Phase heading renders from `title` (not `name`).
+    assert "Phase 1: Tier 1 Runtime" in html
+    # The envelope-shaped wave's flight actually rendered (not silently
+    # dropped) — the flights block + a flight badge are present.
+    assert '<div class="flights">' in html
+    assert "Flight 1" in html
+    # Deps column reads `depends_on` (v3), not `deps` — "#99" can only be the
+    # rendered dependency of issue #2.
+    assert "#99" in html


### PR DESCRIPTION
## Summary

`scripts/generate-status-panel` is a standalone duplicate of the `wave_status/dashboard` renderer and had drifted from the v3 plan schema, crashing on any real plan. Reported by deep-thought (gitlab-workspace) on Plan #78's first end-to-end `/wavemachine` run.

## Changes

- **`phase["name"]` → KeyError** (v3 uses `title`): now `phase.get("name") or phase.get("title", "")`.
- **Flight-envelope crash** (same family as #663): the script iterated the per-wave flight value directly and crashed on the legacy `{"flights":[...], "strategy":..., "conflict_count":...}` envelope. Now uses an inlined `wave_flight_list()` normalizer (the script is stdlib-only, can't import `wave_status.state`).
- **Deps column** read `deps` but v3 uses `depends_on` → silently rendered "none" on every real plan. Two-key fallback.

## Linked Issues

Closes #665

## Test Plan

- New `tests/test_status_panel_schema.py`: subprocess run against a `title`-schema plan with an envelope-shaped flights wave and a `depends_on` issue; asserts exit 0, phase heading from `title`, flight rendered, dep rendered.
- state/dashboard/panel suites → 136 pass; `ruff` clean; `py_compile` clean.
- Code review: 1 minor (deps column) fixed in-PR. trivy: 0 HIGH/CRITICAL.

## Follow-up

`scripts/generate-status-panel` duplicates `wave_status/dashboard/generator.py` — the durable fix is to dedup so renderer fixes (#663, #665) don't have to be applied twice. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)