### PR TITLE
test(wave-engine): disposition stale wavemachine/nextwave skill-tests — suite 60→0 failed (#753)

### DIFF
--- a/tests/test_nextwave_skill.py
+++ b/tests/test_nextwave_skill.py
@@ -99,6 +99,7 @@ class TestSkillFileShape:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: Prime/flight/kahuna logic moved INTO the per-wave Workflow (skills/nextwave/per-wave-workflow.js) at the dynamic-workflows cutover; the nextwave skill is now a thin launcher. Covered by #785 e2e + the per-wave-workflow/campaign-loop tests. Retire/relocate to test the Workflow.", strict=False)
 class TestAC1_PrimeReadsKahunaBranch:
     """The Orchestrator (Step 1) reads ``kahuna_branch`` from wave state and
     feeds it into the Prime(pre-wave) prompt; Prime(pre-wave)'s template
@@ -161,6 +162,7 @@ class TestAC1_PrimeReadsKahunaBranch:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: the flight prompt + kahuna directive live in per-wave-workflow.js now, not the nextwave skill. Covered by #785 e2e. Retire/relocate to test the Workflow.", strict=False)
 class TestAC2_FlightPromptKahunaDirective:
     """Flight stub prompt carries the directive that work bases on
     ``origin/<kahuna_branch>`` and PRs target ``<kahuna_branch>``. Per
@@ -203,6 +205,7 @@ class TestAC2_FlightPromptKahunaDirective:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: PR-create base routing lives in per-wave-workflow.js now, not the nextwave skill. Covered by #785 e2e. Retire/relocate to test the Workflow.", strict=False)
 class TestAC3_PrCreateBaseRouting:
     """Prime(post-flight) — which actually calls ``pr_create`` — uses
     ``base=<kahuna_branch>`` unconditionally per cc-workflow#580."""
@@ -256,6 +259,7 @@ class TestAC3_PrCreateBaseRouting:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: the kahuna-unconditional logic lives in per-wave-workflow.js now, not the nextwave skill. Covered by #785 e2e. Retire/relocate to test the Workflow.", strict=False)
 class TestAC4_KahunaIsUnconditional:
     """Per cc-workflow#580 there is no legacy non-KAHUNA path. Step 1
     refuses to proceed if ``kahuna_branch`` is unset, the Prime(pre-wave)
@@ -327,6 +331,7 @@ class TestAC4_KahunaIsUnconditional:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691/#605: the devspec § reference shifted with the dynamic-workflows restructure; remap to the current § or retire.", strict=False)
 class TestDevSpecCrossReference:
     """The Dev Spec §5.2.3 reference must remain in the skill so future
     readers can find the authoritative contract."""
@@ -384,6 +389,7 @@ def _prime_post_flight_prompt(text: str) -> str:
     return "".join(quote_lines)
 
 
+@pytest.mark.xfail(reason="#753/#691: Prime(post-flight) logic lives in per-wave-workflow.js now (the Prime prompts), not the nextwave skill. Covered by #785 e2e + per-wave-workflow tests. Retire/relocate to test the Workflow.", strict=False)
 class TestPrimePostFlightCanonicalLineUnderLongCi:
     """Prime(post-flight) prompt declares the canonical-line contract,
     lists forbidden phrases (including the Plan #581 narration), and

--- a/tests/test_wavemachine_skill.py
+++ b/tests/test_wavemachine_skill.py
@@ -615,7 +615,6 @@ class TestAC1_NoUnqualifiedEpic:
         )
 
 
-@pytest.mark.xfail(reason="#753/#605: the exit taxonomy was moved into WAVE_AXIOMS (Axiom 3 closed-list + Axiom 4 Concerns Channel); the skill's '## Exhaustive Legal Exits' now CROSS-REFERENCES the axioms instead of restating the ### Mechanical/Plan-reality/Explicit-non-exits subsections (the #605 cross-reference-don't-restate philosophy). These assertions test the pre-#605 restated form — remap them to assert the cross-ref, or retire (the taxonomy is covered by WAVE_AXIOMS + test_wave_axioms).", strict=False)
 class TestAC2_ExhaustiveLegalExits:
     """R-17: the skill body contains a ``## Exhaustive Legal Exits``
     section matching the §5.3.2 structural template — exact heading, with
@@ -629,6 +628,7 @@ class TestAC2_ExhaustiveLegalExits:
             re.MULTILINE,
         ), "Must contain '## Exhaustive Legal Exits' heading (exact)"
 
+    @pytest.mark.xfail(reason="#753/#605: exit taxonomy moved to WAVE_AXIOMS Axiom 3/4; the section cross-references instead of restating this. Remap to the cross-ref form or retire.", strict=False)
     def test_closed_list_framing_present(self, skill_text: str) -> None:
         """The opening sentence must assert the closed-list contract."""
         section = _section(skill_text, "Exhaustive Legal Exits")
@@ -639,6 +639,7 @@ class TestAC2_ExhaustiveLegalExits:
             re.IGNORECASE | re.DOTALL,
         ), "Section must declare the closed-list contract"
 
+    @pytest.mark.xfail(reason="#753/#605: the ### Mechanical exits subsection moved into WAVE_AXIOMS Axiom 3; the section cross-references now. Remap or retire.", strict=False)
     def test_mechanical_exits_subsection(self, skill_text: str) -> None:
         section = _section(skill_text, "Exhaustive Legal Exits")
         # _section stops at the next ## or ### — so grab a wider window.
@@ -666,6 +667,7 @@ class TestAC2_ExhaustiveLegalExits:
             f"(found {len(numbered)})"
         )
 
+    @pytest.mark.xfail(reason="#753/#605: the ### Plan-reality drift exits subsection moved into WAVE_AXIOMS Axiom 3; the section cross-references now. Remap or retire.", strict=False)
     def test_plan_reality_drift_exits_subsection(
         self, skill_text: str
     ) -> None:
@@ -685,6 +687,7 @@ class TestAC2_ExhaustiveLegalExits:
             "Must contain '### Plan-reality drift exits' subsection"
         )
 
+    @pytest.mark.xfail(reason="#753/#605: explicit-non-exits are now inline under the cross-ref (not a ### subsection); the taxonomy lives in WAVE_AXIOMS Axiom 3. Remap or retire.", strict=False)
     def test_explicit_non_exits_subsection(self, skill_text: str) -> None:
         lines = skill_text.splitlines(keepends=True)
         start = next(
@@ -712,6 +715,7 @@ class TestAC2_ExhaustiveLegalExits:
             f"(found {len(bullets)})"
         )
 
+    @pytest.mark.xfail(reason="#753/#605: asserts 'WAVE_AXIOMS.md' in the exit section, but the section cross-references 'Per WAVE_AXIOMS Axiom 3' (no .md suffix). Remap the assertion to the cross-ref wording or retire.", strict=False)
     def test_cross_reference_to_axiom_corpus(
         self, skill_text: str
     ) -> None:

--- a/tests/test_wavemachine_skill.py
+++ b/tests/test_wavemachine_skill.py
@@ -69,7 +69,10 @@ def _section(text: str, header: str) -> str:
 
 
 def _bootstrap(text: str) -> str:
-    return _section(text, "Pre-Wave Kahuna Bootstrap")
+    # #691 cutover relocated the kahuna bootstrap into the campaign "Launch
+    # sequence" (step 3: once-per-Plan wave_init with kahuna:{plan_id,slug},
+    # idempotent skip on resume) — it's no longer its own section.
+    return _section(text, "Launch sequence")
 
 
 def _gate(text: str) -> str:
@@ -115,6 +118,7 @@ class TestSkillFileShape:
     def test_kahuna_branch_referenced(self, skill_text: str) -> None:
         assert "kahuna_branch" in skill_text
 
+    @pytest.mark.xfail(reason="#753/#691: the gate_evaluating state is a per-wave-Workflow gate internal (per-wave-workflow.js), not the driver skill; covered by #785 e2e.", strict=False)
     def test_gate_evaluating_referenced(self, skill_text: str) -> None:
         """Both new ``action`` values from §5.2.2 must appear."""
         assert "gate_evaluating" in skill_text
@@ -150,6 +154,7 @@ class TestAC1_PreWaveBootstrap:
             bootstrap,
         ), "Bootstrap must call wave_init with `kahuna: { plan_id, slug }`"
 
+    @pytest.mark.xfail(reason="#753/#691: resume-skip now lives in 'Launch sequence' (idempotent: a resume sees kahuna_branch populated + skips). Remap this assertion to that wording, or retire.", strict=False)
     def test_bootstrap_skips_when_kahuna_branch_present(
         self, skill_text: str
     ) -> None:
@@ -178,6 +183,7 @@ class TestAC1_PreWaveBootstrap:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: trust-gate + kahuna-promotion logic relocated from the wavemachine DRIVER skill into skills/nextwave/per-wave-workflow.js (the per-wave Workflow); behavior covered by tests/regression/test_wave_engine_e2e_smoke.sh (#785). These driver-skill assertions are stale — retire/relocate to test the Workflow.", strict=False)
 class TestAC2_GateStepGroupAndConcurrency:
     """Gate step group documents the four trust signals, calls them
     concurrently in a single tool-use block, and explicitly cites R-23."""
@@ -262,6 +268,7 @@ class TestAC2_GateStepGroupAndConcurrency:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: all-green kahuna-promotion lifecycle relocated to skills/nextwave/per-wave-workflow.js; covered by #785 e2e smoke. Stale driver-skill assertion — retire/relocate.", strict=False)
 class TestAC3_AllGreenPath:
     """When all four trust signals pass, the gate auto-merges
     kahuna→main, records disposition in ``kahuna_branches`` history,
@@ -327,6 +334,7 @@ class TestAC3_AllGreenPath:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: any-red kahuna-preserve lifecycle relocated to skills/nextwave/per-wave-workflow.js; covered by #785 e2e smoke. Stale driver-skill assertion — retire/relocate.", strict=False)
 class TestAC4_AnyRedPath:
     """When one or more signals fail, the gate transitions to
     ``gate_blocked``, emits Procedure C notifications, preserves the
@@ -389,6 +397,7 @@ class TestAC4_AnyRedPath:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: the commutativity PROBE_UNAVAILABLE gate path relocated to skills/nextwave/per-wave-workflow.js; covered by #785 e2e smoke. Stale driver-skill assertion — retire/relocate.", strict=False)
 class TestProbeUnavailable:
     """The synthesized ``PROBE_UNAVAILABLE`` verdict (cross-server
     contract per ``mcp-server-sdlc#218``) must be treated as
@@ -448,6 +457,7 @@ class TestProbeUnavailable:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(reason="#753/#691: the gate procedure-D reentry path relocated to skills/nextwave/per-wave-workflow.js; covered by #785 e2e smoke. Stale driver-skill assertion — retire/relocate.", strict=False)
 class TestAC8_ProcedureDReentry:
     """When ``/wavemachine`` is restarted with wave state in
     ``gate_evaluating``, the gate is re-invoked idempotently — pure-read
@@ -507,6 +517,7 @@ class TestDevSpecCrossReference:
     """The Dev Spec §5.2.2 reference must remain in the skill so future
     readers can find the authoritative gate contract."""
 
+    @pytest.mark.xfail(reason="#753/#691/#605: the §5.2.2 devspec reference shifted with the dynamic-workflows restructure; remap to the current § or retire.", strict=False)
     def test_devspec_5_2_2_referenced(self, skill_text: str) -> None:
         assert re.search(r"§\s*5\.2\.2|Dev Spec.*5\.2\.2", skill_text), (
             "Dev Spec §5.2.2 must be cross-referenced from the skill"
@@ -521,6 +532,7 @@ class TestDevSpecCrossReference:
 
 
 class TestNonNegotiables:
+    @pytest.mark.xfail(reason="#753/#691: R-23 (commutativity) is a per-wave-Workflow gate internal, not a driver-skill non-negotiable; covered by #785 e2e + the Workflow tests.", strict=False)
     def test_r23_in_non_negotiables(self, skill_text: str) -> None:
         non_neg = _section(skill_text, "Non-Negotiables")
         assert non_neg, "Non-Negotiables section not found"
@@ -529,6 +541,7 @@ class TestNonNegotiables:
             r"single tool.use block", non_neg, re.IGNORECASE
         ), "Non-Negotiables must encode 'single tool-use block' for R-23"
 
+    @pytest.mark.xfail(reason="#753/#691: PROBE_UNAVAILABLE is a per-wave-Workflow gate internal, not a driver-skill non-negotiable; covered by #785 e2e.", strict=False)
     def test_probe_unavailable_in_non_negotiables(
         self, skill_text: str
     ) -> None:
@@ -542,6 +555,7 @@ class TestNonNegotiables:
             re.IGNORECASE,
         ), "Non-Negotiables must mark PROBE_UNAVAILABLE as conservative-fail"
 
+    @pytest.mark.xfail(reason="#753/#691: no-short-circuit-on-first-failure is a per-wave-Workflow gate-eval internal, not a driver-skill non-negotiable; covered by #785 e2e.", strict=False)
     def test_no_short_circuit_in_non_negotiables(
         self, skill_text: str
     ) -> None:
@@ -601,6 +615,7 @@ class TestAC1_NoUnqualifiedEpic:
         )
 
 
+@pytest.mark.xfail(reason="#753/#605: the exit taxonomy was moved into WAVE_AXIOMS (Axiom 3 closed-list + Axiom 4 Concerns Channel); the skill's '## Exhaustive Legal Exits' now CROSS-REFERENCES the axioms instead of restating the ### Mechanical/Plan-reality/Explicit-non-exits subsections (the #605 cross-reference-don't-restate philosophy). These assertions test the pre-#605 restated form — remap them to assert the cross-ref, or retire (the taxonomy is covered by WAVE_AXIOMS + test_wave_axioms).", strict=False)
 class TestAC2_ExhaustiveLegalExits:
     """R-17: the skill body contains a ``## Exhaustive Legal Exits``
     section matching the §5.3.2 structural template — exact heading, with


### PR DESCRIPTION
## Summary
Clears the last 60 failures in the pytest suite — all stale wave-engine SKILL tests. The #691 dynamic-workflows cutover moved trust-gate / kahuna-promotion / Prime / flight logic OUT of the wavemachine + nextwave DRIVER skills INTO `skills/nextwave/per-wave-workflow.js`, and #605 moved the legal-exit taxonomy into `WAVE_AXIOMS.md`. The tests still assert the driver skills contain that relocated content.

## Changes
- **Relocate-class** (gate / all-green / any-red / probe / Prime / flight / PR-routing / kahuna): class- or method-level `@pytest.mark.xfail(reason=..., strict=False)`, each reason pointing at where the logic moved + the covering test (`test_wave_engine_e2e_smoke.sh` #785 + per-wave-workflow/campaign-loop tests).
- **Restructure-class** (Exhaustive Legal Exits → WAVE_AXIOMS Axiom 3/4 cross-ref; devspec § refs; bootstrap resume-skip): xfail with a "remap to cross-ref / current form, or retire" note. `_bootstrap()` remapped to the current "Launch sequence" section (4 tests now pass).
- **Review fix:** dropped an over-broad class-xfail that masked 2 still-live #605 positive guards (`test_top_of_file_axioms_block`, `test_section_heading_present`) — method-xfailed only the genuinely-failing members so the live guards keep guarding.

These are tests-of-the-wrong-file post-refactor, **not hidden regressions** — verified by code-review that the asserted content is present in `per-wave-workflow.js`/`gate.js`.

## Test Plan
- `pytest tests/test_wavemachine_skill.py tests/test_nextwave_skill.py` → **13 passed, 56 xfailed, 2 xpassed, 0 failed**.
- Full suite: 60 → 0 failed.
- Precheck: validate ✓, trivy ✓ (0 HIGH/CRITICAL), spec ✓, code-review ✓ (1 important finding fixed).

## Linked Issues
Closes #753. Follow-up (to be filed): rewrite the xfailed tests against `per-wave-workflow.js` + add the wave-engine tests to `validate.sh` so they stop silently rotting (the root cause — they were never in the CI gate).