### PR TITLE
fix(wave-impl): root wave_finalize at the target repo in the trust gate

### DIFF
--- a/skills/nextwave-next/gate.js
+++ b/skills/nextwave-next/gate.js
@@ -79,7 +79,7 @@ export function commutativitySignalPrompt({ waveId, kahunaBranch, protectedBranc
 // Idempotent: re-opening an already-open kahuna→protected PR returns the existing one (wave_finalize
 // is idempotent on the branch pair). opened=false (with a reason) ONLY when the branch/artifacts are
 // missing — in which case the gate HOLDs (it cannot prove a wave it can't even PR). Never fabricates.
-export function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, planId }) {
+export function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, targetRepoDir, planId }) {
   return [
     `You are the wave GATE PR-OPEN node for wave ${waveId} of ${targetRepo}. Open (idempotently) the`,
     `${kahunaBranch}→${protectedBranch} promotion PR/MR as a DRAFT, then return its number. This runs`,
@@ -88,7 +88,11 @@ export function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, t
     ``,
     `1. Open (or return the existing — idempotent) ${kahunaBranch}→${protectedBranch} PR via sdlc-server`,
     `   wave_finalize(plan_id=${planId ?? '<the wave plan id>'}, kahuna_branch="${kahunaBranch}",`,
-    `   target_branch="${protectedBranch}"). If it returns kahuna_branch_not_found or no_artifacts, STOP`,
+    `   target_branch="${protectedBranch}", root="${targetRepoDir}"). The root is LOAD-BEARING (#699 finding`,
+    `   #8): wave_finalize defaults to the SESSION's project for both the plan's durable wave-status AND the`,
+    `   git branch check — but this wave's plan + the ${kahunaBranch} branch live in the TARGET repo clone`,
+    `   ${targetRepoDir}, NOT the session project. Without root it returns kahuna_branch_not_found even though`,
+    `   the branch exists on the remote. If it STILL returns kahuna_branch_not_found or no_artifacts, STOP`,
     `   and return opened=false with the reason in notes (the gate will HOLD — do NOT fabricate a PR).`,
     `2. Ensure the PR is a DRAFT (so a green CI cannot auto-merge it before the gate decides): if`,
     `   wave_finalize did not create it as a draft, convert it (gh -R ${targetRepo} pr ready --undo <number>).`,

--- a/skills/nextwave-next/per-wave-workflow.bundled.js
+++ b/skills/nextwave-next/per-wave-workflow.bundled.js
@@ -491,7 +491,7 @@ function commutativitySignalPrompt({ waveId, kahunaBranch, protectedBranch, targ
 // Idempotent: re-opening an already-open kahuna→protected PR returns the existing one (wave_finalize
 // is idempotent on the branch pair). opened=false (with a reason) ONLY when the branch/artifacts are
 // missing — in which case the gate HOLDs (it cannot prove a wave it can't even PR). Never fabricates.
-function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, planId }) {
+function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, targetRepoDir, planId }) {
   return [
     `You are the wave GATE PR-OPEN node for wave ${waveId} of ${targetRepo}. Open (idempotently) the`,
     `${kahunaBranch}→${protectedBranch} promotion PR/MR as a DRAFT, then return its number. This runs`,
@@ -500,7 +500,11 @@ function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, targetRe
     ``,
     `1. Open (or return the existing — idempotent) ${kahunaBranch}→${protectedBranch} PR via sdlc-server`,
     `   wave_finalize(plan_id=${planId ?? '<the wave plan id>'}, kahuna_branch="${kahunaBranch}",`,
-    `   target_branch="${protectedBranch}"). If it returns kahuna_branch_not_found or no_artifacts, STOP`,
+    `   target_branch="${protectedBranch}", root="${targetRepoDir}"). The root is LOAD-BEARING (#699 finding`,
+    `   #8): wave_finalize defaults to the SESSION's project for both the plan's durable wave-status AND the`,
+    `   git branch check — but this wave's plan + the ${kahunaBranch} branch live in the TARGET repo clone`,
+    `   ${targetRepoDir}, NOT the session project. Without root it returns kahuna_branch_not_found even though`,
+    `   the branch exists on the remote. If it STILL returns kahuna_branch_not_found or no_artifacts, STOP`,
     `   and return opened=false with the reason in notes (the gate will HOLD — do NOT fabricate a PR).`,
     `2. Ensure the PR is a DRAFT (so a green CI cannot auto-merge it before the gate decides): if`,
     `   wave_finalize did not create it as a draft, convert it (gh -R ${targetRepo} pr ready --undo <number>).`,
@@ -1225,7 +1229,7 @@ if (!halt && pending.size === 0) {
   // the gate has weighed all four signals. If the PR can't be opened (kahuna branch/artifacts
   // missing), the gate HOLDs — we cannot prove a wave we cannot even PR (conservative, §3.4).
   const prOpen = await agent(
-    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, planId: PLAN_ID }),
+    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
     { label: 'gate:open-pr', phase: 'Trust gate', schema: OPEN_PR_RESULT, agentType: 'general-purpose' },
   ).catch((e) => {
     log(`[#5] open promotion PR soft-fail → gate HOLDs (no PR to verify): ${e?.message || e}`)

--- a/skills/nextwave-next/per-wave-workflow.js
+++ b/skills/nextwave-next/per-wave-workflow.js
@@ -608,7 +608,7 @@ if (!halt && pending.size === 0) {
   // the gate has weighed all four signals. If the PR can't be opened (kahuna branch/artifacts
   // missing), the gate HOLDs — we cannot prove a wave we cannot even PR (conservative, §3.4).
   const prOpen = await agent(
-    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, planId: PLAN_ID }),
+    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
     { label: 'gate:open-pr', phase: 'Trust gate', schema: OPEN_PR_RESULT, agentType: 'general-purpose' },
   ).catch((e) => {
     log(`[#5] open promotion PR soft-fail → gate HOLDs (no PR to verify): ${e?.message || e}`)

--- a/tests/regression/gate_signals_roundtrip.mjs
+++ b/tests/regression/gate_signals_roundtrip.mjs
@@ -76,6 +76,8 @@ try {
   assert.match(op, /idempotent/i) // re-open returns the existing PR
   assert.match(op, /do NOT merge/i) // PR-open node never merges
   assert.match(op, /692/) // plan_id threaded through
+  assert.match(op, new RegExp(`root="${A.targetRepoDir}"`)) // #8: wave_finalize rooted at the TARGET repo, not the session project
+  assert.match(op, /LOAD-BEARING/) // the root rationale is spelled out
   assert.equal(OPEN_PR_RESULT.required[0], 'opened')
   assert.equal(OPEN_PR_RESULT.properties.opened.type, 'boolean')
   assert.equal(OPEN_PR_RESULT.properties.pr_number.type, 'integer')


### PR DESCRIPTION
## Summary

8th (final) finding from the #699 live integration gate (run `wf_b45bda62-716`): the gate's PR-open node called `wave_finalize` without a `root`, so it queried the **session** project's wave-status (claudecode-workflow) instead of the **target** repo (ccwork-testtarget) where the plan + kahuna branch live → `kahuna_branch_not_found` → gate correctly HELD. Only `wave_finalize` takes `root`; the other wave-status state tools bind to the session project by design. Targets `kahuna/692-dynamic-workflows`.

## Changes

- `skills/nextwave-next/gate.js` — `openPromotionPrPrompt` threads `targetRepoDir` and instructs `wave_finalize(..., root=<targetRepoDir>)`.
- `skills/nextwave-next/per-wave-workflow.js` — call site passes `targetRepoDir: TARGET_REPO_DIR`.
- `tests/regression/gate_signals_roundtrip.mjs` — asserts the prompt threads `root="<targetRepoDir>"`.
- Regenerated `per-wave-workflow.bundled.js`.

## Linked Issues

Closes #703

## Test Plan

- `scripts/ci/validate.sh` → **157 passed, 0 failed**; bundle in sync; gate roundtrip green.
- **Independent review:** 0 findings — signature/call-site/bundle/test all consistent, safe for the same-repo case, no unpassed callers.
- **Empirical (the proof):** resumed live-gate run → **gate `PASS`, `promoted: true`**, PR #49 merged `kahuna/9101-live-gate → live-gate-main`, story #8 landed on the protected branch, kahuna branch auto-deleted, real `ccwork-testtarget` main untouched. The reworked engine is validated end-to-end including actual promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)