### PR TITLE
fix(nextwave): wave-aware push-gate + reconcile fail-loud on blocked push

### DIFF
--- a/scripts/hooks/workflow/pre-push-test-gate.sh
+++ b/scripts/hooks/workflow/pre-push-test-gate.sh
@@ -28,6 +28,36 @@ if ! printf '%s' "$COMMAND" | grep -qE '^\s*git\s+push'; then
 	exit 0
 fi
 
+# Integration-ref exemption (#724): pushes whose destination refs are all
+# kahuna/* or wave-*/* are governed by the WAVE trust gate (commutativity +
+# kahuna→release merge-result CI + code-reviewer + trivy), not this session
+# sentinel — which is redundant for integration pushes and wrongly blocks
+# legitimate no-test (docs/config) waves. Exempt only when EVERY refspec
+# targets an integration branch; if any refspec targets a protected branch
+# (e.g. `git push origin main kahuna/56`) we fall through and gate as before.
+# Match the destination ref, never a substring of the whole command, so
+# `git push origin main` is never exempted.
+read -ra _push_tokens <<<"$COMMAND"
+_after_push=0 _seen_remote=0 _n_refspecs=0 _n_integration=0
+for _tok in "${_push_tokens[@]}"; do
+	if [[ $_after_push -eq 0 ]]; then
+		[[ "$_tok" == "push" ]] && _after_push=1
+		continue
+	fi
+	[[ "$_tok" == -* ]] && continue # flags: -u, -o, --force-with-lease, …
+	if [[ $_seen_remote -eq 0 ]]; then
+		_seen_remote=1 # first non-flag token after `push` is the remote
+		continue
+	fi
+	# remaining non-flag tokens are refspecs (src or src:dst); dest is after `:`
+	_dst="${_tok##*:}"
+	_n_refspecs=$((_n_refspecs + 1))
+	[[ "$_dst" == kahuna/* || "$_dst" == wave-*/* ]] && _n_integration=$((_n_integration + 1))
+done
+if [[ $_n_refspecs -gt 0 && $_n_refspecs -eq $_n_integration ]]; then
+	exit 0
+fi
+
 SENTINEL="/tmp/claude-tests-ran-${SESSION_ID}"
 
 if [[ -f "$SENTINEL" ]]; then

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -158,6 +158,7 @@ closed**: the only ways the per-wave Workflow stops are the script's coded exits
 | cost | `budget` floor | stop before the ceiling |
 | impasse | planner `done` with pending left | planner can't schedule remaining → human |
 | per-issue breaker | issue reworked > `MAX_REWORK` | one issue keeps breaking → human |
