### PR TITLE
feat(wave-status init): auto-infer cross_repo / target_repos from issue refs (#598)

### DIFF
--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -491,6 +491,37 @@ def current_phase_info(plan_data: dict, state_data: dict) -> dict:
 # State-machine operations
 # ---------------------------------------------------------------------------
 
+def _infer_cross_repo(plan_data: dict) -> None:
+    """Auto-populate per-phase ``cross_repo`` / ``target_repos`` from issue refs (#598).
+
+    For each phase that does NOT already carry a ``cross_repo`` key, resolve every
+    issue's repo (``_issue_repo``) and collect the distinct slugs that differ from
+    the plan's default repo. If any are found, set ``cross_repo: True`` and
+    ``target_repos: [<sorted slugs>]`` so ``/nextwave`` emits the cross-repo recipe
+    without the operator hand-setting the fields (the inference is trivially
+    mechanical — any issue resolving to a non-default ``owner/repo`` is cross-repo).
+
+    An explicit ``cross_repo`` on a phase (either value) is left untouched — operator
+    intent wins. Single-repo phases are left WITHOUT the fields (absent, not False),
+    matching the round-trip contract that single-repo phases carry neither field.
+    """
+    default_repo = _plan_default_repo(plan_data)
+    for phase in plan_data.get("phases", []):
+        if not isinstance(phase, dict) or "cross_repo" in phase:
+            continue
+        targets: set[str] = set()
+        for wave in phase.get("waves", []):
+            for issue in wave.get("issues", []):
+                if not isinstance(issue, dict):
+                    continue
+                repo = _issue_repo(plan_data, issue)
+                if repo and repo != default_repo:
+                    targets.add(repo)
+        if targets:
+            phase["cross_repo"] = True
+            phase["target_repos"] = sorted(targets)
+
+
 def init_state(plan_data: dict, root: Path, *, force: bool = False) -> None:
     """Validate *plan_data*, write ``phases-waves.json``, ``state.json``,
     and ``flights.json`` under ``<root>/.claude/status/`` [R-02].
@@ -522,6 +553,11 @@ def init_state(plan_data: dict, root: Path, *, force: bool = False) -> None:
             "Error: plan already initialized. Use 'init --extend' to add "
             "phases, or 'init --force' to overwrite the existing plan."
         )
+
+    # Auto-infer per-phase cross_repo / target_repos from issue refs (#598) —
+    # mutates plan_data in place before it is persisted verbatim. No-op when the
+    # fields are already set (operator override) or the plan is single-repo.
+    _infer_cross_repo(plan_data)
 
     # --- phases-waves.json (structure, written once) ---
     save_json(phases_path, plan_data)

--- a/tests/test_wave_status.py
+++ b/tests/test_wave_status.py
@@ -970,6 +970,105 @@ class TestCrossRepoPlanRoundTrip:
             "Wave-Engineering/mcp-server-nerf",
         ]
 
+    _AUTO_INFER_PLAN: dict = {
+        "project": "test-auto-infer",
+        "base_branch": "main",
+        "master_issue": 400,
+        "repo": "Wave-Engineering/claudecode-workflow",
+        "phases": [
+            {
+                # No cross_repo set — must be INFERRED from the qualified-ref issue (#598).
+                "name": "Auto-Infer Phase",
+                "waves": [
+                    {
+                        "id": "wave-1",
+                        "name": "W1",
+                        "issues": [
+                            {"number": 1, "title": "local", "deps": []},
+                            {
+                                "number": 48,
+                                "title": "remote",
+                                "deps": [],
+                                "ref": "Wave-Engineering/mcp-server-discord#48",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                # All-local — must remain WITHOUT the fields (absent, not False).
+                "name": "All-Local Phase",
+                "waves": [
+                    {
+                        "id": "wave-2",
+                        "name": "W2",
+                        "issues": [{"number": 2, "title": "local2", "deps": []}],
+                    },
+                ],
+            },
+        ],
+    }
+
+    def test_init_auto_infers_cross_repo_from_qualified_ref(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """#598: init auto-populates cross_repo + target_repos on a phase whose
+        issues resolve to a non-default repo, and leaves an all-local phase bare."""
+        repo = temp_git_repo
+        _write_plan(repo, self._AUTO_INFER_PLAN)
+
+        rc, _, err = run_cli(["init", "plan.json"], repo)
+        assert rc == 0, f"init failed: {err}"
+
+        persisted = self._read_phases(repo)
+        assert persisted["phases"][0]["cross_repo"] is True
+        assert persisted["phases"][0]["target_repos"] == [
+            "Wave-Engineering/mcp-server-discord",
+        ]
+        # All-local phase must NOT be polluted.
+        assert "cross_repo" not in persisted["phases"][1]
+        assert "target_repos" not in persisted["phases"][1]
+
+    def test_init_does_not_override_explicit_cross_repo(
+        self, temp_git_repo: Path, run_cli
+    ) -> None:
+        """#598: an explicit cross_repo (even False) wins — inference must not override."""
+        plan = {
+            "project": "test-explicit-wins",
+            "base_branch": "main",
+            "master_issue": 401,
+            "repo": "Wave-Engineering/claudecode-workflow",
+            "phases": [
+                {
+                    "name": "Explicit False Phase",
+                    "cross_repo": False,  # operator override — must survive
+                    "waves": [
+                        {
+                            "id": "wave-1",
+                            "name": "W1",
+                            "issues": [
+                                {
+                                    "number": 48,
+                                    "title": "remote",
+                                    "deps": [],
+                                    "ref": "Wave-Engineering/mcp-server-discord#48",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+        repo = temp_git_repo
+        _write_plan(repo, plan)
+
+        rc, _, err = run_cli(["init", "plan.json"], repo)
+        assert rc == 0, f"init failed: {err}"
+
+        persisted = self._read_phases(repo)
+        assert persisted["phases"][0]["cross_repo"] is False  # not overridden
+        assert "target_repos" not in persisted["phases"][0]
+
     def test_init_extend_round_trips_cross_repo_fields(
         self, temp_git_repo: Path, run_cli
     ) -> None:


### PR DESCRIPTION
## Summary
`wave-status init` round-tripped `cross_repo`/`target_repos` when present but never populated them — so a hand-built cross-repo plan JSON silently dropped `/nextwave`'s cross-repo recipe (it reads `phases[].cross_repo`). Now init auto-infers them.

## Changes
- New `_infer_cross_repo`, run before the verbatim persist: per phase, resolve each issue's repo (`_issue_repo`: per-issue repo → qualified ref `owner/repo#N` → plan default); collect distinct slugs ≠ default; if any, set `cross_repo: true` + `target_repos: [sorted slugs]`.
- Explicit `cross_repo` (either value) is **not** overridden; single-repo phases stay bare (absent, not False).
- Field name is `target_repos` (recipe-doc/prepwaves/existing-test convention), not the issue body's `cross_repo_targets`.

## Tests
+2 (infer-from-qualified-ref; no-override-of-explicit); existing round-trip tests unaffected. `test_wave_status.py` **55 passed**; `validate.sh` **156/0**.

## Linked Issues
Closes #598. Part of #725 Phase 2.