### PR TITLE
feat(wave-impl): #687 trust-gate wiring + promotion seam

### DIFF
--- a/skills/nextwave-next/SEAMS.md
+++ b/skills/nextwave-next/SEAMS.md
@@ -19,9 +19,9 @@ depend only on the return shapes here — not on how they are produced.
 
 | Seam | Issue | What it provides |
 |---|---|---|
-| rehydrate / idempotency | **#686** | durable resume: seed loop state from wave-status; idempotent worktree setup + 3-point cleanup |
-| real gate signals | **#687** | the four trust signals via sdlc-server, the plan/worker/reconcile MCP tool calls, and promotion |
-| wave-status persistence | **#688** | the durable resume substrate: per-iteration loop blob + per-issue MR/close + terminal disposition |
+| rehydrate / idempotency | **#686** (FILLED) | durable resume: seed loop state from wave-status; idempotent worktree setup + 3-point cleanup |
+| real gate signals | **#687** (FILLED) | the four trust signals via sdlc-server, the plan/worker/reconcile MCP tool calls, and promotion |
+| wave-status persistence | **#688** (FILLED) | the durable resume substrate: per-iteration loop blob + per-issue MR/close + terminal disposition |
 
 ---
 
@@ -79,12 +79,16 @@ wave-status and returns the loop blob; worktree setup/cleanup are idempotent fil
 
 ---
 
-## #687 — real gate signals via sdlc-server (+ plan/worker/reconcile MCP + promote)
+## #687 — real gate signals via sdlc-server (+ plan/worker/reconcile MCP + promote) — FILLED
 
 The `agent()` **prompts** for plan / worker / reconcile / the four gate signals are
-**real and shipped** (not seams). The seam is the **sdlc-server tool calls those agents
-make** — currently `// TODO(#687 gate wiring)` lines inside the prompts, plus the
-`gateSignalStub()` fallback and the promotion stub.
+**real and shipped** (not seams). The seam was the **sdlc-server tool calls those agents
+make**. #687 **FILLED** it: the four trust-signal prompts + the conservative-fail SIG +
+the promotion prompt live in `gate.js`; the `// TODO(#687 gate wiring)` lines are gone, the
+`gateSignalStub()` always-pass placeholder is **deleted**, and each signal's `.catch` now
+returns `conservativeFail()` (passed:false → HOLD). The plan/worker/reconcile prompts name
+the real `spec_get` / `flight_partition` / `commutativity_verify` / `pr_create` / `pr_merge`
+calls. Promotion is wired as CODE that runs only on a live wave's auto+PASS success exit.
 
 ### The four trust signals (§3.4) — each returns `SIG`
 
@@ -172,8 +176,9 @@ they are what make the loop deterministic and resumable:
    HOLD reason (incl. per-issue breaker) skips it — that is by construction, not a seam.
 5. **Persistence is idempotent** — re-running `persistIteration` / `persistTerminal` with
    the same state is a no-op-or-overwrite, never a duplicate-side-effect.
