### PR TITLE
feat(stop-hook): detect concluded-and-asked over-pause + prod-axis safety guard (#776)

### DIFF
--- a/scripts/stop-action-bias-detector.sh
+++ b/scripts/stop-action-bias-detector.sh
@@ -91,4 +91,35 @@ JSON
 	exit 0
 fi
 
+# --- concluded ∧ asked (cc-workflow#776 / fleet incident 2026-06-21) ---------
+# A subtler over-pause than the bare permission-ask above: the turn STATES a
+# team-converged conclusion AND asks the user to ratify it in the SAME message
+# ("we converged … BJ, your call?"). For an already-converged decision in the
+# agent's delegated lane, the converging IS the green light; routing it back to
+# the user for ratify is the over-pause. Requires the CONJUNCTION (conclusion
+# marker AND ratify-ask) so a bare prod gate ("BJ — your call on the prod
+# push?"), which has no conclusion marker, does NOT fire and stays surfaced.
+PATTERN_CONCLUSION='(?i)\b(converged|convergence|agreed|aligned|endorsed|locked in|the right move|only logical|consensus|we (all )?agree|team[\- ]converged)\b'
+PATTERN_RATIFY='(?i)\b(BJ|@?schwifty7759)\b[^.?!\n]{0,40}\b(ratify|approve|your (call|nod|go|go-ahead|read|move|sign[\- ]?off|concur))\b[^.?!\n]{0,10}\?'
+# SAFETY negative-guard (cc-workflow#776): never fire when a genuinely-gated axis
+# (prod / deploy / release / ship / go-live / force-push / irreversible / secrets /
+# migration / …) appears ANYWHERE in the turn. NOTE: this matches the whole
+# message, not only the ratify-ask clause — an unrelated mention of a gated term
+# also suppresses. That is deliberately the SAFE direction: this hook's "block"
+# PUSHES the agent to act, so firing on a real prod gate would push an unapproved
+# prod action, violating CLAUDE.md's ABSOLUTE prod rule. A missed nudge
+# (false-negative) is cheap; pushing prod (false-positive) is not — so the axis
+# list is intentionally over-broad. Applied ONLY to this new case — the
+# permission-ask patterns above legitimately catch "should I merge/push?".
+PATTERN_GATED_AXIS='(?i)\b(prod|production|deploy|release|rollout|ship|cut[\- ]?over|go[\- ]?live|force[\- ]?push|publish|promote|rotate|tear[\- ]?down|irreversible|destroy|destructive|drop|wipe|delete|secret|credential|migrat|tag|merge to (main|master|prod)|fleet[\- ]wide)\b'
+
+if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_CONCLUSION" 2>/dev/null &&
+	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_RATIFY" 2>/dev/null &&
+	! printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_GATED_AXIS" 2>/dev/null; then
+	cat <<'JSON'
+{"decision":"block","reason":"Per CLAUDE.md MANDATORY: Default to Action + standing authority — you stated a team-converged conclusion AND asked the user to ratify it in the same turn (the concluded-and-asked over-pause). For an already-converged decision in your delegated lane (non-prod, team-aligned, within your standing authority), the converging IS the green light; surfacing it for ratify is the over-pause. Stop ONLY for: (a) a genuinely new irreversible/prod action the user has NOT already agreed to; (b) a real fork where the user's choice changes what gets built; (c) novel risk requiring user-judgment they hold. Otherwise continue by taking the action."}
+JSON
+	exit 0
+fi
+
 exit 0

--- a/tests/regression/test_stop_action_bias_detector.sh
+++ b/tests/regression/test_stop_action_bias_detector.sh
@@ -95,6 +95,24 @@ assert_passes "gate_stated" "This is a prod deploy you haven't agreed to in this
 # Distance / unrelated.
 assert_passes "distant" "I want this done right, so the details matter and I checked them all carefully."
 
+# --- concluded-and-asked (cc-workflow#776) — conclusion + ratify-ask conjunction
+# A team-converged conclusion AND a ratify-ask in the same turn is the over-pause.
+assert_blocks "concluded_asked" "We've converged and the team is aligned — this is the right move. BJ, your call?"
+assert_blocks "concluded_asked_schwifty" "Consensus reached on the approach. @schwifty7759, your go-ahead to ratify?"
+# Conjunction is required: conclusion-only or ratify-only must NOT fire.
+assert_passes "conclusion_only" "The team converged on the approach and we're fully aligned."
+assert_passes "ratify_only" "BJ, your call on this one?"
+# SAFETY: concluded + ratify-ask on a GATED axis (prod/deploy/release/secrets/migration)
+# must NOT fire — the block pushes the agent to ACT, and pushing an unapproved prod
+# action violates the ABSOLUTE prod rule. A false-negative here is the safe direction.
+assert_passes "concluded_asked_prod" "We converged on the rollout approach — BJ, your call on the prod deploy?"
+assert_passes "concluded_asked_release" "Team is aligned on the cut. @schwifty7759, approve the release?"
+assert_passes "concluded_asked_secrets" "We agreed on the secret-rotation plan — BJ, your go-ahead?"
+# Extended gated-axis (code-review #2): ship / go-live / force-push are prod-shaped.
+assert_passes "concluded_asked_ship" "We converged — this is the right move. BJ, your go-ahead to ship it?"
+assert_passes "concluded_asked_golive" "Team is aligned on the cut. @schwifty7759, your call to go live?"
+assert_passes "concluded_asked_forcepush" "We agreed on the rebase plan. BJ, approve the force-push to main?"
+
 # --- Loop guard: stop_hook_active=true → allow the stop even on positive input
 label="loop_guard"
 path=$(make_transcript "$label" "Want me to proceed?")


### PR DESCRIPTION
## Summary
The fleet-wide `stop-action-bias-detector.sh` caught bare permission-asks ("want me to…?", "should I proceed?") but missed a subtler over-pause that bit two fleet agents — and this session — live on 2026-06-21: the turn **states a team-converged conclusion AND asks the user to ratify it in the same message** ("we converged … BJ, your call?"). For an already-converged decision in the agent's delegated lane, the converging IS the green light; routing it back for ratify is the over-pause.

## Changes
- New detection case requires the **conjunction** (conclusion-marker ∧ ratify-ask), so a bare prod gate ("BJ — your call on prod?") with no conclusion marker does NOT fire and stays correctly surfaced.
- **SAFETY negative-guard:** the new case never fires when the turn touches a gated axis (prod/deploy/release/ship/go-live/force-push/secrets/migration/…). This hook's `block` *pushes* the agent to act — firing on a real prod gate would push an unapproved prod action (ABSOLUTE prod rule). Guard applied ONLY to the new case; the existing permission-ask patterns are untouched and still catch "should I merge/push?".
- Detection rule converged with pattern/argus (schiphol-pentest); **repo is the source of truth** (the installed `~/.local/bin` copy is overwritten on `./install`).

## Tests
`tests/regression/test_stop_action_bias_detector.sh`: +7→ **32/32** green (2 positive, 5 negative incl. 3 prod-axis safety + 3 extended-axis gap cases). `validate.sh` **154/0**. trivy PASS. Adversarial code-review: no critical; bash negation/precedence + scope-isolation verified correct; 2 important + 1 minor fixed.

## Linked Issues
Part of #776. Refs cc-workflow#732 (the hook); fleet incident 2026-06-21.