### PR TITLE
fix(wave-status): reset current_action to idle on wavemachine-stop (#636)

### DIFF
--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -942,12 +942,19 @@ def wavemachine_stop(root: Path) -> dict:
     Deletes ``wavemachine_active``, ``wavemachine_started_at``, and
     ``wavemachine_launcher``.  Idempotent — succeeds even if no wavemachine
     run is active (worker abort paths need this to be safe on re-entry).
+
+    Also resets ``current_action`` to ``idle`` (cc-workflow#636). This is the
+    campaign-exit "finally" run on EVERY exit path, so resetting the action here
+    guarantees a transient heartbeat (e.g. ``waiting-ci`` left by post-merge CI
+    polling) cannot linger past campaign end and trip the next campaign's
+    pre-flight. Idempotent — idle→idle is a no-op.
     """
     d = status_dir(root)
     state_data = load_state(d / "state.json")
     state_data.pop("wavemachine_active", None)
     state_data.pop("wavemachine_started_at", None)
     state_data.pop("wavemachine_launcher", None)
+    state_data["current_action"] = {"action": "idle", "label": "idle", "detail": ""}
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
     return state_data

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -45,6 +45,8 @@ from wave_status.state import (
     store_flight_plan,
     waiting,
     waiting_ci,
+    wavemachine_start,
+    wavemachine_stop,
 )
 
 
@@ -590,6 +592,38 @@ class TestWaitingCi:
         # Timestamp should be refreshed (or at minimum present)
         assert ts_after >= ts_before
         assert len(ts_after) > 0
+
+
+class TestWavemachineStop:
+    """``wavemachine_stop()`` is the campaign-exit finally (#636)."""
+
+    def test_clears_wavemachine_ownership(self, project_root: Path) -> None:
+        wavemachine_start(project_root, launcher="main")
+        result = wavemachine_stop(project_root)
+        assert "wavemachine_active" not in result
+        assert "wavemachine_started_at" not in result
+        assert "wavemachine_launcher" not in result
+
+    def test_resets_stale_waiting_ci_to_idle(self, project_root: Path) -> None:
+        """#636: a waiting-ci heartbeat left by post-merge CI polling must NOT
+        survive campaign exit and trip the next campaign's pre-flight."""
+        wavemachine_start(project_root, launcher="main")
+        waiting_ci(project_root, detail="PR #621 attempt 58: 0/0 passed")
+        # Sanity: the stale action is present before stop.
+        mid = load_json(status_dir(project_root) / "state.json")
+        assert mid["current_action"]["action"] == "waiting-ci"
+        # Exit resets it.
+        result = wavemachine_stop(project_root)
+        assert result["current_action"]["action"] == "idle"
+        persisted = load_json(status_dir(project_root) / "state.json")
+        assert persisted["current_action"]["action"] == "idle"
+
+    def test_idempotent_on_reentry(self, project_root: Path) -> None:
+        """Worker abort paths re-enter; idle->idle is a safe no-op."""
+        wavemachine_stop(project_root)
+        result = wavemachine_stop(project_root)
+        assert result["current_action"]["action"] == "idle"
+        assert "wavemachine_active" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
After `pr_merge`, `current_action` lingered as `waiting-ci` (a CI-polling heartbeat) past its valid lifetime and could trip the next `/wavemachine` campaign's pre-flight.

## Root cause
`wavemachine_stop()` is the campaign-exit "finally" (run on every exit path) but cleared only the `wavemachine_*` ownership keys — it never reset `current_action`. So a transient `waiting-ci` heartbeat survived into the next campaign.

## Changes
- `wavemachine_stop()` now also resets `current_action` to idle. Runs on every exit path → no stale heartbeat persists past campaign end. Idempotent (safe on worker-abort re-entry).

## Tests
+3 in `test_state.py` (clears ownership; resets stale `waiting-ci` → idle with disk-persist; idempotent re-entry). `test_state.py` 111 passed; `validate.sh` **155/0**.

## Linked Issues
Closes #636. Part of #725 bootstrap.