+| reconcile-blocked | reconcile returns `blocked` | a push to origin was rejected (pre-push gate / permissions / protected ref) → HOLD with the reason; reconcile never substitutes local merges (#724) |
 | gate HOLD | a trust signal failed | post-success gate fired → human review |
 
 Unease that matches none of these is NOT an exit: it rides the `concerns[]` channel
@@ -179,6 +180,23 @@ stalling on (#78/#79/#90), now expressed as bounded control flow.
 - Deterministic hooks (pre-push test gate, secret gate) fire inside each worker — the
   Workflow orchestrates, it does not enforce.
 - One wave per invocation. `/wavemachine` drives the campaign loop over waves.
+
+### Troubleshooting: docs/config waves + the pre-push test gate (#724)
+
+`scripts/hooks/workflow/pre-push-test-gate.sh` blocks `git push` unless a per-session
+test sentinel exists. A **docs/config wave** runs no test suite, so reconcile's push to
+`kahuna/<N>` had no sentinel and was blocked — and reconcile used to *silently* fall back
+to local merge commits, stranding the wave's work off origin and emitting a degenerate
+`kahuna→release` MR (`has_conflicts` / `no_merge_result_pr`) that can never promote.
+
+Fixed two ways (#724): (1) the gate now **exempts integration refs** — a push whose
+destination refs are all `kahuna/*` or `wave-*/*` exits 0 without a sentinel (those refs
+are governed by the four-signal trust gate, not the session heuristic; protected-ref
+pushes in the same session still gate). (2) reconcile now **fails loud** — a rejected
+push returns `blocked` and HOLDs the wave (the `reconcile-blocked` exit), never a local
+merge. **Recovery for a wave stranded by the old behavior:**
+`PUSH_GATE_DISABLED=1 git push origin kahuna/<N>` to fast-forward origin, then re-trigger
+the promotion MR's gate — fix-forward into the gate, not a bypass.
 
 ## Pair
 

--- a/skills/nextwave/per-wave-workflow.bundled.js
+++ b/skills/nextwave/per-wave-workflow.bundled.js
@@ -828,6 +828,8 @@ const RECONCILE = {
     conflicts_resolved: { type: 'array', items: { type: 'string' } }, // cross-flight fixes done here (§3.2.3)
     concerns: { type: 'array', items: { type: 'string' } },
     suite_summary: { type: 'string' },
+    blocked: { type: 'boolean' }, // #724: true ⇒ a push to origin was REJECTED (gate/permissions/protected ref) → HOLD; reconcile must NOT local-merge
+    block_reason: { type: 'string' }, // #724: the rejection text, surfaced in the wave HOLD
     notes: { type: 'string' },
   },
 }
@@ -1106,9 +1108,15 @@ function primeReconcilePrompt(built, merged) {
     `   // #688 wave-status persistence is FILLED as a standalone step the LOOP runs right after you return`,
     `   //   (persistIteration → wave_record_mr + wave_close_issue per newly-merged issue, then the durable`,
     `   //   loop blob). Do NOT record MRs / close issues here — just return merged; the loop persists it (§3.3).`,
+    `5. FAIL LOUD on a REJECTED push (#724): if pushing a flight branch or ${KAHUNA_BRANCH} to origin is rejected —`,
+    `   pre-push test gate, permissions, or a protected-ref guard — STOP and return blocked=true + block_reason`,
+    `   (the rejection text). Do NOT substitute LOCAL merge commits / local-only branches to "keep going": that`,
+    `   strands the wave off origin and produces a degenerate ${KAHUNA_BRANCH}→release MR that can never promote.`,
+    `   A blocked push HOLDs the wave with a clear cause — the loop never promotes work that never reached origin.`,
     ``,
     `Return: merged (issues now green in ${KAHUNA_BRANCH} this round), needs_rework (list of {issue, reason} you`,
-    `reset), conflicts_resolved (files + 1-line how), concerns (array), suite_summary (final test line), notes.`,
+    `reset), conflicts_resolved (files + 1-line how), concerns (array), suite_summary (final test line),`,
+    `blocked (true ONLY if a push to origin was rejected — see step 5) + block_reason, notes.`,
   ].join('\n')
 }
 
@@ -1188,6 +1196,12 @@ while (true) {
     agentType: 'general-purpose',
   })
   for (const c of rec.concerns || []) allConcerns.push({ issue: 'reconcile', concern: c })
+
+  // #724: a push rejected by the pre-push gate / permissions / protected-ref guard HOLDs the wave
+  // LOUDLY. Reconcile is instructed never to substitute local merge commits (which strand work off
+  // origin + emit a degenerate kahuna→release MR), so a blocked reconcile means nothing landed this
+  // round. Set halt + break → the gate is skipped and the campaign driver surfaces the block reason.
+  if (rec.blocked) { halt = `reconcile-blocked: ${rec.block_reason || 'push to origin rejected'}`; break }
 
   // ── DETERMINISTIC state update + progress accounting ──
   const newlyMerged = (rec.merged || []).filter((n) => !merged.has(n))

--- a/skills/nextwave/per-wave-workflow.js
+++ b/skills/nextwave/per-wave-workflow.js
@@ -207,6 +207,8 @@ const RECONCILE = {
     conflicts_resolved: { type: 'array', items: { type: 'string' } }, // cross-flight fixes done here (§3.2.3)
     concerns: { type: 'array', items: { type: 'string' } },
     suite_summary: { type: 'string' },
+    blocked: { type: 'boolean' }, // #724: true ⇒ a push to origin was REJECTED (gate/permissions/protected ref) → HOLD; reconcile must NOT local-merge
+    block_reason: { type: 'string' }, // #724: the rejection text, surfaced in the wave HOLD
     notes: { type: 'string' },
   },
 }
