### PR TITLE
test(drift): xfail #601 AC3 skill-doc tests — incomplete feature, not rot (#753)

### DIFF
--- a/tests/test_drift_instrumentation_skill.py
+++ b/tests/test_drift_instrumentation_skill.py
@@ -203,10 +203,21 @@ class TestAC2_ReportSubcommand:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(
+    reason="#601 AC3 not yet implemented: the drift-instrumentation script "
+    "(AC1/AC2) is done and tested, but the wavemachine SKILL.md does not yet "
+    "document the mechanism / three events / Axiom 9 / rejected alternatives. "
+    "Remove this marker when #601's skill-documentation AC lands.",
+    strict=False,
+)
 class TestAC3_SkillDocumentation:
     """The SKILL body must document the chosen mitigation mechanism, name
     the three drift-signal events, reference WAVE_AXIOMS.md (and Axiom 9
-    specifically), and document the rejected alternatives."""
+    specifically), and document the rejected alternatives.
+
+    NOTE: xfail until #601 writes the wavemachine drift-mitigation doc section.
+    These are tests for an incomplete feature, not test-rot — the disposition is
+    to track via #601, not to author the skill docs here (that's #601's design)."""
 
     def test_section_heading_present(self, skill_text: str) -> None:
         assert re.search(


### PR DESCRIPTION
## Summary
`test_drift_instrumentation_skill.py` is for **#601** (long-session drift mitigation, OPEN). The script half (AC1/AC2) is implemented and its 7 tests pass; the **AC3 skill-documentation half is not yet written** (the wavemachine SKILL.md doesn't document the mechanism / three drift events / Axiom 9 / rejected alternatives). So these 8 are tests for an **incomplete feature**, not test-rot.

## Changes
- Class-level `@pytest.mark.xfail(strict=False)` on `TestAC3_SkillDocumentation` with a reason string instructing removal when #601's skill-doc AC lands. AC1/AC2 (the script tests) left live.

## Tests
`tests/test_drift_instrumentation_skill.py`: 7 passed, 8 xfailed (no failures). `validate.sh` PASS; trivy PASS; code-review confirmed the disposition (incomplete feature, `strict=False` correct, not fix-now/delete).

## Linked Issues
Part of #753. Refs #601 (remove the xfail when its skill-doc AC is implemented).