-6. **The `#687` gate stubs are the ONLY always-pass placeholders.** Once #687 lands, real
-   signals replace them; until then a skeleton run reaches PASS so the full spine is
-   exercisable end-to-end. **When wiring #687, also drop the per-signal `.catch(() => gateSignalStub(...))`
-   fallbacks** — in production an agent/signal error must HOLD (conservative-fail), never silently PASS.
-   (Skeleton keeps the fallbacks so the spine runs before the real signals exist.)
+6. **A gate signal that ERRORS HOLDs the wave — it never silently PASSes** (#687 FILLED).
+   The skeleton's always-pass `gateSignalStub()` is deleted; each signal's `.catch` now
+   returns `conservativeFail()` (passed:false). An agent/tool error is the absence of
+   evidence, and a trust gate HOLDs on absence of evidence. The gate stays unanimous:
+   `failed.length === 0` ⇒ PASS. Any future signal added here MUST keep this property —
+   no `.catch` may resolve to a passing SIG.

--- a/skills/nextwave-next/gate.js
+++ b/skills/nextwave-next/gate.js
@@ -1,0 +1,165 @@
+// gate.js — the #687 trust-gate seam helper for per-wave-workflow.js.
+//
+// Design of record: docs/wavemachine-workflows-migration.md §3.4 (trust gate).
+// Seam contract: skills/nextwave-next/SEAMS.md (#687 — real gate signals via sdlc-server
+// (+ plan/worker/reconcile MCP + promote)).
+//
+// WHY A HELPER MODULE: the workflow script cannot call MCP/CLI directly (§3.3) — every
+// real action is an agent() call. This module owns, WITHOUT bloating the loop:
+//   1. the four trust-signal agent PROMPTS — each names the REAL sdlc-server tool the
+//      signal agent must call (commutativity_verify / ci_wait_run on the MR merge-result
+//      pipeline [#452] / code-reviewer on a kahuna worktree [#667] / trivy HIGH,CRITICAL),
+//      and the EXACT pass predicate the agent must apply.
+//   2. the conservative-fail SIG the loop substitutes when a signal agent ERRORS — the
+//      production replacement for the skeleton's always-pass gateSignalStub(): an agent or
+//      tool error HOLDs the wave, it NEVER silently PASSes (SEAMS invariant 6).
+//   3. the promotion agent PROMPT (the success-exit terminal step): wave_finalize opens the
+//      kahuna→protected MR, pr_merge(skip_train:true) lands it on all-green, the kahuna
+//      branch is deleted, disposition recorded. CODE ONLY — the loop calls it solely on a
+//      live wave's success exit (gated by the human cutover, #691); never during a build.
+//
+// DIFF-SCOPING (§3.4): every static signal is scoped to the wave's CHANGED FILES
+// (kahuna-vs-protected), NEVER the whole tree — otherwise pre-existing baseline debt
+// spuriously HOLDs an otherwise-clean wave. Lint/typecheck are NOT a fifth signal; they
+// ride INSIDE the CI signal (ci_wait_run runs the project's full gate on the merge result).
+
+// ── Conservative-fail SIG (replaces the always-pass gateSignalStub) ──────────────────
+// SEAMS invariant 6: when #687 lands, the per-signal `.catch(() => gateSignalStub(...))`
+// fallbacks go away. In production an agent/signal ERROR is not evidence of safety — it is
+// the ABSENCE of evidence, and the gate is a trust gate, so absence of evidence = HOLD.
+// The loop wraps each signal's `.catch` with this: a failed signal returns passed:false.
+export function conservativeFail(signal, err) {
+  const msg = err?.message || (typeof err === 'string' ? err : JSON.stringify(err ?? 'unknown error'))
+  return {
+    signal,
+    passed: false, // conservative-fail: an errored signal HOLDs the wave, never PASSes
+    detail: `signal ERRORED — conservative-fail (HOLD): ${msg}`,
+  }
+}
+
+// ── 1. commutativity signal ──────────────────────────────────────────────────────────
+// Single-target mode (one changeset = the whole kahuna composed diff): is kahuna safe to
+// land in the protected branch? pass = verdict ∈ {STRONG, MEDIUM}; PROBE_UNAVAILABLE (or a
+// timeout sharing its body shape) = conservative-fail, per the tool's own contract.
+export function commutativitySignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepoDir }) {
+  return [
+    `Trust-gate COMMUTATIVITY signal for wave ${waveId}.`,
+    `Call sdlc-server commutativity_verify in SINGLE-TARGET mode — the KAHUNA composed-diff safety gate:`,
+    `  repo_path=${targetRepoDir}`,
+    `  base_ref=${protectedBranch}`,
+    `  changesets=[{ id: "kahuna", head_ref: "${kahunaBranch}" }]`,
+    `Apply the pass predicate EXACTLY: passed = (verdict ∈ {STRONG, MEDIUM}). Every other verdict FAILS,`,
+    `INCLUDING PROBE_UNAVAILABLE and any timeout/handler-synthesized body — those are CONSERVATIVE-FAIL`,
+    `(the probe could not prove safety, so the gate must HOLD), per the tool's documented contract.`,
+    `Do NOT do any other work. Return signal="commutativity", passed (bool), detail (the verdict + 1 line).`,
+  ].join('\n')
+}
+
+// ── 2. CI signal (#452: MR merge-result pipeline, NOT merge-commit branch HEAD) ───────
+// ci_wait_run on the kahuna→protected MR. pass accepts BOTH the real green AND the GitHub
+// merge-queue "validated, nothing to run on push" shape the tool emits (final_status
+// "not_applicable" / reason "merge_group_validated") — else a clean merge-queue wave HOLDs
+// spuriously. Lint/typecheck ride INSIDE this signal (the project's full gate runs in CI),
+// diff-scoped to the wave's changed files (§3.4).
+export function ciSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo }) {
+  return [
+    `Trust-gate CI signal for wave ${waveId}. Wait on the ${kahunaBranch}→${protectedBranch} MR/PR`,
+    `MERGE-RESULT pipeline — NOT the merge-commit branch HEAD [sdlc #452].`,
+    ``,
+    `1. Find the open ${kahunaBranch}→${protectedBranch} PR/MR (sdlc-server pr_status / pr_list, or`,
+    `   gh -R ${targetRepo}). The CI you wait on is the pipeline produced by MERGING kahuna INTO`,
+    `   ${protectedBranch} (the merge result), not the branch's own latest push.`,
+    `2. Call sdlc-server ci_wait_run on that merge-result ref (repo=${targetRepo}).`,
+    `3. Pass predicate — passed = ANY of:`,
+    `     • final_status == "success", OR`,
+    `     • final_status == "not_applicable" AND reason == "merge_group_validated"  (GitHub merge-queue:`,
+    `       a skipped push pipeline + a passing merge_group run IS a validated merge result — do NOT HOLD on it).`,
+    `   Any other final_status (failure / timed_out / cancelled / unknown) FAILS.`,
+    `   The project's lint + typecheck RIDE INSIDE this pipeline, diff-scoped to the wave's changed files`,
+    `   (§3.4) — they are not a separate signal; pre-existing baseline debt must NOT fail this signal.`,
+    `Do NOT do any other work. Return signal="ci", passed (bool), detail (final_status/reason + 1 line).`,
+  ].join('\n')
+}
+
+// ── 3. review signal (#667: code-reviewer on a worktree of kahuna) ────────────────────
+// agentType feature-dev:code-reviewer with isolation:'worktree' (set at the call site, not
+// here) so the reviewer sees the kahuna branch NATIVELY — no diff-materialization workaround.
+// Scoped to the kahuna-vs-protected diff (CHANGED FILES only, §3.4). pass = no
+// critical/important findings.
+export function reviewSignalPrompt({ waveId, kahunaBranch, protectedBranch }) {
+  return [
+    `Trust-gate REVIEW signal for wave ${waveId}. You are running on a WORKTREE of ${kahunaBranch}`,
+    `(isolation:'worktree' — the branch is checked out natively; #667). Review the ${kahunaBranch}-vs-`,
+    `${protectedBranch} diff for correctness / architecture / unstated intent — the rung a test cannot`,
+    `encode (§9 verification ladder).`,
+    ``,
+    `SCOPE STRICTLY to the wave's CHANGED FILES (the kahuna-vs-${protectedBranch} diff), NEVER the whole`,
+    `tree (§3.4) — pre-existing baseline debt in untouched files must NOT fail this signal.`,
+    `Pass predicate: passed = NO critical and NO important findings in the changed files. Nits/minor do`,
+    `not fail the signal (record them in detail).`,
+    `Do NOT modify any code — this is a read-only signal. Return signal="review", passed (bool),`,
+    `detail (finding count by severity + 1 line).`,
+  ].join('\n')
+}
+
+// ── 4. trivy signal (HIGH/CRITICAL dependency vulns on kahuna) ────────────────────────
+// pass = no HIGH/CRITICAL findings WITH AN AVAILABLE FIX (an unfixable upstream advisory
+// must not permanently wedge the gate — that is a deferral decision, not a wave defect).
+export function trivySignalPrompt({ waveId, kahunaBranch, targetRepoDir }) {
+  return [
+    `Trust-gate TRIVY signal for wave ${waveId}. Scan ${kahunaBranch} for dependency vulnerabilities:`,
+    `  trivy fs --scanners vuln --severity HIGH,CRITICAL ${targetRepoDir}`,
+    `(ensure ${kahunaBranch} is the checked-out / scanned state of ${targetRepoDir}).`,
+    `Pass predicate: passed = NO HIGH/CRITICAL finding that has an AVAILABLE FIXED VERSION. An`,
+    `unfixable upstream advisory (no fixed version published) does NOT fail the signal — record it in`,
+    `detail as a deferral. If trivy is not installed or the scan cannot run, that is CONSERVATIVE-FAIL`,
+    `(passed=false) — the gate must not PASS on the absence of a scan.`,
+    `Do NOT do any other work. Return signal="trivy", passed (bool), detail (count + 1 line).`,
+  ].join('\n')
+}
+
+// ── Promotion (the success-exit terminal step — CODE ONLY) ────────────────────────────
+// Called by the workflow ONLY when MODE==='auto' AND the gate verdict is PASS — i.e. only on
+// a live wave's success exit. wave_finalize opens (idempotent) the kahuna→protected MR;
+// pr_merge(skip_train:true) lands it once the merge-result CI is green (commutativity already
+// proved skip_train safe in the gate); the kahuna branch is deleted; disposition recorded.
+// On a merge-queue-ENFORCED repo skip_train is silently dropped and the PR is enrolled — the
+// agent waits for it to land (pr_merge_wait) rather than treating enrolled-but-not-merged as done.
+//
+// SAFETY (#691): this prompt is the CODE for promotion. It executes a real kahuna→protected
+// merge, so it runs SOLELY from the workflow's auto+PASS branch on a live wave that reached the
+// success exit — which is itself gated by the human cutover (#691). Building/validating this
+// module never invokes it.
+export function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, planId }) {
+  return [
+    `You are the wave PROMOTION node for wave ${waveId} of ${targetRepo}. The trust gate returned PASS`,
+    `and the wave is in AUTO mode. Land ${kahunaBranch} into ${protectedBranch}, then return. Do NOT do`,
+    `any other work; do NOT re-run the gate (it already PASSed).`,
+    ``,
+    `1. Open (or return the existing — idempotent) ${kahunaBranch}→${protectedBranch} MR via sdlc-server`,
+    `   wave_finalize(plan_id=${planId ?? '<the wave plan id>'}, kahuna_branch="${kahunaBranch}",`,
+    `   target_branch="${protectedBranch}"). If it returns kahuna_branch_not_found or no_artifacts,`,
+    `   STOP and return promoted=false with the reason in notes (do NOT fabricate a merge).`,
+    `2. Merge it: sdlc-server pr_merge(number=<the MR number>, skip_train=true) — commutativity_verify`,
+    `   already proved the composed diff safe, so the train is unnecessary. On a merge-queue-ENFORCED`,
+    `   repo skip_train is silently dropped and the PR is ENROLLED (merged=false, queued): in that case`,
+    `   wait for it to actually land on ${protectedBranch} (pr_merge_wait) before reporting promoted.`,
+    `3. Once ${kahunaBranch} is on ${protectedBranch}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
+    `   api / git push origin --delete) — the wave is done; the integration branch is disposable.`,
+    ``,
+    `Return: promoted (true ONLY if the merge actually landed on ${protectedBranch}), mr_ref (the MR`,
+    `URL/number), notes (1-2 sentences; include any error — and on error, promoted=false).`,
+  ].join('\n')
+}
+
+// The promotion agent's structured return (side-effect + outcome, not judgment).
+export const PROMOTE_RESULT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['promoted'],
+  properties: {
+    promoted: { type: 'boolean' }, // true ONLY if the merge actually landed on the protected branch
+    mr_ref: { type: 'string' },
+    notes: { type: 'string' },
+  },
+}

--- a/skills/nextwave-next/per-wave-workflow.js
+++ b/skills/nextwave-next/per-wave-workflow.js
@@ -583,7 +583,10 @@ if (!halt && pending.size === 0) {
       trivySignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, targetRepoDir: TARGET_REPO_DIR }),
       { label: 'gate:trivy', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
     ).catch((e) => conservativeFail('trivy', e)),
-  ])).filter(Boolean)
+    // A null/undefined slot (an SDK-level failure upstream of the per-signal .catch) must become a
+    // conservative-fail, NEVER be dropped — the gate must always weigh exactly 4 signals, or a
+    // missing signal silently becomes a PASS (absence-of-evidence-as-safety). #687 review.
+  ])).map((s, i) => s ?? conservativeFail(['commutativity', 'ci', 'review', 'trivy'][i], 'signal slot returned null/undefined'))
 
   const failed = signals.filter((s) => !s.passed)
   gate = failed.length === 0

--- a/skills/nextwave-next/per-wave-workflow.js
+++ b/skills/nextwave-next/per-wave-workflow.js
@@ -17,15 +17,18 @@
 //       wave-pilot-iter3b-replan-wf (the §3.1 dynamic re-plan loop)
 //   - the trust gate's 4-signal parallel fan-out + ff-or-hold verdict.
 //
-// WHAT IS A SEAM (stubbed, filled by a wave-2 foundational issue):
-//   - rehydrate / idempotency               → TODO(#686 resumability/rehydrate)
-//   - real gate signals via sdlc-server      → TODO(#687 gate wiring)
-//   - wave-status persistence (durable state) → TODO(#688 wave-status persistence)
+// SEAM STATUS (filled by the wave-2 foundational issues):
+//   - rehydrate / idempotency               → #686 (FILLED — resume.js)
+//   - real gate signals via sdlc-server      → #687 (FILLED — gate.js)
+//   - wave-status persistence (durable state) → #688 (FILLED — wave-status.js)
 //   See SEAMS.md (this dir) for the exact function/return signatures each seam expects.
 //
 // The agent() prompts below are REAL (worker / Prime-plan / Prime-reconcile /
-// signal). The sdlc-server MCP TOOL CALLS those agents make are the seam — the
-// stubs return obvious placeholders so the loop runs end-to-end in skeleton form.
+// signal). With #687 filled, the sdlc-server MCP TOOL CALLS those agents make are
+// REAL too: the four trust signals name commutativity_verify / ci_wait_run (on the MR
+// merge-result pipeline [#452]) / code-reviewer on a kahuna worktree [#667] / trivy,
+// each errors CONSERVATIVE-FAIL (HOLD, never silent PASS), and the auto-mode promotion
+// (wave_finalize → pr_merge) is wired as CODE that runs only on a live wave's success exit.
 
 // #688 wave-status persistence seam helper: durable blob shape/path + the persist
 // agent prompts (the MCP record/close calls + the .claude/status/ blob write). See
@@ -45,6 +48,20 @@ import {
   wtPathFor,
   issueBranchFor,
 } from './resume.js'
+// #687 trust-gate seam helper: the four trust-signal agent prompts (each naming the real
+// sdlc-server tool — commutativity_verify / ci_wait_run on the MR merge-result pipeline [#452] /
+// code-reviewer on a kahuna worktree [#667] / trivy), the conservative-fail SIG that replaces the
+// always-pass skeleton stub on a signal error (SEAMS invariant 6), and the auto-mode promotion
+// prompt (wave_finalize → pr_merge — CODE ONLY, run solely on a live wave's success exit). See gate.js.
+import {
+  conservativeFail,
+  commutativitySignalPrompt,
+  ciSignalPrompt,
+  reviewSignalPrompt,
+  trivySignalPrompt,
+  promotePrompt,
+  PROMOTE_RESULT,
+} from './gate.js'
 
 export const meta = {
   name: 'per-wave-workflow',
@@ -71,6 +88,7 @@ const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // integration 
 const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // promotion target on the success exit
 const ALL_ISSUES = (params.issues ?? []).map(Number) // the wave's issue numbers
 const MODE = params.mode ?? 'auto' // 'auto' (gate verdict drives promotion) | 'interactive' (verdict returned, human routes)
+const PLAN_ID = params.planId ?? null // wave plan id — wave_finalize needs it to assemble the kahuna→protected MR body (#687 promote)
 const budget = params.budget ?? { total: 0, remaining: () => Infinity } // optional cost guard
 const budgetRemaining = typeof budget.remaining === 'function' ? budget.remaining : () => (budget.remaining ?? Infinity) // tolerate `remaining` passed as a number, not a fn
 
@@ -285,15 +303,9 @@ async function persistTerminal(disposition, detail) {
   log(`[#688] persisted terminal — wave ${WAVE_ID} ${disposition}: ${detail} → ${path}`)
 }
 
-// SEAM #687 — real gate signals. Stub returns a passing placeholder so the gate
-// fan-out runs end-to-end. The REAL signal is the agent() prompt shown inline in
-// the trust gate below; this helper is only the stubbed return for skeleton runs.
-function gateSignalStub(name) {
-  // TODO(#687 gate wiring): delete this stub. The trust gate below shows the real
-  // agent() calls (commutativity_verify / ci_wait_run on the MR merge-result
-  // pipeline [sdlc #452] / code-reviewer on a kahuna worktree [#667] / trivy).
-  return { signal: name, passed: true, detail: `[SEAM #687] ${name} stub — always-pass placeholder` }
-}
+// SEAM #687 — FILLED. The always-pass gateSignalStub() is GONE: a signal that ERRORS now
+// returns conservativeFail() (passed:false → HOLD), never a silent PASS (SEAMS invariant 6).
+// The real signal prompts + the conservative-fail SIG + the promotion prompt live in gate.js.
 
 // SEAM #686 — idempotent worktree setup (FILLED). Awaited as a SINGLE step before parallel()
 // so workers are HANDED a path, never asked to create one (race-safety is structural, §4.2).
@@ -358,7 +370,8 @@ function primePlanPrompt(merged, pending, lastRework) {
     `For each pending issue fetch its spec (sdlc-server spec_get / work_item) and file manifest, then run`,
     `flight_overlap + flight_partition to pick a maximal NON-CONFLICTING parallel group. A surfaced dependency`,
     `from "just re-opened" goes in THIS group (re-run against the now-merged provider). When in doubt, sequence.`,
-    `// TODO(#687 gate wiring): real spec_get / flight_partition / flight_overlap sdlc-server calls.`,
+    `Use the REAL sdlc-server tools: spec_get / work_item (specs + file manifests), flight_overlap +`,
+    `flight_partition (the conflict-free grouping). Do not guess a partition you can compute.`,
     ``,
     `Return: done (true ONLY if nothing schedulable remains — that is an IMPASSE, not success),`,
     `group (issue numbers for the next parallel flight-group), rationale (1-2 sentences).`,
@@ -378,8 +391,8 @@ function workerPrompt(n, worktree) {
     `target files exist + the acceptance test passes). If so, return status="already-present" and do NOT redo work.`,
     ``,
     `Otherwise — SPEC EXECUTOR rules:`,
-    `1. Fetch the spec + acceptance criteria (sdlc-server spec_get / spec_acceptance_criteria for #${n}).`,
-    `   // TODO(#687 gate wiring): real spec_get / spec_acceptance_criteria + work_item sdlc-server calls.`,
+    `1. Fetch the spec + acceptance criteria via the REAL sdlc-server tools for #${n}: spec_get,`,
+    `   spec_acceptance_criteria, work_item (the issue body + AC are the executable contract).`,
     `2. Implement EXACTLY what the issue specifies. Where the story has a canonical acceptance test, run it as an`,
     `   ORACLE (self-authored tests are necessary but not sufficient — §9 verification ladder).`,
     `3. Run the project gate in your worktree (./scripts/ci/validate.sh + the test suite). The pre-push test gate`,
@@ -411,8 +424,9 @@ function primeReconcilePrompt(built, merged) {
     `   IDEMPOTENT (§3.3): if a branch is already in ${KAHUNA_BRANCH}, SKIP it (do not double-merge).`,
     `2. Resolve conflicts coherently — combine, do not drop. A shared interface two issues touch is a CROSS-FLIGHT`,
     `   fix you make HERE (you have the multi-branch view); record it in conflicts_resolved (§3.2.3).`,
-    `3. Run commutativity_verify across the merged set + the FULL suite (the composition / commutativity check).`,
-    `   // TODO(#687 gate wiring): real commutativity_verify + merge (pr_create/pr_merge) sdlc-server calls.`,
+    `3. Run the REAL sdlc-server tools: commutativity_verify (PAIRWISE mode across this group's branches —`,
+    `   base_ref=${KAHUNA_BRANCH} — to decide whether a merge train is needed) BEFORE merging, then`,
+    `   pr_create + pr_merge to land each flight branch into ${KAHUNA_BRANCH}, plus the FULL suite.`,
     `4. If a flight's code BREAKS another's interface (signature mismatch surfaced at integration): UNDO just that`,
     `   flight's merge (keep integration green) and report it in needs_rework with the precise reason — the loop`,
     `   re-opens it as a surfaced dependency and re-schedules it next group (§3.1 dynamic re-plan).`,
@@ -538,40 +552,24 @@ log(`Flight loop done: ${loopOutcome} in ${groupsRun.length} groups (concerns: $
 phase('Trust gate')
 let gate
 if (!halt && pending.size === 0) {
-  // The 4 canonical signals run in PARALLEL (independent), aggregate to a verdict.
-  // The agent() prompts are REAL; the sdlc-server tool calls inside them are SEAM #687.
+  // The 4 canonical signals run in PARALLEL (independent), aggregate to a verdict. The agent()
+  // prompts (gate.js) name the REAL sdlc-server tools; each signal's `.catch` now returns
+  // conservativeFail() (passed:false → HOLD), NOT an always-pass stub — an agent/tool error is
+  // the absence of evidence, and a trust gate HOLDs on absence of evidence (SEAMS invariant 6).
   const signals = (await parallel([
-    // 1. commutativity across kahuna
+    // 1. commutativity — kahuna composed-diff safety vs the protected branch (single-target mode)
     () => agent(
-      [
-        `Trust-gate COMMUTATIVITY signal for wave ${WAVE_ID}. Run commutativity_verify across ${KAHUNA_BRANCH}`,
-        `(base ${PROTECTED_BRANCH}). pass = verdict ∈ {STRONG, MEDIUM}; fail otherwise (incl. PROBE_UNAVAILABLE`,
-        `= conservative-fail). // TODO(#687 gate wiring): real commutativity_verify sdlc-server call.`,
-        `Return signal="commutativity", passed (bool), detail.`,
-      ].join('\n'),
+      commutativitySignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepoDir: TARGET_REPO_DIR }),
       { label: 'gate:commutativity', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
-      // TODO(#687): each gate signal's .catch falls back to an always-PASS stub (skeleton only). When the
-      // real signals land, drop these fallbacks so an agent error HOLDs (conservative-fail), never PASSes.
-    ).catch(() => gateSignalStub('commutativity')),
-    // 2. CI on the MR merge-result pipeline — NOT the merge-commit branch HEAD (sdlc #452)
+    ).catch((e) => conservativeFail('commutativity', e)),
+    // 2. CI on the MR MERGE-RESULT pipeline — NOT the merge-commit branch HEAD (sdlc #452)
     () => agent(
-      [
-        `Trust-gate CI signal for wave ${WAVE_ID}. ci_wait_run for the ${KAHUNA_BRANCH}→${PROTECTED_BRANCH} MR`,
-        `MERGE-RESULT pipeline (NOT the merge-commit branch HEAD; skipped-branch + passing-merge-result =`,
-        `validated) [sdlc #452]. Lint/typecheck ride INSIDE this signal, diff-scoped to the wave's changed files`,
-        `(never tree-scoped — §3.4). // TODO(#687 gate wiring): real ci_wait_run sdlc-server call.`,
-        `Return signal="ci", passed (final_status==success), detail.`,
-      ].join('\n'),
+      ciSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO }),
       { label: 'gate:ci', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
-    ).catch(() => gateSignalStub('ci')),
-    // 3. review the full kahuna-vs-main diff — worktree of kahuna, native checkout (#667)
+    ).catch((e) => conservativeFail('ci', e)),
+    // 3. review the kahuna-vs-protected diff — code-reviewer on a WORKTREE of kahuna, native checkout (#667)
     () => agent(
-      [
-        `Trust-gate REVIEW signal for wave ${WAVE_ID}. Review the full ${KAHUNA_BRANCH}-vs-${PROTECTED_BRANCH}`,
-        `diff for correctness / architecture / unstated intent (the rung a test cannot encode — §9 ladder).`,
-        `Scope to the wave's CHANGED FILES only (§3.4). pass = no critical/important findings.`,
-        `Return signal="review", passed (bool), detail.`,
-      ].join('\n'),
+      reviewSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH }),
       {
         label: 'gate:review',
         phase: 'Trust gate',
@@ -579,17 +577,12 @@ if (!halt && pending.size === 0) {
         agentType: 'feature-dev:code-reviewer',
         isolation: 'worktree', // worktree of kahuna so the reviewer sees the branch natively (#667)
       },
-    ).catch(() => gateSignalStub('review')),
+    ).catch((e) => conservativeFail('review', e)),
     // 4. trivy HIGH/CRITICAL dependency scan of kahuna
     () => agent(
-      [
-        `Trust-gate TRIVY signal for wave ${WAVE_ID}. Run trivy fs --scanners vuln --severity HIGH,CRITICAL on`,
-        `${KAHUNA_BRANCH}. pass = no HIGH/CRITICAL findings with available fixes.`,
-        `// TODO(#687 gate wiring): the trivy scan rides the deterministic pre-push/secret hooks + this signal.`,
-        `Return signal="trivy", passed (bool), detail.`,
-      ].join('\n'),
+      trivySignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, targetRepoDir: TARGET_REPO_DIR }),
       { label: 'gate:trivy', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
-    ).catch(() => gateSignalStub('trivy')),
+    ).catch((e) => conservativeFail('trivy', e)),
   ])).filter(Boolean)
 
   const failed = signals.filter((s) => !s.passed)
