### PR TITLE
fix(wave-status): coarse driver-states for the async campaign loop (#738)

### DIFF
--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -205,6 +205,27 @@ narrative prose. "Wave N complete, starting N+1" between waves is forbidden — 
 wall-clock (the cc-workflow#600 "Bug B" failure mode). In `interactive` mode the human
 STOP is the one deliberate pause; everything else is a tight tool-use chain.
 
+## Coarse driver status (#738) — and the stall-guard contract (#736)
+
+The per-wave Workflow runs **async**: the driver launches it, **ends its turn**, and is
+re-invoked on the completion verdict. So the campaign loop writes a **coarse
+`current_action`** at its boundaries (the dynamic-model replacement for the legacy
+per-phase lifecycle, which the engine no longer drives), via the `wave-status` CLI:
+
+- **Immediately before launching a per-wave Workflow** — `wave-status awaiting-verdict <waveId>`.
+  This is the LAST status write of the launch tool-use block, so when the turn ends to await
+  the async verdict, `current_action.action == "awaiting-verdict"`.
+- **On a HOLD / interactive verdict** (the one deliberate human pause) — `wave-status hold "<reason>"`
+  before surfacing the diff and stopping.
+- (Optional, for dashboard truthfulness) `wave-status promoting <waveId>` while a PASS wave promotes.
+
+**This is the contract the stall-guard Stop hook depends on (#736).** The guard no-ops when
+`current_action.action` is `awaiting-verdict` (a legitimate async await — NOT a stall) or
+`hold` (a legitimate human pause); it blocks only when `wavemachine_active` is set and the
+action implies the driver should be launching the next wave but the turn ended without it.
+Writing `awaiting-verdict` in the same tool-use block as the launch is therefore
+**load-bearing** — omit it and the guard false-fires on the await (cc-workflow#736).
+
 ## Resumability (mirrors §3.3, one level up)
 
 On cold start the campaign rehydrates from wave-status's wave-completion records

--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -25,17 +25,21 @@ from wave_status import deferrals
 from wave_status.dashboard.derived_state import compute_derived_state
 from wave_status.dashboard.generator import generate_dashboard
 from wave_status.state import (
+    awaiting_verdict,
     close_issue,
     complete,
     extend_state,
     flight,
     flight_done,
     get_project_root,
+    hold,
     init_state,
+    launching,
     load_json,
     load_state,
     planning,
     preflight,
+    promoting,
     record_mr,
     review,
     save_json,
@@ -219,6 +223,34 @@ def _cmd_waiting_ci(args: argparse.Namespace) -> None:
     root = get_project_root()
     detail = args.detail if args.detail else ""
     waiting_ci(root, detail=detail)
+    _safe_regenerate_dashboard(root)
+
+
+def _cmd_launching(args: argparse.Namespace) -> None:
+    """Handle ``launching [wave]`` — dynamic-driver coarse state (#738)."""
+    root = get_project_root()
+    launching(root, wave_id=args.wave or "")
+    _safe_regenerate_dashboard(root)
+
+
+def _cmd_awaiting_verdict(args: argparse.Namespace) -> None:
+    """Handle ``awaiting-verdict [wave]`` — coarse state (#738)."""
+    root = get_project_root()
+    awaiting_verdict(root, wave_id=args.wave or "")
+    _safe_regenerate_dashboard(root)
+
+
+def _cmd_promoting(args: argparse.Namespace) -> None:
+    """Handle ``promoting [wave]`` — coarse state (#738)."""
+    root = get_project_root()
+    promoting(root, wave_id=args.wave or "")
+    _safe_regenerate_dashboard(root)
+
+
+def _cmd_hold(args: argparse.Namespace) -> None:
+    """Handle ``hold [reason]`` — coarse state (#738)."""
+    root = get_project_root()
+    hold(root, reason=args.reason or "")
     _safe_regenerate_dashboard(root)
 
 
@@ -490,6 +522,23 @@ def _build_parser() -> argparse.ArgumentParser:
     p_wci = sub.add_parser("waiting-ci", help="Heartbeat during CI polling")
     p_wci.add_argument("detail", nargs="?", default="", help="Optional detail string")
     p_wci.set_defaults(func=_cmd_waiting_ci)
+
+    # dynamic-driver coarse states (#738)
+    p_lc = sub.add_parser("launching", help="Coarse state: about to launch the per-wave Workflow")
+    p_lc.add_argument("wave", nargs="?", default="", help="Wave id")
+    p_lc.set_defaults(func=_cmd_launching)
+
+    p_av = sub.add_parser("awaiting-verdict", help="Coarse state: per-wave Workflow in flight, awaiting verdict")
+    p_av.add_argument("wave", nargs="?", default="", help="Wave id")
+    p_av.set_defaults(func=_cmd_awaiting_verdict)
+
+    p_pr = sub.add_parser("promoting", help="Coarse state: promoting a PASS wave")
+    p_pr.add_argument("wave", nargs="?", default="", help="Wave id")
+    p_pr.set_defaults(func=_cmd_promoting)
+
+    p_hd = sub.add_parser("hold", help="Coarse state: paused for human attention (HOLD / adjudication)")
+    p_hd.add_argument("reason", nargs="?", default="", help="Hold reason")
+    p_hd.set_defaults(func=_cmd_hold)
 
     # close-issue
     p_ci = sub.add_parser("close-issue", help="Close an issue by number or qualified ref")

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -754,6 +754,43 @@ def waiting_ci(root: Path, detail: str = "") -> dict:
     return _set_action(root, "waiting-ci", "waiting-ci", detail)
 
 
+# ---------------------------------------------------------------------------
+# Dynamic-workflows campaign-driver coarse states (#738).
+#
+# The dynamic engine runs wave-internal phases inside the async per-wave
+# Workflow (off-session); it does NOT drive the fine per-phase lifecycle above
+# (preflight/planning/flight/...), which is legacy-synchronous-orchestrator
+# vocabulary. Instead the /wavemachine driver writes these COARSE states at the
+# in-session boundaries it genuinely knows — the same boundaries where it sets
+# wavemachine_active. They keep the dashboard truthful during an async wave AND
+# are the signal the stall-guard Stop hook keys on (#736): it no-ops on
+# ``awaiting-verdict`` (legitimate async await) and ``hold`` (human adjudication
+# pause), and only blocks when the driver should be launching the next wave.
+# ---------------------------------------------------------------------------
+
+def launching(root: Path, wave_id: str = "") -> dict:
+    """Coarse state: the driver is about to launch the per-wave Workflow (#738)."""
+    return _set_action(root, "launching", "launching", wave_id)
+
+
+def awaiting_verdict(root: Path, wave_id: str = "") -> dict:
+    """Coarse state: the per-wave Workflow is in flight; the driver has ended its
+    turn and is awaiting the async completion verdict (#738). The stall-guard
+    no-ops on this — it is a legitimate await, not a stall (#736)."""
+    return _set_action(root, "awaiting-verdict", "awaiting-verdict", wave_id)
+
+
+def promoting(root: Path, wave_id: str = "") -> dict:
+    """Coarse state: a PASS verdict came back; the wave is being promoted (#738)."""
+    return _set_action(root, "promoting", "promoting", wave_id)
+
+
+def hold(root: Path, reason: str = "") -> dict:
+    """Coarse state: the campaign is paused for human attention — a HOLD verdict
+    or interactive adjudication (#738). The stall-guard no-ops on this (#736)."""
+    return _set_action(root, "hold", "hold", reason)
+
+
 def set_current_wave(wave_id: str, root: Path) -> dict:
     """Set ``current_wave`` to *wave_id* in ``state.json``.
 

--- a/tests/test_wave_status.py
+++ b/tests/test_wave_status.py
@@ -1273,3 +1273,50 @@ class TestNoExternalDependencies:
             env=env,
         )
         assert result.returncode == 0, f"import failed: {result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Dynamic-driver coarse states (#738) — the states the stall-guard reads (#736)
+# ---------------------------------------------------------------------------
+
+class TestCoarseDriverStates:
+    """The /wavemachine driver writes coarse current_action states at its
+    in-session boundaries under the async dynamic-workflows engine."""
+
+    def test_coarse_states_set_current_action(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        repo = temp_git_repo
+        _write_plan(repo)
+        rc, _out, err = run_cli(["init", "plan.json"], repo)
+        assert rc == 0, f"init failed: {err}"
+
+        state_path = repo / ".claude" / "status" / "state.json"
+
+        cases = [
+            (["awaiting-verdict", "wave-1"], "awaiting-verdict", "wave-1"),
+            (["hold", "gate-blocked: trivy"], "hold", "gate-blocked: trivy"),
+            (["launching", "wave-2"], "launching", "wave-2"),
+            (["promoting", "wave-1"], "promoting", "wave-1"),
+        ]
+        for argv, expect_action, expect_detail in cases:
+            rc, _out, err = run_cli(argv, repo)
+            assert rc == 0, f"{argv[0]} failed: {err}"
+            ca = json.loads(state_path.read_text(encoding="utf-8"))["current_action"]
+            assert ca["action"] == expect_action, f"{argv[0]}: action={ca}"
+            assert ca["detail"] == expect_detail, f"{argv[0]}: detail={ca}"
+
+    def test_awaiting_verdict_and_hold_are_the_noop_states_for_736(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """The two states the stall-guard must no-op on are settable and distinct
+        from a 'should-be-launching' state."""
+        repo = temp_git_repo
+        _write_plan(repo)
+        run_cli(["init", "plan.json"], repo)
+        state_path = repo / ".claude" / "status" / "state.json"
+
+        run_cli(["awaiting-verdict", "wave-3"], repo)
+        assert json.loads(state_path.read_text())["current_action"]["action"] == "awaiting-verdict"
+        run_cli(["hold", "interactive"], repo)
+        assert json.loads(state_path.read_text())["current_action"]["action"] == "hold"


### PR DESCRIPTION
## Summary

Under the dynamic-workflows engine the fine per-phase `current_action` lifecycle (preflight/planning/flight/waiting-ci) is **orphaned** — the async per-wave Workflow owns wave-internal phases off-session and the driver never drives those setters — yet the dashboard still reads `current_action`, so it shows stale/idle state while a wave runs. Surfaced by the legacy-vs-dynamic sweep's completeness critic.

## Changes

Add **coarse driver-states** the `/wavemachine` campaign loop writes at the in-session boundaries it genuinely knows (the same boundaries where it sets `wavemachine_active`): `launching` / `awaiting-verdict` / `promoting` / `hold`.

- **`state.py`** — the four setters via `_set_action`.
- **`__main__.py`** — their `wave-status` CLI subcommands.
- **`wavemachine/SKILL.md`** — wiring: `awaiting-verdict` is the **last** status write of the launch tool-use block (so it is the persisted action when the turn ends to await the async verdict); `hold` on a HOLD/interactive pause. This is the explicit contract the **#736** stall-guard reads (no-op on `awaiting-verdict`/`hold`; block only when the driver should be launching).
- **tests** — `TestCoarseDriverStates` pins all four states + the two #736 no-op states.

**Decision recorded:** coarse-driver-states (not cross-context Workflow-driven, not full retire). Full retirement of the orphaned fine lifecycle is a noted follow-up.

This is the **producer side**; #736 (the stall-guard hook that reads these states) is the consumer, landing next.

## Linked Issues

Closes #738

## Test Plan

- Independent code-review: **0 findings** — verified the load-bearing #736 contract (the only two turn-ending boundaries, launch + interactive STOP, are both covered by `awaiting-verdict`/`hold`).
- `./scripts/ci/validate.sh` → **152 passed, 0 failed**; `test_wave_status.py` **48 passed** (incl. 2 new). trivy 0 HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)