### PR TITLE
feat(wave-impl): #686 resumability + idempotency seam

### DIFF
--- a/skills/nextwave-next/per-wave-workflow.js
+++ b/skills/nextwave-next/per-wave-workflow.js
@@ -35,6 +35,8 @@ import { blobPath, toBlob, persistIterationPrompt, persistTerminalPrompt } from 
 // idempotent worktree setup / 3-point cleanup builders + prompts (§3.3/§4.2/§4.3). The pure halves
 // (parseRehydrate, the git-command builders) are unit-tested without a live sdlc-server. See resume.js.
 import {
+  parseRehydrate,
+  coldStart,
   rehydratePrompt,
   setupWorktreesPrompt,
   cleanupMergedPrompt,
@@ -219,9 +221,14 @@ async function rehydrate() {
     log(`[#686] rehydrate soft-fail → cold start: ${e?.message || e}`)
     return null
   })
-  if (!seed) return { merged: [], pending: [...ALL_ISSUES], reworkCount: {}, idleRounds: 0, groupsRun: 0 }
-  log(`[#686] rehydrated — merged=[${(seed.merged || []).join(',') || 'none'}] pending=[${(seed.pending || []).join(',') || 'none'}] idle=${seed.idleRounds || 0} groups=${seed.groupsRun || 0}`)
-  return seed
+  if (!seed) return coldStart(ALL_ISSUES)
+  // Structural defense (#686 review): normalize the AGENT return through parseRehydrate — excludes
+  // merged from pending (so a resume never re-does merged work even if the agent hallucinates an
+  // overlap), clamps counters, string-keys reworkCount, backfills dropped issues. The live path now
+  // gets the same guarantee the test pins, not the raw agent seed.
+  const norm = parseRehydrate(seed, ALL_ISSUES)
+  log(`[#686] rehydrated — merged=[${norm.merged.join(',') || 'none'}] pending=[${norm.pending.join(',') || 'none'}] idle=${norm.idleRounds} groups=${norm.groupsRun}`)
+  return norm
 }
 
 // SEAM #688 — persistence (FILLED). Runs right after Prime(reconcile) each iteration (§3.3):

--- a/skills/nextwave-next/per-wave-workflow.js
+++ b/skills/nextwave-next/per-wave-workflow.js
@@ -31,6 +31,18 @@
 // agent prompts (the MCP record/close calls + the .claude/status/ blob write). See
 // wave-status.js + SEAMS.md (#688). The loop calls persistIteration/persistTerminal below.
 import { blobPath, toBlob, persistIterationPrompt, persistTerminalPrompt } from './wave-status.js'
