### PR TITLE
fix(skills): restore orphaned introduction-gates to 5 skills (#753)

### DIFF
--- a/skills/assesswaves/SKILL.md
+++ b/skills/assesswaves/SKILL.md
@@ -3,6 +3,12 @@ name: assesswaves
 description: Quick assessment of whether a piece of work is suitable for wave-pattern execution (parallel or serial). Lighter than /prepwaves — helps decide decomposition before (or after) issues are created.
 ---
 
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-assesswaves does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-assesswaves
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
 # AssessWaves — Is This Work Wave-Patternable?
 
 Decide whether a set of work items can benefit from wave-pattern execution. Recommends a topology and verdict; does not create issues or flight plans. Use before `/prepwaves`.

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -5,6 +5,12 @@ usage: |
   /disc send #ch "msg"  /disc read #ch  /disc list  /disc create #ch  /disc thread "name" in #ch
 ---
 
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-disc does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-disc
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
 # Disc — disc-server MCP Router
 
 Route all /disc intents to `disc-server` MCP tool calls.

--- a/skills/dod/SKILL.md
+++ b/skills/dod/SKILL.md
@@ -3,6 +3,12 @@ name: dod
 description: Project Definition of Done verification against the Deliverables Manifest — verify every deliverable, run tests, check VRTM, produce pass/fail report
 ---
 
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-dod does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-dod
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
 # Project DoD Verification
 
 Read the Deliverables Manifest from the project's Dev Spec and mechanically verify every deliverable exists at its declared path, every test passes, and VRTM is complete. Generate a pass/fail report and require explicit human sign-off before any campaign state change.

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -3,6 +3,12 @@ name: precheck
 description: Pre-commit gate — verify branch/issue, run code-reviewer, present checklist, then stop and wait for approval
 ---
 
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-precheck does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-precheck
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
 # Pre-Commit Gate
 
 Mandatory verification before any commit. Checks compliance, runs code review, presents the checklist, and **stops**. Does NOT commit/push/PR.

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -3,6 +3,12 @@ name: prepwaves
 description: Validate sub-issue specs, compute dependency waves, prepare for wave-pattern execution
 ---
 
+<!-- introduction-gate: If introduction.md exists in this skill's directory AND
+     the marker file /tmp/.skill-intro-prepwaves does NOT exist, read introduction.md,
+     present its contents to the user, then create the marker: touch /tmp/.skill-intro-prepwaves
+     Do NOT delete introduction.md — it lives in a protected directory.
+     Do this BEFORE executing any skill logic below. -->
+
 # PrepWaves — Plan Wave Execution
 
 Analyze one or more Plan tracking issues, validate their sub-issue specs, compute dependency-ordered waves, and persist the plan so `/nextwave` can execute it. Supports parallel, serial, and mixed topologies.


### PR DESCRIPTION
## Summary
A **real defect** surfaced while triaging #753: assesswaves, disc, dod, precheck, prepwaves each have an `introduction.md` but lost their `introduction-gate` block during the Phase 0/1 skill trims — so the intro is orphaned and never presented. 22/27 skills carry gate+intro (the norm), so these 5 are accidental drops.

## Changes
- Add the canonical `introduction-gate` block (byte-identical to reseed/engage) after the frontmatter of all 5 SKILL.md files, each with its own `/tmp/.skill-intro-<name>` marker.

## Tests
Fixes `tests/test_dod_skill.py::test_introduction_gate_present` (real defect, not test-rot). `validate.sh` PASS (154/0); trivy PASS; code-review verified gates byte-identical to canonical, markers correct, YAML intact, intros substantive (not vestigial).

## Linked Issues
Part of #753. The dod rich-structure tests (27) are stale (dod was rewritten as a routing stub in #305) — separate test-modernization batch.