### PR TITLE
feat(wave-impl): #689 per-wave Workflow anchor (skeleton + seams)

### DIFF
--- a/skills/nextwave-next/SEAMS.md
+++ b/skills/nextwave-next/SEAMS.md
@@ -174,4 +174,6 @@ they are what make the loop deterministic and resumable:
    the same state is a no-op-or-overwrite, never a duplicate-side-effect.
 6. **The `#687` gate stubs are the ONLY always-pass placeholders.** Once #687 lands, real
    signals replace them; until then a skeleton run reaches PASS so the full spine is
-   exercisable end-to-end.
+   exercisable end-to-end. **When wiring #687, also drop the per-signal `.catch(() => gateSignalStub(...))`
+   fallbacks** — in production an agent/signal error must HOLD (conservative-fail), never silently PASS.
+   (Skeleton keeps the fallbacks so the spine runs before the real signals exist.)

--- a/skills/nextwave-next/SEAMS.md
+++ b/skills/nextwave-next/SEAMS.md
@@ -1,0 +1,177 @@
+# SEAMS — interface contract for `per-wave-workflow.js`
+
+This is the **anchor's interface contract**. `per-wave-workflow.js` (#689) ships the
+real, validated spine — the closed-legal-exit flight loop, the dynamic re-plan, and the
+trust-gate fan-out. The pieces that touch the real sdlc-server MCP, the durable
+wave-status store, and the durable worktrees are **seams**: each is a named function (or
+inline `agent()` prompt) with a fixed return shape and an obvious-placeholder stub, so
+the skeleton runs end-to-end today and the foundational wave-2 issues fill each seam
+**without changing the loop**.
+
+Every seam is marked in the script with a `// TODO(#…)` comment matching the table below.
+Filling a seam means: replace the stub body with the real sdlc-server-backed
+implementation, keep the **signature and return shape** identical. The loop/exits/re-plan
+depend only on the return shapes here — not on how they are produced.
+
+---
+
+## Seam → issue map
+
+| Seam | Issue | What it provides |
+|---|---|---|
+| rehydrate / idempotency | **#686** | durable resume: seed loop state from wave-status; idempotent worktree setup + 3-point cleanup |
+| real gate signals | **#687** | the four trust signals via sdlc-server, the plan/worker/reconcile MCP tool calls, and promotion |
+| wave-status persistence | **#688** | the durable resume substrate: per-iteration loop blob + per-issue MR/close + terminal disposition |
+
+---
+
+## #686 — resumability / rehydrate / idempotency
+
+The script cannot call MCP/CLI directly (§3.3), so a cheap rehydrate **agent** reads
+wave-status and returns the loop blob; worktree setup/cleanup are idempotent file ops.
+
+### `rehydrate() → REHYDRATE`
+
+```js
+// REHYDRATE schema (in per-wave-workflow.js):
+{
+  merged:      number[],                       // issues already on kahuna (skip them)
+  pending:     number[],                       // issues still to do
+  reworkCount: { [issueNum: string]: number }, // optional; per-issue rework tally
+  idleRounds:  number,                         // optional; thrash counter to restore
+  groupsRun:   number,                         // optional; group count to seed the MAX_GROUPS bound
+}
+```
+
+- **Cold start (no prior state):** `{ merged: [], pending: [...ALL_ISSUES] }` — the stub's behavior.
+- **Real impl:** an `agent()` that reads `.claude/status/` (durable, NOT `/tmp`) for this
+  `WAVE_ID` and returns the persisted loop blob. The loop seeds `pending`/`merged`/
+  `reworkCount`/`idleRounds` and the `groupsRunBase` bound from it. **Idempotency is the
+  crux** (§3.3): on resume the loop must skip finished work — which it does as long as
+  `rehydrate()` reports the already-merged set accurately.
+
+### `setupWorktrees(group: number[]) → { [issueNum]: worktreePath }`
+
+- Awaited as a **single step before `parallel()`** — workers are *handed* a path, never
+  asked to create one (race-safety is structural, §4.2).
+- **Idempotent:** reuse an existing branch on resume (`git worktree add <path> <branch>`),
+  **never `-b`** (which fails if the branch exists). First, sweep prior wave-ids' worktree
+  dirs + `git worktree prune` (crash recovery, §4.3).
+- Returns the issue→path map the worker prompt is handed. Paths live under
+  `<targetRepoDir>/.claude/.worktrees/wave-<id>/issue-<n>` (durable, gitignored).
+- Branch name `wave-<id>/issue-<n>` **shares the `wave-<id>/` stem with the dir** so a
+  single glob (`git branch -D wave-<id>/*`) cleans both.
+
+### `cleanupMerged(issues: number[]) → void` and `cleanupTerminal() → void`
+
+3-point cleanup (§4.3), clean at **both ends**:
+- `cleanupMerged` — per just-merged issue: `worktree remove --force` → `worktree prune` →
+  `rm -rf` → `git branch -D wave-<id>/issue-<n>`. Keeps peak disk ≈ current group.
+- `cleanupTerminal` — wave-terminal: remove remaining `wave-<id>` worktrees + prune +
+  `git branch -D wave-<id>/*`.
+- Removal order is defensive + idempotent. **Prune branches, not just worktrees**
+  (`worktree remove` leaves the branch behind).
+
+> The worker's `status: "already-present"` return is the worker-side half of #686
+> idempotency: a worker whose branch already carries the implementation returns
+> `already-present` and does no work, so a killed run resumes exactly where it died.
+> The reconcile's "if a branch is already in kahuna, SKIP it" is the reconcile-side half.
+
+---
+
+## #687 — real gate signals via sdlc-server (+ plan/worker/reconcile MCP + promote)
+
+The `agent()` **prompts** for plan / worker / reconcile / the four gate signals are
+**real and shipped** (not seams). The seam is the **sdlc-server tool calls those agents
+make** — currently `// TODO(#687 gate wiring)` lines inside the prompts, plus the
+`gateSignalStub()` fallback and the promotion stub.
+
+### The four trust signals (§3.4) — each returns `SIG`
+
+```js
+// SIG schema:
+{ signal: string, passed: boolean, detail?: string }
+```
+
+Run **in parallel** (single `parallel([...])` block — already wired). Each is an
+`agent()` whose prompt names the real sdlc-server call; #687 makes the call real:
+
+| Signal | `agentType` | Real sdlc-server call | pass = |
+|---|---|---|---|
+| commutativity | `general-purpose` | `commutativity_verify(base_ref=<protected>, changesets=[{id:"kahuna", head_ref:<kahuna>}])` | verdict ∈ {STRONG, MEDIUM}; `PROBE_UNAVAILABLE` = **conservative-fail** |
+| ci | `general-purpose` | `ci_wait_run` on the **kahuna→protected MR merge-result pipeline** (NOT merge-commit branch HEAD) [sdlc #452] | `final_status == "success"` |
+| review | `feature-dev:code-reviewer` (`isolation:'worktree'` on kahuna [#667]) | code-reviewer over the **kahuna-vs-protected diff**, diff-scoped (§3.4) | no critical/important findings |
+| trivy | `general-purpose` | `trivy fs --scanners vuln --severity HIGH,CRITICAL` on kahuna | no HIGH/CRITICAL with available fixes |
+
+- The gate is a **unanimous** gate: `failed.length === 0` ⇒ PASS, else HOLD.
+- Static analysis must be **diff-scoped (kahuna-vs-main), never tree-scoped** (§3.4) — or
+  pre-existing baseline debt spuriously HOLDs an otherwise-clean wave. Lint/typecheck are
+  **not** a fifth signal; they ride inside the CI signal.
+
+### plan / worker / reconcile MCP calls
+
+Inside the (real) prompts, replace the `// TODO(#687 gate wiring)` lines with real calls:
+- **plan:** `spec_get`, `work_item`, `flight_overlap`, `flight_partition`. Returns `NEXTGROUP`.
+- **worker:** `spec_get`, `spec_acceptance_criteria`. Implements + commits in the handed
+  worktree. Returns `WORK` (incl. the §3.2 `concerns`/`deferrals` fields). Inherits the
+  sdlc-server MCP + deterministic hooks; preload skills via the agent's `skills:`.
+- **reconcile:** `commutativity_verify`, `pr_create`/`pr_merge` to kahuna. Returns `RECONCILE`
+  (`merged`, `needs_rework:[{issue,reason}]`, `conflicts_resolved`, `concerns`). Persistence
+  folds in here (see #688).
+
+### Promotion (the success-exit terminal step)
+
+The `MODE === 'auto'` PASS branch currently logs a `[SEAM #687] promote stub`. #687 makes
+it real: `wave_finalize` opens the kahuna→protected MR, `pr_merge(skip_train:true)` on
+all-green, delete the kahuna branch, record disposition. `interactive` mode never
+promotes — it returns the verdict (the return IS the human gate, §5).
+
+---
+
+## #688 — wave-status persistence (the durable resume substrate)
+
+Persistence is **folded into the reconcile node** (it already writes wave-status, §3.3).
+Three call sites in the script, all currently log-only stubs:
+
+### `persistIteration(state) → void` — called every loop iteration
+
+```js
+// state shape passed in:
+{ merged: Set<number>, pending: Set<number>,
+  reworkCount: { [issue]: number }, idleRounds: number, groupsRun: number }
+```
+
+- **Per merged issue:** `wave_record_mr(issue_number, mr_ref)` + `wave_close_issue(issue)`.
+- **Then write the loop blob** durably to `.claude/status/` (the exact blob `rehydrate()`
+  reads back — same shape as `REHYDRATE`). This is what makes a killed run resumable.
+
+### `persistTerminal(disposition, detail) → void` — at promote/hold
+
+- `disposition ∈ {"promoted", "held"}`. Record the wave's terminal disposition + `detail`
+  into wave-status's wave-completion record, so the **campaign driver's** rehydrate (§5,
+  `/wavemachine-next`) can prune a promoted wave on cold start.
+
+> **Durable state must NOT live in `/tmp`** (`lesson_tmp_identity_boot_wipe`). The
+> `/tmp/wavemachine/` bus is fine for within-run comms; resume state belongs in
+> `.claude/status/`.
+
+---
+
+## Invariants the seams must not break
+
+These hold for the skeleton today and must keep holding after every seam is filled —
+they are what make the loop deterministic and resumable:
+
+1. **The loop reads only the return shapes above** — never how they were produced. A seam
+   fill changes the body, never the signature.
+2. **Workers are handed a worktree path; they never create one.** Setup is a single
+   awaited step before `parallel()`.
+3. **`rehydrate()`'s `merged` set is authoritative for skip-on-resume.** If it is accurate,
+   the loop resumes correctly; idempotent workers/reconcile make re-runs safe even if not.
+4. **The trust gate runs ONLY on the success exit** (`!halt && pending.size === 0`). Any
+   HOLD reason (incl. per-issue breaker) skips it — that is by construction, not a seam.
+5. **Persistence is idempotent** — re-running `persistIteration` / `persistTerminal` with
+   the same state is a no-op-or-overwrite, never a duplicate-side-effect.
+6. **The `#687` gate stubs are the ONLY always-pass placeholders.** Once #687 lands, real
+   signals replace them; until then a skeleton run reaches PASS so the full spine is
+   exercisable end-to-end.

--- a/skills/nextwave-next/SKILL.md
+++ b/skills/nextwave-next/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: nextwave-next
+description: Execute one wave via the per-wave Workflow — the §3 spine (rehydrate → dynamic flight loop → trust gate → promote) as a deterministic JS Workflow, not an LLM orchestrator
+---
+
+# NextWave-Next — Execute One Wave via the per-wave Workflow
+
+> **Migration successor to `/nextwave`.** This is the Dynamic-Workflows shape of the
+> per-wave primitive: the orchestrator's deterministic control flow is moved into a
+> JS Workflow script (`per-wave-workflow.js`), and the LLM is called only for the
+> steps that genuinely need judgment (plan / implement / reconcile / review). The old
+> `/nextwave` (Orchestrator/Prime/Flight on a filesystem bus) is unchanged and stays in
+> place during migration. Design of record: `docs/wavemachine-workflows-migration.md`.
+
+## Axioms
+
+Bound by WAVE_AXIOMS 2, 3, 4, 5, 6, 8, 9 (`WAVE_AXIOMS.md` at the repo root). The
+closed-list legal-exits enumeration, the Concerns Channel pressure valve, the
+cost-asymmetry default-forward stance, the approval-frequency rule, and the
+user-attention-as-cost framing live in that file. In this successor those axioms are
+no longer prose the orchestrator must remember — they are **loop guards in the
+Workflow script it cannot forget or override** (`per-wave-workflow.js`, §3.1). When
+justification prose seems missing, it is in `WAVE_AXIOMS.md` by design.
+
+## What this is
+
+`/nextwave-next` runs **one** Workflow — `per-wave-workflow.js` — for a single wave.
+That script IS the §3 spine:
+
+```
+rehydrate (durable resume)
+   → flight loop  [ serial groups; parallel issues; dynamic re-plan; CLOSED legal exits ]
+       per group:  plan(Prime) → parallel issue-workers → merge+reconcile(Prime)
+   → trust gate   [ 4 signals in parallel → one more legal exit ]
+   → promote (kahuna→protected)  OR  hold-for-review
+```
+
+Every halt is a coded condition; every judgment is an `agent()`; nothing can stall the
+campaign on a question it did not need to ask. The skill's job is thin: resolve the
+wave's inputs, launch the Workflow, and surface its verdict.
+
+## Why a Workflow, not an LLM orchestrator
+
+We ran the wave Orchestrator as an LLM doing deterministic control flow — a reasoner
+forced to act as a state machine — and patched every recurring stall inside that frame
+(WAVE_AXIOMS, the Concerns Channel, the Stop-hook `decision:block`, #78/#79/#90). The
+guard-count was the tell: when you keep adding rules to make a tool behave against its
+nature, question the tool (`lesson_cage_bars_signal_wrong_tool`). A Workflow relocates
+the control flow into deterministic JS and calls the LLM only inside bounded sub-tasks
+(a flight implements; a reconcile resolves a conflict), where a "distracted" agent can
+only fail *its own task*, never halt the wave. See migration doc §1.
+
+## Inputs (the Workflow's `input` blob)
+
+Supplied by the caller (`/wavemachine-next` per wave, or a human launching one wave):
+
+| Field | Meaning |
+|---|---|
+| `waveId` | the wave id (e.g. `W-3`) |
+| `issues` | the wave's issue numbers (one repo — single-repo-per-wave axiom, §4.1) |
+| `targetRepo` | `owner/repo` for `gh -R` scoping |
+| `targetRepoDir` | the clone the durable worktrees attach to (§4.2) |
+| `kahunaBranch` | the integration target; every flight PR targets this, never the protected branch |
+| `protectedBranch` | the promotion target on the success exit |
+| `mode` | `auto` (verdict drives promotion) \| `interactive` (verdict returned; human routes) |
+| `budget` | optional `{ total, remaining() }` cost guard (the `cost` legal exit) |
+
+The closed numeric guards (`maxGroups`, `maxRework`, `maxIdle`, `costFloor`) have
+safe defaults in the script and rarely need overriding.
+
+## Procedure
+
+1. **Resolve wave inputs.** Read the next pending wave for this Plan (`wave_next_pending`),
+   its issue list, the `kahuna_branch` (always populated — `/wavemachine-next` bootstraps it
+   at Plan launch), the target repo + clone dir, and the protected branch (from
+   `.claude-project.md`). Refuse if `kahuna_branch` is unset — wave state was not
+   bootstrapped through the campaign launch sequence.
+2. **Validate specs.** Confirm every wave issue is structurally buildable
+   (`spec_validate_structure`). Any INVALID → report and exit (not an error — a Legal Exit).
+3. **Launch the Workflow.** Run `per-wave-workflow.js` with the `input` blob above. The
+   script owns everything from here: rehydrate → flight loop → trust gate → promote.
+4. **Consume the verdict.** The Workflow's return is the per-wave gate (§5): a Workflow
+   cannot pause mid-run for human input, so its *ending with a verdict* IS the gate.
+   The return carries `gate` ∈ `PASS | HOLD | SKIPPED` plus `concerns`/`deferrals`
+   (informational — surfaced and continued, never halted-on).
+   - `auto` mode: `PASS` ⇒ the Workflow already promoted (its terminal step). Report it.
+   - `interactive` mode: surface the verdict + the kahuna→protected diff and STOP for
+     the human; the human routes promotion. (`/wavemachine-next` owns this branch in a campaign.)
+5. **Report.** Surface a human-readable summary: groups run, issues merged, any HOLD
+   reason, collected concerns/deferrals. Post wave status to `#wave-status` if running
+   under a campaign.
+
+## What is REAL vs SEAM in the Workflow
+
+`per-wave-workflow.js` is the **anchor**: the loop / exits / re-plan / gate fan-out are
+real and complete (the validated pilot shape, hardened). The sdlc-server tool calls the
+agents make are **seams**, marked with `// TODO(#…)` and backed by obvious-placeholder
+stubs so the skeleton runs end-to-end. The seam contracts live in
+`skills/nextwave-next/SEAMS.md`:
+
+- **#686** — rehydrate / idempotency (durable resume, worktree setup/cleanup)
+- **#687** — real gate signals via sdlc-server (commutativity / CI / review / trivy + promote)
+- **#688** — wave-status persistence (the durable resume substrate)
+
+## Must-preserve behaviors (§3.2)
+
+All three live *inside* the Workflow and **none can halt the wave**:
+
+1. **Surface a concern + keep going** — a `concerns[]` field on the worker/reconcile
+   return; the script collects it (informational) and does NOT branch on it. "Keep
+   going" is the default.
+2. **Decide to defer a fix** — the agent decides; returns `deferrals:[{issue,reason,risk}]`;
+   the script records and proceeds.
+3. **Creatively fix mid-wave without asking** — intra-flight fixes inside the worker's
+   worktree; cross-flight fixes in the reconcile agent (the only multi-branch view);
+   surfaced dependencies re-open via the re-plan loop. `commutativity_verify` is the detector.
+
+## Exhaustive Legal Exits
+
+Per WAVE_AXIOMS Axiom 3 the legal-exits list is closed — and here it is **mechanically
+closed**: the only ways the per-wave Workflow stops are the script's coded exits
+(`per-wave-workflow.js` §3.1 loop + §3.4 gate). They are:
+
+| Exit | Condition | Meaning |
+|---|---|---|
+| success | `pending` empty | all issues merged to kahuna → trust gate runs |
+| runaway | `groupsRun ≥ MAX_GROUPS` | too many groups → human review |
+| thrash | `idleRounds ≥ MAX_IDLE` | groups with zero net merges → not converging |
+| cost | `budget` floor | stop before the ceiling |
+| impasse | planner `done` with pending left | planner can't schedule remaining → human |
+| per-issue breaker | issue reworked > `MAX_REWORK` | one issue keeps breaking → human |
+| gate HOLD | a trust signal failed | post-success gate fired → human review |
+
+Unease that matches none of these is NOT an exit: it rides the `concerns[]` channel
+(Axiom 4) and the loop continues. The dynamic-flight insight: a dependency that surfaces
+mid-wave (reported by reconcile as `needs_rework`) re-opens the issue and becomes the
+next group — **no human halt**. That is the failure class the LLM-orchestrator kept
+stalling on (#78/#79/#90), now expressed as bounded control flow.
+
+## Non-Negotiables
+
+- EXECUTION primitive — NO design decisions. Workers are SPEC EXECUTORS.
+- **NEVER merge directly to the protected branch.** Flight PRs target the kahuna branch;
+  the kahuna→protected merge is the only path to the protected branch and is gated by
+  the four-signal trust gate (§3.4).
+- **Single-repo per wave** (§4.1) — a wave resolves to exactly one `target_repo`.
+- **Durable worktrees, not `/tmp`** (§4.2, `lesson_tmp_identity_boot_wipe`): the wave's
+  worktrees live under `<target>/.claude/.worktrees/wave-<id>/`. Idempotent re-attach on
+  resume (reuse the branch, never `-b`); 3-point cleanup; prune branches not just worktrees.
+- Deterministic hooks (pre-push test gate, secret gate) fire inside each worker — the
+  Workflow orchestrates, it does not enforce.
+- One wave per invocation. `/wavemachine-next` drives the campaign loop over waves.
+
+## Pair
+
+- `/prepwaves` — plans the waves.
+- **`/nextwave-next` — executes one wave via `per-wave-workflow.js`. This skill.**
+- `/wavemachine-next` — drives the campaign loop, one per-wave Workflow per pending wave.
+- `/dod` — verifies the project at Plan end.
+
+Successor pairing mirrors the legacy `/prepwaves` → `/nextwave` → `/wavemachine` chain;
+`-next` skills are the Dynamic-Workflows variants and do not modify the originals.

--- a/skills/nextwave-next/per-wave-workflow.js
+++ b/skills/nextwave-next/per-wave-workflow.js
@@ -53,6 +53,7 @@ const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // promotion target on
 const ALL_ISSUES = (params.issues ?? []).map(Number) // the wave's issue numbers
 const MODE = params.mode ?? 'auto' // 'auto' (gate verdict drives promotion) | 'interactive' (verdict returned, human routes)
 const budget = params.budget ?? { total: 0, remaining: () => Infinity } // optional cost guard
+const budgetRemaining = typeof budget.remaining === 'function' ? budget.remaining : () => (budget.remaining ?? Infinity) // tolerate `remaining` passed as a number, not a fn
 
 // Closed numeric guards (§3.1) — the whole safety story is these + the exit set.
 const MAX_GROUPS = params.maxGroups ?? 24
@@ -317,11 +318,11 @@ phase('Flight loop')
 // state (script-held, free); mirrored durably to wave-status each iteration (§3.3)
 const pending = new Set(seed.pending)
 const merged = new Set(seed.merged)
-const reworkCount = { ...(seed.reworkCount || {}) }
+const reworkCount = Object.fromEntries(Object.entries(seed.reworkCount || {}).map(([k, v]) => [Number(k), v])) // numeric keys (JSON resume returns them as strings)
 let lastRework = []
 let idleRounds = seed.idleRounds || 0
 const groupsRun = [] // running record; length seeds from seed.groupsRun for the bound
-let groupsRunBase = seed.groupsRun || 0
+let groupsRunBase = Math.max(0, Number(seed.groupsRun) || 0) // rehydration-proof: corrupt/missing/negative seed → 0, so the runaway guard always fires
 let halt = null // null = still converging; else a HOLD reason (NEVER a success)
 
 // Collected §3.2 must-preserve data — recorded, never branched-on.
@@ -333,7 +334,7 @@ while (true) {
   if (pending.size === 0) break // success (halt stays null)
   if (groupsRunBase + groupsRun.length >= MAX_GROUPS) { halt = 'runaway'; break } // → human review
   if (idleRounds >= MAX_IDLE) { halt = 'thrash'; break } // groups with zero net merges → not converging
-  if (budget.total && budget.remaining() < COST_FLOOR) { halt = 'cost'; break } // stop before the ceiling
+  if (budget.total && budgetRemaining() < COST_FLOOR) { halt = 'cost'; break } // stop before the ceiling
 
   // ── PLAN next group from CURRENT state (Prime; judgment) ──
   const plan = await agent(primePlanPrompt(merged, pending, lastRework), {
@@ -388,14 +389,15 @@ while (true) {
 
   lastRework = []
   for (const r of rec.needs_rework || []) {
-    if ((reworkCount[r.issue] = (reworkCount[r.issue] || 0) + 1) > MAX_REWORK) {
-      halt = `rework:#${r.issue}` // per-issue breaker → HOLD, NOT success
+    const ri = Number(r.issue) // normalize: pending/merged/reworkCount are numeric-keyed (string keys leak in via JSON resume)
+    if ((reworkCount[ri] = (reworkCount[ri] || 0) + 1) > MAX_REWORK) {
+      halt = `rework:#${ri}` // per-issue breaker → HOLD, NOT success
       break
     }
-    pending.add(r.issue) // surfaced dep → re-opened → next group
-    merged.delete(r.issue)
+    pending.add(ri) // surfaced dep → re-opened → next group
+    merged.delete(ri)
     lastRework.push(r)
-    log(`Surfaced dependency: #${r.issue} re-opened (rework #${reworkCount[r.issue]}) — ${r.reason}`)
+    log(`Surfaced dependency: #${ri} re-opened (rework #${reworkCount[ri]}) — ${r.reason}`)
   }
 
   groupsRun.push({ group, merged: newlyMerged, needs_rework: rec.needs_rework || [], suite: rec.suite_summary })
@@ -425,6 +427,8 @@ if (!halt && pending.size === 0) {
         `Return signal="commutativity", passed (bool), detail.`,
       ].join('\n'),
       { label: 'gate:commutativity', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
+      // TODO(#687): each gate signal's .catch falls back to an always-PASS stub (skeleton only). When the
+      // real signals land, drop these fallbacks so an agent error HOLDs (conservative-fail), never PASSes.
     ).catch(() => gateSignalStub('commutativity')),
     // 2. CI on the MR merge-result pipeline — NOT the merge-commit branch HEAD (sdlc #452)
     () => agent(

--- a/skills/nextwave-next/per-wave-workflow.js
+++ b/skills/nextwave-next/per-wave-workflow.js
@@ -1,0 +1,521 @@
+// per-wave-workflow.js — the production per-wave Workflow (§3 spine).
+//
+// Design of record: docs/wavemachine-workflows-migration.md
+//   §3   the spine: rehydrate → flight loop → trust gate → promote
+//   §3.1 the dynamic flight loop (closed legal exits + hard progress guarantee + halt sentinel + dynamic re-plan)
+//   §3.2 must-preserve behaviors (surface-concern, defer-a-fix, intra/cross-flight fixes — recorded, never branch-to-halt)
+//   §3.3 resumability (rehydrate from wave-status; idempotent workers/reconcile)
+//   §3.4 trust gate (4 parallel signals, ff-or-hold)
+//   §4   cross-repo (single-repo-per-wave; durable worktrees; 3-point cleanup)
+//
+// WHAT IS REAL HERE (the validated part — harden, do not reinvent):
+//   - the closed-legal-exit while-loop, the halt sentinel, the deterministic
+//     progress accounting, and the dynamic re-plan (a surfaced dependency
+//     re-opens an issue and becomes the next group). This mirrors the two
+//     validated pilots verbatim in control-flow shape:
+//       wave-pilot-iter3-spine-wf  (flight → reconcile → gate)
+//       wave-pilot-iter3b-replan-wf (the §3.1 dynamic re-plan loop)
+//   - the trust gate's 4-signal parallel fan-out + ff-or-hold verdict.
+//
+// WHAT IS A SEAM (stubbed, filled by a wave-2 foundational issue):
+//   - rehydrate / idempotency               → TODO(#686 resumability/rehydrate)
+//   - real gate signals via sdlc-server      → TODO(#687 gate wiring)
+//   - wave-status persistence (durable state) → TODO(#688 wave-status persistence)
+//   See SEAMS.md (this dir) for the exact function/return signatures each seam expects.
+//
+// The agent() prompts below are REAL (worker / Prime-plan / Prime-reconcile /
+// signal). The sdlc-server MCP TOOL CALLS those agents make are the seam — the
+// stubs return obvious placeholders so the loop runs end-to-end in skeleton form.
+
+export const meta = {
+  name: 'per-wave-workflow',
+  description:
+    'Production per-wave Workflow (§3 spine): rehydrate → dynamic flight loop (closed legal exits + dynamic re-plan) → trust gate → promote kahuna or hold-for-review. Parameterized by wave issue list, kahuna branch, target repo.',
+  phases: [
+    { title: 'Rehydrate', detail: 'durable resume — seed loop state from wave-status (§3.3)' },
+    { title: 'Flight loop', detail: 'serial groups, parallel issues, dynamic re-plan, CLOSED legal exits (§3.1)' },
+    { title: 'Trust gate', detail: '4 signals in parallel → ff-or-hold (success exit only) (§3.4)' },
+    { title: 'Promote', detail: 'kahuna→protected-branch on PASS, else hold-for-review' },
+  ],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PARAMETERS — a per-wave Workflow is launched per wave with this input blob.
+// The campaign driver (skills/wavemachine-next) supplies it from the approved
+// phase/wave plan. Defaults make the script self-describing when run bare.
+// ─────────────────────────────────────────────────────────────────────────────
+const params = (typeof input !== 'undefined' && input) || {}
+const WAVE_ID = params.waveId ?? 'W-?'
+const TARGET_REPO = params.targetRepo ?? 'Wave-Engineering/ccwork-testtarget' // owner/repo for gh -R scoping
+const TARGET_REPO_DIR = params.targetRepoDir ?? '/home/bakerb/sandbox/github/ccwork-testtarget' // clone the worktrees attach to
+const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // integration target; never the protected branch
+const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // promotion target on the success exit
+const ALL_ISSUES = (params.issues ?? []).map(Number) // the wave's issue numbers
+const MODE = params.mode ?? 'auto' // 'auto' (gate verdict drives promotion) | 'interactive' (verdict returned, human routes)
+const budget = params.budget ?? { total: 0, remaining: () => Infinity } // optional cost guard
+
+// Closed numeric guards (§3.1) — the whole safety story is these + the exit set.
+const MAX_GROUPS = params.maxGroups ?? 24
+const MAX_REWORK = params.maxRework ?? 3
+const MAX_IDLE = params.maxIdle ?? 2
+const COST_FLOOR = params.costFloor ?? 80_000
+
+// Durable worktree root (§4.2) — NOT /tmp (reboot-wiped, resume-hostile). Gitignored, hyphenated stem shared by dir+branch.
+const WT_ROOT = `${TARGET_REPO_DIR}/.claude/.worktrees/wave-${WAVE_ID}`
+const wtPath = (n) => `${WT_ROOT}/issue-${n}`
+const issueBranch = (n) => `wave-${WAVE_ID}/issue-${n}` // shares the wave-<id>/ stem so `git branch -D wave-<id>/*` cleans both
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STRUCTURED-RETURN SCHEMAS (real — these are the agent contracts)
+// ─────────────────────────────────────────────────────────────────────────────
+const REHYDRATE = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['merged', 'pending'],
+  properties: {
+    merged: { type: 'array', items: { type: 'integer' } },
+    pending: { type: 'array', items: { type: 'integer' } },
+    reworkCount: { type: 'object', additionalProperties: { type: 'integer' } },
+    idleRounds: { type: 'integer' },
+    groupsRun: { type: 'integer' },
+  },
+}
+const NEXTGROUP = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['done', 'group'],
+  properties: {
+    done: { type: 'boolean' }, // planner can schedule nothing more from current state
+    group: { type: 'array', items: { type: 'integer' } }, // the next flight-group (parallel issues)
+    rationale: { type: 'string' },
+  },
+}
+const WORK = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['issue', 'status'],
+  properties: {
+    issue: { type: 'integer' },
+    status: { type: 'string', enum: ['implemented', 'blocked', 'already-present'] }, // already-present = idempotent resume hit (§3.3)
+    branch: { type: 'string' },
+    worktree: { type: 'string' },
+    files_changed: { type: 'array', items: { type: 'string' } },
+    // §3.2 must-preserve: structured fields the SCRIPT RECORDS but does NOT branch-to-halt on.
+    concerns: { type: 'array', items: { type: 'string' } }, // surface-a-concern-and-continue
+    deferrals: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['issue', 'reason'],
+        properties: { issue: { type: 'integer' }, reason: { type: 'string' }, risk: { type: 'string' } },
+      },
+    },
+    notes: { type: 'string' },
+  },
+}
+const RECONCILE = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['merged', 'needs_rework'],
+  properties: {
+    merged: { type: 'array', items: { type: 'integer' } }, // issues now on kahuna this round
+    needs_rework: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['issue', 'reason'],
+        properties: { issue: { type: 'integer' }, reason: { type: 'string' } }, // surfaced dep / interface break
+      },
+    },
+    conflicts_resolved: { type: 'array', items: { type: 'string' } }, // cross-flight fixes done here (§3.2.3)
+    concerns: { type: 'array', items: { type: 'string' } },
+    suite_summary: { type: 'string' },
+    notes: { type: 'string' },
+  },
+}
+const SIG = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['signal', 'passed'],
+  properties: { signal: { type: 'string' }, passed: { type: 'boolean' }, detail: { type: 'string' } },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SEAM STUBS — return obvious placeholders. The foundational wave-2 issues
+// replace each body with the real sdlc-server-backed implementation. The exact
+// function names + return shapes here ARE the interface contract (see SEAMS.md).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// SEAM #686 — durable resume. The script can't call MCP/CLI directly (§3.3), so a
+// cheap rehydrate agent reads wave-status and returns the loop blob. Stub: cold start.
+async function rehydrate() {
+  // TODO(#686 resumability/rehydrate): replace with an agent() that reads wave-status
+  // (.claude/status/, durable) for this wave and returns {merged, pending, reworkCount,
+  // idleRounds, groupsRun}. Must skip already-finished work on a cold restart.
+  // Real shape:
+  //   return agent(rehydratePrompt(WAVE_ID, ALL_ISSUES, TARGET_REPO),
+  //     { label: 'rehydrate', phase: 'Rehydrate', schema: REHYDRATE, agentType: 'general-purpose' })
+  log(`[SEAM #686] rehydrate stub → cold start (no prior wave-status state assumed)`)
+  return { merged: [], pending: [...ALL_ISSUES], reworkCount: {}, idleRounds: 0, groupsRun: 0 }
+}
+
+// SEAM #688 — persistence. Folded into Prime(post-flight) in the real design (it
+// already writes wave-status): record each merged issue's MR + close it, then the
+// loop blob. Stub: log only.
+async function persistIteration(state) {
+  // TODO(#688 wave-status persistence): replace with the wave-status mirror —
+  // per merged issue: wave_record_mr + wave_close_issue; then write the loop blob
+  // {merged, pending, reworkCount, idleRounds, groupsRun} durably to .claude/status/.
+  // Called every iteration so a killed run resumes exactly where it died (§3.3).
+  log(`[SEAM #688] persist stub — merged=${[...state.merged].join(',') || 'none'} pending=${[...state.pending].join(',') || 'none'} idle=${state.idleRounds}`)
+}
+
+// SEAM #688 — terminal persistence (promote OR hold disposition recorded durably).
+async function persistTerminal(disposition, detail) {
+  // TODO(#688 wave-status persistence): record the wave's terminal disposition
+  // (promoted | held) + detail into wave-status's wave-completion record, so the
+  // campaign driver's rehydrate (§5) can prune a promoted wave on cold start.
+  log(`[SEAM #688] persist terminal stub — wave ${WAVE_ID} ${disposition}: ${detail}`)
+}
+
+// SEAM #687 — real gate signals. Stub returns a passing placeholder so the gate
+// fan-out runs end-to-end. The REAL signal is the agent() prompt shown inline in
+// the trust gate below; this helper is only the stubbed return for skeleton runs.
+function gateSignalStub(name) {
+  // TODO(#687 gate wiring): delete this stub. The trust gate below shows the real
+  // agent() calls (commutativity_verify / ci_wait_run on the MR merge-result
+  // pipeline [sdlc #452] / code-reviewer on a kahuna worktree [#667] / trivy).
+  return { signal: name, passed: true, detail: `[SEAM #687] ${name} stub — always-pass placeholder` }
+}
+
+// Worktree setup is awaited as a SINGLE step before parallel() — workers are HANDED
+// a path, never asked to create one (race-safety is structural, §4.2). Idempotent:
+// reuse an existing branch on resume, never -b (§4.2). Stubbed as a seam of #686 idempotency.
+async function setupWorktrees(group) {
+  // TODO(#686 resumability/rehydrate): real idempotent worktree creation —
+  //   sweep prior wave-ids' dirs + `git worktree prune` (crash recovery, §4.3),
+  //   then per issue: if branch exists `git worktree add <path> <branch>` (reuse),
+  //   else `git worktree add <path> -b <branch> origin/<KAHUNA_BRANCH>`.
+  // Returns a map issue→path the worker prompt is handed.
+  const map = {}
+  for (const n of group) map[n] = wtPath(n)
+  log(`[SEAM #686] worktree setup stub — group [${group.join(', ')}] → ${WT_ROOT}/issue-<n>`)
+  return map
+}
+
+// 3-point cleanup (§4.3): per-merge removal keeps peak disk ≈ current group.
+// Prune branches too (shared wave-<id>/ stem → single glob cleans both).
+async function cleanupMerged(issues) {
+  // TODO(#686 resumability/rehydrate): real per-merge cleanup —
+  //   git -C <repo> worktree remove --force <path>; git worktree prune; rm -rf <path>;
+  //   git -C <repo> branch -D wave-<id>/issue-<n>
+  if (issues.length) log(`[SEAM #686] cleanup stub — removed worktrees+branches for [${issues.join(', ')}]`)
+}
+async function cleanupTerminal() {
+  // TODO(#686 resumability/rehydrate): wave-terminal sweep — remove remaining
+  //   wave-<id> worktrees + `git worktree prune` + `git branch -D wave-<id>/*`.
+  log(`[SEAM #686] terminal cleanup stub — swept remaining wave-${WAVE_ID} worktrees+branches`)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// REAL agent() PROMPTS (the judgment nodes — these are not seams).
+// The sdlc-server tool calls inside them are seams; the prompt shape is real.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Prime(plan): sees CURRENT state (merged/pending/lastRework). A dependency that
+// surfaced mid-wave (in lastRework) becomes THIS group. Uses flight_partition/flight_overlap.
+function primePlanPrompt(merged, pending, lastRework) {
+  return [
+    `You are the wave PRIME planner for wave ${WAVE_ID} of ${TARGET_REPO}. Plan the NEXT flight-group from`,
+    `CURRENT state — independent issues run in parallel within a group; dependency-ordered across groups.`,
+    `  merged so far: [${[...merged].join(', ') || 'none'}]`,
+    `  pending:       [${[...pending].join(', ') || 'none'}]`,
+    `  just re-opened (surfaced deps to schedule FIRST): ${JSON.stringify(lastRework)}`,
+    ``,
+    `For each pending issue fetch its spec (sdlc-server spec_get / work_item) and file manifest, then run`,
+    `flight_overlap + flight_partition to pick a maximal NON-CONFLICTING parallel group. A surfaced dependency`,
+    `from "just re-opened" goes in THIS group (re-run against the now-merged provider). When in doubt, sequence.`,
+    `// TODO(#687 gate wiring): real spec_get / flight_partition / flight_overlap sdlc-server calls.`,
+    ``,
+    `Return: done (true ONLY if nothing schedulable remains — that is an IMPASSE, not success),`,
+    `group (issue numbers for the next parallel flight-group), rationale (1-2 sentences).`,
+  ].join('\n')
+}
+
+// Worker: per-issue, worktree-isolated. SPEC EXECUTOR. Idempotent on resume.
+// Carries the §3.2 must-preserve fields (concerns/deferrals) as STRUCTURED RETURN.
+function workerPrompt(n, worktree) {
+  const branch = issueBranch(n)
+  return [
+    `You are a FLIGHT worker for issue #${n} of ${TARGET_REPO}, wave ${WAVE_ID}.`,
+    `Working directory: ${worktree} (handed to you — do NOT create your own worktree). Branch: ${branch}`,
+    `(already checked out, based on origin/${KAHUNA_BRANCH}). Your PR targets ${KAHUNA_BRANCH}, NEVER ${PROTECTED_BRANCH}.`,
+    ``,
+    `IDEMPOTENT RESUME (§3.3): FIRST check if your branch already contains this implementation (e.g. the spec's`,
+    `target files exist + the acceptance test passes). If so, return status="already-present" and do NOT redo work.`,
+    ``,
+    `Otherwise — SPEC EXECUTOR rules:`,
+    `1. Fetch the spec + acceptance criteria (sdlc-server spec_get / spec_acceptance_criteria for #${n}).`,
+    `   // TODO(#687 gate wiring): real spec_get / spec_acceptance_criteria + work_item sdlc-server calls.`,
+    `2. Implement EXACTLY what the issue specifies. Where the story has a canonical acceptance test, run it as an`,
+    `   ORACLE (self-authored tests are necessary but not sufficient — §9 verification ladder).`,
+    `3. Run the project gate in your worktree (./scripts/ci/validate.sh + the test suite). The pre-push test gate`,
+    `   + secret gate are deterministic HOOKS — they fire regardless; do not bypass.`,
+    `4. Commit in your worktree (do NOT push — Prime(reconcile) handles merge): use a wave-pattern commit message.`,
+    `   You MAY make intra-flight fixes freely inside your worktree without asking (§3.2.3).`,
+    ``,
+    `§3.2 must-preserve — return these as DATA (the script records, it does NOT halt on them):`,
+    `  concerns:  things that feel off but are not blockers — "surface a concern and keep going" is the DEFAULT.`,
+    `  deferrals: fixes you DECIDE to defer — {issue, reason, risk}. You decide; the script records and proceeds.`,
+    ``,
+    `Return: issue (${n}), status ("implemented"|"blocked"|"already-present"), branch, worktree, files_changed,`,
+    `concerns (array), deferrals (array), notes (1-2 sentences).`,
+  ].join('\n')
+}
+
+// Prime(reconcile): the ONLY cross-flight view. Merges to kahuna, resolves
+// conflicts + interface breaks (cross-flight fixes, §3.2.3), reports surfaced deps
+// as needs_rework. commutativity_verify is the detector. Folds in persistence (§3.3).
+function primeReconcilePrompt(built, merged) {
+  const list = built.map((w) => `   - issue #${w.issue}: branch ${w.branch} in ${w.worktree} (status ${w.status})`).join('\n')
+  return [
+    `You are the wave PRIME reconcile node for wave ${WAVE_ID} of ${TARGET_REPO} — the ONLY node with the`,
+    `cross-flight view. Integrate this group's flights into ${KAHUNA_BRANCH} and detect interface breaks.`,
+    `Already merged: [${[...merged].join(', ') || 'none'}]. This group's built flights:`,
+    list || '   (none built)',
+    ``,
+    `1. Merge each flight's branch into ${KAHUNA_BRANCH} in dependency order (providers before consumers).`,
+    `   IDEMPOTENT (§3.3): if a branch is already in ${KAHUNA_BRANCH}, SKIP it (do not double-merge).`,
+    `2. Resolve conflicts coherently — combine, do not drop. A shared interface two issues touch is a CROSS-FLIGHT`,
+    `   fix you make HERE (you have the multi-branch view); record it in conflicts_resolved (§3.2.3).`,
+    `3. Run commutativity_verify across the merged set + the FULL suite (the composition / commutativity check).`,
+    `   // TODO(#687 gate wiring): real commutativity_verify + merge (pr_create/pr_merge) sdlc-server calls.`,
+    `4. If a flight's code BREAKS another's interface (signature mismatch surfaced at integration): UNDO just that`,
+    `   flight's merge (keep integration green) and report it in needs_rework with the precise reason — the loop`,
+    `   re-opens it as a surfaced dependency and re-schedules it next group (§3.1 dynamic re-plan).`,
+    `   // TODO(#688 wave-status persistence): per merged issue, wave_record_mr + wave_close_issue, then write the`,
+    `   //   loop blob durably — persistence is folded into THIS node (§3.3).`,
+    ``,
+    `Return: merged (issues now green in ${KAHUNA_BRANCH} this round), needs_rework (list of {issue, reason} you`,
+    `reset), conflicts_resolved (files + 1-line how), concerns (array), suite_summary (final test line), notes.`,
+  ].join('\n')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PHASE 1 — REHYDRATE (§3.3): seed loop state from durable wave-status.
+// ─────────────────────────────────────────────────────────────────────────────
+phase('Rehydrate')
+const seed = await rehydrate() // SEAM #686
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PHASE 2 — THE DYNAMIC FLIGHT LOOP (§3.1) — REAL, complete. The validated part.
+// ─────────────────────────────────────────────────────────────────────────────
+phase('Flight loop')
+
+// state (script-held, free); mirrored durably to wave-status each iteration (§3.3)
+const pending = new Set(seed.pending)
+const merged = new Set(seed.merged)
+const reworkCount = { ...(seed.reworkCount || {}) }
+let lastRework = []
+let idleRounds = seed.idleRounds || 0
+const groupsRun = [] // running record; length seeds from seed.groupsRun for the bound
+let groupsRunBase = seed.groupsRun || 0
+let halt = null // null = still converging; else a HOLD reason (NEVER a success)
+
+// Collected §3.2 must-preserve data — recorded, never branched-on.
+const allConcerns = []
+const allDeferrals = []
+
+while (true) {
+  // ── CLOSED LEGAL EXITS (the whole safety story) ──
+  if (pending.size === 0) break // success (halt stays null)
+  if (groupsRunBase + groupsRun.length >= MAX_GROUPS) { halt = 'runaway'; break } // → human review
+  if (idleRounds >= MAX_IDLE) { halt = 'thrash'; break } // groups with zero net merges → not converging
+  if (budget.total && budget.remaining() < COST_FLOOR) { halt = 'cost'; break } // stop before the ceiling
+
+  // ── PLAN next group from CURRENT state (Prime; judgment) ──
+  const plan = await agent(primePlanPrompt(merged, pending, lastRework), {
+    label: `plan:${groupsRunBase + groupsRun.length + 1}`,
+    phase: 'Flight loop',
+    schema: NEXTGROUP,
+    agentType: 'general-purpose',
+  })
+  if (plan.done || !plan.group || plan.group.length === 0) { halt = 'impasse'; break } // planner can't schedule remaining → human
+
+  const group = plan.group.filter((n) => pending.has(n)) // defensive: only schedule still-pending issues
+  if (group.length === 0) { halt = 'impasse'; break }
+  log(`Group ${groupsRunBase + groupsRun.length + 1}: building [${group.join(', ')}] (merged: [${[...merged].join(', ') || 'none'}])`)
+
+  // ── SETUP: await a single worktree-creation step BEFORE parallel() (race-safe, §4.2) ──
+  const wtMap = await setupWorktrees(group) // SEAM #686 (idempotent)
+
+  // ── RUN group issues in PARALLEL (isolated workers; intra-flight fixes inside) ──
+  const built = (await parallel(group.map((n) => () =>
+    agent(workerPrompt(n, wtMap[n]), {
+      label: `flight:#${n}`,
+      phase: 'Flight loop',
+      schema: WORK,
+      agentType: 'general-purpose',
+      // Cross-repo wave (§4.2): the pre-created target-repo worktree IS the isolation —
+      // do NOT pass isolation:'worktree' (that worktrees the PLAN repo, wrong codebase).
+      // Same-repo waves would set isolation:'worktree' here instead.
+    }))))
+    .filter(Boolean)
+
+  // Collect §3.2 must-preserve data from workers (record; do not branch).
+  for (const w of built) {
+    for (const c of w.concerns || []) allConcerns.push({ issue: w.issue, concern: c })
+    for (const d of w.deferrals || []) allDeferrals.push(d)
+  }
+  const implemented = built.filter((w) => w.status === 'implemented' || w.status === 'already-present')
+
+  // ── MERGE + RECONCILE (Prime(post-flight) — the ONLY cross-flight view) ──
+  const rec = await agent(primeReconcilePrompt(implemented, merged), {
+    label: `merge:${groupsRunBase + groupsRun.length + 1}`,
+    phase: 'Flight loop',
+    schema: RECONCILE,
+    agentType: 'general-purpose',
+  })
+  for (const c of rec.concerns || []) allConcerns.push({ issue: 'reconcile', concern: c })
+
+  // ── DETERMINISTIC state update + progress accounting ──
+  const newlyMerged = (rec.merged || []).filter((n) => !merged.has(n))
+  newlyMerged.forEach((n) => { merged.add(n); pending.delete(n) })
+  idleRounds = newlyMerged.length ? 0 : idleRounds + 1 // thrash detector
+  await cleanupMerged(newlyMerged) // SEAM #686 — per-merge worktree+branch removal (§4.3)
+
+  lastRework = []
+  for (const r of rec.needs_rework || []) {
+    if ((reworkCount[r.issue] = (reworkCount[r.issue] || 0) + 1) > MAX_REWORK) {
+      halt = `rework:#${r.issue}` // per-issue breaker → HOLD, NOT success
+      break
+    }
+    pending.add(r.issue) // surfaced dep → re-opened → next group
+    merged.delete(r.issue)
+    lastRework.push(r)
+    log(`Surfaced dependency: #${r.issue} re-opened (rework #${reworkCount[r.issue]}) — ${r.reason}`)
+  }
+
+  groupsRun.push({ group, merged: newlyMerged, needs_rework: rec.needs_rework || [], suite: rec.suite_summary })
+  await persistIteration({ merged, pending, reworkCount, idleRounds, groupsRun: groupsRunBase + groupsRun.length }) // SEAM #688
+  if (halt) break // breaker tripped inside the for-loop → leave the while with pending still non-empty
+}
+
+const loopOutcome = halt || (pending.size === 0 ? 'success' : 'incomplete')
+log(`Flight loop done: ${loopOutcome} in ${groupsRun.length} groups (concerns: ${allConcerns.length}, deferrals: ${allDeferrals.length})`)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PHASE 3 — TRUST GATE (§3.4) — REAL fan-out. Runs ONLY on the success exit.
+// Any HOLD reason (incl. per-issue breaker) skips the gate.
+// ─────────────────────────────────────────────────────────────────────────────
+phase('Trust gate')
+let gate
+if (!halt && pending.size === 0) {
+  // The 4 canonical signals run in PARALLEL (independent), aggregate to a verdict.
+  // The agent() prompts are REAL; the sdlc-server tool calls inside them are SEAM #687.
+  const signals = (await parallel([
+    // 1. commutativity across kahuna
+    () => agent(
+      [
+        `Trust-gate COMMUTATIVITY signal for wave ${WAVE_ID}. Run commutativity_verify across ${KAHUNA_BRANCH}`,
+        `(base ${PROTECTED_BRANCH}). pass = verdict ∈ {STRONG, MEDIUM}; fail otherwise (incl. PROBE_UNAVAILABLE`,
+        `= conservative-fail). // TODO(#687 gate wiring): real commutativity_verify sdlc-server call.`,
+        `Return signal="commutativity", passed (bool), detail.`,
+      ].join('\n'),
+      { label: 'gate:commutativity', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
+    ).catch(() => gateSignalStub('commutativity')),
+    // 2. CI on the MR merge-result pipeline — NOT the merge-commit branch HEAD (sdlc #452)
+    () => agent(
+      [
+        `Trust-gate CI signal for wave ${WAVE_ID}. ci_wait_run for the ${KAHUNA_BRANCH}→${PROTECTED_BRANCH} MR`,
+        `MERGE-RESULT pipeline (NOT the merge-commit branch HEAD; skipped-branch + passing-merge-result =`,
+        `validated) [sdlc #452]. Lint/typecheck ride INSIDE this signal, diff-scoped to the wave's changed files`,
+        `(never tree-scoped — §3.4). // TODO(#687 gate wiring): real ci_wait_run sdlc-server call.`,
+        `Return signal="ci", passed (final_status==success), detail.`,
+      ].join('\n'),
+      { label: 'gate:ci', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
+    ).catch(() => gateSignalStub('ci')),
+    // 3. review the full kahuna-vs-main diff — worktree of kahuna, native checkout (#667)
+    () => agent(
+      [
+        `Trust-gate REVIEW signal for wave ${WAVE_ID}. Review the full ${KAHUNA_BRANCH}-vs-${PROTECTED_BRANCH}`,
+        `diff for correctness / architecture / unstated intent (the rung a test cannot encode — §9 ladder).`,
+        `Scope to the wave's CHANGED FILES only (§3.4). pass = no critical/important findings.`,
+        `Return signal="review", passed (bool), detail.`,
+      ].join('\n'),
+      {
+        label: 'gate:review',
+        phase: 'Trust gate',
+        schema: SIG,
+        agentType: 'feature-dev:code-reviewer',
+        isolation: 'worktree', // worktree of kahuna so the reviewer sees the branch natively (#667)
+      },
+    ).catch(() => gateSignalStub('review')),
+    // 4. trivy HIGH/CRITICAL dependency scan of kahuna
+    () => agent(
+      [
+        `Trust-gate TRIVY signal for wave ${WAVE_ID}. Run trivy fs --scanners vuln --severity HIGH,CRITICAL on`,
+        `${KAHUNA_BRANCH}. pass = no HIGH/CRITICAL findings with available fixes.`,
+        `// TODO(#687 gate wiring): the trivy scan rides the deterministic pre-push/secret hooks + this signal.`,
+        `Return signal="trivy", passed (bool), detail.`,
+      ].join('\n'),
+      { label: 'gate:trivy', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
+    ).catch(() => gateSignalStub('trivy')),
+  ])).filter(Boolean)
+
+  const failed = signals.filter((s) => !s.passed)
+  gate = failed.length === 0
+    ? { verdict: 'PASS', promote: `${KAHUNA_BRANCH}→${PROTECTED_BRANCH}`, signals }
+    : { verdict: 'HOLD', failing: failed, signals }
+} else {
+  gate = { verdict: 'SKIPPED', reason: halt || 'loop did not reach clean success' }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PHASE 4 — PROMOTE or HOLD-FOR-REVIEW.
+//   AUTO: promote kahuna→protected on PASS.
+//   INTERACTIVE: the workflow ENDS returning the verdict (the return IS the human gate, §5).
+// ─────────────────────────────────────────────────────────────────────────────
+phase('Promote')
+let result
+if (gate.verdict === 'PASS') {
+  if (MODE === 'auto') {
+    // TODO(#687 gate wiring): real promotion — wave_finalize opens the kahuna→protected MR,
+    //   pr_merge(skip_train:true) on all-green, delete the kahuna branch, record disposition.
+    log(`[SEAM #687] promote stub — would auto-merge ${KAHUNA_BRANCH}→${PROTECTED_BRANCH}`)
+    await persistTerminal('promoted', `gate PASS, ${KAHUNA_BRANCH}→${PROTECTED_BRANCH}`) // SEAM #688
+    result = { gate: 'PASS', promoted: true, wave: WAVE_ID }
+  } else {
+    // INTERACTIVE: do NOT promote — return the verdict; the campaign driver surfaces it + the human routes.
+    await persistTerminal('held', 'gate PASS, interactive — awaiting human promotion') // SEAM #688
+    result = { gate: 'PASS', promoted: false, wave: WAVE_ID, reason: 'interactive: human routes promotion' }
+  }
+} else if (gate.verdict === 'HOLD') {
+  await persistTerminal('held', `gate HOLD: ${(gate.failing || []).map((s) => s.signal).join(', ')}`) // SEAM #688
+  result = { gate: 'HOLD', wave: WAVE_ID, failing: gate.failing }
+} else {
+  await persistTerminal('held', `gate SKIPPED: ${gate.reason}`) // SEAM #688
+  result = { gate: 'SKIPPED', wave: WAVE_ID, reason: gate.reason, haltReason: halt }
+}
+
+// Wave-terminal cleanup (§4.3): remove remaining worktrees + prune (both ends, not end-only).
+await cleanupTerminal() // SEAM #686
+
+// The return IS the per-wave gate the campaign driver (§5) consumes and routes on.
+return {
+  wave: WAVE_ID,
+  kahunaBranch: KAHUNA_BRANCH,
+  targetRepo: TARGET_REPO,
+  loopOutcome,
+  groups: groupsRunBase + groupsRun.length,
+  groupsRun,
+  merged: [...merged],
+  pending: [...pending],
+  reworkCount,
+  concerns: allConcerns, // §3.2 surfaced-and-continued — informational
+  deferrals: allDeferrals, // §3.2 decided-and-recorded — informational
+  gate: result.gate,
+  ...result,
+}

--- a/skills/wavemachine-next/SKILL.md
+++ b/skills/wavemachine-next/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: wavemachine-next
+description: Campaign driver — loops one per-wave Workflow per pending wave, routes on its verdict, closed campaign exits; auto-vs-interactive is a one-line advance-vs-wait branch
+---
+
+# Wavemachine-Next — Campaign Driver for the per-wave Workflow
+
+> **Migration successor to `/wavemachine`.** The campaign loop runs **in the main
+> session** (not as a nested Workflow): it launches one per-wave Workflow per pending
+> wave, reads its verdict, and advances. The old `/wavemachine` (loops `/nextwave auto`)
+> is unchanged and stays in place during migration. Design of record:
+> `docs/wavemachine-workflows-migration.md` §5.
+
+## Axioms
+
+Bound by WAVE_AXIOMS 2, 3, 4, 5, 6, 8, 9 (`WAVE_AXIOMS.md`). The campaign autonomy
+contract (loop runs to terminal state or Legal Exit), the closed-list exits, the
+Concerns Channel, the cost-asymmetry default-forward stance, the approval-frequency
+rule (`auto` advances on PASS with no per-wave human gate; `interactive` surfaces the
+verdict per wave), and user-attention-as-cost all live in that file. This skill is the
+operational binding.
+
+## What this is
+
+`/wavemachine-next` runs **one per-wave Workflow per pending wave** — the §3.1
+closed-legal-exits pattern lifted one level. It is the campaign loop of §5, run in the
+top-level session because:
+
+1. **Interactive review-between-waves is a hard requirement, and a Workflow can't pause
+   for it** — so a skill driver must exist regardless; a nested auto-only Workflow would
+   merely duplicate it.
+2. **The campaign loop is thin** — N pre-approved waves, one launch + verdict each. All
+   determinism and all judgment live *inside* each per-wave Workflow (the §3.1 reconcile
+   + the §3.4 trust gate); there is almost nothing at campaign altitude to get wrong.
+3. **Resume is native + reboot-proof** — the skill rehydrates `promoted`/`pendingWaves`
+   from wave-status (§3.3); a nested Workflow has only within-session resume.
+4. **Observability** — each wave is its own `/workflows` run, individually inspectable.
+
+**Mental model:** issue specs are source; the per-wave Workflows are the compiler;
+sdlc-server tools are the runtime; **`/wavemachine-next` is `make all` for the wave
+compiler.**
+
+## The campaign loop (§5 — this is the whole skill)
+
+Campaign state is script-held in the main session and mirrored to wave-status each
+iteration. There is **no campaign-level planner** — waves are drawn from the
+pre-approved phase/wave plan via `nextPendingWave()` — so success is `pendingWaves`
+empty and nothing else (the §3.1 `plan.done`/success sentinel-collision is designed out,
+not guarded against).
+
+```
+pendingWaves = approved phase/wave plan   # rehydrate prunes already-promoted
+halt = null                               # null = converging; else a HOLD reason (NEVER a success)
+waveRetry = {}; promoted = {}
+MAX_WAVES = 64, MAX_WAVE_RETRY = 2, CAMPAIGN_FLOOR = 120_000
+
+loop:
+  # ── CLOSED LEGAL EXITS (campaign level) ──
+  if pendingWaves empty:                         break                  # success — all waves promoted
+  if promoted.size >= MAX_WAVES:                 halt='runaway'; break  # defensive bound → human
+  if budget.total and budget.remaining() < CAMPAIGN_FLOOR: halt='cost'; break
+
+  wave    = nextPendingWave()                    # from the approved plan
+  verdict = run /nextwave-next for `wave`        # §3 spine → { gate: PASS | HOLD | SKIPPED }
+
+  # ── ROUTE ON VERDICT — auto-vs-interactive is ONE advance-vs-wait line ──
+  if verdict.gate == 'PASS':
+      promoted.add(wave); pendingWaves.delete(wave); waveRetry[wave] = 0
+      if MODE == 'interactive':  surface verdict + kahuna diff; STOP for human; advance on their go
+      continue                                   # auto: advance immediately
+  if (waveRetry[wave] = (waveRetry[wave]||0)+1) > MAX_WAVE_RETRY: halt=`wave-breaker:${wave}`; break
+  halt = 'wave-hold'; break                       # HOLD/SKIPPED → human review (the per-wave gate fired)
+```
+
+**Mode is a one-line advance-vs-wait branch, NOT two architectures.** `auto` advances
+on `PASS`; `interactive` surfaces the verdict and STOPS for the human, then advances on
+their go. Both run the identical loop body.
+
+## Closed campaign-exit set (mirrors §3.1)
+
+| Exit | Condition | Meaning |
+|---|---|---|
+| success | `pendingWaves` empty | every wave promoted to the protected branch |
+| runaway | `promoted ≥ MAX_WAVES` | defensive bound → human |
+| cost | budget floor | stop before the ceiling |
+| wave-hold | a wave returns HOLD/SKIPPED | the per-wave gate fired → human review |
+| wave-breaker | a wave reworked > `MAX_WAVE_RETRY` | one wave won't converge → human |
+
+- **No campaign-level planner → no `plan done`/success collision.** Waves come from the
+  pre-approved plan; there is no planner verdict to misread.
+- **Progress is structural.** Each iteration either promotes a wave (`PASS`) or halts —
+  a campaign iteration cannot make zero net progress and continue, so no idle-round
+  detector is needed; the retry breaker covers a wave that repeatedly fails to reach `PASS`.
+
+## Pre-flight (refuse to start on failure)
+
+1. **Supporting CLIs on PATH** — `wave-status`, `generate-status-panel`, `mcp-log`.
+   Missing → refuse and name each; re-run `./install`.
+2. **Plan exists** (`wave_show()`); **no other wave active**; **base branch clean**;
+   **previous wave merged**; **at least one pending wave**; **no concurrent campaign**.
+
+On any refusal: explain, suggest remediation, do NOT enter the loop. (Same gates as the
+legacy `/wavemachine` pre-flight; see that skill for the detailed rationale.)
+
+## Launch sequence (before the loop)
+
+1. Set the `wavemachine_active` flag (`wave-status wavemachine-start --launcher main`).
+   Unset it on EVERY exit path (`wave-status wavemachine-stop`) — treat as a `finally`.
+2. Regenerate + open the status panel (`generate-status-panel` then `xdg-open`).
+3. **Pre-wave kahuna bootstrap** — once per Plan: `wave_init` with `kahuna:{plan_id, slug}`
+   creates `kahuna/<plan_id>-<slug>` off the protected branch and writes `kahuna_branch`
+   into wave state. Idempotent — a resume invocation sees the field populated and skips.
+   Every per-wave Workflow is launched with that `kahunaBranch`.
+4. Announce to `#wave-status`; emit `mcp-log wavemachine_start`.
+
+## Per-wave handoff (no narrator gap)
+
+When a per-wave Workflow returns, the immediately following assistant message is a
+tool-use block (status-panel regen + discord-status-post + next iteration's launch), NOT
+narrative prose. "Wave N complete, starting N+1" between waves is forbidden — it costs
+wall-clock (the cc-workflow#600 "Bug B" failure mode). In `interactive` mode the human
+STOP is the one deliberate pause; everything else is a tight tool-use chain.
+
+## Resumability (mirrors §3.3, one level up)
+
+On cold start the campaign rehydrates from wave-status's wave-completion records
+(`wave_previous_merged` / `wave_topology`) and skips already-promoted waves;
+`promoted` / `pendingWaves` seed from there. Same durable substrate as the inner loop.
+The per-wave Workflow itself rehydrates its own loop state (`per-wave-workflow.js`
+rehydrate phase, SEAM #686) — the campaign driver only tracks wave-grain completion.
+
+## Exhaustive Legal Exits
+
+Per WAVE_AXIOMS Axiom 3 the campaign legal-exits list is the closed set above. Per
+Axiom 4, unease that matches no exit rides the Concerns Channel (`[concern]` comment +
+optional Discord ping) and the loop CONTINUES. Explicit non-exits (do NOT halt): phase
+transitions, first multi-issue wave, session elapsed time, first-time execution of a
+described pattern, recent successes increasing anxiety, general caution. If something
+goes wrong it surfaces as a wave verdict (`HOLD`/`SKIPPED`) or a campaign exit above —
+absence of those is presumption of healthy operation.
+
+## Non-Negotiables
+
+- **One Plan at a time.** Pre-flight refuses if another campaign is active.
+- **`wavemachine_active` must always reflect reality** — set on entry, unset on every
+  exit path. No `Edit` to `state.json`; go through the CLI.
+- **NEVER run the loop in a background sub-agent.** The loop is top-level. (CC sub-agents
+  lack the `Agent`/`Task` tool — `lesson_cc_subagent_tools.md` — so only the top-level
+  session can launch a Workflow.)
+- **The per-wave Workflow owns all wave-internal work.** `/wavemachine-next` only launches
+  one per wave and routes on its verdict — it never spawns flights/Prime/reconcile itself.
+- **The kahuna→protected merge is the per-wave Workflow's trust-gate job**, not the
+  campaign driver's. The driver advances on `PASS`; it never merges to the protected branch.
+- **Per-wave handoff is a single tool-use boundary** — no inter-wave narration.
+- **Structured blocker report on any abort** — name the wave (or failing signals), the
+  exit type, and the remediation path.
+
+## Pair
+
+- `/prepwaves` — plans the waves.
+- `/nextwave-next` — executes one wave via `per-wave-workflow.js`.
+- **`/wavemachine-next` — loops one per-wave Workflow per pending wave. This skill.**
+- `/dod` — verifies the project at Plan end.


### PR DESCRIPTION
## Summary

The anchor for the Wavemachine→Dynamic-Workflows migration: the production per-wave Workflow — the §3 spine (rehydrate → dynamic flight loop → trust gate → promote) — hardened from the two VALIDATED iter-3 pilots into production-shaped, parameterized code. This defines the interfaces every wave-2 foundational piece attaches to. First-draft production code for human review; not auto-merged.

Design of record: `docs/wavemachine-workflows-migration.md` (§3 spine, §3.1 dynamic flight loop, §3.2 must-preserve, §3.4 trust gate, §4 cross-repo, §5 campaign loop).

## Changes

- `skills/nextwave-next/per-wave-workflow.js` — the per-wave Workflow script. Begins with the required `export const meta`. Parameterized by the wave's issue list, kahuna branch, target repo, protected branch, and mode.
- `skills/nextwave-next/SKILL.md` — single-wave entry skill (§5): launches the per-wave Workflow for one wave, consumes its verdict.
- `skills/wavemachine-next/SKILL.md` — campaign-loop driver (§5): one per-wave Workflow per pending wave, closed campaign exits, auto-vs-interactive as a one-line advance-vs-wait branch.
- `skills/nextwave-next/SEAMS.md` — the seam interface contract: exact function/return signatures each wave-2 issue fills.

## What is REAL vs SEAM

**REAL (the validated part — hardened, complete):**
- The §3.1 dynamic flight loop: closed legal-exit set + hard progress guarantee + `halt` sentinel (HOLD never a success) + deterministic progress accounting.
- The dynamic re-plan: a surfaced cross-flight dependency (`needs_rework` from reconcile) re-opens an issue and becomes the next group — bounded by `MAX_GROUPS`/`MAX_REWORK`/`MAX_IDLE`. Mirrors the validated 3b pilot.
- The §3.4 trust gate: 4 signals in parallel → unanimous ff-or-hold verdict; runs ONLY on the success exit.
- The §3.2 must-preserve behaviors as structured returns the script records but never branches-to-halt on (`concerns`, `deferrals`).
- The agent() prompts (plan / worker / reconcile / 4 signals).

**SEAM-stubbed (obvious placeholders, marked `// TODO(#…)`):**
- `#686` — rehydrate / idempotency (durable resume; idempotent worktree setup + 3-point cleanup).
- `#687` — real gate signals via sdlc-server (commutativity / CI on the MR merge-result pipeline [sdlc #452] / code-reviewer on a kahuna worktree [#667] / trivy) + plan/worker/reconcile MCP calls + promotion.
- `#688` — wave-status persistence (the durable resume substrate).

The seam contracts (function names + return shapes) are the interface every wave-2 piece builds against — see `SEAMS.md`.

## Test Plan

- `node --check skills/nextwave-next/per-wave-workflow.js` — passes (JS parses).
- `./scripts/ci/validate.sh` — **153 passed, 0 failed** (SKILL.md frontmatter for both new skills, install discovery, all regression tests; legacy `nextwave`/`wavemachine` untouched).

Hard constraints honored: legacy `skills/nextwave/` + `skills/wavemachine/` untouched; no `./install` run; no `~/.claude/skills/` change; distinct `-next` names; nothing merged to `main`.

## Linked Issues

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)