### PR TITLE
test: kahuna sandbox smoke

### DIFF
--- a/.kahuna-smoke
+++ b/.kahuna-smoke
@@ -1,0 +1,1 @@
+kahuna ruleset smoke 1781760770


### PR DESCRIPTION
Throwaway — validates kahuna/* ruleset allows review-free merge. Auto-cleaned.