### PR TITLE
test(install): gate test_install_check_clean as full-env opt-in; drop CI deselect (#795)

### DIFF
--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -21,8 +21,9 @@ cd "$ROOT"
 # `from wave_status import ...` resolves in the test process.
 export PYTHONPATH="$ROOT/src${PYTHONPATH:+:$PYTHONPATH}"
 
-# The non-CI-portable test_install_check_clean now self-skips under CI=true
-# (skipif in tests/test_install.py, cc-workflow#795) — no runner-level deselect
-# needed; the skip is visible in the test output with its reason.
+# The full-env-only test_install_check_clean self-skips unless CC_FULL_ENV_TESTS
+# is set (skipif in tests/test_install.py, cc-workflow#795) — so it's skipped by
+# default here AND on a stock dev box; no runner-level deselect needed, and the
+# skip is visible in the test output with its reason.
 echo "==> pytest tests/ (PYTHONPATH=src)"
 python3 -m pytest tests/ -q

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -21,12 +21,8 @@ cd "$ROOT"
 # `from wave_status import ...` resolves in the test process.
 export PYTHONPATH="$ROOT/src${PYTHONPATH:+:$PYTHONPATH}"
 
-# cc-workflow#795: TestInstallCheckClean::test_install_check_clean asserts a
-# PERFECTLY in-sync install, which needs a deps-complete env (e.g. `bun` for MCP
-# builds). CI's minimal runner leaves 2 settings.template.json hook items out of
-# sync, so that one test is not CI-portable yet. Deselected LOUDLY here pending a
-# proper CI-portability fix tracked in #795 (install deps in CI, or skipif when
-# deps are incomplete) — every other test stays gated.
-echo "==> pytest tests/ (PYTHONPATH=src) — deselecting 1 non-CI-portable test (#795: test_install_check_clean)"
-python3 -m pytest tests/ -q \
-	--deselect "tests/test_install.py::TestInstallCheckClean::test_install_check_clean"
+# The non-CI-portable test_install_check_clean now self-skips under CI=true
+# (skipif in tests/test_install.py, cc-workflow#795) — no runner-level deselect
+# needed; the skip is visible in the test output with its reason.
+echo "==> pytest tests/ (PYTHONPATH=src)"
+python3 -m pytest tests/ -q

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -296,6 +296,18 @@ class TestInstalledBinaryRuns:
 class TestInstallCheckClean:
     """Immediately after install, install.sh --check reports no drift."""
 
+    @pytest.mark.skipif(
+        not os.environ.get("CC_FULL_ENV_TESTS"),
+        reason=(
+            "Full-environment integration test: asserts a PERFECTLY in-sync install, "
+            "which needs the complete toolchain — sudo to write /etc/logrotate.d, secret "
+            "tokens, and bun for MCP-server builds. It false-fails in ANY partial env "
+            "(CI's minimal runner AND a stock dev box: /etc/ logrotate DIFFERS, tokens "
+            "absent). So it runs only when CC_FULL_ENV_TESTS is set. Proper fix: scope "
+            "the assertion to sandbox-controllable artifacts (skills/scripts), ignoring "
+            "system/secret/build items the sandbox can't provision (cc-workflow#795)."
+        ),
+    )
     def test_install_check_clean(self, sandbox_home: Path) -> None:
         # Install first
         rc, out, err = run_install([], sandbox_home)


### PR DESCRIPTION
## Summary
Removing the `test.sh` deselect (from the #795 CI-gating) surfaced that `test_install_check_clean` isn't merely CI-fragile — it false-fails in **any** partial environment. A fresh sandbox `install --check` is out-of-sync on items the sandbox can't provision: `/etc/logrotate.d/cc-mcp-logs` DIFFERS (no sudo), bot tokens absent, MCP builds need `bun`. It only passes fully-provisioned (which is why it silently drifted red mid-session).

## Changes
- **`skipif(not CC_FULL_ENV_TESTS)`** on `test_install_check_clean` — it's a full-environment integration test; runs only when opted in, skips cleanly (visible reason) by default in CI **and** on a stock dev box.
- **Removed the `scripts/ci/test.sh` deselect** — the test now self-skips, so the gate needs no special-case (cleaner; skip lives with the test).

## Test Plan
- Default (no `CC_FULL_ENV_TESTS`): test **skips** (verified). `validate.sh` 158/0. Suite green by default everywhere; the CI gate (#796) needs no deselect.

## Linked Issues
Part of #795. **Proper fix noted in #795:** scope the assertion to sandbox-controllable artifacts (skills/scripts), ignoring system/secret/build items — so it runs by default again and still catches real install drift.