### PR TITLE
docs(claude-md): MANDATORY default-to-action rule + enforcing Stop hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,25 @@ Every issue MUST be wave-pattern quality: detailed enough that a spec-driven age
 
 ---
 
+## MANDATORY: Default to Action — never stop on a question you can answer
+
+**If you know what needs doing and it is safe, understood, and in your lane, DO IT. Do not stop to ask.** Stopping is not the safe default — it blocks every agent and human downstream and spends the user's attention, the scarcest resource. Acting on a reversible, understood step is cheap; a needless halt is expensive. This is enforced, not just advised: the `stop-action-bias-detector.sh` Stop hook blocks a turn that ends by asking permission to do something you already know how to do.
+
+**Before you stop, you must be able to name a specific, current reason.** A legitimate stop is exactly one of:
+
+- a genuinely NEW irreversible or production-affecting action the user has **not already agreed to** (per the ABSOLUTE prod rule), or
+- a real architectural / design fork where the user's choice changes what you build.
+
+If you cannot name one of those, you do not stop — you act, then report what you did.
+
+**Agreement persists.** Once the user has directed or agreed to a line of work, you do not re-confirm each step of it. Completing directed work — including a fleet deploy you were told to do — is not a new gate. Re-asking is the failure, not the safety.
+
+**The tell.** The moment you draft "want me to…", "should I…", "shall I…", "ready for me to…", or present a known next step as a question — that is the signal to delete the question and take the step. The checklist a gate already presents (e.g. `/precheck`) is the approval surface; narrating a second one is stalling.
+
+Rationale memories: `principle_user_attention_is_the_cost`, `principle_cost_asymmetry_continue_vs_exit`, `feedback_bj_throughput_dont_wait`.
+
+---
+
 ## Branching Strategy
 
 Trunk-based flow. Always branch from `main`: `git checkout main && git pull && git checkout -b <type>/<N>-description`. Types: `feature`, `fix`, `chore`, `doc`. PR/MRs target `main`.

