### PR TITLE
feat(reseed): auto-revive via durable SessionStart{clear} hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+- **`/reseed` auto-revive hook (#757).** `SessionStart{matcher:"clear"}` hook (`reseed-revive.sh`) injects the seed content into the fresh agent context and fires a tmux keystroke — no user action needed after `/reseed`. Flow: `/reseed` writes the seed, arms `<project_root>/.claude/reseed-armed.json` (seed_path + tmux_pane + mtime), then sends `/clear` to its own tmux pane via `tmux send-keys`. Hook fires on the fresh session: if armed file is fresh (< 5 min, by mtime — cross-project isolation via CWD-scoped path), seed content is injected via stdout (system-reminder) and `tmux send-keys "continue"` kicks the agent off. Stale armed files trigger a confirm-request instead. Armed file consumed on inject; seed file kept for manual recovery. No user action after `/reseed`; BJ never touches it again.
+
 ### Changed
 
 - Agent identity now stored at `<project_root>/.claude/agent-identity.json` (reboot-durable, gitignored) instead of `/tmp/claude-agent-<md5>.json`. All readers fall back to the legacy `/tmp` path during the transition window. Closes #723.

--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -88,6 +88,15 @@
             "command": "~/.claude/scripts/hooks/nerf/session-start-compact.sh"
           }
         ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/hooks/workflow/reseed-revive.sh"
+          }
+        ]
       }
     ],
     "PreCompact": [

--- a/scripts/hooks/workflow/reseed-revive.sh
+++ b/scripts/hooks/workflow/reseed-revive.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# reseed-revive.sh — CC SessionStart hook (matcher: "clear")
+#
+# Dormant unless an armed reseed file exists for this project. When armed
+# and fresh, injects the seed content into the fresh agent context (stdout)
+# and fires a tmux keystroke to kick the agent off — fully autonomous revival
+# with no user action after /reseed.
+#
+# Contract (CC SessionStart hook, matcher: "clear"):
+#   stdin:  JSON with .session_id, .cwd, .source
+#   stdout: injected as system-reminder into the fresh agent context
+#   exit:   always 0 (best-effort; never block session start)
+#
+# Armed file: <cwd>/.claude/reseed-armed.json
+#   { "session_id": "...", "seed_path": "...", "armed_at": "...", "tmux_pane": "..." }
+#
+# Safety gate: auto-revive ONLY when fresh (< 5 min mtime). CWD-scoping of
+# the armed file provides cross-project isolation; freshness provides temporal
+# isolation. Session ID is NOT checked — /clear starts a new session ID by
+# design, so old-vs-new ID is always a mismatch and would break every use.
+# Consume-don't-lose: armed file deleted after inject; seed file kept until agent confirms.
+#
+# Issue: cc-workflow#757
+
+LOG() { printf '[hooks/workflow/reseed-revive] %s\n' "$*" >&2; }
+
+FRESH_WINDOW_SECS=300 # 5 minutes
+
+INPUT=$(cat 2>/dev/null || true)
+HOOK_CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)
+HOOK_CWD="${HOOK_CWD:-$(pwd)}"
+
+ARMED_FILE="${HOOK_CWD}/.claude/reseed-armed.json"
+
+# --- No armed file → no-op ---
+if [[ ! -f "$ARMED_FILE" ]]; then
+	exit 0
+fi
+
+# --- Read armed metadata ---
+ARMED_JSON=$(cat "$ARMED_FILE" 2>/dev/null || true)
+SEED_PATH=$(printf '%s' "$ARMED_JSON" | jq -r '.seed_path // empty' 2>/dev/null || true)
+TMUX_PANE=$(printf '%s' "$ARMED_JSON" | jq -r '.tmux_pane // empty' 2>/dev/null || true)
+
+# --- Freshness check via mtime (portable: python3 preferred, date fallback) ---
+now=$(date +%s)
+file_mtime=$(python3 -c "import os,sys; print(int(os.path.getmtime(sys.argv[1])))" "$ARMED_FILE" 2>/dev/null ||
+	stat -c %Y "$ARMED_FILE" 2>/dev/null ||
+	stat -f %m "$ARMED_FILE" 2>/dev/null ||
+	echo 0)
+age_secs=$((now - file_mtime))
+is_fresh=false
+[[ $age_secs -lt $FRESH_WINDOW_SECS ]] && is_fresh=true
+
+# --- Seed file readable? ---
+if [[ -z "$SEED_PATH" || ! -f "$SEED_PATH" ]]; then
+	LOG "seed_path missing or unreadable ($SEED_PATH) — clearing armed file"
+	rm -f "$ARMED_FILE"
+	exit 0
+fi
+
+SEED_CONTENT=$(cat "$SEED_PATH" 2>/dev/null || true)
+
+if [[ "$is_fresh" == "true" ]]; then
+	# --- AUTO-REVIVE ---
+	# Inject seed content into fresh context; trigger agent via tmux
+	printf '[RESEED AUTO-REVIVE] Your context was seeded before /clear. Read the seed below, run /engage to confirm rules, then continue your work unblocked.\n\n%s\n' "$SEED_CONTENT"
+
+	# Kick the agent via tmux after a short delay for TUI init
+	if [[ -n "$TMUX_PANE" ]]; then
+		(sleep 2 && tmux send-keys -t "$TMUX_PANE" "continue" Enter) &
+		disown
+	else
+		LOG "no tmux pane available — agent will need manual trigger"
+	fi
+
+	# Consume armed file (seed file preserved until agent confirms)
+	rm -f "$ARMED_FILE"
+	LOG "auto-revived: seed injected, tmux trigger sent, armed file consumed"
+
+else
+	# --- CONFIRM REQUEST (stale armed file) ---
+	age_min=$((age_secs / 60))
+
+	printf '[RESEED PENDING — confirm required] An armed seed exists but auto-revive was skipped (stale: %dm old).\nSeed path: %s\nRun: Read "%s" and revive — or delete %s to discard.\n' \
+		"$age_min" "$SEED_PATH" "$SEED_PATH" "$ARMED_FILE"
+
+	# Nudge the agent to surface the confirm request
+	if [[ -n "$TMUX_PANE" ]]; then
+		(sleep 2 && tmux send-keys -t "$TMUX_PANE" "pending reseed — confirm or discard?" Enter) &
+		disown
+	fi
+
+	LOG "confirm-request injected: stale (${age_min}m)"
+fi
+
+exit 0

