### PR TITLE
fix(nextwave): preserveKahuna — persist per-plan kahuna across waves

### DIFF
--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -74,6 +74,7 @@ Supplied by the caller (`/wavemachine` per wave, or a human launching one wave):
 | `targetRepo` | `owner/repo` for `gh -R` scoping |
 | `targetRepoDir` | the clone the durable worktrees attach to (§4.2) |
 | `kahunaBranch` | the integration target; every flight PR targets this, never the protected branch |
+| `preserveKahuna` | #722: `true` ⇒ persistent per-plan kahuna (shared across a plan's waves) — promote does NOT delete it. Default `false` = per-wave disposable (deleted on promote). See lifecycle below. |
 | `protectedBranch` | the promotion target on the success exit |
 | `mode` | `auto` (verdict drives promotion) \| `interactive` (verdict returned; human routes) |
 | `planId` | wave plan id — the gate's PR-open node needs it to assemble the kahuna→protected MR body (#687/#5) |
@@ -81,6 +82,26 @@ Supplied by the caller (`/wavemachine` per wave, or a human launching one wave):
 
 The closed numeric guards (`maxGroups`, `maxRework`, `maxIdle`, `costFloor`) have
 safe defaults in the script and rarely need overriding.
+
+### Kahuna branch lifecycle — per-wave disposable vs per-plan persistent (#722)
+
+Two models; the campaign driver picks one by the **shape of the `kahunaBranch` it passes** and
+the `preserveKahuna` flag:
+
+- **Per-wave disposable (default, `preserveKahuna` omitted/false).** `kahunaBranch` defaults to
+  `kahuna/<waveId>`; the wave promotes it onto the protected branch and the promote node **deletes
+  it** — the integration branch existed only for this wave. Each wave branches fresh off the
+  protected/release HEAD.
+- **Per-plan persistent (`preserveKahuna: true`).** A campaign that threads ONE kahuna across a
+  plan's waves (e.g. `kahuna/56-quartermaster-docs-labs`, cumulative integration over waves 1..N)
+  passes `preserveKahuna: true` so the promote node **does NOT delete** the branch after each wave.
+  Deleting it after wave 1 (the old unconditional behavior) stranded waves 2..N off a **diverged
+  base** — origin recreated at the post-promotion HEAD while local work still descended from the
+  pre-promotion base, so the next wave's push was rejected non-fast-forward. `preserveKahuna: true`
+  eliminates that. The plan's final wave (or the driver) retires the branch.
+
+**Drivers MUST match the flag to the branch shape:** a shared per-plan `kahunaBranch` with
+`preserveKahuna` left false will delete the branch mid-plan and break the remaining waves.
 
 ## Procedure
 

