### PR TITLE
doc(axioms): add Axiom 10 (single-repo-per-wave) + plan-time validator (#670)

### DIFF
--- a/WAVE_AXIOMS.md
+++ b/WAVE_AXIOMS.md
@@ -22,8 +22,9 @@
      "First round" — 2026-05-05 BJ + patchwork. V2 structural rework
      2026-05-06 cc-workflow#605 (added Axiom 9, reshaped 1-8 to the
      three-subsection template, wired the wave-pattern skill bodies
-     to cross-reference instead of restate). Will grow as new failure
-     modes are observed. -->
+     to cross-reference instead of restate). 2026-06-22 cc-workflow#670
+     (added Axiom 10 — single-repo-per-wave — + the plan-time validator).
+     Will grow as new failure modes are observed. -->
 
 ---
 
@@ -267,6 +268,28 @@ The companion principle (`principle_cost_asymmetry_continue_vs_exit.md`, capture
 When the agent feels unease that doesn't match a Legal Exit, the answer is Axiom 4's Concerns Channel — `[concern]` comment, optional Discord ping, continue. The unease is captured durably; the campaign continues; the human's attention is not burned.
 
 **See:** Axiom 2, Axiom 3, Axiom 4, Axiom 5, Axiom 6, `principle_user_attention_is_the_cost.md`, `principle_cost_asymmetry_continue_vs_exit.md`.
+
+---
+
+## Axiom 10 — A wave targets exactly one repo.
+
+### Rule
+
+A single wave's issues all resolve to **one repository**. A wave never straddles two repos. Cross-repo coordination is expressed as **serial phases** (expand in repo A's waves, then contract in repo B's waves), never as a single straddling wave.
+
+### Why
+
+The wave is the **atomic promotion unit**: it assembles into one `kahuna/<wave-id>` branch, the trust gate evaluates that branch, and it fast-forwards into *that repo's* `main`. `kahuna` and its `main` live in one repo. A wave spanning two repos would need two kahuna branches and two ff-into-main promotions — and there is **no two-phase commit across git remotes**, so the two mains can never be promoted atomically. There is always a window where one repo's main has the change and the other's does not — the exact broken intermediate the gate exists to prevent. The coordinated cross-repo contract change is not a counter-example: its correct shape is **expand-contract across serial phases** (repo A ships a backward-compatible expand → repo B consumes it → repo A contracts), each phase's waves single-repo and independently promotable.
+
+### How to apply
+
+**Plan-time validator (prepwaves / assesswaves):** when computing/presenting waves, resolve every issue in each wave to its `owner/repo` (per-issue `repo` field, else plan-level `repo`, else the project repo). If any single wave's issues resolve to **more than one** distinct repo, **refuse** — name the wave and the conflicting repos, and direct the planner to split it into serial single-repo phases. Phase-level `cross_repo: true` remains valid — a *phase* may span repos across its *waves*; the invariant is **per-wave, not per-phase**.
+
+**Forbidden:**
+- Grouping issues from two repos into one wave.
+- "It's just a small cross-repo tweak" — there is still no atomic two-remote promotion; split it into serial phases.
+
+**See:** Axiom 1 (serial is a valid topology), `lesson_cross_repo_wave_orchestration.md`, the prepwaves cross-repo detection step.
 
 ---
 

--- a/skills/assesswaves/SKILL.md
+++ b/skills/assesswaves/SKILL.md
@@ -13,6 +13,10 @@ description: Quick assessment of whether a piece of work is suitable for wave-pa
 
 Decide whether a set of work items can benefit from wave-pattern execution. Recommends a topology and verdict; does not create issues or flight plans. Use before `/prepwaves`.
 
+## Axioms
+
+Bound by WAVE_AXIOMS 1, 7, and 10 (`WAVE_AXIOMS.md` at the repo root). **Axiom 1** (serial is a valid topology) and **Axiom 7** (the assessment-skill binding) govern the topology verdict; **Axiom 10** (a wave targets exactly one repo) bounds the recommendation — never recommend a single wave that spans repos; cross-repo work is serial single-repo phases (expand-contract).
+
 ## Tools Used
 
 - `mcp__sdlc-server__spec_validate_structure` — check each issue's spec shape

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -13,6 +13,10 @@ description: Validate sub-issue specs, compute dependency waves, prepare for wav
 
 Analyze one or more Plan tracking issues, validate their sub-issue specs, compute dependency-ordered waves, and persist the plan so `/nextwave` can execute it. Supports parallel, serial, and mixed topologies.
 
+## Axioms
+
+Bound by WAVE_AXIOMS 1 and 10 (`WAVE_AXIOMS.md` at the repo root). `/prepwaves` is a planning skill, so the campaign-runtime axioms (2–6, 8, 9) bind `/nextwave` and `/wavemachine`, not this skill. **Axiom 1** (serial is a valid topology) governs how it classifies and presents waves; **Axiom 10** (a wave targets exactly one repo) is the plan-time invariant this skill enforces — see the single-repo validator in step 4.
+
 ## Tools Used
 
 - `mcp__sdlc-server__epic_sub_issues` — enumerate children of a Plan tracking issue (the tool name is a historical identifier; it enumerates sub-issues of any parent, and `/prepwaves` calls it on the Plan)
@@ -46,6 +50,8 @@ Analyze one or more Plan tracking issues, validate their sub-issue specs, comput
 
    Assemble the returned lines into the readiness table. If any sub-issue is NOT READY, stop and ask the user how to proceed.
 4. **Compute waves.** Call `wave_compute(epic_ref)` (param name is historical — pass the Plan's issue ref) to get the topologically-sorted wave plan, then `wave_topology(...)` to classify. Present the wave plan (waves, issues, dependency chain, branch naming `feature/<N>-<desc>`).
+
+   **Single-repo-per-wave validator (Axiom 10).** After computing waves, resolve every issue in each wave to its `owner/repo` (per-issue `repo`, else plan-level `repo`, else the project repo). If any single wave's issues span **more than one** distinct repo, **STOP and refuse** — name the offending wave and its conflicting repos, and tell the planner to split it into serial single-repo phases (expand-contract), never one straddling wave (there is no atomic two-remote promotion). A *phase* may still span repos across its waves (`cross_repo: true`, step 5) — the invariant is per-wave, not per-phase.
 5. **Cross-repo detection.** For each Phase about to be persisted, walk every sub-issue's ref. Resolve each ref's `owner/repo` (per-issue `repo` field, else plan-level `repo`, else the orchestrator's current project repo). Collect distinct repo slugs that differ from the orchestrator's project repo. If the set is non-empty, set `cross_repo: true` and `target_repos: [<slug>, ...]` on that Phase in the plan JSON. Single-repo Phases leave both fields unset. Cheap — no extra LLM calls; pure walk over refs already in `wave_compute`'s output.
 6. **Approval gate.** Wait for explicit user approval. Iterate on the plan here — not during `/nextwave`.
 7. **Persist.** Call `wave_init(plan_json)` — the tool auto-detects existing plans and uses extend mode, preserving completed waves. Use Phase-prefixed wave IDs (e.g., `wave-2a`) to avoid collisions when extending. Cross-repo fields (`cross_repo`, `target_repos`) round-trip without modification (the underlying `wave-status init` writes the plan dict verbatim to `phases-waves.json`).


### PR DESCRIPTION
## Summary
Formalizes an implicit invariant as binding: **a wave targets exactly one repo.** A wave is the atomic promotion unit (one kahuna branch → ff into *that* repo's main); there's no two-phase commit across git remotes, so a wave straddling two repos can never promote atomically. Cross-repo coordination is expand-contract across serial single-repo phases.

## Changes
- **WAVE_AXIOMS.md:** new Axiom 10 (Rule/Why/How-to-apply/See) + provenance note.
- **prepwaves:** added the missing `## Axioms` block (the #605 axiom-wiring remnant) citing Axioms 1 + 10, plus the **plan-time validator** in step 4 — refuse any wave whose issues span >1 repo (phase-level `cross_repo` stays valid; the invariant is per-wave).
- **assesswaves:** added its missing `## Axioms` block (1, 7, 10).

## Tests
`validate.sh` **156/0** (WAVE_AXIOMS structure + skill frontmatter); 10 axioms.

## Linked Issues
Closes #670. Folds the #605 prepwaves/assesswaves axiom-wiring remnant. Part of #725 Phase 2.