--- a/skills/reseed/SKILL.md
+++ b/skills/reseed/SKILL.md
@@ -82,29 +82,45 @@ dropped, and (b) verify every grant carries its *live status*, not just its orig
 This single pass is where the recall the first draft missed gets recovered — a state-focused
 seed under-captures on the first pass by construction, so the re-scan is not optional polish.
 
-## Step 2 — Write to the right path (durability caveat)
+## Step 2 — Write seed and arm the auto-revive hook
 
-**`/tmp` is reboot-wiped** (`lesson_tmp_identity_boot_wipe`). That is fine for a
-same-session readback, but a seed lost to a reboot leaves no revival path.
+Always write to a **durable path** (not `/tmp` — reboot-wiped per `lesson_tmp_identity_boot_wipe`):
 
-- **Same-session reduction** (the normal case) → `/tmp/<topic>-reseed.md` is fine
-  (name it for the work, e.g. `/tmp/workflows-migration-reseed.md`).
-- **Reduction might span a reboot** (long pause, end-of-day, anything where the
-  machine could cycle before revival) → write to a **durable path under
-  `.claude/`**, not `/tmp`.
+```bash
+project_root=$(pwd)
+seed_path="${project_root}/.claude/<topic>-reseed.md"
+```
 
-Surface this choice to the human; default to `/tmp` unless a reboot is plausible.
+After writing the seed, arm the hook so the next `/clear` auto-revives without any user action:
 
-## Step 3 — Hand off
+```bash
+project_root=$(pwd)
+cat > "${project_root}/.claude/reseed-armed.json" << EOF
+{
+  "seed_path": "${project_root}/.claude/<topic>-reseed.md",
+  "armed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "tmux_pane": "${TMUX_PANE:-}"
+}
+EOF
+```
 
-State the next human action unambiguously — the human is about to drop your
-context, so a missed instruction can't be re-asked:
+## Step 3 — Trigger the clear
+
+With the hook armed, trigger `/clear` immediately via tmux — do not ask the user to do it:
+
+```bash
+tmux send-keys -t "${TMUX_PANE}" "/clear" Enter
+```
+
+Then end your turn with a brief note:
+
+> "Seed written and armed. Clearing now — I'll auto-revive and continue."
+
+The `SessionStart{clear}` hook (`reseed-revive.sh`) fires on the fresh session, injects the seed content, and sends a `continue` keystroke. The agent revives and picks up where it left off — no user action needed.
+
+**If tmux is not available** (`$TMUX_PANE` empty): fall back to the manual flow:
 
 > "Seed written to `<path>`. Run `/clear`, then paste: `Read <path> and revive`."
-
-(Once the `SessionStart{clear}` auto-revive hook ships, this collapses further to
-"armed — just `/clear`," with the seed injected on revival. Until then, the paste
-is the deterministic path.)
 
 ## Important
 


### PR DESCRIPTION
## Summary

Eliminates the manual paste step at the end of `/reseed`. A new dormant `SessionStart{matcher:"clear"}` hook (`reseed-revive.sh`) fires on every `/clear`, injects the seed content into the fresh agent context, and sends a tmux keystroke to kick the agent off — no user action needed after `/reseed`.

## Changes

- `scripts/hooks/workflow/reseed-revive.sh` — new hook; dormant unless `<project_root>/.claude/reseed-armed.json` exists; injects seed via stdout + fires `tmux send-keys "continue"`; consumes armed file on inject, preserves seed file
- `config/settings.template.json` — add `SessionStart{matcher:"clear"}` entry
- `skills/reseed/SKILL.md` — Step 2 arms the hook; Step 3 triggers `/clear` via tmux directly; no manual paste
- `CHANGELOG.md` — Unreleased entry

## Linked Issues

Closes #757

## Test Plan

- `./scripts/ci/validate.sh`: 160/160 pass
- `python3 -m pytest tests/`: 1345 pass, 64 xfail, 2 xpass, exit 0
- `trivy fs`: 0 HIGH/CRITICAL
- Code review: 3 findings fixed (session_id check removed — new session ID is always different by design; `set -uo pipefail` dropped — conflicts with best-effort exit-0 contract; `stat -c` made portable via python3 mtime fallback chain)