@@ -485,9 +487,15 @@ function primeReconcilePrompt(built, merged) {
     `   // #688 wave-status persistence is FILLED as a standalone step the LOOP runs right after you return`,
     `   //   (persistIteration → wave_record_mr + wave_close_issue per newly-merged issue, then the durable`,
     `   //   loop blob). Do NOT record MRs / close issues here — just return merged; the loop persists it (§3.3).`,
+    `5. FAIL LOUD on a REJECTED push (#724): if pushing a flight branch or ${KAHUNA_BRANCH} to origin is rejected —`,
+    `   pre-push test gate, permissions, or a protected-ref guard — STOP and return blocked=true + block_reason`,
+    `   (the rejection text). Do NOT substitute LOCAL merge commits / local-only branches to "keep going": that`,
+    `   strands the wave off origin and produces a degenerate ${KAHUNA_BRANCH}→release MR that can never promote.`,
+    `   A blocked push HOLDs the wave with a clear cause — the loop never promotes work that never reached origin.`,
     ``,
     `Return: merged (issues now green in ${KAHUNA_BRANCH} this round), needs_rework (list of {issue, reason} you`,
-    `reset), conflicts_resolved (files + 1-line how), concerns (array), suite_summary (final test line), notes.`,
+    `reset), conflicts_resolved (files + 1-line how), concerns (array), suite_summary (final test line),`,
+    `blocked (true ONLY if a push to origin was rejected — see step 5) + block_reason, notes.`,
   ].join('\n')
 }
 
@@ -567,6 +575,12 @@ while (true) {
     agentType: 'general-purpose',
   })
   for (const c of rec.concerns || []) allConcerns.push({ issue: 'reconcile', concern: c })
+
+  // #724: a push rejected by the pre-push gate / permissions / protected-ref guard HOLDs the wave
+  // LOUDLY. Reconcile is instructed never to substitute local merge commits (which strand work off
+  // origin + emit a degenerate kahuna→release MR), so a blocked reconcile means nothing landed this
+  // round. Set halt + break → the gate is skipped and the campaign driver surfaces the block reason.
+  if (rec.blocked) { halt = `reconcile-blocked: ${rec.block_reason || 'push to origin rejected'}`; break }
 
   // ── DETERMINISTIC state update + progress accounting ──
   const newlyMerged = (rec.merged || []).filter((n) => !merged.has(n))

