### PR TITLE
feat(name): paste-ready /rename next-step to mirror identity into CC session name

### DIFF
--- a/skills/name/SKILL.md
+++ b/skills/name/SKILL.md
@@ -47,13 +47,7 @@ Report the current session identity, or pick one if not yet established.
 5. **Announce** — Always respond with:
    > I'm **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>`.
 
-6. **Set session display name** — So the Remote Control UI shows your identity:
-   ```
-   /rename <Dev-Name> <Dev-Avatar> (<Dev-Team>)
-   ```
-   Example: `/rename neuron ⚡ (cc-workflow)`. Skip silently if `/rename` is unavailable.
-
-7. **Check in via Discord** — Call `mcp__disc-server__disc_send` to announce yourself in `#roll-call`:
+6. **Check in via Discord** — Call `mcp__disc-server__disc_send` to announce yourself in `#roll-call`:
 
    ```
    mcp__disc-server__disc_send({
@@ -72,3 +66,23 @@ Report the current session identity, or pick one if not yet established.
    ```
 
    If the `disc-server` MCP is not registered or the call fails, skip silently — check-in is best-effort.
+
+7. **Close with the session-name next-step (FINAL output line)** — Claude Code's native
+   session name (shown in the session picker, prompt bar, and `--resume`) is **user-driven
+   only**: an agent cannot run `/rename` itself, and there is no hook/setting/API to set the
+   name programmatically. So do NOT emit a bare `/rename` and assume it ran. Instead, end the
+   skill's output with a single, paste-ready next-step so the operator can mirror the identity
+   into CC's UI in one action:
+
+   > Run `/rename <Dev-Name>` to mirror this identity into Claude Code's session name.
+
+   - Use the **bare Dev-Name** (e.g. `/rename babelfish`) — NOT the avatar emoji or the team.
+     CC's session name is a plain label; the emoji/parens form does not belong in it.
+   - Make this the **last line** of the skill's output. It is the deterministic paste path, and
+     because CC's Prompt-Suggestions ghost-text is a model prediction over the recent
+     conversation, a single unambiguous closing imperative also maximizes the chance CC
+     pre-fills `/rename <Dev-Name>` for →+Enter acceptance. (Non-deterministic — the paste is
+     the reliable path.)
+   - **Interactive sessions only.** A spawned/background/orchestrated agent has no operator to
+     accept the suggestion — skip this line when there is no human in the loop. The identity
+     file remains the source of truth; CC's session name is a one-way mirror, never a replacement.


### PR DESCRIPTION
## Summary

The `/name` skill assigned a Dev-Name but its session-name step emitted a bare `/rename <Dev-Name> <Dev-Avatar> (<Dev-Team>)` and assumed it ran — which it never did (an agent can't invoke a slash command; CC session naming is user-driven only, verified against CC docs). This reframes it as an operator-facing, paste-ready next-step.

## Changes

- `/name` step 7 now closes with `Run /rename <Dev-Name>` (BARE Dev-Name — no emoji/team, which CC's session-name field won't take cleanly), as the **final output line**.
- Final-line placement is deliberate: it's the deterministic paste path AND maximizes the chance CC's model-based Prompt-Suggestions ghost-text pre-fills `/rename <Dev-Name>` for →+Enter acceptance.
- Reordered: Discord check-in is now step 6, the rename next-step is step 7 (last).
- Documented interactive-only scope (spawned/background agents have no operator to accept) and mirror-not-replace (the identity file stays source of truth; CC's session name is a one-way mirror).
- No change to identity selection / persistence / announcement / Discord check-in.

## Linked Issues

Closes #718

## Test Plan

- `./scripts/ci/validate.sh` → **155 passed, 0 failed** (shellcheck/shfmt, SKILL.md frontmatter, install registration, regression suites).
- Code review: no findings. spec_validate_structure (#718): PASS. trivy: 0 HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)