+// #686 resumability + idempotency seam helper: the rehydrate read-back + agent prompt, and the
+// idempotent worktree setup / 3-point cleanup builders + prompts (§3.3/§4.2/§4.3). The pure halves
+// (parseRehydrate, the git-command builders) are unit-tested without a live sdlc-server. See resume.js.
+import {
+  rehydratePrompt,
+  setupWorktreesPrompt,
+  cleanupMergedPrompt,
+  cleanupTerminalPrompt,
+  wtRoot,
+  wtPathFor,
+  issueBranchFor,
+} from './resume.js'
 
 export const meta = {
   name: 'per-wave-workflow',
@@ -66,10 +78,11 @@ const MAX_REWORK = params.maxRework ?? 3
 const MAX_IDLE = params.maxIdle ?? 2
 const COST_FLOOR = params.costFloor ?? 80_000
 
-// Durable worktree root (§4.2) — NOT /tmp (reboot-wiped, resume-hostile). Gitignored, hyphenated stem shared by dir+branch.
-const WT_ROOT = `${TARGET_REPO_DIR}/.claude/.worktrees/wave-${WAVE_ID}`
-const wtPath = (n) => `${WT_ROOT}/issue-${n}`
-const issueBranch = (n) => `wave-${WAVE_ID}/issue-${n}` // shares the wave-<id>/ stem so `git branch -D wave-<id>/*` cleans both
+// Durable worktree root (§4.2) — NOT /tmp (reboot-wiped, resume-hostile). Gitignored, hyphenated
+// stem shared by dir+branch. The path/branch helpers live in resume.js (the #686 seam owner) so
+// the dir, branch, and the cleanup glob all derive from ONE fs-safe wave-id sanitization (§4.3).
+const WT_ROOT = wtRoot(TARGET_REPO_DIR, WAVE_ID)
+const issueBranch = (n) => issueBranchFor(WAVE_ID, n) // shares the wave-<id>/ stem so `git branch -D wave-<id>/*` cleans both
 
 // ─────────────────────────────────────────────────────────────────────────────
 // STRUCTURED-RETURN SCHEMAS (real — these are the agent contracts)
@@ -147,6 +160,27 @@ const SIG = {
   required: ['signal', 'passed'],
   properties: { signal: { type: 'string' }, passed: { type: 'boolean' }, detail: { type: 'string' } },
 }
+// #686 — the worktree-setup agent's structured return: issue→path map (string-keyed, JSON-native).
+const WORKTREES = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['worktrees'],
+  properties: {
+    worktrees: { type: 'object', additionalProperties: { type: 'string' } }, // { "<issue>": "<absPath>" }
+    notes: { type: 'string' },
+  },
+}
+// #686 — the cleanup agent's structured return (side-effects, not judgment; never halts the wave).
+const CLEANUP_RESULT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['persisted'],
+  properties: {
+    persisted: { type: 'boolean' },
+    recorded: { type: 'array', items: { type: 'integer' } }, // issues cleaned this call
+    notes: { type: 'string' },
+  },
+}
 // #688 — the persist agent's structured return (it does side-effects, not judgment).
 const PERSIST_RESULT = {
   type: 'object',
@@ -167,17 +201,27 @@ const PERSIST_RESULT = {
 // function names + return shapes here ARE the interface contract (see SEAMS.md).
 // ─────────────────────────────────────────────────────────────────────────────
 
-// SEAM #686 — durable resume. The script can't call MCP/CLI directly (§3.3), so a
-// cheap rehydrate agent reads wave-status and returns the loop blob. Stub: cold start.
+// SEAM #686 — durable resume (FILLED). The script can't call MCP/CLI directly (§3.3), so a
+// cheap rehydrate agent READS the durable wave-status blob (.claude/status/, NEVER /tmp) and
+// returns the REHYDRATE loop seed: {merged, pending, reworkCount, idleRounds, groupsRun}. On a
+// COLD start (no blob) it returns all issues pending / nothing merged; on a WARM start it returns
+// the persisted core so the loop SKIPS finished work (SEAMS invariant 3 — `merged` is authoritative
+// for skip-on-resume). reworkCount keys come back JSON-string-keyed; the loop Number-casts them
+// (see the `Object.fromEntries(... Number(k) ...)` seed below). The pure read-back logic is
+// resume.js parseRehydrate (unit-tested); the agent is the file read the script can't do itself.
 async function rehydrate() {
-  // TODO(#686 resumability/rehydrate): replace with an agent() that reads wave-status
-  // (.claude/status/, durable) for this wave and returns {merged, pending, reworkCount,
-  // idleRounds, groupsRun}. Must skip already-finished work on a cold restart.
-  // Real shape:
-  //   return agent(rehydratePrompt(WAVE_ID, ALL_ISSUES, TARGET_REPO),
-  //     { label: 'rehydrate', phase: 'Rehydrate', schema: REHYDRATE, agentType: 'general-purpose' })
-  log(`[SEAM #686] rehydrate stub → cold start (no prior wave-status state assumed)`)
-  return { merged: [], pending: [...ALL_ISSUES], reworkCount: {}, idleRounds: 0, groupsRun: 0 }
+  const seed = await agent(
+    rehydratePrompt({ waveId: WAVE_ID, allIssues: ALL_ISSUES, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
+    { label: 'rehydrate', phase: 'Rehydrate', schema: REHYDRATE, agentType: 'general-purpose' },
+  ).catch((e) => {
+    // A rehydrate failure must NOT kill the resume — degrade to cold start (re-do, never crash on
+    // your own restart, §3.3). Idempotent workers/reconcile make the re-run safe.
+    log(`[#686] rehydrate soft-fail → cold start: ${e?.message || e}`)
+    return null
+  })
+  if (!seed) return { merged: [], pending: [...ALL_ISSUES], reworkCount: {}, idleRounds: 0, groupsRun: 0 }
+  log(`[#686] rehydrated — merged=[${(seed.merged || []).join(',') || 'none'}] pending=[${(seed.pending || []).join(',') || 'none'}] idle=${seed.idleRounds || 0} groups=${seed.groupsRun || 0}`)
+  return seed
 }
 
 // SEAM #688 — persistence (FILLED). Runs right after Prime(reconcile) each iteration (§3.3):
@@ -244,33 +288,49 @@ function gateSignalStub(name) {
   return { signal: name, passed: true, detail: `[SEAM #687] ${name} stub — always-pass placeholder` }
 }
 
-// Worktree setup is awaited as a SINGLE step before parallel() — workers are HANDED
-// a path, never asked to create one (race-safety is structural, §4.2). Idempotent:
-// reuse an existing branch on resume, never -b (§4.2). Stubbed as a seam of #686 idempotency.
+// SEAM #686 — idempotent worktree setup (FILLED). Awaited as a SINGLE step before parallel()
+// so workers are HANDED a path, never asked to create one (race-safety is structural, §4.2).
+// The agent runs the create-or-reuse git commands (the script can't run git itself, §3.3):
+// reuse an existing branch on resume (`git worktree add <path> <branch>`, NEVER -b), after a
+// crash-recovery prune/sweep (§4.3). Returns the issue→path map the worker prompt is handed.
+// Defensive: if the agent omits a path, fall back to the canonical wtPathFor() so the loop
+// always hands every worker a path (the dirs are durable + idempotent regardless).
 async function setupWorktrees(group) {
-  // TODO(#686 resumability/rehydrate): real idempotent worktree creation —
-  //   sweep prior wave-ids' dirs + `git worktree prune` (crash recovery, §4.3),
-  //   then per issue: if branch exists `git worktree add <path> <branch>` (reuse),
-  //   else `git worktree add <path> -b <branch> origin/<KAHUNA_BRANCH>`.
-  // Returns a map issue→path the worker prompt is handed.
+  const res = await agent(
+    setupWorktreesPrompt({ waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, kahunaBranch: KAHUNA_BRANCH, group }),
+    { label: `worktrees:${group.join(',')}`, phase: 'Flight loop', schema: WORKTREES, agentType: 'general-purpose' },
+  ).catch((e) => {
+    log(`[#686] setupWorktrees soft-fail (using canonical paths): ${e?.message || e}`)
+    return null
+  })
+  const got = (res && res.worktrees) || {}
   const map = {}
-  for (const n of group) map[n] = wtPath(n)
-  log(`[SEAM #686] worktree setup stub — group [${group.join(', ')}] → ${WT_ROOT}/issue-<n>`)
+  for (const n of group) map[n] = got[String(n)] || got[n] || wtPathFor(TARGET_REPO_DIR, WAVE_ID, n) // canonical fallback
+  log(`[#686] worktrees ready — group [${group.join(', ')}] → ${WT_ROOT}/issue-<n>`)
   return map
 }
 
-// 3-point cleanup (§4.3): per-merge removal keeps peak disk ≈ current group.
-// Prune branches too (shared wave-<id>/ stem → single glob cleans both).
+// SEAM #686 — per-merge cleanup (FILLED). 4-point sequence per just-merged issue (§4.3):
+// `worktree remove --force` → `worktree prune` → `rm -rf` → `git branch -D wave-<id>/issue-<n>`.
+// Keeps peak disk ≈ current group. The branch -D is load-bearing (worktree remove leaves the
+// branch behind — pilot 1 accreted dead refs without it). Never halts the wave on a soft error.
 async function cleanupMerged(issues) {
-  // TODO(#686 resumability/rehydrate): real per-merge cleanup —
-  //   git -C <repo> worktree remove --force <path>; git worktree prune; rm -rf <path>;
-  //   git -C <repo> branch -D wave-<id>/issue-<n>
-  if (issues.length) log(`[SEAM #686] cleanup stub — removed worktrees+branches for [${issues.join(', ')}]`)
+  if (!issues.length) return
+  await agent(
+    cleanupMergedPrompt({ waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, issues }),
+    { label: `cleanup:${issues.join(',')}`, phase: 'Flight loop', schema: CLEANUP_RESULT, agentType: 'general-purpose' },
+  ).catch((e) => { log(`[#686] cleanupMerged soft-fail (loop continues): ${e?.message || e}`); return null })
+  log(`[#686] cleaned worktrees+branches for [${issues.join(', ')}]`)
 }
+
+// SEAM #686 — wave-terminal cleanup (FILLED). Sweep the wave's remaining worktrees + prune +
+// glob-delete every wave-<id>/* branch (§4.3) — clean at BOTH ends, not end-only. Idempotent.
 async function cleanupTerminal() {
-  // TODO(#686 resumability/rehydrate): wave-terminal sweep — remove remaining
-  //   wave-<id> worktrees + `git worktree prune` + `git branch -D wave-<id>/*`.
-  log(`[SEAM #686] terminal cleanup stub — swept remaining wave-${WAVE_ID} worktrees+branches`)
+  await agent(
+    cleanupTerminalPrompt({ waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
+    { label: 'cleanup:terminal', phase: 'Promote', schema: CLEANUP_RESULT, agentType: 'general-purpose' },
+  ).catch((e) => { log(`[#686] cleanupTerminal soft-fail: ${e?.message || e}`); return null })
+  log(`[#686] swept remaining wave-${WAVE_ID} worktrees+branches`)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/skills/nextwave-next/resume.js
+++ b/skills/nextwave-next/resume.js
@@ -1,0 +1,267 @@
+// resume.js — the #686 resumability + idempotency seam helper for per-wave-workflow.js.
+//
+// Design of record: docs/wavemachine-workflows-migration.md
+//   §3.3 resumability (rehydrate from wave-status; idempotent worker/reconcile — the crux)
+//   §4.2 durable worktrees (idempotent create, reuse-branch-on-resume, never -b)
+//   §4.3 cleanup discipline (the 3-point cleanup; prune BRANCHES too, shared wave-<id>/ stem)
+// Seam contract: skills/nextwave-next/SEAMS.md (#686 — resumability / rehydrate / idempotency).
+//
+// WHY A HELPER MODULE: the workflow script cannot call MCP/CLI directly (§3.3) — every
+// side-effect is an agent() call. This module owns the parts that make resume + idempotency
+// honor their contracts WITHOUT bloating the loop, and — critically — keeps the PURE,
+// deterministic half (blob parse → loop seed; git-command construction) separable and
+// unit-testable WITHOUT a live sdlc-server:
+//   1. rehydrate's blob → loop-seed reconstruction (the exact inverse of wave-status.js toBlob);
+//   2. the rehydrate agent PROMPT (reads .claude/status/, returns the REHYDRATE blob);
+//   3. the idempotent worktree setup + 3-point cleanup git-command builders + their agent prompts.
+//
+// IDEMPOTENCY (SEAMS invariant 3 + 5, §3.3): the crux of safe cross-session resume.
+//   - rehydrate()'s `merged` set is AUTHORITATIVE for skip-on-resume. parseRehydrate is total:
+//     a missing/corrupt blob degrades to a clean cold start (all issues pending), never throws.
+//   - worktree setup reuses an existing branch on resume (`git worktree add <path> <branch>`,
+//     never `-b`), so a killed-and-restarted run re-attaches the same worktree instead of failing.
+//   - the worker half (status:"already-present") and the reconcile half ("skip if already in
+//     kahuna") live in the workflow's agent prompts; this module supplies the structural pieces.
+
+import { blobPath, statusDir } from './wave-status.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PURE — the rehydrate read-back half (no I/O, no agent; fully unit-testable).
+// These are the exact inverse of wave-status.js toBlob(): blob → REHYDRATE loop seed.
+// The loop (per-wave-workflow.js) seeds pending/merged/reworkCount/idleRounds/groupsRun
+// from this; reworkCount numeric keys are JSON-stringified in the blob and the loop
+// Number-casts them — parseRehydrate returns them faithfully (string-keyed object).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The empty/initial state for a cold start (no prior blob): every issue pending, nothing merged.
+export function coldStart(allIssues) {
+  return { merged: [], pending: [...(allIssues ?? [])].map(Number), reworkCount: {}, idleRounds: 0, groupsRun: 0 }
+}
+
+// Coerce one durable blob (as read from .claude/status/wave-<id>.json) into the REHYDRATE
+// loop seed. TOTAL by construction — any missing/garbage field degrades safely so a resume
+// never crashes on a half-written or schema-drifted blob (§3.3: a killed run must resume,
+// not die again on its own resume). A terminal:'promoted' blob is NOT treated as resumable
+// loop state by the per-wave workflow — that pruning is the campaign driver's job (§5) — but
+// we still surface it so callers can decide; parseRehydrate only reconstructs the loop core.
+//
+// `allIssues` is the wave's full issue list: it backfills `pending` so an issue that is
+// neither merged nor recorded-pending in a stale blob is still scheduled (never silently dropped).
+export function parseRehydrate(blob, allIssues) {
+  const all = [...(allIssues ?? [])].map(Number).filter(Number.isFinite)
+  if (!blob || typeof blob !== 'object') return coldStart(all)
+
+  const intList = (v) => (Array.isArray(v) ? v.map(Number).filter(Number.isFinite) : [])
+  const merged = uniqSorted(intList(blob.merged))
+  const mergedSet = new Set(merged)
+
+  // pending = (blob.pending ∪ any allIssues not yet merged), minus anything already merged.
+  // The union with allIssues is the safety net: a blob that forgot an issue still schedules it.
+  const pendingBlob = intList(blob.pending)
+  const backfill = all.filter((n) => !mergedSet.has(n))
+  const pending = uniqSorted([...pendingBlob, ...backfill].filter((n) => !mergedSet.has(n)))
+
+  // reworkCount: keep string-keyed (JSON-native); values coerced to finite non-negative ints.
+  // The loop Number-casts the keys — we return them faithfully (no cast here) so the round-trip
+  // is exactly what wave-status.js documents.
+  const reworkCount = {}
+  for (const [k, v] of Object.entries(blob.reworkCount ?? {})) {
+    const nk = Number(k)
+    const nv = Number(v)
+    if (Number.isFinite(nk) && Number.isFinite(nv)) reworkCount[String(nk)] = Math.max(0, Math.trunc(nv))
+  }
+
+  const idleRounds = clampNonNeg(blob.idleRounds)
+  const groupsRun = clampNonNeg(blob.groupsRun)
+
+  return { merged, pending, reworkCount, idleRounds, groupsRun }
+}
+
+function uniqSorted(arr) {
+  return [...new Set(arr)].sort((a, b) => a - b)
+}
+function clampNonNeg(v) {
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PURE — git command builders for the idempotent worktree lifecycle (§4.2/§4.3).
+// Returned as argv-string commands so the agent prompt can run them verbatim AND a
+// test can assert the exact shape (reuse-branch-not-`-b`, branch-prune, glob stem).
+// All paths/branches share the `wave-<id>/` stem so one glob cleans dir + branch.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// fs-safe wave id (mirror wave-status.js blobPath sanitization so dir/branch/blob agree).
+export const safeWaveId = (waveId) => String(waveId).replace(/[^A-Za-z0-9._-]/g, '_')
+export const wtRoot = (targetRepoDir, waveId) => `${targetRepoDir}/.claude/.worktrees/wave-${safeWaveId(waveId)}`
+export const wtPathFor = (targetRepoDir, waveId, n) => `${wtRoot(targetRepoDir, waveId)}/issue-${n}`
+export const issueBranchFor = (waveId, n) => `wave-${safeWaveId(waveId)}/issue-${n}`
+
+// Setup (§4.2 + the §4.3 setup-sweep): for ONE issue, the idempotent create sequence.
+// `branchExists` lets the caller (or test) pick the reuse path vs the create path:
+//   - branch exists (resume): `git worktree add <path> <branch>` — REUSE, never -b.
+//   - branch absent (fresh):  `git worktree add <path> -b <branch> origin/<kahuna>`.
+// Either way a `prune` precedes so a stale registration from a crash doesn't block the add.
+export function worktreeSetupCmds({ targetRepoDir, waveId, kahunaBranch, issue, branchExists }) {
+  const path = wtPathFor(targetRepoDir, waveId, issue)
+  const branch = issueBranchFor(waveId, issue)
+  const g = `git -C ${q(targetRepoDir)}`
+  const add = branchExists
+    ? `${g} worktree add ${q(path)} ${q(branch)}` // reuse existing branch on resume (NEVER -b)
+    : `${g} worktree add ${q(path)} -b ${q(branch)} ${q(`origin/${kahunaBranch}`)}`
+  return [
+    `${g} worktree prune`, // crash recovery: drop stale registrations before (re)attaching
+    add,
+  ]
+}
+
+// Per-merge cleanup (§4.3): the 4-point sequence for ONE just-merged issue.
+// worktree remove --force → worktree prune → rm -rf → git branch -D wave-<id>/issue-<n>.
+// `worktree remove` leaves the branch behind, so the explicit branch -D is load-bearing
+// (pilot 1 accreted dead refs without it). Every step tolerates already-absent (idempotent).
+export function cleanupMergedCmds({ targetRepoDir, waveId, issue }) {
+  const path = wtPathFor(targetRepoDir, waveId, issue)
+  const branch = issueBranchFor(waveId, issue)
+  const g = `git -C ${q(targetRepoDir)}`
+  return [
+    `${g} worktree remove --force ${q(path)}`,
+    `${g} worktree prune`,
+    `rm -rf ${q(path)}`,
+    `${g} branch -D ${q(branch)}`,
+  ]
+}
+
+// Wave-terminal cleanup (§4.3): sweep the wave's REMAINING worktrees + prune + glob-delete
+// every wave-<id>/* branch. The dir and branches share the wave-<id> stem so a single glob
+// (`git branch -D wave-<id>/*`, plus rm -rf of the wave dir) cleans both.
+export function cleanupTerminalCmds({ targetRepoDir, waveId }) {
+  const root = wtRoot(targetRepoDir, waveId)
+  const branchGlob = `wave-${safeWaveId(waveId)}/*`
+  const g = `git -C ${q(targetRepoDir)}`
+  return [
+    // remove each remaining registered worktree under the wave root, then prune the registry
+    `for wt in ${q(root)}/issue-*; do [ -e "$wt" ] && ${g} worktree remove --force "$wt" 2>/dev/null || true; done`,
+    `${g} worktree prune`,
+    `rm -rf ${q(root)}`,
+    // delete every branch under the wave stem (worktree remove leaves branches behind).
+    // SINGLE-QUOTE the refs pattern: it is a git ref-glob, NOT a shell glob — unquoted, a shell with
+    // nullglob/failglob set would expand it against the cwd (→ empty/error → for-each-ref lists ALL
+    // refs → branch -D nukes every local branch). safeWaveId guarantees [A-Za-z0-9._-], so the quote is safe.
+    `${g} for-each-ref --format='%(refname:short)' 'refs/heads/${branchGlob}' | xargs -r ${g} branch -D`,
+  ]
+}
+
+// minimal single-quote shell-quoter (paths/branches here are repo-controlled, never user input,
+// but quoting keeps spaces + the for-each-ref glob honest).
+function q(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AGENT PROMPTS — the I/O half (the script can't read files / run git directly, §3.3).
+// Each is a string the workflow hands to agent(); the structured return is asserted by
+// the workflow's schema. These are NOT exercised by the unit test (they need a live
+// agent/filesystem); the test pins the pure halves above.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// rehydrate: read the durable blob and return the REHYDRATE loop seed. The agent reads the
+// file (cheap read-only op); the per-wave workflow seeds its loop variables from the return.
+// Cold start (no file) → all issues pending. Warm start → the persisted loop core, faithfully.
+export function rehydratePrompt({ waveId, allIssues, targetRepo, targetRepoDir }) {
+  const path = blobPath(targetRepoDir, waveId)
+  const dir = statusDir(targetRepoDir)
+  return [
+    `You are the wave REHYDRATE node for wave ${waveId} of ${targetRepo}. Your ONLY job: read the durable`,
+    `wave-status blob and return the loop seed so a cold-started run resumes exactly where it died (§3.3).`,
+    `Do NOT do any other work — no git, no MCP, no implementation. This is a cheap read-only read.`,
+    ``,
+    `STEP 1 — read the durable blob (durable resume state lives under .claude/status/, NEVER /tmp):`,
+    `  Read the file: ${path}`,
+    `  (Its parent dir is ${dir}. If the file does NOT exist, this is a COLD START.)`,
+    ``,
+    `STEP 2 — return the loop seed:`,
+    `  COLD START (file absent / empty / unparseable JSON): return`,
+    `    merged=[], pending=[${[...(allIssues ?? [])].map(Number).join(', ')}], reworkCount={}, idleRounds=0, groupsRun=0.`,
+    `  WARM START (file parses): return its fields VERBATIM —`,
+    `    merged   = the blob's "merged" array (issues already on kahuna; the loop SKIPS these),`,
+    `    pending  = the blob's "pending" array (issues still to do),`,
+    `    reworkCount = the blob's "reworkCount" object EXACTLY (keys are issue numbers as strings —`,
+    `                  do NOT renumber or drop them; the loop Number-casts the keys itself),`,
+    `    idleRounds  = the blob's "idleRounds" (integer, default 0),`,
+    `    groupsRun   = the blob's "groupsRun" (integer, default 0).`,
+    `  If a field is missing from an otherwise-valid blob, default it (merged/pending → [], reworkCount → {},`,
+    `  idleRounds/groupsRun → 0). Any issue in [${[...(allIssues ?? [])].map(Number).join(', ')}] that is`,
+    `  neither merged nor pending in the blob MUST be added to pending (never silently dropped).`,
+    ``,
+    `Return: merged (int[]), pending (int[]), reworkCount (object), idleRounds (int), groupsRun (int).`,
+  ].join('\n')
+}
+
+// setupWorktrees: idempotent create of one worktree PER issue in the group, as a single awaited
+// step before parallel() (race-safety is structural, §4.2). Reuse an existing branch on resume
+// (never -b). First sweep PRIOR wave-ids' dirs + prune (crash recovery, §4.3). Returns issue→path.
+export function setupWorktreesPrompt({ waveId, targetRepo, targetRepoDir, kahunaBranch, group }) {
+  const root = wtRoot(targetRepoDir, waveId)
+  const pairs = group.map((n) => ({
+    issue: n,
+    path: wtPathFor(targetRepoDir, waveId, n),
+    branch: issueBranchFor(waveId, n),
+  }))
+  return [
+    `You are the wave WORKTREE-SETUP node for wave ${waveId} of ${targetRepo}. Pre-create one durable`,
+    `worktree per issue in this group, IDEMPOTENTLY, then return the issue→path map. This is the SINGLE`,
+    `awaited step before the parallel workers run — workers are HANDED a path, they never create one (§4.2).`,
+    `Do NOT implement anything. Operate in the TARGET clone: ${targetRepoDir}.`,
+    ``,
+    `STEP 0 — crash-recovery sweep (§4.3): prune stale registrations and remove any PRIOR wave's worktree`,
+    `  dirs under ${targetRepoDir}/.claude/.worktrees/ whose stem is NOT wave-${safeWaveId(waveId)} (the`,
+    `  CURRENT wave's dir is PRESERVED + re-attached, not swept). Run: git -C ${targetRepoDir} worktree prune.`,
+    ``,
+    `STEP 1 — per issue, create-or-reuse (idempotent, §4.2). For EACH issue below, in order:`,
+    ...pairs.map(
+      (p) =>
+        `  • issue #${p.issue}: branch ${p.branch}, path ${p.path}.\n` +
+        `      If ${p.path} is ALREADY a registered worktree → reuse it as-is (no-op).\n` +
+        `      Else if branch ${p.branch} ALREADY exists → git -C ${targetRepoDir} worktree add ${p.path} ${p.branch}  (REUSE the branch — NEVER -b).\n` +
+        `      Else (fresh) → git -C ${targetRepoDir} worktree add ${p.path} -b ${p.branch} origin/${kahunaBranch}.`,
+    ),
+    ``,
+    `Worktree root for this wave: ${root} (durable, gitignored — NOT /tmp). The dir + branch share the`,
+    `wave-${safeWaveId(waveId)}/ stem so a later glob cleans both.`,
+    ``,
+    `Return: a "worktrees" object mapping each issue number (as a string key) to its ABSOLUTE worktree path,`,
+    `e.g. ${JSON.stringify(Object.fromEntries(pairs.map((p) => [String(p.issue), p.path])))}.`,
+  ].join('\n')
+}
+
+// cleanupMerged: per just-merged issue, the 4-point removal (§4.3). Keeps peak disk ≈ current group.
+export function cleanupMergedPrompt({ waveId, targetRepo, targetRepoDir, issues }) {
+  const blocks = issues.map((n) => ({ issue: n, cmds: cleanupMergedCmds({ targetRepoDir, waveId, issue: n }) }))
+  return [
+    `You are the wave CLEANUP node (per-merge) for wave ${waveId} of ${targetRepo}. Remove the worktree`,
+    `AND branch for each just-merged issue so peak disk stays ≈ the current group (§4.3). IDEMPOTENT:`,
+    `every step tolerates already-absent — never fail the wave on a missing worktree/branch.`,
+    ``,
+    `For EACH issue below, run the 4-point sequence in order (worktree remove --force → worktree prune →`,
+    `rm -rf → branch -D; the branch -D is load-bearing — worktree remove leaves the branch behind):`,
+    ...blocks.flatMap((b) => [`  • issue #${b.issue}:`, ...b.cmds.map((c) => `      ${c}`)]),
+    ``,
+    `Return: persisted=true once done; recorded = the issue numbers you cleaned; notes (any soft error).`,
+  ].join('\n')
+}
+
+// cleanupTerminal: wave-terminal sweep (§4.3) — remaining worktrees + prune + glob-delete every branch.
+export function cleanupTerminalPrompt({ waveId, targetRepo, targetRepoDir }) {
+  const cmds = cleanupTerminalCmds({ targetRepoDir, waveId })
+  return [
+    `You are the wave CLEANUP node (terminal) for wave ${waveId} of ${targetRepo}. The wave has ended`,
+    `(promoted or held) — reclaim disk: remove the wave's REMAINING worktrees + prune + delete every`,
+    `wave-${safeWaveId(waveId)}/* branch (§4.3). IDEMPOTENT: tolerate already-absent. Operate in ${targetRepoDir}.`,
+    ``,
+    `Run, in order (the branch glob is load-bearing — worktree remove leaves branches behind):`,
+    ...cmds.map((c) => `  ${c}`),
+    ``,
+    `Return: persisted=true once done; notes (any soft error — never halt on one).`,
+  ].join('\n')
+}

--- a/tests/regression/resume_rehydrate_roundtrip.mjs
+++ b/tests/regression/resume_rehydrate_roundtrip.mjs
@@ -130,6 +130,10 @@ try {
     // a blob that merged an issue NOT in ALL_ISSUES keeps it merged (still skipped) without crashing
     const extra = parseRehydrate({ merged: [3, 999], pending: [8] }, ALL_ISSUES)
     assert.ok(extra.merged.includes(999) && !extra.pending.includes(999), 'unknown merged issue stays skipped')
+    // adversarial: a blob (or hallucinated agent return) with a merged issue ALSO in pending must never re-schedule it
+    const overlap = parseRehydrate({ merged: [3, 12], pending: [3, 8, 100] }, ALL_ISSUES)
+    assert.ok(!overlap.pending.includes(3), 'overlap: a merged issue is removed from pending (no re-do of merged work)')
+    assert.ok(overlap.pending.includes(8) && overlap.pending.includes(100), 'overlap: non-merged pending preserved')
     ok('a missing/empty/corrupt/partial blob degrades to a safe state — a killed run resumes, never dies on restart')
   } catch (e) { bad('robust cold start', e) }
 

--- a/tests/regression/resume_rehydrate_roundtrip.mjs
+++ b/tests/regression/resume_rehydrate_roundtrip.mjs
@@ -1,0 +1,205 @@
+// resume_rehydrate_roundtrip.mjs — #686 resumability + idempotency round-trip test.
+//
+// Asserts the load-bearing #686 invariant: a wave-status blob representing a MID-RUN state
+// (some issues merged, some pending, a reworkCount) rehydrates to the EXACT loop seed
+// {merged, pending, reworkCount, idleRounds, groupsRun} the per-wave Workflow needs to SKIP
+// finished work — including the numeric-key round-trip (reworkCount keys are JSON-stringified
+// in the blob; the loop Number-casts them, parseRehydrate returns them faithfully string-keyed).
+//
+// WHAT THIS PROVES (the pure, deterministic half — no live sdlc-server needed):
+//   1. toBlob (the #688 serializer persistIteration writes) → JSON file → parseRehydrate (the
+//      #686 read-back rehydrate() drives) reconstructs the original loop state exactly. A resumed
+//      loop seeds `merged` (authoritative skip set, SEAMS invariant 3) so it does NOT redo merged
+//      issues — the kill-resume AC's "already-merged issues are skipped" at the state level.
+//   2. Idempotency / stability: re-applying the same rehydrated state (re-serialize → re-parse) is
+//      a fixed point — byte-identical blob, identical seed. A killed-and-restarted run that
+//      re-rehydrates lands on the same state, never drifting.
+//   3. Robustness: a missing / empty / corrupt / partial blob degrades to a clean COLD start (all
+//      issues pending, nothing merged) — a killed run resumes, it never dies on its own restart.
+//   4. The idempotent worktree-setup + 3-point-cleanup git COMMANDS are correctly shaped:
+//      reuse-branch-on-resume (never -b), branch -D present (worktree remove leaves it behind),
+//      and dir + branch + cleanup-glob share one wave-<id> stem (§4.2/§4.3, pilot-validated).
+//
+// WHAT THIS DOES NOT PROVE (needs a live sdlc-server — documented, not faked):
+//   The FULL live kill-resume — start a real multi-group wave, kill it mid-reconcile, restart,
+//   and observe the resumed run skip already-merged issues with no duplicate merges — is an
+//   INTEGRATION test. It exercises the agent()-driven side-effects (wave_record_mr / wave_close_issue
+//   on merge, the rehydrate/worktree/cleanup agents actually reading files + running git, the
+//   worker's status:"already-present" re-entry, the reconcile "already in kahuna → skip"). Those
+//   are NOT exercised here. To run it: see the HOW-TO block at the bottom of this file.
+
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import assert from 'node:assert/strict'
+import { toBlob, blobPath, statusDir } from '../../skills/nextwave-next/wave-status.js'
+import {
+  parseRehydrate,
+  coldStart,
+  worktreeSetupCmds,
+  cleanupMergedCmds,
+  cleanupTerminalCmds,
+  issueBranchFor,
+  wtPathFor,
+} from '../../skills/nextwave-next/resume.js'
+
+let failures = 0
+const ok = (name) => console.log(`  [PASS] ${name}`)
+const bad = (name, e) => { console.log(`  [FAIL] ${name}: ${e?.message || e}`); failures++ }
+
+console.log('test_resume_rehydrate_roundtrip')
+console.log('──────────────────────────────────────────')
+
+// The wave's full issue list — backfill safety net (an issue absent from a stale blob must still schedule).
+const ALL_ISSUES = [3, 8, 12, 45, 100]
+
+// ── Fixture: a MID-RUN loop state (the live in-memory shape persistIteration receives) ──
+// merged 3 issues, 2 still pending, with a reworkCount (numeric, loop-native keys), mid-thrash.
+const midRun = {
+  waveId: 'W-7',
+  merged: new Set([12, 3, 45]), // unsorted on purpose — toBlob sorts deterministically
+  pending: new Set([8, 100]),
+  reworkCount: { 8: 2, 45: 1 }, // numeric keys (loop-native)
+  idleRounds: 1,
+  groupsRun: 4,
+}
+
+const root = mkdtempSync(join(tmpdir(), 'wave-686-rt-'))
+try {
+  // ── 1. write the durable mid-run blob, then rehydrate it back to the loop seed ──────────
+  try {
+    const blob = toBlob(midRun)
+    const dir = statusDir(root)
+    const path = blobPath(root, midRun.waveId)
+    assert.ok(path.startsWith(dir) && !path.includes('/tmp/wavemachine'), 'resume state under .claude/status/, not the tmp bus')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(path, JSON.stringify(blob, null, 2))
+
+    // rehydrate = read back + parseRehydrate (what rehydrate() returns from the agent's file read)
+    const reread = JSON.parse(readFileSync(path, 'utf8'))
+    const seed = parseRehydrate(reread, ALL_ISSUES)
+
+    // the loop seeds Sets + Number-casts reworkCount keys exactly as per-wave-workflow.js does
+    assert.deepEqual(seed.merged, [3, 12, 45], 'merged set reconstructed (the authoritative skip set)')
+    assert.deepEqual(seed.pending, [8, 100], 'pending set reconstructed')
+    assert.deepEqual(seed.reworkCount, { 8: 2, 45: 1 }, 'reworkCount round-trips (numeric ↔ JSON-string keys)')
+    assert.equal(seed.idleRounds, 1, 'idleRounds (thrash counter) restored')
+    assert.equal(seed.groupsRun, 4, 'groupsRun (MAX_GROUPS bound seed) restored')
+
+    // the load-bearing resume guarantee: a resumed loop SKIPS the merged issues.
+    for (const m of [3, 12, 45]) assert.ok(!seed.pending.includes(m), `merged #${m} is NOT re-scheduled`)
+    ok('mid-run state rehydrates to a loop seed that skips finished work (merged/pending/reworkCount/idleRounds/groupsRun)')
+
+    // reworkCount keys survive as clean integers (JSON stringifies them; the loop Number-casts)
+    for (const k of Object.keys(seed.reworkCount)) {
+      assert.equal(typeof k, 'string')
+      assert.ok(Number.isInteger(Number(k)) && Number(k) >= 0)
+    }
+    ok('reworkCount keys survive as clean non-negative integers (JSON-string ↔ numeric)')
+  } catch (e) { bad('mid-run rehydrate', e) }
+
+  // ── 2. idempotency / stability: re-applying the rehydrated state is a fixed point ───────
+  try {
+    const blob = toBlob(midRun)
+    const seed = parseRehydrate(blob, ALL_ISSUES)
+    // feed the rehydrated seed straight back through the serializer → re-parse: must be stable.
+    const reseed = parseRehydrate(toBlob({
+      waveId: 'W-7',
+      merged: seed.merged,
+      pending: seed.pending,
+      reworkCount: seed.reworkCount,
+      idleRounds: seed.idleRounds,
+      groupsRun: seed.groupsRun,
+    }), ALL_ISSUES)
+    assert.deepEqual(reseed, seed, 're-rehydrating the same state is a fixed point (no drift on resume)')
+    // and the blob itself is byte-identical on replay (the #688 idempotent-overwrite contract)
+    assert.equal(JSON.stringify(toBlob(midRun)), JSON.stringify(blob), 'replaying same state → byte-identical blob')
+    ok('rehydrate is idempotent — a killed-and-restarted run re-rehydrates to the identical state')
+  } catch (e) { bad('idempotent reseed', e) }
+
+  // ── 3. robustness: missing / empty / corrupt / partial blob → clean COLD start ──────────
+  try {
+    const cold = coldStart(ALL_ISSUES)
+    assert.deepEqual(parseRehydrate(null, ALL_ISSUES), cold, 'no blob (cold start) → all pending, nothing merged')
+    assert.deepEqual(parseRehydrate({}, ALL_ISSUES), cold, 'empty blob → all pending')
+    assert.deepEqual(parseRehydrate('garbage', ALL_ISSUES), cold, 'non-object blob → cold start, never throws')
+    // a partial blob (merged only) backfills pending from ALL_ISSUES minus merged (never drops an issue)
+    const partial = parseRehydrate({ merged: [3, 12] }, ALL_ISSUES)
+    assert.deepEqual(partial.merged, [3, 12])
+    assert.deepEqual(partial.pending, [8, 45, 100], 'partial blob backfills pending from the wave issue list')
+    // a blob that merged an issue NOT in ALL_ISSUES keeps it merged (still skipped) without crashing
+    const extra = parseRehydrate({ merged: [3, 999], pending: [8] }, ALL_ISSUES)
+    assert.ok(extra.merged.includes(999) && !extra.pending.includes(999), 'unknown merged issue stays skipped')
+    ok('a missing/empty/corrupt/partial blob degrades to a safe state — a killed run resumes, never dies on restart')
+  } catch (e) { bad('robust cold start', e) }
+
+  // ── 4. idempotent worktree-setup + 3-point cleanup git commands are correctly shaped ────
+  try {
+    const targetRepoDir = '/home/x/ccwork-testtarget'
+    const waveId = 'W-7'
+    const kahunaBranch = 'kahuna/W-7'
+
+    // RESUME path: branch already exists → reuse it, NEVER -b (the §4.2 idempotency crux)
+    const reuse = worktreeSetupCmds({ targetRepoDir, waveId, kahunaBranch, issue: 8, branchExists: true })
+    assert.ok(reuse.some((c) => c.includes('worktree prune')), 'setup prunes stale registrations first (crash recovery)')
+    const reuseAdd = reuse.find((c) => c.includes('worktree add'))
+    assert.ok(!reuseAdd.includes(' -b '), 'resume reuses the existing branch — NEVER -b (would fail if branch exists)')
+    assert.ok(reuseAdd.includes(issueBranchFor(waveId, 8)), 'reuse add names the existing wave branch')
+
+    // FRESH path: branch absent → create with -b off origin/<kahuna>
+    const fresh = worktreeSetupCmds({ targetRepoDir, waveId, kahunaBranch, issue: 8, branchExists: false })
+    const freshAdd = fresh.find((c) => c.includes('worktree add'))
+    assert.ok(freshAdd.includes(' -b '), 'fresh create uses -b')
+    assert.ok(freshAdd.includes(`origin/${kahunaBranch}`), 'fresh branch is based on origin/<kahuna>')
+    ok('worktree setup is idempotent: reuse-branch-on-resume (never -b), -b only on fresh create')
+
+    // per-merge cleanup = the 4-point sequence, branch -D included, correct order
+    const cm = cleanupMergedCmds({ targetRepoDir, waveId, issue: 45 })
+    assert.equal(cm.length, 4, '4-point cleanup')
+    assert.ok(cm[0].includes('worktree remove --force'), '1: worktree remove --force')
+    assert.ok(cm[1].includes('worktree prune'), '2: worktree prune')
+    assert.ok(cm[2].startsWith('rm -rf'), '3: rm -rf')
+    assert.ok(cm[3].includes('branch -D') && cm[3].includes(issueBranchFor(waveId, 45)),
+      '4: branch -D the wave branch (worktree remove leaves the branch behind — pilot-1 dead-ref bug)')
+    assert.ok(cm.some((c) => c.includes(wtPathFor(targetRepoDir, waveId, 45))), 'cleanup targets the issue worktree path')
+    ok('per-merge cleanup is the 4-point §4.3 sequence with the load-bearing branch -D')
+
+    // terminal cleanup glob shares the wave-<id> stem (single glob cleans dir + branch)
+    const ct = cleanupTerminalCmds({ targetRepoDir, waveId })
+    assert.ok(ct.some((c) => c.includes('worktree prune')), 'terminal prunes the registry')
+    assert.ok(ct.some((c) => c.includes(`wave-${waveId}/`)), 'terminal branch glob shares the wave-<id>/ stem (§4.3 — dir+branch one glob)')
+    assert.ok(ct.some((c) => c.includes('branch -D')), 'terminal deletes wave branches, not just worktrees')
+    ok('terminal cleanup sweeps remaining worktrees + glob-deletes wave-<id>/* branches (both ends, §4.3)')
+  } catch (e) { bad('worktree/cleanup command shape', e) }
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
+
+console.log('')
+if (failures) { console.log(`  ${failures} assertion group(s) failed`); process.exit(1) }
+console.log('  all #686 resume + idempotency round-trip checks passed')
+
+// ─────────────────────────────────────────────────────────────────────────────────────────
+// HOW TO RUN THE FULL LIVE KILL-AND-RESUME INTEGRATION TEST (requires a live sdlc-server)
+// ─────────────────────────────────────────────────────────────────────────────────────────
+// The pure half above proves the SERIALIZATION + idempotency contract. The end-to-end AC —
+// "a killed run resumes to an identical final state with no duplicated side effects" — is an
+// integration test that the unit harness CANNOT cover, because it needs the agent()-driven
+// side-effects against a real sdlc-server + a real target repo. To run it manually:
+//
+//   1. Provision a throwaway target repo + a multi-group wave (e.g. ccwork-testtarget, 4-5 issues
+//      with one cross-group dependency so the loop runs ≥2 groups).
+//   2. Launch the per-wave Workflow (skills/nextwave-next/per-wave-workflow.js) via the SDK
+//      Workflow({ scriptPath }) with { waveId, targetRepo, targetRepoDir, kahunaBranch, issues }.
+//   3. KILL the process mid-reconcile of group 2 (after group 1's issues merged + persistIteration
+//      wrote .claude/status/wave-<id>.json, before the wave completes). Confirm the durable blob on
+//      disk shows group-1 issues in `merged`.
+//   4. RESTART the same Workflow with the same input (cold start — no resumeFromRunId). rehydrate()
+//      reads the blob; the loop seeds `merged` and SKIPS group 1; setupWorktrees reuses the existing
+//      branches (never -b); the worker returns status:"already-present" for anything already done;
+//      reconcile SKIPS branches already in kahuna.
+//   5. ASSERT: the resumed run's final merged set == an uninterrupted run's; NO issue's MR is
+//      recorded twice (wave_record_mr is issue-keyed/idempotent); NO branch is double-merged; the
+//      target repo has no duplicate commits on kahuna.
+//
+// This file deliberately does NOT claim that path is automated. It is the remaining manual gate.

--- a/tests/regression/test_resume_rehydrate.sh
+++ b/tests/regression/test_resume_rehydrate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# test_resume_rehydrate.sh — #686 resumability + idempotency seam regression test.
+#
+# Picked up by scripts/ci/validate.sh's "Regression tests" loop (tests/regression/*.sh).
+# Two assertions for the #686 seam:
+#   1. node --check on the seam helper + the workflow that imports it (syntax must hold).
+#   2. the rehydrate/idempotency round-trip: mid-run loop state → blob → rehydrate → equal
+#      (skip-on-resume), idempotent reseed (fixed point), corrupt-blob → safe cold start, and
+#      the idempotent worktree-setup + 3-point-cleanup git-command shapes. Logic lives in the
+#      sibling .mjs.
+#
+# What this CANNOT cover (needs a live sdlc-server): the full live kill-and-resume integration
+# test. The HOW-TO for that manual gate is documented at the bottom of the sibling .mjs.
+#
+# Implementation of (2): tests/regression/resume_rehydrate_roundtrip.mjs
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "test_resume_rehydrate"
+echo "──────────────────────────────────────────"
+
+if ! command -v node &>/dev/null; then
+	echo "  [FAIL] node not found — required for the #686 resume + idempotency test"
+	exit 1
+fi
+
+node --check "$REPO_DIR/skills/nextwave-next/resume.js"
+echo "  [PASS] resume.js syntax (node --check)"
+node --check "$REPO_DIR/skills/nextwave-next/per-wave-workflow.js"
+echo "  [PASS] per-wave-workflow.js syntax (node --check)"
+
+exec node "$REPO_DIR/tests/regression/resume_rehydrate_roundtrip.mjs"


### PR DESCRIPTION
## Summary

Fills the **#686 resumability + idempotency seams** in the per-wave Workflow (`skills/nextwave-next/per-wave-workflow.js`) — the riskiest, never-pilot-tested piece (no pilot ever killed-and-resumed a run). The loop, the #687 gate seams, and the #688 persistence seam are untouched; signatures/return-shapes are honored verbatim per `SEAMS.md`.

## Changes

- **New `skills/nextwave-next/resume.js`** (the #686 seam owner). The workflow script cannot call MCP/CLI/git directly (§3.3), so each seam is an `agent()` call; this module owns the pure, unit-testable halves + the agent prompts:
  - `parseRehydrate(blob, allIssues)` / `coldStart` — the rehydrate read-back (inverse of #688 `toBlob`). **Total by construction**: missing/empty/corrupt/partial blob degrades to a clean cold start; backfills `pending` from the wave issue list so no issue is silently dropped. reworkCount keys round-trip JSON-string-keyed (the loop Number-casts them).
  - `worktreeSetupCmds` / `cleanupMergedCmds` / `cleanupTerminalCmds` — idempotent git-command builders. Reuse-branch-on-resume (**never `-b`**, §4.2); the 4-point cleanup (`worktree remove --force` → `prune` → `rm -rf` → `branch -D`, §4.3); dir + branch + cleanup-glob share one `wave-<id>` stem.
  - `rehydratePrompt` / `setupWorktreesPrompt` / `cleanupMergedPrompt` / `cleanupTerminalPrompt`.
- **`per-wave-workflow.js`**: filled `rehydrate()`, `setupWorktrees()`, `cleanupMerged()`, `cleanupTerminal()` (signatures/return-shapes unchanged). Added `WORKTREES` + `CLEANUP_RESULT` schemas. Path/branch helpers now derive from resume.js so dir/branch/glob agree on one fs-safe wave-id. Every seam `agent()` soft-fails (`.catch` → log + continue) so cleanup/rehydrate failures never halt the wave; rehydrate degrades to cold start (idempotent workers/reconcile make the re-run safe).
- **Worker / reconcile idempotency halves** were already real in the prompts (worker `status:"already-present"`; reconcile "already in kahuna → skip"); the `WORK` enum + the loop's `implemented` filter already wire them.
- Hardened the terminal branch-glob to single-quote the git ref pattern (defends against a shell with `nullglob`/`failglob` that would otherwise list all refs → `branch -D` everything) — from code review.

## Linked Issues

Closes #686

## Test Plan

Run: `./scripts/ci/validate.sh` → **155 passed, 0 failed** (was 154; +1 new regression test).

New `tests/regression/test_resume_rehydrate.sh` + `resume_rehydrate_roundtrip.mjs` — the strongest test possible **without a live sdlc-server**, the pure deterministic half:
- Seeds a durable mid-run blob (3 merged, 2 pending, a reworkCount), rehydrates it, asserts the reconstructed `{merged,pending,reworkCount,idleRounds,groupsRun}` exactly matches — including the numeric-key round-trip — so a resumed loop **skips finished work**.
- Idempotency: re-applying the rehydrated state is a fixed point (no drift); replay → byte-identical blob.
- Robustness: missing/empty/corrupt/partial blob → safe cold start (a killed run resumes, never dies on its own restart).
- The idempotent worktree-setup + 3-point-cleanup git-command shapes (reuse-never-`-b`, the load-bearing `branch -D`, shared wave-`<id>` stem).

**Honestly NOT covered here (needs live infra):** the full live kill-and-resume — start a real multi-group wave, kill it mid-reconcile, restart, observe the resumed run skip already-merged issues with no duplicate merges. That exercises the agent-driven side-effects (`wave_record_mr`/`wave_close_issue`, the rehydrate/worktree/cleanup agents actually reading files + running git, worker re-entry, reconcile skip). It is an **integration test requiring sdlc-server**; the exact HOW-TO is documented at the bottom of `resume_rehydrate_roundtrip.mjs`. This PR does **not** claim that path is automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)