### PR TITLE
feat(prepwaves): wire wave_campaign_precheck residue gate + subsume multi-phase guard (#716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+- `/prepwaves` step 0.5 — **campaign residue gate**: calls `wave_campaign_precheck` (server contract mcp-server-sdlc#457) before any sub-agent fan-out or approval and surfaces a prior campaign's residue (`classification` + `residue{plan_id, wavemachine_active, pending_waves, promoted_waves, kahuna_branches}` + `options`/`recommended`) for an operator preserve-wait / preserve-extend / replace choice; nothing is deleted without explicit confirmation. Subsumes the former narrow `phases-waves.json` multi-Phase guard, with an on-disk fallback for defense-in-depth. Closes #716.
+- Kit-canonical docs (`WAVE_AXIOMS.md` + the referenced `docs/*`) are globalized to `~/.claude/` on install, so a `/ccfold`-merged CLAUDE.md resolves them in any repo (single source, no per-repo vendoring). Closes #792.
+
+### Changed
+
+- The **pytest suite now runs in CI** — `scripts/ci/test.sh` on both `pull_request` and `merge_group`. Root-cause fix for the suite rotting unnoticed: it previously ran nowhere in CI. Closes #795 (CI-gating slice; the xfailed-test rewrite remains in #795).
+- Triaged the rotted test suite to green (195 → 0 failed): stale wave-engine skill-tests dispositioned via reasoned `xfail` (logic relocated to `per-wave-workflow.js` by #691 / `WAVE_AXIOMS` by #605; covered by the #785 e2e smoke). Closes #753.
+
 ## [6.0.0] - 2026-06-20
 
 ### Breaking

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -42,10 +42,11 @@ Bound by WAVE_AXIOMS 1 and 10 (`WAVE_AXIOMS.md` at the repo root). `/prepwaves` 
 
    Server contract: mcp-server-sdlc#457. Consumer half: cc-workflow#716. Field names are #457's verbatim — read `state`/`classification`/`options`/`recommended`/`residue.kahuna_branches`, not any earlier paraphrase.
 
-1. **Persisted-plan handling — subsumed by the 0.5 residue gate (cc-workflow#716 AC-4).** The former narrow `phases-waves.json` multi-Phase guard is now folded into `wave_campaign_precheck`: an existing persisted plan — including a multi-Phase plan written by `/devspec upshift` — surfaces at step 0.5 as `state == "residue_found"` (its `residue.plan_id` + `pending_waves`/`promoted_waves` reflect the persisted plan), and the operator resolves it there:
+1. **Persisted-plan handling — subsumed by the 0.5 residue gate (cc-workflow#716 AC-4).** The former narrow `phases-waves.json` multi-Phase guard is now folded into `wave_campaign_precheck`: an existing persisted plan — including a multi-Phase plan written by `/devspec upshift` — should surface at step 0.5 as `state == "residue_found"` (its `residue.plan_id` + `pending_waves`/`promoted_waves` reflect the persisted plan), and the operator resolves it there:
    - `preserve_wait` / `preserve_extend` → keep the existing plan; run `/nextwave` to execute it (this replaces the old "persist is unnecessary, run `/nextwave`" message).
    - `replace` → clear it and re-plan from scratch.
    - **Single-Phase re-run** (same `plan_id` re-prepped) needs no stop — `wave_init`'s extend/idempotent path at step 7 handles it; proceed normally.
+   - **On-disk fallback (don't depend on the seam).** If step 0.5 returned `state == "clean"` but `.claude/status/phases-waves.json` exists with `phases.length > 1`, **STOP anyway**: report the persisted multi-Phase plan and tell the user to run `/nextwave` to execute it or delete the file to re-plan. This keeps the multi-Phase guarantee independent of how `wave_campaign_precheck` classifies a persisted-but-unstarted plan (a freshly `/devspec upshift`'d plan with no runtime footprint may read as `clean` if #457 keys residue on runtime signals) — so prepwaves never silently re-plans over an existing multi-Phase topology.
 
 2. **Inputs.** Plan tracking-issue numbers passed by the user (`/prepwaves #2` or `/prepwaves #2 #3 ...`). Each Plan becomes one Phase in `phases-waves.json`.
 3. **Pre-flight readiness table.** For each Plan:

--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -19,6 +19,7 @@ Bound by WAVE_AXIOMS 1 and 10 (`WAVE_AXIOMS.md` at the repo root). `/prepwaves` 
 
 ## Tools Used
 
+- `mcp__sdlc-server__wave_campaign_precheck` — residue gate (step 0.5): detect a prior campaign's leftover state (active driver, pending/promoted waves, stale kahuna branches) before planning a new one. Pure read, no mutation (server contract: mcp-server-sdlc#457)
 - `mcp__sdlc-server__epic_sub_issues` — enumerate children of a Plan tracking issue (the tool name is a historical identifier; it enumerates sub-issues of any parent, and `/prepwaves` calls it on the Plan)
 - `mcp__sdlc-server__spec_validate_structure` — pre-flight check each sub-issue's shape (Changes / Tests / Acceptance / Dependencies)
 - `mcp__sdlc-server__spec_dependencies` — extract declared edges
@@ -28,12 +29,23 @@ Bound by WAVE_AXIOMS 1 and 10 (`WAVE_AXIOMS.md` at the repo root). `/prepwaves` 
 
 ## Procedure
 
-0. **Clean-tree gate (FIRST — before anything).** `/prepwaves` MUST refuse to run on a dirty working tree. Another agent's uncommitted work in the same checkout has stranded a prep before (Plan #581: 394 uncommitted lines in a foreign branch required a hand-rolled patch-and-revert to recover). Run `git status --porcelain`; if it returns **any** lines, **STOP** and refuse: report the offending paths (modified + untracked) and tell the user to commit, stash, or clean them first. Do NOT auto-stash or auto-clean — a dirty tree is the user's to resolve, never `/prepwaves`'s. Only a clean tree proceeds to the Multi-Phase guard below.
+0. **Clean-tree gate (FIRST — before anything).** `/prepwaves` MUST refuse to run on a dirty working tree. Another agent's uncommitted work in the same checkout has stranded a prep before (Plan #581: 394 uncommitted lines in a foreign branch required a hand-rolled patch-and-revert to recover). Run `git status --porcelain`; if it returns **any** lines, **STOP** and refuse: report the offending paths (modified + untracked) and tell the user to commit, stash, or clean them first. Do NOT auto-stash or auto-clean — a dirty tree is the user's to resolve, never `/prepwaves`'s. Only a clean tree proceeds to the Campaign residue gate below.
 
-1. **Multi-Phase guard.** Before any work, check if `.claude/status/phases-waves.json` already exists in the project. If it does, read it and inspect `phases.length`:
-   - If `phases.length > 1` (multi-Phase topology already written by `/devspec upshift`): **STOP.** Report to the user: "`phases-waves.json` already contains a multi-Phase topology (N phases, M waves, K stories). This was written by `/devspec upshift` — `/prepwaves` persist is unnecessary. Run `/nextwave` to begin execution, or delete `phases-waves.json` to re-plan from scratch."
-   - If `phases.length === 1` and the plan's `plan_id` matches one of the user's input Plan refs: this is a re-run of a single-Phase prep. Proceed normally (wave_init's extend/idempotent path handles it).
-   - If the file does not exist: proceed normally (fresh prep).
+0.5. **Campaign residue gate (`wave_campaign_precheck`).** Before planning a new campaign, call `mcp__sdlc-server__wave_campaign_precheck(root)` (pure read — never mutates) to detect leftover state from a prior campaign in this checkout. This catches the failure mode where a fresh `/prepwaves` silently stomps an in-flight or half-promoted campaign. Branch on the returned `state`:
+   - `state == "clean"` → proceed to the Multi-Phase guard.
+   - `state == "residue_found"` → **STOP** and surface, do NOT auto-resolve:
+     - `classification` — `"dead"` (a stale/abandoned campaign, safe to replace) vs `"ambiguous"` (possibly-live, needs human judgment).
+     - `residue` — `plan_id`, `wavemachine_active`, `pending_waves`, `promoted_waves`, `kahuna_branches[]`.
+     - `options` (`preserve_wait` / `preserve_extend` / `replace`) and the server's `recommended` option.
+
+     Present these and **wait for the user to choose**. `replace` (the usual `recommended` for `"dead"`) clears the residue and re-plans; `preserve_*` keeps the existing campaign. Never pick for the user — a half-promoted campaign is theirs to resolve.
+
+   Server contract: mcp-server-sdlc#457. Consumer half: cc-workflow#716. Field names are #457's verbatim — read `state`/`classification`/`options`/`recommended`/`residue.kahuna_branches`, not any earlier paraphrase.
+
+1. **Persisted-plan handling — subsumed by the 0.5 residue gate (cc-workflow#716 AC-4).** The former narrow `phases-waves.json` multi-Phase guard is now folded into `wave_campaign_precheck`: an existing persisted plan — including a multi-Phase plan written by `/devspec upshift` — surfaces at step 0.5 as `state == "residue_found"` (its `residue.plan_id` + `pending_waves`/`promoted_waves` reflect the persisted plan), and the operator resolves it there:
+   - `preserve_wait` / `preserve_extend` → keep the existing plan; run `/nextwave` to execute it (this replaces the old "persist is unnecessary, run `/nextwave`" message).
+   - `replace` → clear it and re-plan from scratch.
+   - **Single-Phase re-run** (same `plan_id` re-prepped) needs no stop — `wave_init`'s extend/idempotent path at step 7 handles it; proceed normally.
 
 2. **Inputs.** Plan tracking-issue numbers passed by the user (`/prepwaves #2` or `/prepwaves #2 #3 ...`). Each Plan becomes one Phase in `phases-waves.json`.
 3. **Pre-flight readiness table.** For each Plan:


### PR DESCRIPTION
## Summary
The cc-workflow consumer half of the `wave_campaign_precheck` contract (server impl = mcp-server-sdlc#457). Adds `/prepwaves` step 0.5 — the campaign residue gate — so a fresh prep can't silently stomp an in-flight or half-promoted campaign.

## Changes
- **Step 0.5** — calls `wave_campaign_precheck(root)` (pure read) before any sub-agent fan-out or approval. On `state=='residue_found'`, surfaces #457's exact shape (`classification`, `residue{plan_id, wavemachine_active, pending_waves, promoted_waves, kahuna_branches[]}`, `options`, `recommended`) and STOPS for the operator; `replace` is the default recommendation; nothing deleted without confirmation.
- **Subsumes the old multi-Phase guard** (former step 1) into the precheck — a persisted plan (incl. `/devspec upshift` multi-Phase) surfaces as residue; `preserve_*`→run `/nextwave`, `replace`→re-plan.
- Tools Used updated. Field names match #457 verbatim (supersedes my earlier paraphrase).

## Test Plan
- `validate.sh` 158/0. No prepwaves skill-test file exists; the change is skill prose verified against #716's 4 ACs (all covered) + the #457 contract. A `test_prepwaves_skill.py` structure-test is a reasonable future hardening (noted).

## Linked Issues
Closes #716. Consumer of mcp-server-sdlc#457 (awaiting BJ's greenlight). Seam-confirm on persisted-unstarted residue classification posted to strangler.