### PR TITLE
fix(install): skip inline-shell hook bodies in dependency scanner

### DIFF
--- a/scripts/ci/check-deps.sh
+++ b/scripts/ci/check-deps.sh
@@ -60,6 +60,12 @@ _check_hook_scripts() {
 		# is a known interpreter.
 		local script_path first_token
 		first_token=$(echo "$cmd" | awk '{print $1}')
+		# Inline shell snippets (leading assignment, sequenced statements, or
+		# pipelines) are not single hook-script paths — skip the file-existence
+		# check so they don't register as a phantom missing dependency (#669).
+		if [[ "$first_token" == *'='* || "$cmd" == *';'* || "$cmd" == *'&&'* || "$cmd" == *'||'* || "$cmd" == *'|'* ]]; then
+			continue
+		fi
 		case "$first_token" in
 		bash | sh | zsh | env)
 			# Interpreter prefix — the actual script is the last non-flag token

--- a/tests/regression/test_check_deps_hook_scanner.sh
+++ b/tests/regression/test_check_deps_hook_scanner.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test_check_deps_hook_scanner.sh — #669: install hook-scanner must not misread an
+# inline shell-assignment hook body as a missing script path.
+#
+# Picked up by scripts/ci/validate.sh's "Regression tests" loop (tests/regression/*.sh).
+# `_check_hook_scripts` (scripts/ci/check-deps.sh) auto-scans settings.template.json hook
+# commands for referenced script paths. A hook whose `command` is an INLINE shell one-liner
+# (e.g. the wavemachine Stop hook: `state="…"; [ -f "$state" ] || exit 0; …`) is NOT a path —
+# scanning it as one produced a false "1 required dependency missing" on every clean install.
+# This test pins:
+#   1. an inline-shell hook (leading assignment) contributes ZERO missing deps (#669),
+#   2. a bare path to a REAL script contributes zero,
+#   3. a bare path to a GENUINELY-MISSING script is STILL reported (no over-suppression).
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test_check_deps_hook_scanner"
+echo "──────────────────────────────────────────"
+
+if ! command -v jq &>/dev/null; then
+	echo "  [FAIL] jq not found — required for the hook scanner"
+	exit 1
+fi
+
+# A real, existing hook script + a path that does NOT exist.
+mkdir -p "$TMP/config"
+real_hook="$TMP/real-hook.sh"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$real_hook"
+chmod +x "$real_hook"
+missing_hook="$TMP/nonexistent-hook.sh" # deliberately not created
+
+# Template: an inline-shell Stop hook (the #669 repro), a real PreToolUse hook,
+# and a genuinely-missing PreToolUse hook.
+cat >"$TMP/config/settings.template.json" <<JSON
+{
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "state=\"\${CLAUDE_PROJECT_DIR:-.}/.claude/status/state.json\"; [ -f \"\$state\" ] || exit 0; printf '{}'" } ] }
+    ],
+    "PreToolUse": [
+      { "hooks": [ { "type": "command", "command": "$real_hook" } ] },
+      { "hooks": [ { "type": "command", "command": "$missing_hook" } ] }
+    ]
+  }
+}
+JSON
+
+# Source the library under a REPO_DIR pointed at our fixture, then run the scanner.
+REPO_DIR="$TMP"
+# shellcheck source=/dev/null
+source "$ROOT/scripts/ci/check-deps.sh"
+
+_check_hook_scripts >/dev/null 2>&1
+missing=$?
+
+fail=0
+if [[ $missing -eq 1 ]]; then
+	echo "  [PASS] exactly 1 missing dep — the genuinely-missing script, not the inline-shell hook (#669)"
+else
+	echo "  [FAIL] expected 1 missing dep (only the real missing script); got $missing"
+	echo "         (0 ⇒ real missing script no longer detected; ≥2 ⇒ inline-shell hook still false-flagged)"
+	fail=1
+fi
+
+# Focused control: a template with ONLY the inline-shell hook must report ZERO.
+cat >"$TMP/config/settings.template.json" <<JSON
+{
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "state=\"\${CLAUDE_PROJECT_DIR:-.}/.claude/status/state.json\"; [ -f \"\$state\" ] || exit 0; printf '{}'" } ] }
+    ]
+  }
+}
+JSON
+_check_hook_scripts >/dev/null 2>&1
+inline_only=$?
+if [[ $inline_only -eq 0 ]]; then
+	echo "  [PASS] inline-shell hook alone → 0 missing deps (clean-install false positive fixed)"
+else
+	echo "  [FAIL] inline-shell hook alone reported $inline_only missing deps (expected 0)"
+	fail=1
+fi
+
+echo "──────────────────────────────────────────"
+if [[ $fail -eq 0 ]]; then
+	echo "  ALL PASS"
+	exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

`./install` reported a false **"1 required dependency missing"** on a clean install and exited non-zero. The hook-scanner (`scripts/ci/check-deps.sh` `_check_hook_scripts`) treated every hook `command` as a script path to verify — but the wavemachine-stall `Stop` hook's command is an inline shell one-liner beginning `state="…"; [ -f "$state" ] || exit 0; …`, so it took the assignment LHS as a path, found no such file, and flagged it.

## Changes

- `_check_hook_scripts` skips the file-existence check when the command is an inline shell snippet — first token contains `=`, or the command contains `;`, `&&`, `||`, `|`. Bare-path hook commands still path-verify.
- New regression test `tests/regression/test_check_deps_hook_scanner.sh`: an inline-shell hook contributes 0 missing deps; a real script contributes 0; a genuinely-missing script is **still** reported (AC #3 — no over-suppression).

## Linked Issues

Closes #669

## Test Plan

- `./scripts/ci/validate.sh` → **157 passed, 0 failed** (includes the new test).
- **Negative control:** the new test **fails** with the fix reverted (reports 2 missing instead of 1; inline-only reports 1 instead of 0) and **passes** with it — so it genuinely pins the bug.
- Independent code-review: **0 findings at all severities**; reviewer verified the guard against all 10 hook commands in the real template (only the wavemachine Stop hook is suppressed, correctly) and confirmed genuine missing bare-path hooks are still detected. trivy 0 HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)