### PR TITLE
fix(install): deploy kit hooks that share a matcher (config-merge)

### DIFF
--- a/install
+++ b/install
@@ -638,14 +638,37 @@ merge_settings() {
 		((.[1].hooks // {}) | keys) as $local_hook_keys |
 		# New event keys (template only) — add wholesale
 		($tpl_hooks | map(select(.key | IN($local_hook_keys[]) | not))) as $new_hooks |
-		# Shared event keys — union their matcher arrays by .matcher value
+		# Shared event keys — union hook arrays, preserving user overrides while
+		# still deploying the multi-hook kit events (#734, option C).
+		# (No apostrophes in these comments — they live inside a single-quoted jq
+		# program and an apostrophe would terminate the shell string.)
+		# Three add-conditions for a template entry, gated first on de-dup
+		# (its command-signature must not already be present locally):
+		#   1. NEW matcher (not in local) — add (preserves #556 AC1).
+		#   2. EXISTING matcher, but the entry is KIT-OWNED (a command referencing
+		#      a kit path: ~/.local/bin/ or .claude/) — add. This is the #734 fix:
+		#      the kit ships multiple distinct "*" Stop hooks (precheck-asking +
+		#      wavemachine guard + stop-action-bias) that must coexist; a plain
+		#      matcher-keyed union silently dropped all but the first.
+		#   3. EXISTING matcher, NOT kit-owned — DO NOT add. A user hook under a
+		#      shared matcher still overrides the kit version (preserves #556 AC2);
+		#      the kit never resurrects or layers onto a genuinely-custom user hook.
+		# Local/user hooks are always preserved; identical hooks never duplicated.
+		# Signature = sorted list of .hooks[].command.
 		($tpl_hooks | map(select(.key | IN($local_hook_keys[]))) | map({
 			key: .key,
 			value: (
 				(.value // []) as $tpl_arr |
 				(($local_hooks | from_entries)[.key] // []) as $local_arr |
+				($local_arr | map([.hooks[].command // empty] | sort)) as $local_sigs |
 				($local_arr | map(.matcher)) as $local_matchers |
-				$local_arr + ($tpl_arr | map(select(.matcher as $m | $local_matchers | index($m) | not)))
+				$local_arr + ($tpl_arr | map(select(
+					(([.hooks[].command // empty] | sort) as $sig | ($local_sigs | map(. == $sig) | any) | not)
+					and (
+						(.matcher as $m | $local_matchers | index($m) | not)
+						or ([.hooks[].command // empty] | map(test("\\.local/bin/|\\.claude/")) | any)
+					)
+				)))
 			)
 		}) | from_entries) as $merged_shared_hooks |
 

--- a/tests/test_install_merge_hooks_union.py
+++ b/tests/test_install_merge_hooks_union.py
@@ -376,3 +376,71 @@ def test_matcher_union_is_idempotent(sandbox_home: Path) -> None:
     # And the matcher set is exactly {"*", "compact"}.
     matchers = sorted(e["matcher"] for e in after_second["hooks"]["SessionStart"])
     assert matchers == ["*", "compact"]
+
+
+# ---------------------------------------------------------------------------
+# #734: distinct KIT hooks sharing matcher "*" must all deploy (Stop array)
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+def test_kit_multi_hook_same_matcher_all_deploy(sandbox_home: Path) -> None:
+    """The kit ships several distinct hooks under matcher '*' (e.g. the Stop
+    array). When local already has one of them, the OTHER kit hooks must be
+    merged in (not dropped by a matcher-keyed union), while a user's own '*'
+    hook is preserved and identical kit hooks are not duplicated."""
+    template = {
+        "hooks": {
+            "Stop": [
+                {"matcher": "*", "hooks": [{"type": "command", "command": "~/.local/bin/precheck-asking-detector.sh"}]},
+                {"matcher": "*", "hooks": [{"type": "command", "command": "~/.local/bin/stop-action-bias-detector.sh"}]},
+                {"matcher": "*", "hooks": [{"type": "command", "command": "state=\"${CLAUDE_PROJECT_DIR:-.}/.claude/status/state.json\"; exit 0"}]},
+            ]
+        }
+    }
+    local = {
+        "hooks": {
+            "Stop": [
+                # one kit hook already present (must not be duplicated)
+                {"matcher": "*", "hooks": [{"type": "command", "command": "~/.local/bin/precheck-asking-detector.sh"}]},
+                # a user's own '*' hook (non-kit) — must be preserved, never clobbered
+                {"matcher": "*", "hooks": [{"type": "command", "command": "my-custom-stop-hook.sh"}]},
+            ]
+        }
+    }
+    settings_path = sandbox_home / ".claude" / "settings.json"
+    _write_json(settings_path, local)
+
+    sandbox_install = _override_template(sandbox_home, template)
+    rc, _stdout, _stderr = _run_sandbox_install(sandbox_install, ["--config"], sandbox_home)
+    assert rc == 0
+
+    merged = _read_json(settings_path)
+    commands = [h["command"] for e in merged["hooks"]["Stop"] for h in e["hooks"]]
+    # All three kit hooks present.
+    assert sum(c == "~/.local/bin/precheck-asking-detector.sh" for c in commands) == 1, "precheck-asking present exactly once (no duplicate)"
+    assert any("stop-action-bias-detector.sh" in c for c in commands), "the absent kit hook must be merged in (#734)"
+    assert any(".claude/status/state.json" in c for c in commands), "the kit's inline wavemachine guard (kit path) must be merged in"
+    # User's own hook preserved.
+    assert any(c == "my-custom-stop-hook.sh" for c in commands), "user's custom '*' hook must be preserved"
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+def test_user_override_of_kit_hook_not_resurrected(sandbox_home: Path) -> None:
+    """A NON-kit user hook under '*' still overrides per #556 AC2 — a bare
+    template command sharing the matcher is not layered on top."""
+    template = {
+        "hooks": {"Stop": [{"matcher": "*", "hooks": [{"type": "command", "command": "default-bare.sh"}]}]}
+    }
+    local = {
+        "hooks": {"Stop": [{"matcher": "*", "hooks": [{"type": "command", "command": "user-customized.sh"}]}]}
+    }
+    settings_path = sandbox_home / ".claude" / "settings.json"
+    _write_json(settings_path, local)
+    sandbox_install = _override_template(sandbox_home, template)
+    rc, _, _ = _run_sandbox_install(sandbox_install, ["--config"], sandbox_home)
+    assert rc == 0
+    commands = [h["command"] for e in _read_json(settings_path)["hooks"]["Stop"] for h in e["hooks"]]
+    assert "user-customized.sh" in commands
+    assert "default-bare.sh" not in commands, "a non-kit template hook must not override a user hook on a shared matcher"


### PR DESCRIPTION
## Summary

`merge_settings()` unioned shared-event-key hook arrays **by `.matcher`**, so a template hook whose matcher a local hook already used was silently dropped. Multiple distinct kit hooks share `matcher: "*"` (the `Stop` array: `precheck-asking` + the wavemachine stall-guard + `stop-action-bias`), so all but the first failed to deploy fleet-wide — which is why the wavemachine guard *and* the #732 hook were missing from installed `settings.json`.

## Changes

- **Option C** (BJ-selected). In the shared-key union, add a template entry when its command-signature is absent locally **AND** (its matcher is new **OR** it is *kit-owned* — a command referencing `~/.local/bin/` or `.claude/`). Kit hooks coexist; a genuinely-custom user hook under a shared matcher still overrides the kit version (**#556 AC2 preserved**).
- Dedup uses explicit signature **equality** (`map(. == $sig) | any`), not `index($sig)` — jq's `index()` with an *array* argument does subsequence matching, which silently never matched and would have duplicated already-present hooks.

## Linked Issues

Closes #734

## Test Plan

- `tests/test_install_merge_hooks_union.py` +2: kit multi-hook coexist (no duplicate, user hook preserved) and non-kit override-not-resurrected. The **4 existing #556 tests still pass**.
- `./scripts/ci/validate.sh` → **160 passed, 0 failed**; install suite **22 passed** (cellar + merge-union + skill-prune).
- Independent code-review (merge-safety focused): **0 critical / 0 important** — verified no drop/clobber of user hooks (local array emitted verbatim, filter only appends), dedup correctness, kit-owned scoping, `.command // empty` null-guard, and change scoped to the shared-key union only. trivy 0 HIGH/CRITICAL.

Side benefit: restores the wavemachine `Stop` stall-guard to hosts where it had silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)