--- a/tests/regression/test_push_gate_wave_aware.sh
+++ b/tests/regression/test_push_gate_wave_aware.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# test_push_gate_wave_aware.sh — #724: pre-push-test-gate integration-ref exemption.
+#
+# Picked up by scripts/ci/validate.sh's "Regression tests" loop (tests/regression/*.sh).
+# The pre-push test gate blocks `git push` unless a per-session test sentinel exists.
+# That sentinel heuristic is the WRONG gate for integration pushes inside a wave
+# campaign (kahuna/* and wave-*/* are governed by the wave trust gate), and it wrongly
+# blocks legitimate no-test (docs/config) waves. This test pins:
+#   1. push to kahuna/* / wave-*/* exits 0 with NO sentinel (the exemption),
+#   2. push to a protected ref (main / feature/*) still BLOCKS with no sentinel
+#      (no safety regression — the load-bearing AC),
+#   3. a mixed push (one integration + one protected ref) still BLOCKS (strict rule),
+#   4. an existing sentinel still allows any push (pre-existing behavior intact).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GATE="$REPO_DIR/scripts/hooks/workflow/pre-push-test-gate.sh"
+SID="test-724-pushgate-$$"
+SENTINEL="/tmp/claude-tests-ran-${SID}"
+fail=0
+
+echo "test_push_gate_wave_aware"
+echo "──────────────────────────────────────────"
+
+cleanup() { rm -f "$SENTINEL"; }
+trap cleanup EXIT
+
+# Run the gate with a given command; capture stdout (block JSON) — exit is always 0
+# (the hook signals a block via {"decision":"block"} on stdout, not the exit code).
+run_gate() {
+	printf '%s' "{\"session_id\":\"$SID\",\"tool_input\":{\"command\":\"$1\"}}" | bash "$GATE"
+}
+
+# assert_allow: gate output must NOT contain a block decision
+assert_allow() {
+	local out
+	out="$(run_gate "$1")"
+	if printf '%s' "$out" | grep -q '"decision":"block"'; then
+		echo "  [FAIL] expected ALLOW, got BLOCK: $1"
+		fail=1
+	else
+		echo "  [PASS] allow: $1"
+	fi
+}
+
+# assert_block: gate output MUST contain a block decision
+assert_block() {
+	local out
+	out="$(run_gate "$1")"
+	if printf '%s' "$out" | grep -q '"decision":"block"'; then
+		echo "  [PASS] block: $1"
+	else
+		echo "  [FAIL] expected BLOCK, got ALLOW: $1"
+		fail=1
+	fi
+}
+
+# 1 + 2: NO sentinel — integration refs exempt, protected refs still gate.
+cleanup
+assert_allow "git push origin kahuna/56"
+assert_allow "git push -u origin kahuna/56-quartermaster-docs-labs"
+assert_allow "git push origin wave-9101/issue-8"
+assert_allow "git push origin HEAD:kahuna/56"
+assert_block "git push origin main"
+assert_block "git push origin feature/123-foo"
+
+# 3: mixed push (integration + protected) must still BLOCK (strict — never let a
+#    protected-ref push ride in on an integration ref in the same command).
+assert_block "git push origin main kahuna/56"
+
+# 4: an existing sentinel allows any push (pre-existing behavior unchanged).
+touch "$SENTINEL"
+assert_allow "git push origin main"
+cleanup
+
+echo "──────────────────────────────────────────"
+if [[ $fail -eq 0 ]]; then
+	echo "  ALL PASS"
+	exit 0
+fi
+echo "  FAILURES"
+exit 1


### PR DESCRIPTION
## Summary

The pre-push test gate blocked reconcile's push on no-test (docs/config) waves, and reconcile silently fell back to local merge commits — stranding the wave's work off origin and emitting a degenerate `kahuna→release` MR that can never promote. Surfaced live by plan #56 on `blueshift-quartermaster` (docs wave-2 stranded; MR !64 degenerate).

## Changes

- **`pre-push-test-gate.sh` — wave-aware exemption.** A `git push` whose destination refs are **all** `kahuna/*` or `wave-*/*` exits 0 without a test sentinel (those integration refs are governed by the four-signal wave trust gate, not the per-session heuristic). Strict: a protected-ref push (`main`) or a **mixed** push (`main kahuna/56`) still gates. Parsing matches the destination ref, never a substring of the command.
- **`per-wave-workflow.js` — reconcile fails loud.** `RECONCILE` schema gains `blocked`/`block_reason`; the reconcile prompt is instructed to return `blocked` on a rejected push and **never** substitute local merges; the loop HOLDs via the new `reconcile-blocked` legal exit (skips the trust gate, surfaces the reason). Bundle regenerated.
- **`SKILL.md`** — new `reconcile-blocked` row in the Exhaustive Legal Exits table + troubleshooting/recovery section.
- **New test** `tests/regression/test_push_gate_wave_aware.sh` — exemption + protected-ref regression + mixed-ref + sentinel cases.

## Linked Issues

Closes #724

## Test Plan

- `./scripts/ci/validate.sh` → **156 passed, 0 failed** (includes the new regression test).
- New hook test exercised directly across exempt (`kahuna/*`, `wave-*/*`, `HEAD:kahuna/56`) and block (`main`, `feature/*`, mixed `main kahuna/56`, sentinel-present) cases.
- Bundle drift test green; `node --check` on engine + bundle.
- Full pytest failures are pre-existing #472 baseline (stash-compare verified: zero new failures from this diff).
- Independent code-review: 0 critical / 0 important; refspec-security property traced and confirmed fail-closed in every bypass variant. trivy 0 HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)