### PR TITLE
feat(install): --local project-scoped install mode (#778)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,12 @@ This will:
 ./install.sh --config      # Install config files only
 ./install.sh --mcps         # Install MCP servers only (via mcps.json manifest)
 ./install.sh --no-mcps      # Install everything except MCP servers
+./install.sh --local        # Project-scoped install into ./.claude/ (not $HOME)
 ./install.sh --prune        # Remove installed files whose source no longer exists
 ./install.sh --prune --yes  # ...non-interactively
 ```
+
+`--local` installs into `<cwd>/.claude/` instead of global `$HOME/.claude/` + `$HOME/.local/bin` — so a project can dogfood in-flux skills/scripts without touching the global fleet install. It is composable with `--skills`/`--scripts`/`--config` (it changes *where*, not *what*), implies `--no-mcps`, and never touches `$HOME` or `/etc` (logrotate and deprecated-path cleanup are skipped). Kit-owned hook paths in the merged `settings.json` are rewritten to absolute project-local paths. Note: `<cwd>/.claude/bin` is **not** added to `$PATH` — `--local` gives project-local *files*, and hooks resolve via absolute paths. Reverse it with `./uninstall.sh --local`.
 
 `scripts/` is walked recursively: nested files like `scripts/vox-providers/silent.sh` are mirrored to `~/.local/bin/vox-providers/silent.sh` with executable bits preserved. Subtrees named `tests`, `fixtures`, `__pycache__`, or `.pytest_cache` are excluded. `--prune` consults a manifest at `~/.local/bin/.cc-workflow-manifest` (refreshed on every install) plus the current source set; orphans are backed up to `<file>.bak` before removal.
 

--- a/install
+++ b/install
@@ -14,6 +14,13 @@
 #   ./install --mcps             Install MCP servers only (via mcps.json manifest)
 #   ./install --crystallizer     (REMOVED — crystallizer is deprecated)
 #   ./install --no-mcps          Install everything except MCP servers
+#   ./install --local            Project-scoped install into <cwd>/.claude/
+#                                  instead of global $HOME (skills, scripts, config).
+#                                  Composable with --skills/--scripts/--config.
+#                                  Implies --no-mcps and skips logrotate; never
+#                                  touches $HOME or /etc. Files land project-local
+#                                  but <cwd>/.claude/bin is NOT added to $PATH —
+#                                  hooks resolve via absolute paths.
 #   ./install --with-logrotate   Install logrotate policy for ~/.claude/logs/mcp.jsonl
 #                                  (Linux only; no-op elsewhere). Implies non-interactive.
 #   ./install --without-logrotate Skip logrotate install (suppresses the prompt).
@@ -39,14 +46,14 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-SKILLS_DIR="$HOME/.claude/skills"
-SCRIPTS_DIR="$HOME/.local/bin"
-CLAUDE_DIR="$HOME/.claude"
-# Cellar: kit-owned scripts directory (Homebrew/Nix pattern). Wiped and
-# recreated on every install — this is what eliminates orphan rot. Anything
-# that landed here in a prior install is fair game for deletion. SCRIPTS_DIR
-# becomes a symlink farm pointing into here for entries that need PATH.
-CELLAR_DIR="$HOME/.claude/scripts"
+# Path-root variables (SKILLS_DIR, SCRIPTS_DIR, CLAUDE_DIR, CELLAR_DIR) are
+# defined AFTER the arg-parse loop because --local re-roots them at the
+# current working directory instead of $HOME. Nothing between here and the
+# arg loop references them (first use is the --prune block far below), so
+# deferring the definitions is safe. LOCAL_MODE defaults off → byte-for-byte
+# identical to the historical $HOME-rooted layout.
+LOCAL_MODE=false
+LOCAL_ROOT="$HOME"
 DRY_RUN=false
 CHECK_MODE=false
 PRUNE_MODE=false
@@ -126,6 +133,13 @@ while [[ $# -gt 0 ]]; do
 		INSTALL_MCPS=false
 		shift
 		;;
+	--local)
+		# Project-scoped install: re-root everything under <cwd>/.claude/
+		# instead of $HOME. Composable with --skills/--scripts/--config (it
+		# changes WHERE, not WHAT). Vars are re-rooted after this loop.
+		LOCAL_MODE=true
+		shift
+		;;
 	--with-logrotate)
 		LOGROTATE_MODE=on
 		shift
@@ -152,6 +166,43 @@ while [[ $# -gt 0 ]]; do
 		;;
 	esac
 done
+
+# --- Path roots ---------------------------------------------------------------
+# Defined here (post-arg-parse) so --local can re-root them at the current
+# working directory. DEFAULT (no --local): byte-for-byte identical to the
+# historical $HOME-rooted layout.
+#   SKILLS_DIR  → skills install dir
+#   CLAUDE_DIR  → ~/.claude root (statusline, settings.json, discord.json)
+#   CELLAR_DIR  → kit-owned scripts dir (Homebrew/Nix pattern). Wiped and
+#                 recreated on every install — this is what eliminates orphan
+#                 rot. Anything that landed here in a prior install is fair
+#                 game for deletion.
+#   SCRIPTS_DIR → symlink farm pointing into the Cellar for PATH-needing entries.
+if [[ "$LOCAL_MODE" == true ]]; then
+	# Project-scoped: everything under <cwd>/.claude/. SCRIPTS_DIR is a
+	# DEDICATED ./.claude/bin (NOT ./.claude/scripts — that is the Cellar, and
+	# cellar_deploy does `rm -rf "$CELLAR_DIR"`, so a collision would wipe the
+	# farm catastrophically). --local implies project-local FILES, not a
+	# project-local $PATH (./.claude/bin is not on PATH; hooks use absolute paths).
+	LOCAL_ROOT="$(pwd)"
+	SKILLS_DIR="$LOCAL_ROOT/.claude/skills"
+	CLAUDE_DIR="$LOCAL_ROOT/.claude"
+	CELLAR_DIR="$LOCAL_ROOT/.claude/scripts"
+	SCRIPTS_DIR="$CLAUDE_DIR/bin"
+	# --local must never touch $HOME or /etc: force off the global/prod side
+	# effects. MCP registration is user-scope (global) → treat --local as --no-mcps.
+	INSTALL_MCPS=false
+	# Logrotate writes to /etc via sudo → hard-disable under --local.
+	LOGROTATE_MODE=off
+else
+	SKILLS_DIR="$HOME/.claude/skills"
+	SCRIPTS_DIR="$HOME/.local/bin"
+	CLAUDE_DIR="$HOME/.claude"
+	CELLAR_DIR="$HOME/.claude/scripts"
+fi
+# Mandatory invariant: the symlink farm must NEVER equal the Cellar, or the
+# cellar wipe (`rm -rf "$CELLAR_DIR"`) would obliterate the farm.
+[[ "$SCRIPTS_DIR" != "$CELLAR_DIR" ]] || { echo "fatal: farm == cellar"; exit 1; }
 
 # --- Helpers ------------------------------------------------------------------
 info() { echo "  [+] $*"; }
@@ -572,6 +623,58 @@ rewrite_old_hook_paths_in_settings() {
 	echo "$rewritten" >"$target"
 }
 
+# --local only: rewrite KIT-OWNED hook command paths in a settings.json from
+# their global "~/"-relative form (which ALWAYS expands to $HOME, pointing at
+# the GLOBAL install) to ABSOLUTE project-local paths under <cwd>/.claude/.
+# Absolute (not "~/"-relative, not "./"-relative) because cwd at hook-exec
+# time is not guaranteed. Three kit prefixes are rewritten:
+#   ~/.claude/scripts/hooks/...          → $CELLAR_DIR/hooks/...
+#   ~/.local/bin/<name>                  → $SCRIPTS_DIR/<name>
+#   bash ~/.claude/statusline-command.sh → bash $CLAUDE_DIR/statusline-command.sh
+# Foreign/absolute non-kit paths (e.g. /opt/..., a sibling-repo hook) and any
+# inline hook using $CLAUDE_PROJECT_DIR (already project-relative) are LEFT
+# UNTOUCHED. Must run AFTER the settings merge — the merge's kit-ownership
+# detection keys on the original "~/.claude/" / "~/.local/bin/" template
+# strings; absolute <cwd>/.claude/... still matches its "\.claude/" probe.
+# Walks hooks.<event>[].hooks[].command AND statusLine.command. Modifies $1
+# in place via tmpfile rotation. Idempotent for already-absolute paths.
+rewrite_kit_hook_paths_to_local() {
+	local target="$1"
+	[[ -f "$target" ]] || return 0
+	command -v jq &>/dev/null || return 0
+	local rewritten
+	rewritten=$(jq \
+		--arg cellar_hooks "$CELLAR_DIR/hooks/" \
+		--arg farm "$SCRIPTS_DIR/" \
+		--arg statusline "bash $CLAUDE_DIR/statusline-command.sh" '
+		# Rewrite a single command string from its global kit form to the
+		# absolute project-local equivalent. Non-kit strings pass through.
+		def relocate:
+			if . == null then .
+			elif startswith("~/.claude/scripts/hooks/") then
+				$cellar_hooks + ltrimstr("~/.claude/scripts/hooks/")
+			elif startswith("~/.local/bin/") then
+				$farm + ltrimstr("~/.local/bin/")
+			elif . == "bash ~/.claude/statusline-command.sh" then
+				$statusline
+			else . end;
+		(if .hooks then
+			.hooks |= with_entries(
+				if .key == "_comment" then . else
+					.value |= map(
+						.hooks |= map(
+							if .command then .command |= relocate else . end
+						)
+					)
+				end
+			)
+		else . end)
+		| (if (.statusLine | type) == "object" and (.statusLine.command? != null)
+			then .statusLine.command |= relocate else . end)
+	' "$target")
+	echo "$rewritten" >"$target"
+}
+
 # Detect any settings.json hook command paths of the old form. Prints the
 # offending event names (one per line) for use in --check drift reporting.
 detect_old_hook_paths_in_settings() {
@@ -702,6 +805,13 @@ merge_settings() {
 	' "$template" "$target")
 
 	echo "$merged" >"$target"
+
+	# --local: relocate kit-owned "~/"-relative hook paths to absolute
+	# project-local paths. AFTER the merge so the kit-ownership union above
+	# saw the original template strings (it keys on "~/.claude/" / "~/.local/bin/").
+	if [[ "$LOCAL_MODE" == true ]]; then
+		rewrite_kit_hook_paths_to_local "$target"
+	fi
 
 	# Report what changed
 
@@ -1093,14 +1203,17 @@ if [[ "$CHECK_MODE" == true ]]; then
 		fi
 	fi
 
-	# Deprecated paths: flag if still present
-	for dep_path in "${DEPRECATED_PATHS[@]}"; do
-		if [[ -e "$dep_path" || -L "$dep_path" ]]; then
-			total=$((total + 1))
-			drift "$dep_path — DEPRECATED (run ./install to remove)"
-			drifted=$((drifted + 1))
-		fi
-	done
+	# Deprecated paths: flag if still present (skipped under --local — these are
+	# literal $HOME paths, irrelevant to a project-scoped install).
+	if [[ "$LOCAL_MODE" != true ]]; then
+		for dep_path in "${DEPRECATED_PATHS[@]}"; do
+			if [[ -e "$dep_path" || -L "$dep_path" ]]; then
+				total=$((total + 1))
+				drift "$dep_path — DEPRECATED (run ./install to remove)"
+				drifted=$((drifted + 1))
+			fi
+		done
+	fi
 
 	# MCPs: check each MCP's install-remote.sh --check
 	if [[ -f "$REPO_DIR/mcps.json" ]] && command -v claude &>/dev/null; then
@@ -1169,10 +1282,14 @@ if [[ "$CHECK_MODE" == true ]]; then
 fi
 
 # --- Remove deprecated components ---------------------------------------------
-echo ""
-echo "Deprecated → cleanup"
-echo "──────────────────────────────────────────"
-remove_deprecated
+# DEPRECATED_PATHS are literal $HOME paths; a project-scoped install must not
+# touch $HOME, and no legacy project-local install exists, so --local skips it.
+if [[ "$LOCAL_MODE" != true ]]; then
+	echo ""
+	echo "Deprecated → cleanup"
+	echo "──────────────────────────────────────────"
+	remove_deprecated
+fi
 
 # --- Install scripts ----------------------------------------------------------
 # Cellar + symlink-farm layout (closes #560):
@@ -1286,6 +1403,11 @@ if [[ "$INSTALL_CONFIG" == true ]]; then
 				jq 'del(._comment) | del(.hooks._comment)' \
 					"$REPO_DIR/config/settings.template.json" >"$CLAUDE_DIR/settings.json"
 				info "Installed settings.json (stripped _comment keys)"
+				# --local: relocate kit-owned "~/" hook paths to absolute
+				# project-local paths (no merge happened, so do it on the fresh copy).
+				if [[ "$LOCAL_MODE" == true ]]; then
+					rewrite_kit_hook_paths_to_local "$CLAUDE_DIR/settings.json"
+				fi
 			fi
 		fi
 	fi
@@ -1377,7 +1499,9 @@ fi
 # print a single notice and skip — no error, no prompt. The mode is set by
 # --with-logrotate / --without-logrotate; absent either flag the user is
 # prompted (unless --yes was passed, which is taken as consent).
-if [[ "$INSTALL_CONFIG" == true || "$LOGROTATE_MODE" != "prompt" ]]; then
+# Hard-skipped under --local: logrotate installs to /etc via sudo, which a
+# project-scoped install must never do (LOGROTATE_MODE is forced off above too).
+if [[ "$LOCAL_MODE" != true && ("$INSTALL_CONFIG" == true || "$LOGROTATE_MODE" != "prompt") ]]; then
 	echo ""
 	echo "Logrotate (~/.claude/logs/mcp.jsonl)"
 	echo "──────────────────────────────────────────"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -674,6 +674,159 @@ class TestInstallSyntheticTree:
         )
 
 
+def run_install_cwd(
+    args: list[str],
+    home: Path,
+    cwd: Path,
+) -> Tuple[int, str, str]:
+    """Run ``install <args>`` with HOME overridden AND a specific cwd.
+
+    ``--local`` keys its install root off ``$(pwd)``, not ``$HOME``, so the
+    subprocess cwd must be set to the project directory under test.
+    """
+    result = subprocess.run(
+        ["bash", _INSTALL_SCRIPT] + args,
+        capture_output=True,
+        text=True,
+        env=_make_env(home),
+        cwd=str(cwd),
+        timeout=120,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_PYTHON3
+class TestLocalScopeInstall:
+    """``./install --local`` installs into ``<cwd>/.claude/`` instead of
+    global ``$HOME``, leaving the global fleet install untouched."""
+
+    def test_local_scope_placement(self, tmp_path: Path) -> None:
+        """--local from cwd=project lands skills, Cellar, farm, and settings
+        all under project/.claude/."""
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        (home / ".claude" / "skills").mkdir(parents=True)
+        project = tmp_path / "project"
+        project.mkdir()
+
+        rc, out, err = run_install_cwd(["--local"], home, project)
+        assert _install_ok(rc, out, err), (
+            f"--local install failed (rc={rc}):\nstdout: {out}\nstderr: {err}"
+        )
+
+        proj_claude = project / ".claude"
+        # Skills land under project/.claude/skills/<name>/SKILL.md.
+        for skill_name in _expected_skill_dirs():
+            assert (proj_claude / "skills" / skill_name / "SKILL.md").exists(), (
+                f"Missing project-local skill: {skill_name}"
+            )
+        # Cellar at project/.claude/scripts (top-level scripts present).
+        assert (proj_claude / "scripts").is_dir(), "project-local Cellar missing"
+        # Symlink farm at project/.claude/bin (NOT .claude/scripts).
+        assert (proj_claude / "bin").is_dir(), "project-local farm (bin/) missing"
+        for script_name in _expected_standalone_scripts():
+            assert (proj_claude / "scripts" / script_name).exists(), (
+                f"Missing standalone script in project Cellar: {script_name}"
+            )
+        # Settings merged/installed into project/.claude/settings.json.
+        assert (proj_claude / "settings.json").exists(), (
+            "project-local settings.json missing"
+        )
+
+    def test_local_leaves_global_untouched(self, tmp_path: Path) -> None:
+        """After --local, the global $HOME/.claude and $HOME/.local/bin stay
+        empty/absent — no fleet contamination."""
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        (home / ".claude" / "skills").mkdir(parents=True)
+        project = tmp_path / "project"
+        project.mkdir()
+
+        rc, out, err = run_install_cwd(["--local"], home, project)
+        assert _install_ok(rc, out, err), f"--local install failed: {err}"
+
+        # Global skills dir empty.
+        global_skills = home / ".claude" / "skills"
+        assert list(global_skills.iterdir()) == [], (
+            f"--local contaminated global skills: {list(global_skills.iterdir())}"
+        )
+        # Global bin empty.
+        global_bin = home / ".local" / "bin"
+        assert list(global_bin.iterdir()) == [], (
+            f"--local contaminated global bin: {list(global_bin.iterdir())}"
+        )
+        # No global settings.json created.
+        assert not (home / ".claude" / "settings.json").exists(), (
+            "--local created a global settings.json"
+        )
+        # No global Cellar.
+        assert not (home / ".claude" / "scripts").exists(), (
+            "--local created a global Cellar"
+        )
+
+    def test_default_install_unchanged(self, sandbox_home: Path) -> None:
+        """No flag → lands in $HOME as today AND a project-local .claude/ is
+        NOT created in cwd (proves --local is strictly opt-in)."""
+        # Run default install from a project dir; nothing should land there.
+        home = sandbox_home
+        project = home.parent / "project"
+        project.mkdir()
+
+        rc, out, err = run_install_cwd([], home, project)
+        assert _install_ok(rc, out, err), f"default install failed: {err}"
+
+        # Global path populated as usual.
+        assert (home / ".claude" / "skills").iterdir(), "global skills not installed"
+        wave_status = home / ".local" / "bin" / "wave-status"
+        assert wave_status.exists(), "wave-status not in global bin"
+        # The cwd project dir must NOT have a .claude/ created by a default run.
+        assert not (project / ".claude").exists(), (
+            "default (no --local) install created a project-local .claude/"
+        )
+
+    def test_local_uninstall(self, tmp_path: Path) -> None:
+        """uninstall.sh --local removes the project-scoped install while the
+        global install is untouched."""
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        (home / ".claude" / "skills").mkdir(parents=True)
+        project = tmp_path / "project"
+        project.mkdir()
+
+        rc, out, err = run_install_cwd(["--local"], home, project)
+        assert _install_ok(rc, out, err), f"--local install failed: {err}"
+        # Sanity: project install present.
+        assert (project / ".claude" / "skills").is_dir()
+
+        # Uninstall --local from the project dir.
+        result = subprocess.run(
+            ["bash", _UNINSTALL_SCRIPT, "--local"],
+            capture_output=True,
+            text=True,
+            env=_make_env(home),
+            cwd=str(project),
+            timeout=120,
+        )
+        assert _install_ok(result.returncode, result.stdout, result.stderr), (
+            f"--local uninstall failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+        # Project skills removed.
+        for skill_name in _expected_skill_dirs():
+            assert not (project / ".claude" / "skills" / skill_name).exists(), (
+                f"project-local skill not removed: {skill_name}"
+            )
+        # Project statusline removed.
+        assert not (project / ".claude" / "statusline-command.sh").exists(), (
+            "project-local statusline not removed"
+        )
+        # Global install never existed → still clean.
+        assert list((home / ".claude" / "skills").iterdir()) == [], (
+            "--local uninstall touched global skills"
+        )
+
+
 @_SKIP_NO_BASH
 @_SKIP_NO_PYTHON3
 class TestReinstallOverwrites:

--- a/tests/test_install_merge_hooks_union.py
+++ b/tests/test_install_merge_hooks_union.py
@@ -113,15 +113,26 @@ def _run_sandbox_install(
     sandbox_install: Path,
     args: list[str],
     home: Path,
+    cwd: Path | None = None,
 ) -> tuple[int, str, str]:
     result = subprocess.run(
         ["bash", str(sandbox_install)] + args,
         capture_output=True,
         text=True,
         env=_make_env(home),
+        cwd=str(cwd) if cwd is not None else None,
         timeout=120,
     )
     return result.returncode, result.stdout, result.stderr
+
+
+def _install_ok(rc: int, out: str, err: str) -> bool:
+    """Accept a non-zero exit caused solely by the late-stage dependency
+    audit (legitimately missing in a sandbox HOME). See #753."""
+    if rc == 0:
+        return True
+    combined = (out or "") + (err or "")
+    return "dependenc" in combined and "missing" in combined
 
 
 # ---------------------------------------------------------------------------
@@ -444,3 +455,124 @@ def test_user_override_of_kit_hook_not_resurrected(sandbox_home: Path) -> None:
     commands = [h["command"] for e in _read_json(settings_path)["hooks"]["Stop"] for h in e["hooks"]]
     assert "user-customized.sh" in commands
     assert "default-bare.sh" not in commands, "a non-kit template hook must not override a user hook on a shared matcher"
+
+
+# ---------------------------------------------------------------------------
+# --local: project-scoped settings merge + kit hook-path relocation
+# ---------------------------------------------------------------------------
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+def test_local_settings_merge_into_project(sandbox_home: Path) -> None:
+    """``--local --config`` merges into the PROJECT's settings.json (under
+    <cwd>/.claude/), not the global $HOME one, and writes the .bak there."""
+    template = {
+        "hooks": {
+            "SessionStart": [
+                {"matcher": "*", "hooks": [{"type": "command", "command": "default-session-start.sh"}]},
+                {"matcher": "compact", "hooks": [{"type": "command", "command": "session-start-compact.sh"}]},
+            ]
+        }
+    }
+    local = {
+        "hooks": {
+            "SessionStart": [
+                {"matcher": "*", "hooks": [{"type": "command", "command": "user-session-start.sh"}]}
+            ]
+        }
+    }
+    # Pre-seed the PROJECT settings, NOT the global one.
+    project = sandbox_home.parent / "project"
+    project.mkdir(exist_ok=True)
+    proj_settings = project / ".claude" / "settings.json"
+    _write_json(proj_settings, local)
+
+    sandbox_install = _override_template(sandbox_home, template)
+    rc, out, err = _run_sandbox_install(
+        sandbox_install, ["--config", "--local"], sandbox_home, cwd=project
+    )
+    assert _install_ok(rc, out, err), f"--local --config failed: {out}\n{err}"
+
+    # Merge happened in the PROJECT file.
+    merged = _read_json(proj_settings)
+    matchers = [e["matcher"] for e in merged["hooks"]["SessionStart"]]
+    assert "*" in matchers and "compact" in matchers, (
+        "template matcher must merge into the project-local settings"
+    )
+    # .bak written next to the project settings.
+    assert (project / ".claude" / "settings.json.bak").exists(), (
+        "merge .bak should be created in the project, not global"
+    )
+    # Global settings untouched (never created).
+    assert not (sandbox_home / ".claude" / "settings.json").exists(), (
+        "--local merge must not create a global settings.json"
+    )
+
+
+@_SKIP_NO_BASH
+@_SKIP_NO_JQ
+def test_local_hook_path_resolution(sandbox_home: Path) -> None:
+    """--local rewrites KIT-OWNED ~/ hook paths to ABSOLUTE project-local
+    paths, while leaving foreign absolute paths and $CLAUDE_PROJECT_DIR
+    inline hooks untouched. Proves the §4 path-rewriting contract."""
+    template = {
+        "statusLine": {
+            "type": "command",
+            "command": "bash ~/.claude/statusline-command.sh",
+        },
+        "hooks": {
+            "Stop": [
+                {"matcher": "*", "hooks": [{"type": "command", "command": "~/.claude/scripts/hooks/x.sh"}]},
+                {"matcher": "*", "hooks": [{"type": "command", "command": "~/.local/bin/y.sh"}]},
+                {"matcher": "*", "hooks": [{"type": "command", "command": "/opt/foreign/z.sh"}]},
+                {"matcher": "*", "hooks": [{"type": "command", "command": "state=\"${CLAUDE_PROJECT_DIR:-.}/.claude/state.json\"; exit 0"}]},
+            ]
+        },
+    }
+    project = sandbox_home.parent / "project"
+    project.mkdir(exist_ok=True)
+
+    sandbox_install = _override_template(sandbox_home, template)
+    # Fresh install (no pre-existing project settings) exercises the
+    # fresh-copy rewrite path. --config so only the settings work runs.
+    rc, out, err = _run_sandbox_install(
+        sandbox_install, ["--config", "--local"], sandbox_home, cwd=project
+    )
+    assert _install_ok(rc, out, err), f"--local --config failed: {out}\n{err}"
+
+    proj_claude = project / ".claude"
+    merged = _read_json(proj_claude / "settings.json")
+    cmds = {
+        h["command"]
+        for e in merged["hooks"]["Stop"]
+        for h in e["hooks"]
+    }
+    proj = str(project)
+
+    # x.sh: kit Cellar hooks path → absolute <project>/.claude/scripts/hooks/x.sh
+    assert f"{proj}/.claude/scripts/hooks/x.sh" in cmds, (
+        f"kit Cellar hook not relocated to absolute project path; got {cmds}"
+    )
+    # y.sh: kit farm path → absolute <project>/.claude/bin/y.sh
+    assert f"{proj}/.claude/bin/y.sh" in cmds, (
+        f"kit farm hook not relocated to absolute project path; got {cmds}"
+    )
+    # statusLine rewritten to absolute project path.
+    assert merged["statusLine"]["command"] == f"bash {proj}/.claude/statusline-command.sh", (
+        f"statusLine not relocated; got {merged['statusLine']['command']!r}"
+    )
+    # Foreign absolute path UNCHANGED.
+    assert "/opt/foreign/z.sh" in cmds, "foreign absolute hook must be left untouched"
+    # $CLAUDE_PROJECT_DIR inline hook UNCHANGED.
+    assert any("${CLAUDE_PROJECT_DIR:-.}/.claude/state.json" in c for c in cmds), (
+        "CLAUDE_PROJECT_DIR inline hook must be left untouched"
+    )
+    # No surviving ~/ in any KIT-owned command (foreign /opt and the inline
+    # hook never had a ~/ to begin with).
+    for c in cmds:
+        if c.startswith("/opt/") or "CLAUDE_PROJECT_DIR" in c:
+            continue
+        assert "~/" not in c, f"kit command still has unexpanded ~/: {c!r}"
+    assert "~/" not in merged["statusLine"]["command"], (
+        "statusLine still has unexpanded ~/"
+    )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,6 +11,9 @@
 #   ./uninstall.sh --scripts    Remove scripts and packages only
 #   ./uninstall.sh --config     Remove config files only (statusline-command.sh)
 #   ./uninstall.sh --mcps       Remove MCP server registrations only
+#   ./uninstall.sh --local      Remove a project-scoped install from <cwd>/.claude/
+#                                  (mirror of ./install --local). Never touches
+#                                  $HOME. Composable with --skills/--scripts/--config.
 #
 # What full uninstall removes:
 #   Skills      → ~/.claude/skills/<name>/
@@ -26,9 +29,10 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-SKILLS_DIR="$HOME/.claude/skills"
-SCRIPTS_DIR="$HOME/.local/bin"
-CLAUDE_DIR="$HOME/.claude"
+# Path roots default to $HOME; --local re-roots them at <cwd>/.claude/ after
+# arg parsing (mirror of ./install --local). Removal walks read through these
+# vars, so they follow automatically.
+LOCAL_MODE=false
 DRY_RUN=false
 REMOVE_SKILLS=true
 REMOVE_SCRIPTS=true
@@ -66,6 +70,10 @@ while [[ $# -gt 0 ]]; do
 		REMOVE_CONFIG=false
 		shift
 		;;
+	--local)
+		LOCAL_MODE=true
+		shift
+		;;
 	--help | -h)
 		grep '^#' "$0" | sed 's/^# \?//' | tail -n +2
 		exit 0
@@ -76,6 +84,18 @@ while [[ $# -gt 0 ]]; do
 		;;
 	esac
 done
+
+# --- Path roots ---------------------------------------------------------------
+if [[ "$LOCAL_MODE" == true ]]; then
+	LOCAL_ROOT="$(pwd)"
+	SKILLS_DIR="$LOCAL_ROOT/.claude/skills"
+	SCRIPTS_DIR="$LOCAL_ROOT/.claude/bin"
+	CLAUDE_DIR="$LOCAL_ROOT/.claude"
+else
+	SKILLS_DIR="$HOME/.claude/skills"
+	SCRIPTS_DIR="$HOME/.local/bin"
+	CLAUDE_DIR="$HOME/.claude"
+fi
 
 # --- Helpers ------------------------------------------------------------------
 info() { echo "  [+] Removed: $*"; }


### PR DESCRIPTION
## Summary
The installer was global-only (`$HOME/.claude` + `$HOME/.local/bin`), so in-flux skills/scripts couldn't be dogfooded in one project without changing the global fleet install. `./install --local` installs into `<cwd>/.claude/` instead — the enabler for safely dogfooding #725's restored wave engine.

## Changes
- Re-roots the four path vars from a single `LOCAL_ROOT=$(pwd)`: skills→`./.claude/skills`, Cellar→`./.claude/scripts`, farm→`./.claude/bin` (deliberately `bin`, not the Cellar — a `farm == cellar` assertion guards the `rm -rf "$CELLAR_DIR"`).
- Forces off the three global/prod side-effects under `--local`: logrotate (`/etc`+sudo), `remove_deprecated` (`$HOME` paths), MCP registration (user-scope → implies `--no-mcps`).
- Rewrites kit-owned hook paths in the merged `settings.json` to **absolute** project-local paths (`~` always expands to `$HOME`); foreign/`$CLAUDE_PROJECT_DIR` paths untouched; rewrite runs after merge so kit-ownership detection sees the original template.
- Default (no-flag) behavior byte-for-byte unchanged. Matching `./uninstall.sh --local`.

## Tests
+6: project-scope placement, global-untouched isolation, default-unchanged opt-in, local-uninstall, settings-merge-into-project, and the absolute-hook-rewrite proof. install/merge suite **38/0**; `validate.sh` **154/0**; trivy PASS; adversarial code-review **no critical/important**.

## Linked Issues
Closes #778. Enabler for #725.