--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -126,6 +126,16 @@
         "matcher": "*",
         "hooks": [
           {
+            "_comment": "Default to Action (cc-workflow#732): block a turn that ends by asking permission to do something the agent already knows how to do. General sibling of precheck-asking-detector. Kill-switch: STOP_ACTION_BIAS_HOOK_DISABLED=1.",
+            "type": "command",
+            "command": "~/.local/bin/stop-action-bias-detector.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
             "_comment": "Block stop attempts during active /wavemachine campaigns. Validated 2026-05-05 in blueshift-cue Plan #179 (wave-4 → wave-5 without stall). See lesson_stop_hook_with_block.md.",
             "type": "command",
             "command": "state=\"${CLAUDE_PROJECT_DIR:-.}/.claude/status/state.json\"; [ -f \"$state\" ] || exit 0; active=$(jq -r '.wavemachine_active // false' \"$state\" 2>/dev/null); [ \"$active\" = \"true\" ] || exit 0; printf '{\"decision\":\"block\",\"reason\":\"/wavemachine is active and the loop has not completed. After /nextwave auto returns OK, you must immediately invoke /nextwave auto again for the next wave (or trigger the trust-score gate if no more pending waves). Do NOT stall — emit the next tool call now.\"}'"

--- a/scripts/stop-action-bias-detector.sh
+++ b/scripts/stop-action-bias-detector.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# stop-action-bias-detector.sh — CC Stop hook.
+#
+# Detects when the assistant ends a turn by handing a decision back to the
+# user ("want me to proceed?", "should I…?", "shall I…?") instead of acting
+# on something it already knows how to do. Forces the turn to continue with
+# a default-to-action reminder, per CLAUDE.md MANDATORY: Default to Action.
+#
+# This is the GENERAL sibling of precheck-asking-detector.sh (#542), which
+# catches the precheck-specific case. Same Stop-hook contract and budget.
+#
+# Contract (Claude Code Stop hook):
+#   stdin:  JSON with .transcript_path, .session_id, .stop_hook_active
+#   stdout: JSON with {"decision":"block","reason":"..."} to force the
+#           assistant to continue this turn; empty stdout (exit 0) to no-op.
+#
+# Disable: export STOP_ACTION_BIAS_HOOK_DISABLED=1
+#
+# Performance budget: <50ms. Single jq pass over the tail of the transcript;
+# no MCP calls, no network, no file writes.
+#
+# Issue: cc-workflow#732 — paired with the CLAUDE.md prose rule (same issue).
+
+set -uo pipefail
+
+# Kill-switch before any work.
+if [[ "${STOP_ACTION_BIAS_HOOK_DISABLED:-0}" == "1" ]]; then
+	exit 0
+fi
+
+INPUT=$(cat 2>/dev/null || true)
+TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+
+# Loop guard: if this Stop hook already fired this turn (the assistant was
+# already nudged and still chose to end on a permission-ask), allow the stop.
+# A genuine gate re-affirmed after one reminder is respected — the hook kills
+# the REFLEXIVE ask, not the deliberate one.
+STOP_HOOK_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || true)
+if [[ "$STOP_HOOK_ACTIVE" == "true" ]]; then
+	exit 0
+fi
+
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+	exit 0
+fi
+
+# Last assistant text (concat text blocks of the most recent assistant turn;
+# skip thinking + tool_use). Last 200 lines is plenty — a permission-ask is
+# always the most recent assistant message.
+LAST_ASSISTANT_TEXT=$(
+	tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
+		jq -rs '
+        [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
+        | last
+        | (.message.content // [])
+        | map(select(.type == "text") | .text)
+        | join(" ")
+    ' 2>/dev/null
+)
+
+if [[ -z "$LAST_ASSISTANT_TEXT" || "$LAST_ASSISTANT_TEXT" == "null" ]]; then
+	exit 0
+fi
+
+# Permission-ask / decision-handback tells — scoped DELIBERATELY to
+# permission-seeking phrasings, NOT to all questions. A genuine information-
+# seeking question or an architectural fork ("Should I use Postgres or MySQL?",
+# "Which schema should I target?") asks the user to CHOOSE or to supply a FACT —
+# those are legitimate stops the rule protects, and must NOT fire. The failure
+# class is asking PERMISSION TO ACT on something already known.
+#   - PATTERN_PROCEED: "want me to … ?" forms — inherently permission-to-act.
+#   - PATTERN_PERMIT:  "should/shall I" ONLY when followed by an action/permission
+#     verb (proceed, merge, deploy, …). This is the load-bearing guard (#732
+#     review C1): bare "should I" introduces just as many forks/clarifications as
+#     permission-asks, so it is excluded — only the verb-gated form matches, so
+#     "should I use X or Y?" / "which X should I target?" correctly pass through.
+# Each requires a "?" within proximity (no sentence terminator [^.?!\n] between)
+# so a mid-sentence mention doesn't fire. Case-insensitive.
+PATTERN_PROCEED='(?i)\b(want me to|do you want me to|would you like me to|ready (for me to|to proceed))\b[^.?!\n]{0,60}\?'
+PATTERN_PERMIT='(?i)\b(should|shall) i\s+(go ahead|proceed|continue|start|begin|merge|deploy|push|run|commit|create|land|ship|kick off|move on|do (it|that|this|so))\b[^.?!\n]{0,40}\?'
+PATTERN_WORD='(?i)\b(just )?say the word\b' # unanchored like the sibling's edge; kill-switch covers quoted-rule prose
+PATTERN_DEFER='(?i)\blet me know\b[^.?!\n]{0,30}\b(if|whether|when)\b[^.?!\n]{0,30}\b(you want|i should|to proceed|go ahead)\b'
+
+if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_PROCEED" 2>/dev/null ||
+	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_PERMIT" 2>/dev/null ||
+	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_WORD" 2>/dev/null ||
+	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_DEFER" 2>/dev/null; then
+	cat <<'JSON'
+{"decision":"block","reason":"Per CLAUDE.md MANDATORY: Default to Action — you ended by asking permission to do something. If you already know what to do and it is safe, understood, and in your lane, DO IT now instead of asking; stopping blocks everyone downstream and spends the user's attention. Stop ONLY for a genuinely new irreversible/prod action the user has NOT already agreed to, or a real architectural fork. Agreement persists — completing work the user already directed is not a new gate. If this IS a legitimate gate, continue the turn and state it plainly as a gate with the specific reason; otherwise continue by taking the action."}
+JSON
+	exit 0
+fi
+
+exit 0

--- a/tests/regression/test_stop_action_bias_detector.sh
+++ b/tests/regression/test_stop_action_bias_detector.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# test_stop_action_bias_detector.sh — regression tests for the Stop hook that
+# detects permission-ask / decision-handback phrasings ("want me to proceed?",
+# "should I…?") and blocks the stop with a default-to-action reminder.
+#
+# Hook source: scripts/stop-action-bias-detector.sh
+# Issue: cc-workflow#732 (general sibling of #542 precheck-asking-detector)
+#
+# Strategy: build minimal CC-transcript JSONL fixtures, pipe the hook input
+# contract (stdin JSON with .transcript_path [, .stop_hook_active]) through
+# the hook, assert on its stdout (block JSON) and exit code.
+#
+# Wired into CI via scripts/ci/validate.sh.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$REPO_DIR/scripts/stop-action-bias-detector.sh"
+
+if [[ ! -x "$HOOK" ]]; then
+	echo "  [FAIL] hook missing or not executable: $HOOK"
+	exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASSES=0
+FAILS=0
+pass() {
+	echo "  [PASS] $*"
+	PASSES=$((PASSES + 1))
+}
+fail() {
+	echo "  [FAIL] $*"
+	FAILS=$((FAILS + 1))
+}
+
+make_transcript() {
+	local label="$1" text="$2"
+	local path="$TMPDIR/transcript-$label.jsonl"
+	jq -nc --arg text "$text" '{
+        type: "assistant",
+        message: { role: "assistant", content: [ { type: "text", text: $text } ] }
+    }' >"$path"
+	echo "$path"
+}
+
+run_hook() { # $1 transcript_path  [$2 stop_hook_active]
+	jq -nc --arg p "$1" --argjson active "${2:-false}" \
+		'{transcript_path: $p, session_id: "test", stop_hook_active: $active}' | "$HOOK"
+}
+
+assert_blocks() {
+	local label="$1" text="$2" path out
+	path=$(make_transcript "$label" "$text")
+	out=$(run_hook "$path")
+	if [[ "$out" == *'"decision":"block"'* ]]; then pass "blocks: $label"; else fail "should-block: $label — got: ${out:-<empty>}"; fi
+}
+
+assert_passes() {
+	local label="$1" text="$2" path out
+	path=$(make_transcript "$label" "$text")
+	out=$(run_hook "$path")
+	if [[ -z "$out" || "$out" != *'"decision":"block"'* ]]; then pass "passes:  $label"; else fail "should-pass: $label — got: $out"; fi
+}
+
+# --- Positive cases — permission-asks the hook MUST block --------------------
+assert_blocks "want_me_to" "The deploy is ready. Want me to proceed?"
+assert_blocks "should_i" "Both blockers are merged. Should I proceed?"
+assert_blocks "shall_i" "Shall I go ahead and merge it?"
+assert_blocks "do_you_want" "Do you want me to redeploy to the fleet?"
+assert_blocks "ready_for_me" "Ready for me to start #722?"
+assert_blocks "would_you_like" "Would you like me to take the next one?"
+assert_blocks "say_the_word" "It's all staged — just say the word."
+assert_blocks "let_me_know_defer" "Let me know whether you want me to continue."
+
+# --- Negative cases — the hook MUST NOT block -------------------------------
+# Information-seeking questions (asking about a FACT, not permission to act).
+assert_passes "info_which_db" "Which database are you using for this service?"
+assert_passes "info_budget" "What token budget should this campaign target?"
+assert_passes "info_fork" "Two viable approaches here — per-wave or per-plan kahuna. Which do you want?"
+# #732 review C1: architectural forks / clarifications phrased with "should I" are
+# LEGITIMATE stops the rule protects — the verb-gating on PATTERN_PERMIT must let
+# them pass (bare "should I <non-action-verb>" never fires).
+assert_passes "should_i_fork" "Should I use Postgres or MySQL for this service?"
+assert_passes "should_i_which_file" "Which file should I edit — the template or the generated copy?"
+assert_passes "should_i_assume" "Should I assume us-east-1 as the region here?"
+assert_passes "should_i_target" "Which schema should I target for the migration?"
+# Statements / no question mark.
+assert_passes "statement_proceeding" "Both blockers are merged; I'm proceeding with the redeploy now."
+assert_passes "no_qmark" "I can start #722 next."
+# A legitimate gate stated AS a gate (no permission phrasing) is allowed.
+assert_passes "gate_stated" "This is a prod deploy you haven't agreed to in this conversation; I'm holding for your explicit go on prod specifically."
+# Distance / unrelated.
+assert_passes "distant" "I want this done right, so the details matter and I checked them all carefully."
+
+# --- Loop guard: stop_hook_active=true → allow the stop even on positive input
+label="loop_guard"
+path=$(make_transcript "$label" "Want me to proceed?")
+out=$(run_hook "$path" true)
+if [[ -z "$out" ]]; then pass "loop-guard: stop_hook_active=true → silent (no double-block)"; else fail "loop-guard: should be silent, got: $out"; fi
+
+# --- Kill-switch env --------------------------------------------------------
+label="disabled_env"
+path=$(make_transcript "$label" "Want me to proceed?")
+out=$(jq -nc --arg p "$path" '{transcript_path: $p}' | STOP_ACTION_BIAS_HOOK_DISABLED=1 "$HOOK")
+if [[ -z "$out" ]]; then pass "env-disable: positive input but STOP_ACTION_BIAS_HOOK_DISABLED=1 — silent"; else fail "env-disable: should be silent, got: $out"; fi
+
+# --- Missing transcript -----------------------------------------------------
+out=$(echo '{"transcript_path": "/nonexistent/xyz.jsonl"}' | "$HOOK")
+if [[ -z "$out" ]]; then pass "missing-transcript: silent no-op"; else fail "missing-transcript: should be silent, got: $out"; fi
+
+echo ""
+echo "  Results: $PASSES passed, $FAILS failed"
+((FAILS > 0)) && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Recurring fleet-wide failure: agents stopping to ask permission for work they already know how to do (and the user has already directed) — which blocks every agent + human downstream and spends the user's attention. Fixed the way this repo fixes behavior: **enforce in a hook, explain in prose** (the #541/#542 pattern).

## Changes

- **`scripts/stop-action-bias-detector.sh`** — new Claude Code `Stop` hook, general sibling of `precheck-asking-detector.sh`. Reads the transcript; if the last assistant message ends by asking *permission to act* ("want me to proceed?", verb-gated "should I merge/deploy/…?"), returns `{"decision":"block","reason":…}` with a default-to-action reminder. **Verb-gating** on `should/shall I` is load-bearing (review C1): bare "should I use X or Y?" / "which X should I target?" are legitimate architectural-fork / clarification stops the rule *protects* and pass through. Loop-guard via `stop_hook_active`; kill-switch `STOP_ACTION_BIAS_HOOK_DISABLED=1`.
- **`config/settings.template.json`** — wires the hook into the `Stop` array.
- **`tests/regression/test_stop_action_bias_detector.sh`** — 22 cases: positives, the should-I-fork false-positive negatives, loop-guard, kill-switch, missing-transcript.
- **`CLAUDE.md`** — `## MANDATORY: Default to Action` — closed set of legitimate stop-reasons, "agreement persists" (completing directed work is not a new gate), the "want me to / should I" tell. Composes with (does not override) the ABSOLUTE prod rule and the Pre-Commit Gate.

## Linked Issues

Closes #732

## Test Plan

- `./scripts/ci/validate.sh` → **160 passed, 0 failed** (shellcheck-clean hook + the new 22-case regression test).
- Independent code-review (false-positive-focused, since it fires fleet-wide): found **1 critical** — bare `should i`/`shall i` blocked legitimate forks — now **fixed** by verb-gating and pinned by 4 new `assert_passes` negatives (which failed before the fix). Loop-guard, contract parity with the sibling, and prod-rule composition all confirmed. trivy 0 HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)