### PR TITLE
fix(disc): correct discord.json channel schema nested→flat

### DIFF
--- a/docs/discord-config.md
+++ b/docs/discord-config.md
@@ -15,10 +15,12 @@ their agents at their own Discord server without modifying source.
   "guild_id": "1234567890",
   "token_path": "~/secrets/discord-bot-token",
   "scream_hole_url": "http://scream-hole:3000",
+  "default_channel_id": "1487288523638837268",
+  "roll_call_channel_id": "1487382005036617851",
   "channels": {
-    "default":         { "name": "agent-ops",        "id": "1234567890" },
-    "roll-call":       { "name": "roll-call",        "id": "1234567890" },
-    "wave-status":     { "name": "wave-status",      "id": "1234567890" }
+    "agent-ops":   "1487288523638837268",
+    "roll-call":   "1487382005036617851",
+    "wave-status": "1487386934094462986"
   }
 }
 ```
@@ -30,9 +32,9 @@ their agents at their own Discord server without modifying source.
 | `guild_id` | string | Yes | Discord server (guild) ID |
 | `token_path` | string | No | Path to bot token file (default: `~/secrets/discord-bot-token`) |
 | `scream_hole_url` | string | No | Base URL of a [scream-hole](https://github.com/Wave-Engineering/scream-hole) proxy (e.g., `http://scream-hole:3000`). When set, `disc-server` MCP and `discord-watcher` route Discord REST API calls through the proxy instead of hitting Discord directly. Omit to use direct Discord API. |
-| `channels` | object | Yes | Map of channel roles to channel info |
-| `channels.<role>.name` | string | Yes | Human-readable channel name (without `#`) |
-| `channels.<role>.id` | string | Yes | Discord channel snowflake ID |
+| `default_channel_id` | string | Yes | Snowflake ID of the channel playing the **default** role |
+| `roll_call_channel_id` | string | Yes | Snowflake ID of the channel playing the **roll-call** role |
+| `channels` | object | Yes | **Flat** map of channel name → snowflake ID *string* (e.g. `{"agent-ops":"148…","roll-call":"148…"}`). Keyed by real Discord channel names, NOT roles; values are bare id strings, NOT nested objects. |
 
 ### Channel Roles
 
@@ -55,9 +57,9 @@ Every component reads configuration using a three-level fallback:
 | Variable | Overrides | Default |
 |----------|-----------|---------|
 | `DISCORD_GUILD_ID` | `guild_id` | `1486516321385578576` |
-| `DISCORD_DEFAULT_CHANNEL` | `channels.default.id` | `1487288523638837268` |
-| `DISCORD_ROLL_CALL_CHANNEL` | `channels.roll-call.id` | `1487382005036617851` |
-| `DISCORD_WAVE_STATUS_CHANNEL` | `channels.wave-status.id` | `1487386934094462986` |
+| `DISCORD_DEFAULT_CHANNEL` | `default_channel_id` | `1487288523638837268` |
+| `DISCORD_ROLL_CALL_CHANNEL` | `roll_call_channel_id` | `1487382005036617851` |
+| `DISCORD_WAVE_STATUS_CHANNEL` | `channels["wave-status"]` | `1487386934094462986` |
 | `DISCORD_TOKEN_PATH` | `token_path` | `~/secrets/discord-bot-token` |
 | `SCREAM_HOLE_URL` | `scream_hole_url` | *(disabled)* |
 

--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -527,24 +527,25 @@ cat > ~/.claude/discord.json << 'EOF'
 {
   "guild_id": "<collected>",
   "token_path": "<collected>",
+  "default_channel_id": "<id of the channel assigned the default role>",
+  "roll_call_channel_id": "<id of the channel assigned the roll-call role>",
   "channels": {
-    "default":         { "name": "<name>", "id": "<id>" },
-    "roll-call":       { "name": "<name>", "id": "<id>" },
-    "wave-status":     { "name": "<name>", "id": "<id>" }
+    "<default channel name>":   "<id>",
+    "<roll-call channel name>": "<id>",
+    "<wave-status channel name>": "<id>"
   }
 }
 EOF
 ```
 
-Only include `wave-status` if the user assigned it. The config must match the schema in `docs/discord-config.md`.
+Schema notes (must match `docs/discord-config.md`): `channels` is a **flat name→id string map** keyed by the real Discord channel names (NOT roles, NOT nested objects). The two mandatory roles are recorded as top-level pointers — `default_channel_id` / `roll_call_channel_id` — into that map. Only include `wave-status` in `channels` if the user assigned it.
 
 ### Step 7: Verify
 
-Send a test message to the default channel to confirm the full pipeline works. Resolve the channel ID and name from the just-written config (the `default` key in `channels` is a *role*, not a channel name — the actual Discord channel name and ID live under `.channels.default.id` / `.channels.default.name`):
+Send a test message to the default channel to confirm the full pipeline works. The default channel id is the top-level `default_channel_id` pointer:
 
 ```bash