@@ -609,11 +602,28 @@ phase('Promote')
 let result
 if (gate.verdict === 'PASS') {
   if (MODE === 'auto') {
-    // TODO(#687 gate wiring): real promotion — wave_finalize opens the kahuna→protected MR,
-    //   pr_merge(skip_train:true) on all-green, delete the kahuna branch, record disposition.
-    log(`[SEAM #687] promote stub — would auto-merge ${KAHUNA_BRANCH}→${PROTECTED_BRANCH}`)
-    await persistTerminal('promoted', `gate PASS, ${KAHUNA_BRANCH}→${PROTECTED_BRANCH}`) // SEAM #688
-    result = { gate: 'PASS', promoted: true, wave: WAVE_ID }
+    // #687 promotion (CODE, runs ONLY here — a live wave's auto+PASS success exit, itself gated by
+    // the human cutover #691). wave_finalize opens the kahuna→protected MR; pr_merge(skip_train:true)
+    // lands it on all-green (commutativity already proved skip_train safe in the gate); the kahuna
+    // branch is deleted. The script can't call MCP/CLI directly (§3.3) — the promote agent does it.
+    const promo = await agent(
+      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, planId: PLAN_ID }),
+      { label: 'promote', phase: 'Promote', schema: PROMOTE_RESULT, agentType: 'general-purpose' },
+    ).catch((e) => {
+      // A promotion error must NOT be reported as a successful promote (conservative): record HELD,
+      // surface the error, and let the campaign driver / human route it (§5). The gate PASSed, so the
+      // kahuna branch is sound — promotion can be retried on resume; we never claim a merge that failed.
+      log(`[#687] promote soft-fail — wave HELD for manual promotion: ${e?.message || e}`)
+      return { promoted: false, notes: `promote error: ${e?.message || e}` }
+    })
+    const promoted = !!(promo && promo.promoted)
+    await persistTerminal(promoted ? 'promoted' : 'held',
+      promoted
+        ? `gate PASS, promoted ${KAHUNA_BRANCH}→${PROTECTED_BRANCH}${promo.mr_ref ? ` (${promo.mr_ref})` : ''}`
+        : `gate PASS, promotion did not land — ${promo?.notes || 'see promote node'}; HELD for manual promotion`) // SEAM #688
+    result = promoted
+      ? { gate: 'PASS', promoted: true, wave: WAVE_ID, mr_ref: promo.mr_ref }
+      : { gate: 'PASS', promoted: false, wave: WAVE_ID, reason: `promotion did not land: ${promo?.notes || 'see promote node'}` }
   } else {
     // INTERACTIVE: do NOT promote — return the verdict; the campaign driver surfaces it + the human routes.
     await persistTerminal('held', 'gate PASS, interactive — awaiting human promotion') // SEAM #688

--- a/tests/regression/gate_signals_roundtrip.mjs
+++ b/tests/regression/gate_signals_roundtrip.mjs
@@ -1,0 +1,100 @@
+// gate_signals_roundtrip.mjs — #687 trust-gate seam unit test.
+//
+// Pins the load-bearing #687 invariants that DON'T need a live sdlc-server (the agent()-driven
+// signals — commutativity_verify / ci_wait_run / code-reviewer / trivy — need one; those are
+// exercised by a live wave, not here). What IS deterministic and load-bearing:
+//   1. conservativeFail() — the production replacement for the always-pass gateSignalStub:
+//      a signal that ERRORS returns passed:false (HOLD), NEVER passed:true (SEAMS invariant 6).
+//   2. each signal prompt names its REAL sdlc-server tool + the EXACT pass predicate, and is
+//      diff-scoped (the §3.4 refinement: changed-files, never the whole tree).
+//   3. the CI prompt accepts the GitHub merge-queue "merge_group_validated" shape (#452) so a
+//      clean merge-queue wave doesn't spuriously HOLD.
+//   4. the promote prompt is wave_finalize → pr_merge(skip_train) → delete-branch (CODE ONLY).
+
+import assert from 'node:assert/strict'
+import {
+  conservativeFail,
+  commutativitySignalPrompt,
+  ciSignalPrompt,
+  reviewSignalPrompt,
+  trivySignalPrompt,
+  promotePrompt,
+  PROMOTE_RESULT,
+} from '../../skills/nextwave-next/gate.js'
+
+let failures = 0
+const ok = (name) => console.log(`  [PASS] ${name}`)
+const bad = (name, e) => { console.log(`  [FAIL] ${name}: ${e?.message || e}`); failures++ }
+
+console.log('test_gate_signals_roundtrip')
+console.log('──────────────────────────────────────────')
+
+const A = { waveId: 'W-7', kahunaBranch: 'kahuna/692-x', protectedBranch: 'main', targetRepo: 'org/repo', targetRepoDir: '/tmp/repo' }
+
+// ── 1. conservative-fail: an errored signal HOLDs, never PASSes ───────────────────────
+try {
+  for (const sig of ['commutativity', 'ci', 'review', 'trivy']) {
+    const r = conservativeFail(sig, new Error('agent crashed'))
+    assert.equal(r.signal, sig)
+    assert.equal(r.passed, false, `${sig} conservative-fail must be passed:false`)
+    assert.match(r.detail, /conservative-fail/i)
+  }
+  // tolerate non-Error throwables (string / object) without losing the HOLD
+  assert.equal(conservativeFail('ci', 'boom').passed, false)
+  assert.equal(conservativeFail('ci', { code: 7 }).passed, false)
+  assert.equal(conservativeFail('ci', undefined).passed, false)
+  ok('conservativeFail always returns passed:false (HOLD, never silent PASS)')
+} catch (e) { bad('conservative-fail invariant', e) }
+
+// ── 2. each signal prompt names its real tool + pass predicate + is diff-scoped ───────
+try {
+  const c = commutativitySignalPrompt(A)
+  assert.match(c, /commutativity_verify/)
+  assert.match(c, /STRONG/); assert.match(c, /MEDIUM/)
+  assert.match(c, /PROBE_UNAVAILABLE/) // the conservative-fail verdict is named
+  assert.match(c, new RegExp(A.protectedBranch)) // base_ref is the protected branch
+  ok('commutativity prompt: commutativity_verify + STRONG/MEDIUM + PROBE_UNAVAILABLE fail')
+
+  const ci = ciSignalPrompt(A)
+  assert.match(ci, /ci_wait_run/)
+  assert.match(ci, /MERGE-RESULT/) // #452: merge-result pipeline, not branch HEAD
+  assert.match(ci, /NOT the merge-commit branch HEAD/)
+  assert.match(ci, /merge_group_validated/) // #452 GitHub merge-queue shape accepted
+  assert.match(ci, /changed files/) // diff-scoped (§3.4)
+  ok('ci prompt: ci_wait_run on MERGE-RESULT pipeline + merge_group_validated + diff-scoped (#452, §3.4)')
+
+  const rv = reviewSignalPrompt(A)
+  assert.match(rv, /worktree/i) // #667: runs on a worktree of kahuna
+  assert.match(rv, /CHANGED FILES/) // diff-scoped (§3.4)
+  assert.match(rv, /critical/i); assert.match(rv, /important/i) // pass predicate
+  ok('review prompt: worktree-of-kahuna + diff-scoped + no critical/important (#667, §3.4)')
+
+  const tv = trivySignalPrompt(A)
+  assert.match(tv, /trivy fs --scanners vuln --severity HIGH,CRITICAL/)
+  assert.match(tv, /AVAILABLE FIXED VERSION/i) // pass predicate: only fixable vulns fail
+  assert.match(tv, /CONSERVATIVE-FAIL/i) // missing trivy = fail, not pass
+  ok('trivy prompt: HIGH,CRITICAL + available-fix predicate + conservative-fail if uninstalled')
+} catch (e) { bad('signal prompts', e) }
+
+// ── 3. promotion is CODE: wave_finalize → pr_merge(skip_train) → delete-branch ────────
+try {
+  const p = promotePrompt({ ...A, planId: 692 })
+  assert.match(p, /wave_finalize/)
+  assert.match(p, /pr_merge/)
+  assert.match(p, /skip_train/)
+  assert.match(p, /pr_merge_wait/) // merge-queue-enforced fallback: wait for the land
+  assert.match(p, /delete/i) // kahuna branch deleted after promotion
+  assert.match(p, /692/) // plan_id threaded through
+  // promoted:true ONLY if the merge actually landed (no fabricated success)
+  assert.match(p, /promoted \(true ONLY if the merge actually landed/)
+  ok('promote prompt: wave_finalize → pr_merge(skip_train) → delete-branch, promoted-only-if-landed')
+
+  // PROMOTE_RESULT schema shape
+  assert.equal(PROMOTE_RESULT.required[0], 'promoted')
+  assert.equal(PROMOTE_RESULT.properties.promoted.type, 'boolean')
+  ok('PROMOTE_RESULT requires a boolean `promoted`')
+} catch (e) { bad('promotion prompt', e) }
+
+console.log('')
+if (failures) { console.log(`  ${failures} assertion group(s) failed`); process.exit(1) }
+console.log('  all gate-signal checks passed')

--- a/tests/regression/test_gate_signals.sh
+++ b/tests/regression/test_gate_signals.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# test_gate_signals.sh — #687 trust-gate seam regression test.
+#
+# Picked up by scripts/ci/validate.sh's "Regression tests" loop (tests/regression/*.sh).
+# Two assertions for the #687 seam:
+#   1. node --check on the gate helper + the workflow that imports it (syntax must hold).
+#   2. the gate-signal invariants: conservativeFail HOLDs (never silent PASS), each signal
+#      prompt names its real sdlc-server tool + pass predicate (diff-scoped), the CI signal
+#      accepts the GitHub merge-queue shape (#452), and promotion is wave_finalize →
+#      pr_merge(skip_train) → delete-branch. Logic lives in the sibling .mjs.
+#
+# Implementation of (2): tests/regression/gate_signals_roundtrip.mjs
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "test_gate_signals"
+echo "──────────────────────────────────────────"
+
+if ! command -v node &>/dev/null; then
+	echo "  [FAIL] node not found — required for the #687 trust-gate test"
+	exit 1
+fi
+
+node --check "$REPO_DIR/skills/nextwave-next/gate.js"
+echo "  [PASS] gate.js syntax (node --check)"
+node --check "$REPO_DIR/skills/nextwave-next/per-wave-workflow.js"
+echo "  [PASS] per-wave-workflow.js syntax (node --check)"
+
+exec node "$REPO_DIR/tests/regression/gate_signals_roundtrip.mjs"


### PR DESCRIPTION
## Summary

Fill the #687 trust-gate seams in `per-wave-workflow.js`: the four real trust signals via sdlc-server, the conservative-fail conversion, the plan/worker/reconcile MCP wiring, and auto-mode promotion as code. The loop, #686 (resumability), and #688 (wave-status) seams are untouched. Targets `kahuna/692-dynamic-workflows`; **for review — do not auto-merge.**

## What's real now

- **`gate.js`** (new) owns, per the established helper idiom (`resume.js`/`wave-status.js`): the four trust-signal agent prompts, the conservative-fail `SIG`, and the promotion prompt + `PROMOTE_RESULT` schema.
- **The 4 gate signals** (each names the real sdlc-server call, returns `{signal,passed,detail}`, runs in the existing `parallel([...])`; gate is unanimous — `failed.length===0 ⇒ PASS`):
  1. **commutativity** — `commutativity_verify` single-target mode (`base_ref=<protected>`, `changesets=[{id:"kahuna",head_ref:<kahuna>}]`); pass = verdict ∈ {STRONG, MEDIUM}; `PROBE_UNAVAILABLE`/timeout = conservative-fail.
  2. **ci** — `ci_wait_run` on the **kahuna→protected MR MERGE-RESULT pipeline**, not the merge-commit branch HEAD (#452); pass = `final_status=="success"` **OR** (`"not_applicable"` + `reason=="merge_group_validated"`) so a clean GitHub merge-queue wave isn't spuriously held. Lint/typecheck ride inside this signal, diff-scoped.
  3. **review** — `feature-dev:code-reviewer` with `isolation:'worktree'` on kahuna (#667), scoped to the kahuna-vs-protected diff; pass = no critical/important findings.
  4. **trivy** — `trivy fs --scanners vuln --severity HIGH,CRITICAL`; pass = no HIGH/CRITICAL with an available fix; missing trivy = conservative-fail.
- All signals **diff-scoped** (kahuna-vs-protected), never tree-scoped (§3.4) — pre-existing baseline debt cannot HOLD a clean wave.
- **plan/worker/reconcile** prompts now name the real sdlc-server tools (`spec_get`/`work_item`, `flight_overlap`/`flight_partition`, `commutativity_verify`, `pr_create`/`pr_merge`); the `// TODO(#687 gate wiring)` lines are gone.

## .catch → conservative-fail

The always-pass `gateSignalStub()` is **deleted**. Each gate signal's `.catch(() => gateSignalStub(...))` is now `.catch((e) => conservativeFail(signal, e))` → `passed:false` → **HOLD**. An agent/tool error is the absence of evidence, and a trust gate HOLDs on absence of evidence (SEAMS invariant 6, rewritten to match). `conservativeFail` always returns a SIG object, so all 4 signals are always represented in the unanimous tally.

## Promotion — CODE ONLY, did NOT execute

The auto-mode PASS branch now calls a real `promote` agent: `wave_finalize` (idempotent kahuna→protected MR) → `pr_merge(skip_train:true)` → delete the kahuna branch → record disposition. A promote error reports **held** (never a fabricated success). This is **code that runs only when a live wave reaches the auto+PASS success exit** (itself gated by the human cutover #691). **It was not triggered during this build** — no kahuna→main merge was executed; `main` was not touched.

## #452 / #667 verification

- **#452 (ci_wait_run on the merge-result pipeline):** the tool's schema special-cases **GitHub merge-queue** (returns `final_status:"not_applicable"`, `reason:"merge_group_validated"` when a `merge_group` run matches HEAD) — used successfully against GitHub this session, and the CI pass predicate accepts it. **Gap (follow-up):** the issue/design name the **GitLab merge-result-pipeline** case (doc line 319 tags #452 as "ci_wait_run GitLab merge-commit"); the GitLab merge-result handling is **not yet confirmed present** in the tool. This is a real partial gap — tracked below, not a blocker (GitHub path works).
- **#667 (reviewer on a kahuna worktree):** sound for a **same-repo** wave — `isolation:'worktree'` worktrees `CLAUDE_PROJECT_DIR` (the plan repo), which IS the target for a same-repo kahuna, so the reviewer sees the branch natively. For **cross-repo** waves the pre-created target-repo worktree is the isolation instead (per §4.2); the flag is correct only when plan repo == target repo. Wired as designed.

## Follow-ups (non-blocking)

- sdlc-server: confirm/implement `ci_wait_run` GitLab merge-result-pipeline handling (#452) — only the GitHub merge-queue path is verified present.

## Test Plan

- `node --check` on `gate.js` + `per-wave-workflow.js` — pass.
- New `tests/regression/test_gate_signals.sh` (+ `gate_signals_roundtrip.mjs`) pins: conservativeFail always `passed:false`; each signal prompt names its real tool + pass predicate + diff-scoping; CI accepts `merge_group_validated`; promotion = `wave_finalize`→`pr_merge(skip_train)`→delete-branch.
- `./scripts/ci/validate.sh`: **156 passed, 0 failed** (was 155 — the new regression test).
- Not exercisable without a live wave: the agent()-driven signal/promotion runs against a real kahuna→protected MR (noted honestly — same boundary as the #686/#688 seam tests).

## Linked Issues

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
