### PR TITLE
fix(tests): modernize issue skill tests — epic header suffix + doc/docs (#753)

### DIFF
--- a/tests/test_issue_skill.py
+++ b/tests/test_issue_skill.py
@@ -388,7 +388,8 @@ class TestFrontmatter:
         end = skill_text.index("---", 4)
         frontmatter = skill_text[:end + 3]
         for t in SUB_ISSUE_TYPES:
-            assert t in frontmatter.lower(), (
+            # canonical type is singular ("doc"); tolerate the plural in the constant
+            assert t in frontmatter.lower() or t.rstrip("s") in frontmatter.lower(), (
                 f"frontmatter description omits sub-issue type {t!r}"
             )
 
@@ -449,7 +450,8 @@ class TestGuaranteeDocumented:
     def test_introduction_lists_all_sub_issue_types(self, intro_text: str) -> None:
         """introduction.md lists every sub-issue type."""
         for t in SUB_ISSUE_TYPES:
-            assert t in intro_text.lower(), (
+            # canonical type is singular ("doc"); tolerate the plural in the constant
+            assert t in intro_text.lower() or t.rstrip("s") in intro_text.lower(), (
                 f"introduction.md omits sub-issue type {t!r}"
             )
 
@@ -546,15 +548,15 @@ class TestEpicExcluded:
 
     def test_epic_template_present(self, skill_text: str) -> None:
         """The Epic Template still exists."""
-        body = _extract_template_block(skill_text, "Epic Template")
+        body = _extract_template_block(skill_text, "Epic Template (PM-layer only)")
         assert body, "Epic Template block is missing entirely"
 
     def test_epic_template_keeps_epic_specific_headings(
         self, skill_text: str
     ) -> None:
         """The epic template retains its epic-specific structure
-        (Goal / Scope / Definition of Done / Sub-Issues / Wave Map)."""
-        body = _extract_template_block(skill_text, "Epic Template")
+        (Goal / Scope / Definition of Done / Sub-Issues / Success Metrics)."""
+        body = _extract_template_block(skill_text, "Epic Template (PM-layer only)")
         headings = _h2_headings(body)
         for required in ("## Goal", "## Scope", "## Definition of Done", "## Sub-Issues"):
             assert required in headings, (


### PR DESCRIPTION
## Summary
4 stale assertions in `tests/test_issue_skill.py` (#753) — the skill is correct; the tests were behind.

## Changes
- Two epic-template tests extracted header `"Epic Template"`, but the skill's header is `### Epic Template (PM-layer only)` (suffix, like `Feature Template (alias: Story)`). Match the full header — the epic template + its Goal/Scope/DoD/Sub-Issues headings are all genuinely present.
- Two "lists all sub-issue types" tests asserted literal `"docs"`, but the skill's canonical type is singular `"doc"`. Added singular/plural tolerance so the shared `SUB_ISSUE_TYPES` constant (and the emission tests using it) stay untouched.
- Fixed a stale docstring (`Wave Map` → `Success Metrics`, per code-review).

## Tests
`tests/test_issue_skill.py` 42/42 green; `validate.sh` PASS (154/0); trivy PASS; code-review verified assertions meaningful (not vacuous).

## Linked Issues
Part of #753.