-CHANNEL_ID=$(jq -r '.channels.default.id' ~/.claude/discord.json)
-CHANNEL_NAME=$(jq -r '.channels.default.name' ~/.claude/discord.json)
+CHANNEL_ID=$(jq -r '.default_channel_id' ~/.claude/discord.json)
 ```
 
 Then call:

--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -570,7 +570,7 @@ claude mcp list 2>/dev/null | grep -q discord-watcher
 
 This is informational — the setup is complete regardless. The watcher is needed for agents to receive Discord messages during sessions but isn't required for outbound `/disc` calls.
 
-- **If it works:** Confirm: *"Discord configuration complete. Test message sent to #<CHANNEL_NAME>. You can now use `/disc` to interact with your server."*
+- **If it works:** Confirm: *"Discord configuration complete. Test message sent to the default channel. You can now use `/disc` to interact with your server."*
 - **If it fails:** Help troubleshoot (permissions, channel ID mismatch, token issues). The config file has been written — the user can fix the issue and retry with `/ccwork setup discord`.
 
 See [Discord Configuration](docs/discord-config.md) for the full schema reference and per-team scoping strategies.

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -17,7 +17,13 @@ Route all /disc intents to `disc-server` MCP tool calls.
 
 **Resolve identity** — read `/tmp/claude-agent-<md5(project_root)>.json` for `dev_name`, `dev_avatar`, `dev_team` (defaults: Claude, 🤖, unknown).
 
-**Resolve channel/guild** — read `~/.claude/discord.json`: `.guild_id`, `.channels.default.id` (default: 1487288523638837268), `.channels["roll-call"].id` (default: 1487382005036617851). Use `disc_resolve(name, guild_id)` when given a channel name.
+**Resolve channel/guild** — read `~/.claude/discord.json`. `.channels` is a flat name→id **string** map (`{"general":"…","roll-call":"…"}`), so read:
+- guild → `.guild_id`
+- default channel → `.default_channel_id` (top-level)
+- roll-call channel → `.roll_call_channel_id` (top-level)
+- any named channel → `.channels["<name>"]` (the value IS the id string — do NOT append `.id`), or `disc_resolve(name, guild_id)` if the name isn't in the map.
+
+Last-resort fallbacks only if `discord.json` is missing the key: default `1487288523638837268`, roll-call `1487382005036617851`.
 
 **Route intent:**
 - send / check-in / no args → `disc_send(channel_id, "**<name>** <avatar> (<team>): <msg>")` — check-in sends to #roll-call
@@ -26,4 +32,4 @@ Route all /disc intents to `disc-server` MCP tool calls.
 - create channel → `disc_create_channel(guild_id, name)` — confirm with created id
 - create thread → `disc_create_thread(channel_id, name)` — confirm with created id
 
-**Turn-taking on shared channels** — before answering a team-addressed question when many agents are listening, follow the mic convention (claim the talking-stick or defer): `docs/discord-mic-convention.md`.
+**Turn-taking on shared channels** — before answering a team-addressed question when many agents are listening, follow the mic convention (claim the talking-stick or defer). Full convention: https://github.com/Wave-Engineering/claudecode-workflow/blob/main/docs/discord-mic-convention.md (in the cc-workflow repo at `docs/discord-mic-convention.md`; not deployed to the Cellar, so the bare relative path won't resolve from a non-repo session).


### PR DESCRIPTION
## Summary

The disc skill read `.channels.<role>.id` and ccwork *wrote* nested `channels.{default:{name,id}}`, but the canonical/live `~/.claude/discord.json` is **flat**: top-level `default_channel_id`/`roll_call_channel_id` + a flat `channels` map keyed by real channel names → id strings. So `/ccwork discord` produced configs the disc skill couldn't read, and disc channel resolution silently fell back to baked-in IDs. Surfaced by polyjuice's skill-staleness audit (#805); canonical flat schema verified three ways (live config, Discord-domain owner, and the channel-name-keyed map a nested schema can't represent).

## Changes

- **`skills/disc/SKILL.md`** (reader) — resolve `.default_channel_id` / `.roll_call_channel_id` / `.channels["<name>"]` (flat string, no `.id`); baked-in IDs demoted to last-resort; mic-convention pointer → resolvable GitHub URL (docs aren't deployed to the Cellar).
- **`skills/ccwork/SKILL.md`** (writer) — emits the flat schema (top-level role pointers + flat name→id map) instead of nested objects; verify snippet reads `.default_channel_id`.
- **`docs/discord-config.md`** (contract doc) — schema table, env-var override mappings, and the JSON example all flattened to match.

## Linked Issues

Closes #805

## Test Plan

- `./scripts/ci/validate.sh` — green (shellcheck, shfmt, py_compile, 32 SKILL frontmatters, 158 regression tests).
- `pytest tests/` — 1344 passed, 0 failed (4 skipped, 64 xfail expected).
- trivy — 0 HIGH/CRITICAL.
- code-review (opus) — 1 critical (a leftover nested JSON example) found and fixed; reader/writer key agreement cross-checked against the live flat config.