### PR TITLE
fix(wavemachine): document pending-deferral recovery (defer-accept) in skill (#634)

### DIFF
--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -228,6 +228,25 @@ next wave but the turn ended without it. Writing `awaiting-verdict` in the same 
 as the launch is therefore **load-bearing** — omit it and the guard false-fires on the await
 (cc-workflow#736).
 
+## Pending deferral resolution (#634)
+
+`wave_health_check` (and the pre-flight gate) **blocks the loop when a wave has a pending
+deferral** — this is by design: deferrals are human-judgment gates (infra waves HOLD on
+`ORACLE_REQUIRED`; review findings need fix-forward), not stalls. The recovery path is an
+explicit `wave-status` step, run **after** the deferred item has been adjudicated:
+
+1. **Inspect** — the pending deferral and its reason surface in the campaign state / status
+   panel (the same panel the launch sequence opens).
+2. **Accept once adjudicated** — `wave-status defer-accept <index>`. This clears the pending
+   deferral so the next `wave_health_check` / pre-flight passes and the loop advances.
+
+`defer-accept` is the operator's "I have reviewed this and it is safe to proceed" signal —
+**not** an auto-bypass. In `interactive` mode it is the human's call at the HOLD. In `auto`
+mode a pending deferral is a legitimate pause for adjudication: the campaign does **not**
+silently auto-accept a human-judgment gate, so an unattended run halts here until a deferral
+is accepted (consistent with the async-await contract above — the driver is paused, not
+stalled). Following this section alone is sufficient to recover; no source/memory dig needed.
+
 > **Decision (cc-workflow#736 — async-aware INTERIM fix).** The legacy hook reason — "after
 > /nextwave auto returns OK, invoke /nextwave auto again" — encoded the *synchronous* loop and
 > false-fired on every async per-wave Workflow await and on manual promotion adjudication. The


### PR DESCRIPTION
## Summary
`wave_health_check` / pre-flight blocks the `/wavemachine` loop on a pending deferral, but the resolution (`wave-status defer-accept <index>`) wasn't documented anywhere in the skill body — operators got stuck.

## Changes
- Added a "Pending deferral resolution" subsection to `skills/wavemachine/SKILL.md`: the block is by-design (deferrals are human-judgment gates), recovery is inspect → `wave-status defer-accept <index>` once adjudicated; `defer-accept` is an adjudication signal, not an auto-bypass.
- Chose shape 2 (document) over shape 1 (auto-accept on launch) — auto-accepting human-judgment gates is a risky behavioral change, not an interim fix. The CLI verb already exists; this fills the doc gap.

## Tests
`validate.sh` **155/0** (SKILL.md frontmatter + suites). Doc-only skill change.

## Linked Issues
Closes #634. Part of #725 bootstrap.