### PR TITLE
feat(install): globalize WAVE_AXIOMS.md + referenced docs for cross-repo resolution (#792)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Every issue MUST be wave-pattern quality: detailed enough that a spec-driven age
 
 ## MANDATORY: WAVE_AXIOMS
 
-**Read `WAVE_AXIOMS.md` before any wave-pattern work.** Nine binding axioms — violation is a bug. Disagreement is a reason to PR the file, never to override in the moment.
+**Read `WAVE_AXIOMS.md` before any wave-pattern work** — resolve it from the repo root, or the kit-installed `~/.claude/WAVE_AXIOMS.md` in repos that don't carry it (the same resolution applies to the `docs/…` pointers elsewhere in this file: repo root, else `~/.claude/docs/…`). The binding axioms — violation is a bug. Disagreement is a reason to PR the file, never to override in the moment.
 
 ---
 

--- a/install
+++ b/install
@@ -1387,6 +1387,20 @@ if [[ "$INSTALL_CONFIG" == true ]]; then
 		fi
 	fi
 
+	# Kit-canonical docs (cc-workflow#792): globalize WAVE_AXIOMS.md + the docs/
+	# files the canonical CLAUDE.md references, so a /ccfold-merged CLAUDE.md in
+	# ANY repo resolves them from $CLAUDE_DIR — single source, no per-repo vendor,
+	# no drift. Source of truth stays the repo; this copies repo→global each run.
+	for kdoc in WAVE_AXIOMS.md docs/mcp-scoping.md docs/discord-watcher.md \
+		docs/operations/log-rotation.md docs/operations/merge-queue-checklist.md; do
+		if [[ -f "$REPO_DIR/$kdoc" ]]; then
+			if [[ "$DRY_RUN" != true ]]; then
+				mkdir -p "$(dirname "$CLAUDE_DIR/$kdoc")"
+			fi
+			do_copy "$REPO_DIR/$kdoc" "$CLAUDE_DIR/$kdoc"
+		fi
+	done
+
 	if [[ -f "$REPO_DIR/config/settings.template.json" ]]; then
 		if [[ -f "$CLAUDE_DIR/settings.json" ]]; then
 			if [[ "$DRY_RUN" == true ]]; then

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -252,6 +252,19 @@ class TestInstallCreatesArtifacts:
                 f"Missing package artifact: {artifact}"
             )
 
+        # --- Kit-canonical docs globalized (cc-workflow#792) ---
+        # The canonical CLAUDE.md references these; globalizing them under
+        # ~/.claude lets a /ccfold-merged CLAUDE.md resolve them in any repo.
+        claude_dir = sandbox_home / ".claude"
+        for rel in (
+            "WAVE_AXIOMS.md",
+            "docs/mcp-scoping.md",
+            "docs/discord-watcher.md",
+            "docs/operations/log-rotation.md",
+            "docs/operations/merge-queue-checklist.md",
+        ):
+            assert (claude_dir / rel).exists(), f"kit doc not globalized: {rel}"
+
 
 @_SKIP_NO_BASH
 @_SKIP_NO_PYTHON3
@@ -732,6 +745,13 @@ class TestLocalScopeInstall:
         # Settings merged/installed into project/.claude/settings.json.
         assert (proj_claude / "settings.json").exists(), (
             "project-local settings.json missing"
+        )
+        # Kit-canonical docs globalized under the project too (cc-workflow#792).
+        assert (proj_claude / "WAVE_AXIOMS.md").exists(), (
+            "project-local WAVE_AXIOMS.md missing"
+        )
+        assert (proj_claude / "docs" / "operations" / "log-rotation.md").exists(), (
+            "project-local kit docs/ not globalized"
         )
 
     def test_local_leaves_global_untouched(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
`/ccfold` merges cc-workflow's canonical CLAUDE.md into every oaw repo, but that CLAUDE.md's references to `WAVE_AXIOMS.md` + `docs/*` only exist in cc-workflow — so they dangle in every non-cc-workflow repo (raised by @strangler on mcp-server-sdlc).

## Changes
- **Installer** globalizes the 5 kit-canonical files to `$CLAUDE_DIR` (`~/.claude/WAVE_AXIOMS.md`, `~/.claude/docs/**`); `--local` follows the re-rooted `CLAUDE_DIR` automatically. Source of truth stays the repo.
- **CLAUDE.md** states the resolution convention (repo root, else kit-installed `~/.claude/`) + fixes the stale "Nine axioms" (Axiom 10 landed in #670 → count-agnostic).

## Tests
Extended `TestInstallCreatesArtifacts` (global) + `TestLocalScopeInstall` (local) — 2 install tests pass; `validate.sh` **156/0**; trivy PASS; code-review no critical/important (2 minor → #780 follow-up).

## Linked Issues
Closes #792. Unblocks the oaw cross-repo CLAUDE.md convention.