### PR TITLE
chore(identity): set Dev-Team to oaw

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,4 +235,4 @@ Two layers: **Dev-Team** (persisted here, per-project) and **Dev-Name/Dev-Avatar
 
 Identity files are keyed by md5 hash of the project root directory (`/tmp/claude-agent-<dir_hash>.json`). Any skill or behavior that needs agent identity should resolve this file. The full pick procedure lives in `/name` (`skills/name/SKILL.md`).
 
-Dev-Team: cc-workflow
+Dev-Team: oaw


### PR DESCRIPTION
## Summary
cc-workflow joins the **Oak-and-Wave (oaw)** meta-team alongside `mcp-server-sdlc` (@strangler) and `mcp-server-discord` (@polyjuice), so all three repos' agents are one addressable team (`@oaw`). Architects: BJ + babelfish.

## Changes
- `CLAUDE.md`: `Dev-Team: cc-workflow` → `Dev-Team: oaw`.

## Test Plan
`CLAUDE.md` identity-line change only; CI validate confirms no breakage.