--- a/skills/nextwave/gate.js
+++ b/skills/nextwave/gate.js
@@ -200,8 +200,21 @@ export function trivySignalPrompt({ waveId, kahunaBranch, targetRepoDir }) {
 // merge, so it runs SOLELY from the workflow's auto+PASS branch on a live wave that reached the
 // success exit — which is itself gated by the human cutover (#691). Building/validating this
 // module never invokes it.
-export function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber }) {
+export function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber, preserveKahuna = false }) {
   const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${protectedBranch} PR`
+  // #722: a PER-PLAN kahuna (e.g. kahuna/56-…, shared across a plan's waves 1..N) must PERSIST —
+  // deleting it after wave 1 strands waves 2..N off a diverged base. The default (false) keeps the
+  // current per-wave disposable behavior: KAHUNA_BRANCH defaults to kahuna/<waveId>, deleted here.
+  const step4 = preserveKahuna
+    ? [
+      `4. Do NOT delete ${kahunaBranch} (#722: preserveKahuna) — it is a PERSISTENT per-plan integration`,
+      `   branch shared across this plan's remaining waves; deleting it would strand them off a diverged`,
+      `   base. Leave it on origin; the plan's final wave (or the campaign driver) retires it.`,
+    ]
+    : [
+      `4. Once ${kahunaBranch} is on ${protectedBranch}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
+      `   api / git push origin --delete) — the wave is done; this per-wave integration branch is disposable.`,
+    ]
   return [
     `You are the wave PROMOTION node for wave ${waveId} of ${targetRepo}. The trust gate returned PASS`,
     `and the wave is in AUTO mode. The ${kahunaBranch}→${protectedBranch} DRAFT PR is ALREADY OPEN (${prRef})`,
@@ -216,8 +229,7 @@ export function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRep
     `   already proved the composed diff safe, so the train is unnecessary. On a merge-queue-ENFORCED`,
     `   repo skip_train is silently dropped and the PR is ENROLLED (merged=false, queued): in that case`,
     `   wait for it to actually land on ${protectedBranch} (pr_merge_wait) before reporting promoted.`,
-    `4. Once ${kahunaBranch} is on ${protectedBranch}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
-    `   api / git push origin --delete) — the wave is done; the integration branch is disposable.`,
+    ...step4,
     ``,
     `Return: promoted (true ONLY if the merge actually landed on ${protectedBranch}), mr_ref (the PR`,
     `URL/number), notes (1-2 sentences; include any error — and on error, promoted=false).`,

--- a/skills/nextwave/per-wave-workflow.bundled.js
+++ b/skills/nextwave/per-wave-workflow.bundled.js
@@ -612,8 +612,21 @@ function trivySignalPrompt({ waveId, kahunaBranch, targetRepoDir }) {
 // merge, so it runs SOLELY from the workflow's auto+PASS branch on a live wave that reached the
 // success exit — which is itself gated by the human cutover (#691). Building/validating this
 // module never invokes it.
-function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber }) {
+function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber, preserveKahuna = false }) {
   const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${protectedBranch} PR`
+  // #722: a PER-PLAN kahuna (e.g. kahuna/56-…, shared across a plan's waves 1..N) must PERSIST —
+  // deleting it after wave 1 strands waves 2..N off a diverged base. The default (false) keeps the
+  // current per-wave disposable behavior: KAHUNA_BRANCH defaults to kahuna/<waveId>, deleted here.
+  const step4 = preserveKahuna
+    ? [
+      `4. Do NOT delete ${kahunaBranch} (#722: preserveKahuna) — it is a PERSISTENT per-plan integration`,
+      `   branch shared across this plan's remaining waves; deleting it would strand them off a diverged`,
+      `   base. Leave it on origin; the plan's final wave (or the campaign driver) retires it.`,
+    ]
+    : [
+      `4. Once ${kahunaBranch} is on ${protectedBranch}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
+      `   api / git push origin --delete) — the wave is done; this per-wave integration branch is disposable.`,
+    ]
   return [
     `You are the wave PROMOTION node for wave ${waveId} of ${targetRepo}. The trust gate returned PASS`,
     `and the wave is in AUTO mode. The ${kahunaBranch}→${protectedBranch} DRAFT PR is ALREADY OPEN (${prRef})`,
@@ -628,8 +641,7 @@ function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNu
     `   already proved the composed diff safe, so the train is unnecessary. On a merge-queue-ENFORCED`,
     `   repo skip_train is silently dropped and the PR is ENROLLED (merged=false, queued): in that case`,
     `   wait for it to actually land on ${protectedBranch} (pr_merge_wait) before reporting promoted.`,
-    `4. Once ${kahunaBranch} is on ${protectedBranch}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
-    `   api / git push origin --delete) — the wave is done; the integration branch is disposable.`,
+    ...step4,
     ``,
     `Return: promoted (true ONLY if the merge actually landed on ${protectedBranch}), mr_ref (the PR`,
     `URL/number), notes (1-2 sentences; include any error — and on error, promoted=false).`,
@@ -733,6 +745,7 @@ const WAVE_ID = params.waveId ?? 'W-?'
 const TARGET_REPO = params.targetRepo ?? 'Wave-Engineering/ccwork-testtarget' // owner/repo for gh -R scoping
 const TARGET_REPO_DIR = params.targetRepoDir ?? '/home/bakerb/sandbox/github/ccwork-testtarget' // clone the worktrees attach to
 const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // integration target; never the protected branch
+const PRESERVE_KAHUNA = params.preserveKahuna ?? false // #722: true ⇒ persistent per-plan kahuna (shared across a plan's waves) — promote does NOT delete it; default false = per-wave disposable (delete on promote)
 const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // promotion target on the success exit
 const ALL_ISSUES = (params.issues ?? []).map(Number).filter(Number.isFinite) // the wave's issue numbers
 // #4 fail-loud: refuse an empty wave rather than silently defaulting the gate at the protected branch.
@@ -1330,7 +1343,7 @@ if (gate.verdict === 'PASS') {
     // skip_train safe); the kahuna branch is deleted. It never opens a second PR. The script can't
     // call MCP/CLI directly (§3.3) — the promote agent does it.
     const promo = await agent(
-      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber }),
+      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
       { label: 'promote', phase: 'Promote', schema: PROMOTE_RESULT, agentType: 'general-purpose' },
     ).catch((e) => {
       // A promotion error must NOT be reported as a successful promote (conservative): record HELD,

--- a/skills/nextwave/per-wave-workflow.js
+++ b/skills/nextwave/per-wave-workflow.js
@@ -112,6 +112,7 @@ const WAVE_ID = params.waveId ?? 'W-?'
 const TARGET_REPO = params.targetRepo ?? 'Wave-Engineering/ccwork-testtarget' // owner/repo for gh -R scoping
 const TARGET_REPO_DIR = params.targetRepoDir ?? '/home/bakerb/sandbox/github/ccwork-testtarget' // clone the worktrees attach to
 const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // integration target; never the protected branch
+const PRESERVE_KAHUNA = params.preserveKahuna ?? false // #722: true ⇒ persistent per-plan kahuna (shared across a plan's waves) — promote does NOT delete it; default false = per-wave disposable (delete on promote)
 const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // promotion target on the success exit
 const ALL_ISSUES = (params.issues ?? []).map(Number).filter(Number.isFinite) // the wave's issue numbers
 // #4 fail-loud: refuse an empty wave rather than silently defaulting the gate at the protected branch.
@@ -709,7 +710,7 @@ if (gate.verdict === 'PASS') {
     // skip_train safe); the kahuna branch is deleted. It never opens a second PR. The script can't
     // call MCP/CLI directly (§3.3) — the promote agent does it.
     const promo = await agent(
-      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber }),
+      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
       { label: 'promote', phase: 'Promote', schema: PROMOTE_RESULT, agentType: 'general-purpose' },
     ).catch((e) => {
       // A promotion error must NOT be reported as a successful promote (conservative): record HELD,

--- a/tests/regression/gate_signals_roundtrip.mjs
+++ b/tests/regression/gate_signals_roundtrip.mjs
@@ -119,6 +119,20 @@ try {
   ok('PROMOTE_RESULT requires a boolean `promoted`')
 } catch (e) { bad('promotion prompt', e) }
 
+// ── 3b. #722: preserveKahuna gates the branch-delete (per-plan persistent vs per-wave disposable) ──
+try {
+  // default (omitted) and explicit false → per-wave disposable: the prompt DELETES the branch.
+  assert.match(promotePrompt({ ...A, prNumber: PR }), /delete/i)
+  assert.match(promotePrompt({ ...A, prNumber: PR, preserveKahuna: false }), /delete/i)
+  // preserveKahuna:true → persistent per-plan kahuna: the prompt must NOT delete it, and must say so.
+  const kept = promotePrompt({ ...A, prNumber: PR, preserveKahuna: true })
+  assert.doesNotMatch(kept, /--delete/) // no git/gh branch-delete instruction
+  assert.doesNotMatch(kept, /disposable/) // not framed as disposable
+  assert.match(kept, /do not delete/i)
+  assert.match(kept, /#722|persistent per-plan/i)
+  ok('promote prompt: preserveKahuna=true keeps the branch; default/false deletes it (#722)')
+} catch (e) { bad('promote preserveKahuna gating (#722)', e) }
+
 console.log('')
 if (failures) { console.log(`  ${failures} assertion group(s) failed`); process.exit(1) }
 console.log('  all gate-signal checks passed')


### PR DESCRIPTION
## Summary

The per-wave promote node deleted the kahuna integration branch unconditionally. For a **per-plan** kahuna shared across a plan's waves (e.g. `kahuna/56-quartermaster-docs-labs`, cumulative integration over waves 1..N), the wave-1 delete stranded waves 2..N off a **diverged base** — origin recreated at the post-promotion HEAD while local work still descended from the pre-promotion base, so the next push was rejected non-fast-forward. Surfaced live by plan #56 on `blueshift-quartermaster`.

## Changes

- **`gate.js`** — `promotePrompt` takes `preserveKahuna` (default `false`); step 4 is conditional: `false` → delete the branch (current per-wave behavior, unchanged); `true` → instruct NOT to delete (persistent per-plan kahuna).
- **`per-wave-workflow.js`** — parse `params.preserveKahuna ?? false` and thread it into the promote call.
- **`per-wave-workflow.bundled.js`** — regenerated.
- **`gate_signals_roundtrip.mjs`** — `#722` assertions pin both directions (omitted/`false` → deletes; `true` → keeps, no `--delete`/`disposable`).
- **`SKILL.md`** — documents the param + the per-wave-disposable vs per-plan-persistent lifecycle, with the driver guidance to match the flag to the branch shape.

## Design call

#722's first AC poses "per-wave-only vs persistent per-plan kahuna." The live evidence settles it: plan #56 runs a per-plan shared kahuna, and the FF-rejection proves the per-wave delete strands later waves. **Option 2 (`preserveKahuna`, default `false` = non-breaking)** is the only choice that doesn't declare the live campaign's model unsupported.

## Linked Issues

Closes #722

## Test Plan

- `./scripts/ci/validate.sh` → **156 passed, 0 failed** (gate roundtrip + bundle-sync green).
- Independent code-review: **0 findings at all severities**; default-`false`/disposable verified at all three points (param parse, prompt default, threading) and bundle-matches-source confirmed. trivy 0 HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)