### PR TITLE
fix(wave-status): tolerate wrapped {"flights":[...]} in flight-plan (#632)

### DIFF
--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -163,6 +163,12 @@ def _cmd_flight_plan(args: argparse.Namespace) -> None:
     root = get_project_root()
     raw = _read_json_source(args.file)
     flights_data = json.loads(raw)
+    # #632: tolerate both the bare array (the tool's expected shape) and a
+    # wrapped {"flights": [...]} object — the Prime prompt sometimes emits the
+    # wrapper, which otherwise stores an inconsistent shape that crashes the
+    # wave-status read path. Normalize to the bare list at this boundary.
+    if isinstance(flights_data, dict) and "flights" in flights_data:
+        flights_data = flights_data["flights"]
     store_flight_plan(flights_data, root)
     _safe_regenerate_dashboard(root)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,6 +225,20 @@ class TestCmdFlightPlan:
         fl = load_json(status_dir(project_root) / "flights.json")
         assert fl["flights"]["wave-1"] == SAMPLE_FLIGHTS
 
+    def test_flight_plan_tolerates_wrapped_object(self, project_root: Path) -> None:
+        """#632: a wrapped ``{"flights": [...]}`` object (the Prime prompt
+        sometimes emits the wrapper) is normalized to the bare array, not stored
+        as-is — otherwise wave-status reads back an inconsistent shape and the
+        CLI crashes. Must store identically to the bare-array form."""
+        import io
+        stdin_data = json.dumps({"flights": SAMPLE_FLIGHTS})
+        with patch("sys.stdin", io.StringIO(stdin_data)):
+            code = _run_cli(["flight-plan", "-"], project_root)
+        assert code == 0
+
+        fl = load_json(status_dir(project_root) / "flights.json")
+        assert fl["flights"]["wave-1"] == SAMPLE_FLIGHTS
+
     def test_flight_plan_regenerates_dashboard(self, project_root: Path, flights_file: Path) -> None:
         """Dashboard is regenerated after storing flights."""
         # Generate initial dashboard so we know it exists.


### PR DESCRIPTION
## Summary
A real crash fix. The `flight-plan` CLI (`wave_flight_plan`) expects a bare flights array, but the Prime prompt sometimes emits the wrapped `{"flights": [...]}` object — which stored an inconsistent shape and crashed the wave-status read path (`lesson_wave_flight_plan_schema`).

## Changes
- **`src/wave_status/__main__.py`** `_cmd_flight_plan`: normalize at the input boundary — if the parsed JSON is a `{"flights": [...]}` dict, unwrap to the bare list before `store_flight_plan`. Bare arrays unchanged. Robust regardless of prompt drift (which is probabilistic).
- **`tests/test_cli.py`**: `test_flight_plan_tolerates_wrapped_object` — the wrapped shape normalizes to the same stored result as the bare array.

## Test Plan
`pytest tests/test_cli.py::TestCmdFlightPlan` → 4 passed (3 existing + 1 new). `validate.sh` 158/0. Runs in the CI gate.

## Linked Issues
Closes #632. (Prompt-side always-write-bare is optional belt-and-suspenders; the CLI tolerance fixes the crash regardless.)