### PR TITLE
chore(tests): remove dead cc-context existence assertion

### DIFF
--- a/tests/test_cc_context.py
+++ b/tests/test_cc_context.py
@@ -180,11 +180,9 @@ class TestNerfDisplay:
         finally:
             p.unlink(missing_ok=True)
 
-    def test_cc_context_script_exists(self):
-        """The cc-context script must exist at the expected path."""
-        assert CC_CONTEXT_PATH.exists(), (
-            f"cc-context not found at {CC_CONTEXT_PATH}"
-        )
+    # test_cc_context_script_exists removed: cc-context (context-crystallizer)
+    # was removed in #647; the remaining cc-context tests below skip-guard on
+    # CC_CONTEXT_PATH.exists() so they self-disable rather than hard-fail.
 
     def test_cc_context_is_executable(self):
         """The cc-context script must be executable."""


### PR DESCRIPTION
## Summary
Second batch of #753 triage. Removes the one hard-asserting dead test in `tests/test_cc_context.py`.

## Changes
- Remove `test_cc_context_script_exists` — it hard-asserted the cc-context binary at `~/.claude/context-crystallizer/bin/cc-context`, removed with context-crystallizer in #647. Replaced with an explanatory comment.
- The other cc-context tests skip-guard on `CC_CONTEXT_PATH.exists()` and self-disable; the file's live nerf-config + transcript tests are untouched.

## Tests
Drops one pre-existing pytest failure; `./scripts/ci/validate.sh` PASS (154/0); trivy PASS; code-review no findings.

## Linked Issues
Part of #753 (remaining: install/merge tests — gated on a behavior decision; ~99 skill-prose assertions — need test-rot-vs-real-drift triage).