### PR TITLE
fix(uninstall): --local removes project Cellar (.claude/scripts)

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -853,6 +853,10 @@ class TestLocalScopeInstall:
         assert not (project / ".claude" / "statusline-command.sh").exists(), (
             "project-local statusline not removed"
         )
+        # Project Cellar removed.
+        assert not (project / ".claude" / "scripts").exists(), (
+            "project-local Cellar (.claude/scripts) not removed by --local uninstall"
+        )
         # Global install never existed → still clean.
         assert list((home / ".claude" / "skills").iterdir()) == [], (
             "--local uninstall touched global skills"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -90,10 +90,12 @@ if [[ "$LOCAL_MODE" == true ]]; then
 	LOCAL_ROOT="$(pwd)"
 	SKILLS_DIR="$LOCAL_ROOT/.claude/skills"
 	SCRIPTS_DIR="$LOCAL_ROOT/.claude/bin"
+	CELLAR_DIR="$LOCAL_ROOT/.claude/scripts"
 	CLAUDE_DIR="$LOCAL_ROOT/.claude"
 else
 	SKILLS_DIR="$HOME/.claude/skills"
 	SCRIPTS_DIR="$HOME/.local/bin"
+	CELLAR_DIR="$HOME/.claude/scripts"
 	CLAUDE_DIR="$HOME/.claude"
 fi
 
@@ -161,6 +163,11 @@ if [[ "$REMOVE_SCRIPTS" == true ]]; then
 			[[ -d "$sub" ]] || continue
 			rmdir "$sub" 2>/dev/null || true
 		done
+	fi
+	# Remove the Cellar (script files; distinct from the symlink farm above).
+	# Global Cellar is shared with other tools; only remove it on --local.
+	if [[ "$LOCAL_MODE" == true ]]; then
+		do_remove "$CELLAR_DIR"
 	fi
 fi
 


### PR DESCRIPTION
## Summary
`./uninstall.sh --local` removed the symlink farm (`.claude/bin`) but left the project Cellar (`.claude/scripts`) behind. This restores symmetry with `./install --local`, which populates both.

## Changes
- Add `CELLAR_DIR` to both path-root branches in `uninstall.sh` (local: `<cwd>/.claude/scripts`, global: `$HOME/.claude/scripts`)
- Call `do_remove "$CELLAR_DIR"` in the scripts section, gated on `LOCAL_MODE=true` — global Cellar is intentionally left alone (shared state)
- Extend `test_local_uninstall` to assert `.claude/scripts` is gone after `--local` uninstall

## Linked Issues
Closes #780

## Test Plan
- `test_local_uninstall` extended and passes (29s)
- `TestLocalScopeInstall` (4 tests) all pass
- `./scripts/ci/validate.sh` PASS — 160 regression tests
- `pytest tests/` — 1345 passed, 4 skipped, 64 xfailed, 2 xpassed