### PR TITLE
feat(hooks): Godspeed decaying-mandate autonomy model (#818)

### DIFF
--- a/scripts/godspeed-lookback.sh
+++ b/scripts/godspeed-lookback.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# godspeed-lookback.sh — Godspeed mandate lookback utility.
+#
+# Scans a Claude Code JSONL transcript for the most-recent `godspeed` and
+# `HALT!` in user-role turns and emits the arm status. Sourced by both Stop
+# hooks; also runnable standalone with --demo or --eval.
+#
+# Output of godspeed_status():
+#   ARMED <d>     godspeed found d user turns ago; HALT! not newer
+#   HALTED        HALT! is newer than godspeed (or godspeed never appeared)
+#   UNARMED       no godspeed within the last N user turns
+#
+# Usage (sourced):
+#   source godspeed-lookback.sh
+#   result=$(godspeed_status /path/to/transcript.jsonl)
+#
+# Usage (standalone):
+#   ./godspeed-lookback.sh --demo                         # decision matrix
+#   ./godspeed-lookback.sh --eval /path/to/transcript     # evaluate file
+#   ./godspeed-lookback.sh --decide                       # read CC hook stdin
+#
+# Env:
+#   GODSPEED_WINDOW                  lookback window in user turns (default: 200)
+#   GODSPEED_VERIFIED_CONFIDENCE     confidence when test sentinel exists (default: 80)
+#   GODSPEED_UNVERIFIED_CONFIDENCE   confidence when no test sentinel (default: 40)
+#
+# Issue: cc-workflow#818
+
+# ---------------------------------------------------------------------------
+# godspeed_status <transcript_path>
+#
+# Scans the last GODSPEED_WINDOW user turns. Only user-role turns count —
+# assistant echoes of "godspeed" do not arm the mandate.
+# ---------------------------------------------------------------------------
+godspeed_status() {
+	local transcript_path="$1"
+	local N="${GODSPEED_WINDOW:-200}"
+
+	[[ -f "$transcript_path" ]] || {
+		echo "UNARMED"
+		return 0
+	}
+
+	# Read enough lines to cover N user turns. Each user turn has at least
+	# one line; with interleaved assistant/tool lines the real count is higher.
+	# 20× N + 500 is a conservative ceiling that stays fast.
+	local scan_lines=$((N * 20 + 500))
+
+	tail -n "$scan_lines" "$transcript_path" 2>/dev/null |
+		jq -rs --argjson N "$N" '
+      # Collect user turns that carry actual human text — exclude tool-result
+      # wrapper entries (type=="user" but content is tool_result blocks with no
+      # text).  Without this filter every tool result inflates d by 1, causing
+      # the mandate to age out far faster than intended.
+      [.[] | select(
+        .type == "user" and
+        ((.message.content // []) | map(select(.type == "text") | .text) | join("") | length > 0)
+      )] as $user_turns |
+
+      # Reverse so index 0 = most-recent user turn.
+      ($user_turns | reverse | to_entries) as $rev |
+
+      # Find the most-recent user turn containing \bgodspeed\b (case-sensitive,
+      # word-bounded). Assistant echoes are excluded because we already filtered
+      # to type=="user". Returns the first (most-recent) matching entry index,
+      # or -1 if none.
+      ($rev | map(select(
+        (.value.message.content // []) |
+        map(select(.type == "text") | .text) |
+        join(" ") |
+        test("\\bgodspeed\\b")
+      )) | first | .key // -1) as $gs_d |
+
+      # Find the most-recent user turn containing "HALT!" (exact, case-sensitive).
+      ($rev | map(select(
+        (.value.message.content // []) |
+        map(select(.type == "text") | .text) |
+        join(" ") |
+        test("HALT!")
+      )) | first | .key // -1) as $halt_d |
+
+      # Decision:
+      # - godspeed not found or aged out → UNARMED
+      # - HALT! is more recent (smaller d = closer to present) → HALTED
+      # - otherwise → ARMED <d>
+      if $gs_d == -1 or $gs_d >= $N then
+        "UNARMED"
+      elif $halt_d != -1 and $halt_d < $gs_d then
+        "HALTED"
+      else
+        "ARMED \($gs_d)"
+      end
+    ' 2>/dev/null || echo "UNARMED"
+}
+
+# ---------------------------------------------------------------------------
+# godspeed_decision <arm_status> <last_assistant_text> <session_id>
+#
+# Returns the decision given the arm status and context:
+#   GO     continue autonomously
+#   ASK <d> <bar_pct> <supplied_pct>    checkpoint — surface uncertainty
+#   STOP   gated axis hit — always surface regardless of mandate
+#   NOOP   hook stands down
+# ---------------------------------------------------------------------------
+godspeed_decision() {
+	local arm_status="$1"
+	local last_text="$2"
+	local session_id="${3:-}"
+	local N="${GODSPEED_WINDOW:-200}"
+	local verified_pct="${GODSPEED_VERIFIED_CONFIDENCE:-80}"
+	local unverified_pct="${GODSPEED_UNVERIFIED_CONFIDENCE:-40}"
+
+	# Hard gate — always fires regardless of mandate or loop state.
+	#
+	# Narrowed from the original pattern: removed `delete`, `drop`, `tag`,
+	# `wipe`, standalone `ship`/`publish`/`release` — all fire on benign
+	# narration (e.g. "I'll delete the temp file", "publish the docs"). The
+	# remaining words are specific enough to be unambiguous infra/ops indicators.
+	# `migrat[a-z]*` (was `migrat`) fixes the word-boundary false-negative on
+	# "migrate"/"migration".
+	local PATTERN_GATED_AXIS='(?i)\b(prod(?:uction)?|deploy[a-z]*|rollout|force[\- ]?push|go[\- ]?live|cut[\- ]?over|promote|rotate|tear[\- ]?down|irreversible|destroy[a-z]*|destructive|credential[a-z]*|secret[a-z]*|migrat[a-z]*|fleet[\- ]wide)\b|(merge|push)\s+(to\s+)?(main|master|prod)\b'
+	if printf '%s' "$last_text" | grep -Pq "$PATTERN_GATED_AXIS" 2>/dev/null; then
+		echo "STOP"
+		return 0
+	fi
+
+	# No mandate → hook stands down.
+	case "$arm_status" in
+	UNARMED | HALTED)
+		echo "NOOP"
+		return 0
+		;;
+	esac
+
+	# Mandate active — extract d and compute bar.
+	local d
+	d=$(echo "$arm_status" | awk '{print $2}')
+	local bar_pct=$((d * 100 / N))
+
+	# Verification sentinel (written by post-tool-test-sentinel.sh).
+	local sentinel="/tmp/claude-tests-ran-${session_id}"
+	local supplied_pct
+	if [[ -n "$session_id" && -s "$sentinel" ]]; then
+		supplied_pct="$verified_pct"
+	else
+		supplied_pct="$unverified_pct"
+	fi
+
+	if ((supplied_pct >= bar_pct)); then
+		echo "GO"
+	else
+		echo "ASK $d $bar_pct $supplied_pct"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# _godspeed_notify <kind> [d] [N]
+#
+# Notifies BJ via vox + Discord on STOP or ASK. Best-effort; never fails.
+# kind: "STOP" | "ASK"
+# ---------------------------------------------------------------------------
+_godspeed_notify() {
+	local kind="$1"
+	local d="${2:-?}"
+	local N="${GODSPEED_WINDOW:-200}"
+
+	# Agent identity (best-effort).
+	local identity_suffix=""
+	local identity_file=""
+	if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+		identity_file="${CLAUDE_PROJECT_DIR}/.claude/agent-identity.json"
+	fi
+	if [[ -f "$identity_file" ]] && command -v jq &>/dev/null; then
+		local dev_name dev_avatar dev_team
+		dev_name=$(jq -r '.dev_name // empty' "$identity_file" 2>/dev/null || true)
+		dev_avatar=$(jq -r '.dev_avatar // empty' "$identity_file" 2>/dev/null || true)
+		dev_team=$(jq -r '.dev_team // empty' "$identity_file" 2>/dev/null || true)
+		[[ -n "$dev_name" ]] && identity_suffix=" — **${dev_name}** ${dev_avatar} (${dev_team})"
+	fi
+
+	local vox_msg discord_msg
+	if [[ "$kind" == "STOP" ]]; then
+		vox_msg="Hey BJ, a Stop hook fired — gated axis detected. Check the terminal."
+		discord_msg="🛑 **Godspeed STOP** — gated axis detected in last assistant turn. Session paused.${identity_suffix}"
+	else
+		vox_msg="Hey BJ, godspeed mandate checkpoint — the agent has a question. Check the terminal."
+		discord_msg="⚠️ **Godspeed checkpoint** — mandate at d=${d}/N=${N}. Agent naming its uncertainty.${identity_suffix}"
+	fi
+
+	# vox (best-effort).
+	if command -v vox &>/dev/null; then
+		vox "$vox_msg" 2>/dev/null || true
+	fi
+
+	# Discord via stdlib python3 (no external deps).
+	local token_file="$HOME/secrets/discord-bot-token"
+	if [[ -f "$token_file" ]]; then
+		local token
+		token=$(tr -d '[:space:]' <"$token_file")
+		python3 -c "
+import urllib.request, json, sys
+token, channel_id, msg = sys.argv[1], '1518536836673310800', sys.argv[2]
+req = urllib.request.Request(
+    f'https://discord.com/api/v10/channels/{channel_id}/messages',
+    data=json.dumps({'content': msg}).encode(),
+    headers={'Authorization': f'Bot {token}', 'Content-Type': 'application/json'},
+    method='POST'
+)
+urllib.request.urlopen(req, timeout=5)
+" "$token" "$discord_msg" 2>/dev/null || true
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Standalone entrypoint (only when executed directly, not sourced).
+# ---------------------------------------------------------------------------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	case "${1:-}" in
+	--demo)
+		N="${GODSPEED_WINDOW:-200}"
+		V="${GODSPEED_VERIFIED_CONFIDENCE:-80}"
+		U="${GODSPEED_UNVERIFIED_CONFIDENCE:-40}"
+		echo "Godspeed decision matrix (N=${N}, verified=${V}%, unverified=${U}%)"
+		echo ""
+		printf "%-6s %-5s %-26s %-26s\n" "d" "bar%" "VERIFIED (tests green)" "UNVERIFIED"
+		printf "%-6s %-5s %-26s %-26s\n" "------" "-----" "------------------------" "------------------------"
+		for d in 0 25 50 100 150 190 200 250; do
+			if ((d > N)); then
+				printf "%-6s %-5s %-26s %-26s\n" "$d" "—" "NOOP (aged out)" "NOOP (aged out)"
+				continue
+			fi
+			bar=$((d * 100 / N))
+			v_out="GO"
+			((V < bar)) && v_out="ASK"
+			u_out="GO"
+			((U < bar)) && u_out="ASK"
+			((d == N)) && {
+				v_out="ASK"
+				u_out="ASK"
+			}
+			printf "%-6s %-5s %-26s %-26s\n" "$d" "${bar}%" "$v_out" "$u_out"
+		done
+		echo ""
+		echo "Overrides: gated-axis → STOP (any d);  HALT! newer than godspeed → NOOP"
+		;;
+
+	--eval)
+		transcript="${2:-}"
+		[[ -z "$transcript" ]] && {
+			echo "Usage: $0 --eval <transcript.jsonl>" >&2
+			exit 1
+		}
+		godspeed_status "$transcript"
+		;;
+
+	--decide)
+		INPUT=$(cat 2>/dev/null || true)
+		TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+		SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+		LAST_TEXT=$(
+			[[ -f "$TRANSCRIPT_PATH" ]] && tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
+				jq -rs '[.[] | select(.type == "assistant")] | last |
+					(.message.content // []) | map(select(.type == "text") | .text) | join(" ")
+				' 2>/dev/null || echo ""
+		)
+		ARM=$(godspeed_status "$TRANSCRIPT_PATH")
+		godspeed_decision "$ARM" "$LAST_TEXT" "$SESSION_ID"
+		;;
+
+	*)
+		echo "Usage: $0 [--demo | --eval <transcript> | --decide]" >&2
+		exit 1
+		;;
+	esac
+fi

--- a/scripts/precheck-asking-detector.sh
+++ b/scripts/precheck-asking-detector.sh
@@ -1,51 +1,53 @@
 #!/usr/bin/env bash
+# shellcheck source-path=SCRIPTDIR
 # precheck-asking-detector.sh — CC Stop hook.
 #
-# Detects when the assistant has just written a "shall I run /precheck?"
-# style question and forces the turn to continue with corrective context,
-# per CLAUDE.md MANDATORY: Pre-Commit Gate.
+# Detects when the assistant asks permission to run /precheck instead of
+# running it. Per CLAUDE.md MANDATORY: Pre-Commit Gate.
+#
+# Godspeed integration (cc-workflow#818):
+#   - ARMED: uses the decaying-mandate decision model instead of narrow regex.
+#     The mandate already covers "don't ask permission" broadly; the narrow
+#     precheck pattern is superseded.
+#   - UNARMED/HALTED: keeps the original narrow-regex behavior. This hook is
+#     cheap and targeted enough to remain active outside a mandate.
 #
 # Contract (Claude Code Stop hook):
 #   stdin:  JSON with .transcript_path, .session_id, .stop_hook_active
-#   stdout: JSON with {"decision":"block","reason":"..."} to force the
-#           assistant to continue this turn; empty stdout (exit 0) to no-op.
+#   stdout: JSON {"decision":"block","reason":"..."} to block; empty to pass
 #
 # Disable: export PRECHECK_ASKING_HOOK_DISABLED=1
 #
-# Performance budget: <50ms. Single jq pass over the tail of the transcript;
-# no MCP calls, no network, no file writes.
+# Performance budget: <100ms.
 #
-# Issue: cc-workflow#542 — paired with #541 prose tightening.
+# Issue: cc-workflow#542 / #545. Godspeed integration: cc-workflow#818.
 
 set -uo pipefail
 
-# Honor the kill-switch env var before any work.
 if [[ "${PRECHECK_ASKING_HOOK_DISABLED:-0}" == "1" ]]; then
 	exit 0
 fi
 
-# Read hook stdin.
+# Source the lookback utility.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/godspeed-lookback.sh"
+
 INPUT=$(cat 2>/dev/null || true)
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
 
 if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
 	exit 0
 fi
 
-# Pull the last assistant text content. The transcript is JSONL where each
-# line is an event. Reverse-iterate, take the first event of type=assistant
-# with role=assistant, concat all blocks where .type == "text" (skipping
-# thinking and tool_use blocks — thinking is not user-visible and tool_use
-# has no .text). Limit to the last 200 lines for performance; an asking
-# message will always be the most recent assistant turn.
 LAST_ASSISTANT_TEXT=$(
 	tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
 		jq -rs '
-        [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
-        | last
-        | (.message.content // [])
-        | map(select(.type == "text") | .text)
-        | join(" ")
+      [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
+      | last
+      | (.message.content // [])
+      | map(select(.type == "text") | .text)
+      | join(" ")
     ' 2>/dev/null
 )
 
@@ -53,40 +55,32 @@ if [[ -z "$LAST_ASSISTANT_TEXT" || "$LAST_ASSISTANT_TEXT" == "null" ]]; then
 	exit 0
 fi
 
-# Three alternations:
-#   1. Interrogative — trigger word (shall/should/can/may/do you want me to/
-#      ready for|to) within ~40 chars of "precheck", ending with "?" within
-#      ~80 chars. Catches direct asking like "Shall I run /precheck?".
-#   2. Deferral — "let me know" idiom near "precheck", no "?" required.
-#      Catches "Let me know when I should run precheck." which is asking by
-#      deferral.
-#   3. Inverted — "precheck" appears BEFORE the trigger word (broadened
-#      trigger set: should/shall/need/ready/appropriate), within the same
-#      sentence (no sentence-terminating punctuation between), ending with
-#      "?". Catches "Is /precheck something I should run?", "Would /precheck
-#      be appropriate here?", "Precheck — should I do that now?". The
-#      sentence-boundary character class ([^.?!\n]) is the false-positive
-#      guard for cases like "/precheck completed. Should I commit now?" —
-#      the period severs precheck from the trigger word so the inverted
-#      pattern declines to fire. Issue cc-workflow#545.
-# All case-insensitive. Negative cases the regex must NOT match: past-tense
-# precheck mentions, different-command questions ("Shall I run /scp?"),
-# distant trigger-and-precheck pairs, and ordinary checklist text.
-#
-# Falsy edge: an assistant message documenting the rule by quoting a
-# forbidden phrase will trigger the hook. The PRECHECK_ASKING_HOOK_DISABLED
-# kill-switch exists for those cases.
-PATTERN_INTERROGATIVE='(?i)\b(shall|should|can|may|do you want me to|ready (for|to))\b.{0,40}/?precheck.{0,80}\?'
-PATTERN_DEFERRAL='(?i)\blet me know\b.{0,40}/?precheck'
-PATTERN_INVERTED='(?i)/?precheck[^.?!\n]{0,40}\b(should|shall|need|ready|appropriate)\b[^.?!\n]{0,40}\?'
+ARM_STATUS=$(godspeed_status "$TRANSCRIPT_PATH")
 
-if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_INTERROGATIVE" 2>/dev/null ||
-	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_DEFERRAL" 2>/dev/null ||
-	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_INVERTED" 2>/dev/null; then
-	cat <<'JSON'
-{"decision":"block","reason":"Per CLAUDE.md MANDATORY Pre-Commit Gate: don't ask whether to run /precheck — run it. The checklist that /precheck presents is the approval gate; the start of /precheck is unilateral. Continue this turn by invoking /precheck now."}
-JSON
+case "$ARM_STATUS" in
+
+ARMED*)
+	# Mandate active: stop-action-bias-detector.sh owns the full mandate
+	# decision model and all notifications. Stand down here to avoid duplicate
+	# blocks and double Discord/vox pings. When the mandate is in effect the
+	# action-bias hook already covers "don't ask permission" broadly.
 	exit 0
-fi
+	;;
 
-exit 0
+*)
+	# UNARMED / HALTED: original narrow-regex behavior.
+	# Three patterns for "asking whether to run /precheck":
+	#   1. Interrogative  — trigger word within ~40 chars of "precheck", ending "?"
+	#   2. Deferral       — "let me know" idiom near "precheck"
+	#   3. Inverted       — "precheck" before the trigger word, same sentence, ending "?"
+	PATTERN_INTERROGATIVE='(?i)\b(shall|should|can|may|do you want me to|ready (for|to))\b.{0,40}/?precheck.{0,80}\?'
+	PATTERN_DEFERRAL='(?i)\blet me know\b.{0,40}/?precheck'
+	PATTERN_INVERTED='(?i)/?precheck[^.?!\n]{0,40}\b(should|shall|need|ready|appropriate)\b[^.?!\n]{0,40}\?'
+
+	if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_INTERROGATIVE" 2>/dev/null ||
+		printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_DEFERRAL" 2>/dev/null ||
+		printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_INVERTED" 2>/dev/null; then
+		printf '{"decision":"block","reason":"Per CLAUDE.md MANDATORY Pre-Commit Gate: do not ask whether to run /precheck — run it. The checklist that /precheck presents is the approval gate; the start of /precheck is unilateral. Continue this turn by invoking /precheck now."}\n'
+	fi
+	;;
+esac

--- a/scripts/stop-action-bias-detector.sh
+++ b/scripts/stop-action-bias-detector.sh
@@ -1,25 +1,32 @@
 #!/usr/bin/env bash
+# shellcheck source-path=SCRIPTDIR
 # stop-action-bias-detector.sh — CC Stop hook.
 #
-# Detects when the assistant ends a turn by handing a decision back to the
-# user ("want me to proceed?", "should I…?", "shall I…?") instead of acting
-# on something it already knows how to do. Forces the turn to continue with
-# a default-to-action reminder, per CLAUDE.md MANDATORY: Default to Action.
+# Implements the Godspeed decaying-mandate autonomy model (cc-workflow#818),
+# replacing the fuzzy-regex permission-asking detection that false-positived
+# on legitimate gates and questions.
 #
-# This is the GENERAL sibling of precheck-asking-detector.sh (#542), which
-# catches the precheck-specific case. Same Stop-hook contract and budget.
+# Decision model:
+#   1. Gated-axis present (prod/deploy/irreversible) → STOP + notify BJ
+#   2. No mandate (UNARMED/HALTED) → NOOP; hook stands down entirely
+#   3. Mandate active (godspeed in last N user turns):
+#      bar = d/N (d = user turns since godspeed)
+#      supplied = 80% if test sentinel exists, else 40%
+#      supplied >= bar → GO (continue autonomously, no block)
+#      supplied <  bar → ASK (block + checkpoint prompt; model names gap for BJ)
+#
+# Arm:  type `godspeed` in any user turn → mandate active
+# Halt: type `HALT!` (exact) → mandate cancelled until next godspeed
 #
 # Contract (Claude Code Stop hook):
 #   stdin:  JSON with .transcript_path, .session_id, .stop_hook_active
-#   stdout: JSON with {"decision":"block","reason":"..."} to force the
-#           assistant to continue this turn; empty stdout (exit 0) to no-op.
+#   stdout: JSON {"decision":"block","reason":"..."} to block; empty to pass
 #
 # Disable: export STOP_ACTION_BIAS_HOOK_DISABLED=1
 #
-# Performance budget: <50ms. Single jq pass over the tail of the transcript;
-# no MCP calls, no network, no file writes.
+# Performance budget: <100ms. jq scan + optional discord/vox on STOP/ASK.
 #
-# Issue: cc-workflow#732 — paired with the CLAUDE.md prose rule (same issue).
+# Issue: cc-workflow#818. Predecessor: cc-workflow#732/#776.
 
 set -uo pipefail
 
@@ -28,33 +35,27 @@ if [[ "${STOP_ACTION_BIAS_HOOK_DISABLED:-0}" == "1" ]]; then
 	exit 0
 fi
 
+# Source the lookback utility from the same directory as this hook.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/godspeed-lookback.sh"
+
 INPUT=$(cat 2>/dev/null || true)
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)
-
-# Loop guard: if this Stop hook already fired this turn (the assistant was
-# already nudged and still chose to end on a permission-ask), allow the stop.
-# A genuine gate re-affirmed after one reminder is respected — the hook kills
-# the REFLEXIVE ask, not the deliberate one.
-STOP_HOOK_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || true)
-if [[ "$STOP_HOOK_ACTIVE" == "true" ]]; then
-	exit 0
-fi
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
 
 if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
 	exit 0
 fi
 
-# Last assistant text (concat text blocks of the most recent assistant turn;
-# skip thinking + tool_use). Last 200 lines is plenty — a permission-ask is
-# always the most recent assistant message.
+# Extract the last assistant turn text (skip thinking and tool_use blocks).
 LAST_ASSISTANT_TEXT=$(
 	tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
 		jq -rs '
-        [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
-        | last
-        | (.message.content // [])
-        | map(select(.type == "text") | .text)
-        | join(" ")
+      [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
+      | last
+      | (.message.content // [])
+      | map(select(.type == "text") | .text)
+      | join(" ")
     ' 2>/dev/null
 )
 
@@ -62,64 +63,58 @@ if [[ -z "$LAST_ASSISTANT_TEXT" || "$LAST_ASSISTANT_TEXT" == "null" ]]; then
 	exit 0
 fi
 
-# Permission-ask / decision-handback tells — scoped DELIBERATELY to
-# permission-seeking phrasings, NOT to all questions. A genuine information-
-# seeking question or an architectural fork ("Should I use Postgres or MySQL?",
-# "Which schema should I target?") asks the user to CHOOSE or to supply a FACT —
-# those are legitimate stops the rule protects, and must NOT fire. The failure
-# class is asking PERMISSION TO ACT on something already known.
-#   - PATTERN_PROCEED: "want me to … ?" forms — inherently permission-to-act.
-#   - PATTERN_PERMIT:  "should/shall I" ONLY when followed by an action/permission
-#     verb (proceed, merge, deploy, …). This is the load-bearing guard (#732
-#     review C1): bare "should I" introduces just as many forks/clarifications as
-#     permission-asks, so it is excluded — only the verb-gated form matches, so
-#     "should I use X or Y?" / "which X should I target?" correctly pass through.
-# Each requires a "?" within proximity (no sentence terminator [^.?!\n] between)
-# so a mid-sentence mention doesn't fire. Case-insensitive.
-PATTERN_PROCEED='(?i)\b(want me to|do you want me to|would you like me to|ready (for me to|to proceed))\b[^.?!\n]{0,60}\?'
-PATTERN_PERMIT='(?i)\b(should|shall) i\s+(go ahead|proceed|continue|start|begin|merge|deploy|push|run|commit|create|land|ship|kick off|move on|do (it|that|this|so))\b[^.?!\n]{0,40}\?'
-PATTERN_WORD='(?i)\b(just )?say the word\b' # unanchored like the sibling's edge; kill-switch covers quoted-rule prose
-PATTERN_DEFER='(?i)\blet me know\b[^.?!\n]{0,30}\b(if|whether|when)\b[^.?!\n]{0,30}\b(you want|i should|to proceed|go ahead)\b'
+# Get mandate status.
+ARM_STATUS=$(godspeed_status "$TRANSCRIPT_PATH")
 
-if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_PROCEED" 2>/dev/null ||
-	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_PERMIT" 2>/dev/null ||
-	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_WORD" 2>/dev/null ||
-	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_DEFER" 2>/dev/null; then
-	cat <<'JSON'
-{"decision":"block","reason":"Per CLAUDE.md MANDATORY: Default to Action — you ended by asking permission to do something. If you already know what to do and it is safe, understood, and in your lane, DO IT now instead of asking; stopping blocks everyone downstream and spends the user's attention. Stop ONLY for a genuinely new irreversible/prod action the user has NOT already agreed to, or a real architectural fork. Agreement persists — completing work the user already directed is not a new gate. If this IS a legitimate gate, continue the turn and state it plainly as a gate with the specific reason; otherwise continue by taking the action."}
-JSON
+# Compute the decision.
+DECISION_LINE=$(godspeed_decision "$ARM_STATUS" "$LAST_ASSISTANT_TEXT" "$SESSION_ID")
+DECISION=$(echo "$DECISION_LINE" | awk '{print $1}')
+
+case "$DECISION" in
+
+STOP)
+	# Loop guard: if the hook already blocked this turn, stand down so the
+	# model can answer the prod-gate prompt without triggering another block.
+	STOP_HOOK_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || true)
+	if [[ "$STOP_HOOK_ACTIVE" == "true" ]]; then
+		exit 0
+	fi
+	_godspeed_notify "STOP"
+	printf '{"decision":"block","reason":"[godspeed-STOP] Gated axis detected (prod/deploy/irreversible keyword). This action requires explicit user approval — surface it to BJ before proceeding. The Godspeed mandate does not override the ABSOLUTE prod rule."}\n'
+	;;
+
+NOOP)
+	# No mandate active; hook stands down. Normal call-and-response.
 	exit 0
-fi
+	;;
 
-# --- concluded ∧ asked (cc-workflow#776 / fleet incident 2026-06-21) ---------
-# A subtler over-pause than the bare permission-ask above: the turn STATES a
-# team-converged conclusion AND asks the user to ratify it in the SAME message
-# ("we converged … BJ, your call?"). For an already-converged decision in the
-# agent's delegated lane, the converging IS the green light; routing it back to
-# the user for ratify is the over-pause. Requires the CONJUNCTION (conclusion
-# marker AND ratify-ask) so a bare prod gate ("BJ — your call on the prod
-# push?"), which has no conclusion marker, does NOT fire and stays surfaced.
-PATTERN_CONCLUSION='(?i)\b(converged|convergence|agreed|aligned|endorsed|locked in|the right move|only logical|consensus|we (all )?agree|team[\- ]converged)\b'
-PATTERN_RATIFY='(?i)\b(BJ|@?schwifty7759)\b[^.?!\n]{0,40}\b(ratify|approve|your (call|nod|go|go-ahead|read|move|sign[\- ]?off|concur))\b[^.?!\n]{0,10}\?'
-# SAFETY negative-guard (cc-workflow#776): never fire when a genuinely-gated axis
-# (prod / deploy / release / ship / go-live / force-push / irreversible / secrets /
-# migration / …) appears ANYWHERE in the turn. NOTE: this matches the whole
-# message, not only the ratify-ask clause — an unrelated mention of a gated term
-# also suppresses. That is deliberately the SAFE direction: this hook's "block"
-# PUSHES the agent to act, so firing on a real prod gate would push an unapproved
-# prod action, violating CLAUDE.md's ABSOLUTE prod rule. A missed nudge
-# (false-negative) is cheap; pushing prod (false-positive) is not — so the axis
-# list is intentionally over-broad. Applied ONLY to this new case — the
-# permission-ask patterns above legitimately catch "should I merge/push?".
-PATTERN_GATED_AXIS='(?i)\b(prod|production|deploy|release|rollout|ship|cut[\- ]?over|go[\- ]?live|force[\- ]?push|publish|promote|rotate|tear[\- ]?down|irreversible|destroy|destructive|drop|wipe|delete|secret|credential|migrat|tag|merge to (main|master|prod)|fleet[\- ]wide)\b'
-
-if printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_CONCLUSION" 2>/dev/null &&
-	printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_RATIFY" 2>/dev/null &&
-	! printf '%s' "$LAST_ASSISTANT_TEXT" | grep -Pq "$PATTERN_GATED_AXIS" 2>/dev/null; then
-	cat <<'JSON'
-{"decision":"block","reason":"Per CLAUDE.md MANDATORY: Default to Action + standing authority — you stated a team-converged conclusion AND asked the user to ratify it in the same turn (the concluded-and-asked over-pause). For an already-converged decision in your delegated lane (non-prod, team-aligned, within your standing authority), the converging IS the green light; surfacing it for ratify is the over-pause. Stop ONLY for: (a) a genuinely new irreversible/prod action the user has NOT already agreed to; (b) a real fork where the user's choice changes what gets built; (c) novel risk requiring user-judgment they hold. Otherwise continue by taking the action."}
-JSON
+GO)
+	# Mandate active and confidence meets the bar. Continue autonomously.
 	exit 0
-fi
+	;;
 
-exit 0
+ASK)
+	# Mandate active but confidence is below bar. Block and emit checkpoint.
+	# The model's one-liner names its uncertainty for BJ — not re-evaluated by
+	# the hook. BJ's next turn is the resolution.
+	local_d=$(echo "$DECISION_LINE" | awk '{print $2}')
+	local_bar=$(echo "$DECISION_LINE" | awk '{print $3}')
+	local_supplied=$(echo "$DECISION_LINE" | awk '{print $4}')
+	N_val="${GODSPEED_WINDOW:-200}"
+
+	# Loop guard first: if the hook already blocked once this turn, stand down.
+	# (The model answered the checkpoint; don't notify again or pile on.)
+	STOP_HOOK_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || true)
+	if [[ "$STOP_HOOK_ACTIVE" == "true" ]]; then
+		exit 0
+	fi
+
+	_godspeed_notify "ASK" "$local_d" "$N_val"
+	printf '{"decision":"block","reason":"[godspeed-checkpoint] Mandate at d=%s/N=%s (bar=%s%%, supplied=%s%%). State in one sentence what you are uncertain about — specifically: is it (a) execution correctness, (b) scope alignment, or (c) side-effects? If genuinely confident, say so and continue."}\n' \
+		"$local_d" "$N_val" "$local_bar" "$local_supplied"
+	;;
+
+*)
+	exit 0
+	;;
+esac

--- a/tests/regression/test_stop_action_bias_detector.sh
+++ b/tests/regression/test_stop_action_bias_detector.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
-# test_stop_action_bias_detector.sh — regression tests for the Stop hook that
-# detects permission-ask / decision-handback phrasings ("want me to proceed?",
-# "should I…?") and blocks the stop with a default-to-action reminder.
+# test_stop_action_bias_detector.sh — regression tests for the Godspeed
+# decaying-mandate Stop hook (cc-workflow#818).
 #
 # Hook source: scripts/stop-action-bias-detector.sh
-# Issue: cc-workflow#732 (general sibling of #542 precheck-asking-detector)
+#
+# Behavioral contract (#818, replaces #732/#776 fuzzy-regex model):
+#
+#   UNARMED / HALTED (no active godspeed mandate):
+#     - ALL permission-ask phrasings ("Want me to?", "Should I?", etc.)  → NOOP
+#       (hook stands down; no block).  This is the intentional replacement
+#       for the old fuzzy-regex behavior that over-fired on legitimate gates.
+#     - Gated-axis keywords (prod/deploy/force-push/irreversible/…) → STOP
+#       (ABSOLUTE prod rule fires regardless of mandate state).
+#
+#   ARMED (godspeed typed in a recent user turn):
+#     - d=0 (godspeed is the most-recent user turn), bar=0%  → GO (no block).
+#     - Gated-axis keyword in last assistant turn              → STOP (block).
+#
+#   Loop guard: stop_hook_active=true → always silent (no re-block).
+#   Kill-switch: STOP_ACTION_BIAS_HOOK_DISABLED=1 → always silent.
+#   Missing transcript                             → always silent.
 #
 # Strategy: build minimal CC-transcript JSONL fixtures, pipe the hook input
 # contract (stdin JSON with .transcript_path [, .stop_hook_active]) through
@@ -22,112 +37,162 @@ if [[ ! -x "$HOOK" ]]; then
 	exit 1
 fi
 
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+TMPDIR_LOCAL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
 
 PASSES=0
 FAILS=0
-pass() {
-	echo "  [PASS] $*"
-	PASSES=$((PASSES + 1))
-}
-fail() {
-	echo "  [FAIL] $*"
-	FAILS=$((FAILS + 1))
-}
+pass() { echo "  [PASS] $*"; PASSES=$((PASSES + 1)); }
+fail() { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
 
-make_transcript() {
+# ─── transcript builders ────────────────────────────────────────────────────
+
+# Transcript with a single assistant turn (UNARMED state).
+make_unarmed_transcript() {
 	local label="$1" text="$2"
-	local path="$TMPDIR/transcript-$label.jsonl"
-	jq -nc --arg text "$text" '{
+	local path="$TMPDIR_LOCAL/t-unarmed-$label.jsonl"
+	jq -nc --arg t "$text" '{
         type: "assistant",
-        message: { role: "assistant", content: [ { type: "text", text: $text } ] }
+        message: {role: "assistant", content: [{type: "text", text: $t}]}
     }' >"$path"
 	echo "$path"
 }
 
-run_hook() { # $1 transcript_path  [$2 stop_hook_active]
+# Transcript with a user "godspeed" turn followed by an assistant turn
+# (ARMED d=0 state).
+make_armed_transcript() {
+	local label="$1" text="$2"
+	local path="$TMPDIR_LOCAL/t-armed-$label.jsonl"
+	jq -nc '{type: "user", message: {role: "user", content: [{type: "text", text: "godspeed"}]}}' >"$path"
+	jq -nc --arg t "$text" '{
+        type: "assistant",
+        message: {role: "assistant", content: [{type: "text", text: $t}]}
+    }' >>"$path"
+	echo "$path"
+}
+
+run_hook() { # $1 transcript_path  [$2 stop_hook_active=false]
 	jq -nc --arg p "$1" --argjson active "${2:-false}" \
 		'{transcript_path: $p, session_id: "test", stop_hook_active: $active}' | "$HOOK"
 }
 
 assert_blocks() {
 	local label="$1" text="$2" path out
-	path=$(make_transcript "$label" "$text")
+	path=$(make_unarmed_transcript "$label" "$text")
 	out=$(run_hook "$path")
-	if [[ "$out" == *'"decision":"block"'* ]]; then pass "blocks: $label"; else fail "should-block: $label — got: ${out:-<empty>}"; fi
+	if [[ "$out" == *'"decision":"block"'* ]]; then
+		pass "blocks: $label"
+	else
+		fail "should-block: $label — got: ${out:-<empty>}"
+	fi
 }
 
 assert_passes() {
 	local label="$1" text="$2" path out
-	path=$(make_transcript "$label" "$text")
+	path=$(make_unarmed_transcript "$label" "$text")
 	out=$(run_hook "$path")
-	if [[ -z "$out" || "$out" != *'"decision":"block"'* ]]; then pass "passes:  $label"; else fail "should-pass: $label — got: $out"; fi
+	if [[ -z "$out" || "$out" != *'"decision":"block"'* ]]; then
+		pass "passes: $label"
+	else
+		fail "should-pass: $label — got: $out"
+	fi
 }
 
-# --- Positive cases — permission-asks the hook MUST block --------------------
-assert_blocks "want_me_to" "The deploy is ready. Want me to proceed?"
-assert_blocks "should_i" "Both blockers are merged. Should I proceed?"
-assert_blocks "shall_i" "Shall I go ahead and merge it?"
-assert_blocks "do_you_want" "Do you want me to redeploy to the fleet?"
-assert_blocks "ready_for_me" "Ready for me to start #722?"
-assert_blocks "would_you_like" "Would you like me to take the next one?"
-assert_blocks "say_the_word" "It's all staged — just say the word."
-assert_blocks "let_me_know_defer" "Let me know whether you want me to continue."
+assert_armed_blocks() {
+	local label="$1" text="$2" path out
+	path=$(make_armed_transcript "$label" "$text")
+	out=$(run_hook "$path")
+	if [[ "$out" == *'"decision":"block"'* ]]; then
+		pass "blocks-armed: $label"
+	else
+		fail "should-block-armed: $label — got: ${out:-<empty>}"
+	fi
+}
 
-# --- Negative cases — the hook MUST NOT block -------------------------------
-# Information-seeking questions (asking about a FACT, not permission to act).
-assert_passes "info_which_db" "Which database are you using for this service?"
-assert_passes "info_budget" "What token budget should this campaign target?"
-assert_passes "info_fork" "Two viable approaches here — per-wave or per-plan kahuna. Which do you want?"
-# #732 review C1: architectural forks / clarifications phrased with "should I" are
-# LEGITIMATE stops the rule protects — the verb-gating on PATTERN_PERMIT must let
-# them pass (bare "should I <non-action-verb>" never fires).
-assert_passes "should_i_fork" "Should I use Postgres or MySQL for this service?"
-assert_passes "should_i_which_file" "Which file should I edit — the template or the generated copy?"
-assert_passes "should_i_assume" "Should I assume us-east-1 as the region here?"
-assert_passes "should_i_target" "Which schema should I target for the migration?"
-# Statements / no question mark.
-assert_passes "statement_proceeding" "Both blockers are merged; I'm proceeding with the redeploy now."
-assert_passes "no_qmark" "I can start #722 next."
-# A legitimate gate stated AS a gate (no permission phrasing) is allowed.
-assert_passes "gate_stated" "This is a prod deploy you haven't agreed to in this conversation; I'm holding for your explicit go on prod specifically."
-# Distance / unrelated.
-assert_passes "distant" "I want this done right, so the details matter and I checked them all carefully."
+assert_armed_passes() {
+	local label="$1" text="$2" path out
+	path=$(make_armed_transcript "$label" "$text")
+	out=$(run_hook "$path")
+	if [[ -z "$out" || "$out" != *'"decision":"block"'* ]]; then
+		pass "passes-armed: $label"
+	else
+		fail "should-pass-armed: $label — got: $out"
+	fi
+}
 
-# --- concluded-and-asked (cc-workflow#776) — conclusion + ratify-ask conjunction
-# A team-converged conclusion AND a ratify-ask in the same turn is the over-pause.
-assert_blocks "concluded_asked" "We've converged and the team is aligned — this is the right move. BJ, your call?"
-assert_blocks "concluded_asked_schwifty" "Consensus reached on the approach. @schwifty7759, your go-ahead to ratify?"
-# Conjunction is required: conclusion-only or ratify-only must NOT fire.
-assert_passes "conclusion_only" "The team converged on the approach and we're fully aligned."
-assert_passes "ratify_only" "BJ, your call on this one?"
-# SAFETY: concluded + ratify-ask on a GATED axis (prod/deploy/release/secrets/migration)
-# must NOT fire — the block pushes the agent to ACT, and pushing an unapproved prod
-# action violates the ABSOLUTE prod rule. A false-negative here is the safe direction.
-assert_passes "concluded_asked_prod" "We converged on the rollout approach — BJ, your call on the prod deploy?"
-assert_passes "concluded_asked_release" "Team is aligned on the cut. @schwifty7759, approve the release?"
-assert_passes "concluded_asked_secrets" "We agreed on the secret-rotation plan — BJ, your go-ahead?"
-# Extended gated-axis (code-review #2): ship / go-live / force-push are prod-shaped.
-assert_passes "concluded_asked_ship" "We converged — this is the right move. BJ, your go-ahead to ship it?"
-assert_passes "concluded_asked_golive" "Team is aligned on the cut. @schwifty7759, your call to go live?"
-assert_passes "concluded_asked_forcepush" "We agreed on the rebase plan. BJ, approve the force-push to main?"
+# ─── UNARMED: hook stands down on all non-gated phrasings ───────────────────
+# All of the following used to block under the old fuzzy-regex model (#732).
+# #818 intentionally removes this enforcement in UNARMED state to eliminate
+# false positives.  The precheck-asking-detector.sh retains narrow enforcement
+# for the specific "shall I run /precheck?" pattern.
 
-# --- Loop guard: stop_hook_active=true → allow the stop even on positive input
-label="loop_guard"
-path=$(make_transcript "$label" "Want me to proceed?")
+assert_passes "unarmed_permission_ask"    "The work is complete. Want me to proceed?"
+assert_passes "unarmed_should_i"          "Both blockers are merged. Should I proceed?"
+assert_passes "unarmed_shall_i"           "Shall I go ahead and merge it?"
+assert_passes "unarmed_do_you_want"       "Do you want me to redeploy to the fleet?"
+assert_passes "unarmed_concluded_asked"   "We've converged and the team is aligned — BJ, your call?"
+assert_passes "unarmed_info_question"     "Which database are you using for this service?"
+assert_passes "unarmed_statement"         "Both blockers are merged; I'm proceeding with the redeploy now."
+
+# ─── UNARMED: gated-axis keywords → STOP (ABSOLUTE prod rule) ───────────────
+# These must block regardless of mandate state.
+
+assert_blocks "unarmed_gated_production"  "I'm about to push this to production."
+assert_blocks "unarmed_gated_deploy"      "Ready to deploy this to the cluster."
+assert_blocks "unarmed_gated_force_push"  "I'll need to force-push to main to fix this."
+assert_blocks "unarmed_gated_irreversible" "This is an irreversible operation; proceeding."
+assert_blocks "unarmed_gated_credential"  "I'll rotate the credentials now."
+assert_blocks "unarmed_gated_destroy"     "Running terraform destroy on the staging env."
+assert_blocks "unarmed_gated_migrate"     "Starting the database migration now."
+
+# ─── ARMED (d=0): non-gated text → GO (mandate fresh, bar=0%) ───────────────
+
+assert_armed_passes "armed_fresh_normal"         "I'll run the tests now."
+assert_armed_passes "armed_fresh_permission_ask" "Want me to proceed with the next step?"
+assert_armed_passes "armed_fresh_info"           "Looking at the config file."
+
+# ─── ARMED (d=0): gated-axis text → STOP ────────────────────────────────────
+
+assert_armed_blocks "armed_gated_production"  "I'm going to push this to production."
+assert_armed_blocks "armed_gated_deploy"      "Deploying the new image to the cluster."
+assert_armed_blocks "armed_gated_force_push"  "I need to force-push to main here."
+
+# ─── Loop guard: stop_hook_active=true → always silent ───────────────────────
+label="loop_guard_gated"
+path=$(make_unarmed_transcript "$label" "I'm about to push to production.")
 out=$(run_hook "$path" true)
-if [[ -z "$out" ]]; then pass "loop-guard: stop_hook_active=true → silent (no double-block)"; else fail "loop-guard: should be silent, got: $out"; fi
+if [[ -z "$out" ]]; then
+	pass "loop-guard: stop_hook_active=true on gated text → silent"
+else
+	fail "loop-guard: should be silent even on gated text, got: $out"
+fi
 
-# --- Kill-switch env --------------------------------------------------------
-label="disabled_env"
-path=$(make_transcript "$label" "Want me to proceed?")
+label="loop_guard_permission_ask"
+path=$(make_unarmed_transcript "$label" "Want me to proceed?")
+out=$(run_hook "$path" true)
+if [[ -z "$out" ]]; then
+	pass "loop-guard: stop_hook_active=true on permission-ask → silent"
+else
+	fail "loop-guard: should be silent, got: $out"
+fi
+
+# ─── Kill-switch env ─────────────────────────────────────────────────────────
+label="disabled_env_gated"
+path=$(make_unarmed_transcript "$label" "I'm about to push to production.")
 out=$(jq -nc --arg p "$path" '{transcript_path: $p}' | STOP_ACTION_BIAS_HOOK_DISABLED=1 "$HOOK")
-if [[ -z "$out" ]]; then pass "env-disable: positive input but STOP_ACTION_BIAS_HOOK_DISABLED=1 — silent"; else fail "env-disable: should be silent, got: $out"; fi
+if [[ -z "$out" ]]; then
+	pass "env-disable: gated text but STOP_ACTION_BIAS_HOOK_DISABLED=1 → silent"
+else
+	fail "env-disable: should be silent, got: $out"
+fi
 
-# --- Missing transcript -----------------------------------------------------
+# ─── Missing transcript ───────────────────────────────────────────────────────
 out=$(echo '{"transcript_path": "/nonexistent/xyz.jsonl"}' | "$HOOK")
-if [[ -z "$out" ]]; then pass "missing-transcript: silent no-op"; else fail "missing-transcript: should be silent, got: $out"; fi
+if [[ -z "$out" ]]; then
+	pass "missing-transcript: silent no-op"
+else
+	fail "missing-transcript: should be silent, got: $out"
+fi
 
 echo ""
 echo "  Results: $PASSES passed, $FAILS failed"

--- a/tests/test_godspeed.py
+++ b/tests/test_godspeed.py
@@ -1,0 +1,294 @@
+"""
+tests/test_godspeed.py — Unit tests for godspeed-lookback.sh
+
+Tests the decaying-mandate autonomy model (cc-workflow#818).
+Covers: godspeed_status (arm/halt/unarmed) and godspeed_decision (GO/ASK/STOP/NOOP).
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'scripts', 'godspeed-lookback.sh'))
+
+
+# ---------------------------------------------------------------------------
+# Transcript builders
+# ---------------------------------------------------------------------------
+
+def _user(text):
+    return json.dumps({
+        "type": "user",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]}
+    })
+
+
+def _asst(text):
+    return json.dumps({
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}
+    })
+
+
+def _tool_use():
+    """Assistant-role tool_use entry — type=='assistant', does NOT count as user turn."""
+    return json.dumps({
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "tool_use", "name": "Bash", "input": {}}]}
+    })
+
+
+def _make(*lines):
+    return '\n'.join(lines) + '\n'
+
+
+# ---------------------------------------------------------------------------
+# Helpers to invoke the script
+# ---------------------------------------------------------------------------
+
+def run_eval(transcript, env=None):
+    """Invoke --eval <transcript> and return stdout stripped."""
+    merged_env = dict(os.environ)
+    if env:
+        merged_env.update(env)
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+        f.write(transcript)
+        path = f.name
+    try:
+        r = subprocess.run(['bash', SCRIPT, '--eval', path],
+                           capture_output=True, text=True, timeout=15, env=merged_env)
+        return r.stdout.strip()
+    finally:
+        os.unlink(path)
+
+
+def run_decide(transcript, last_asst_text, session_id='gs-test-session',
+               env=None, sentinel=False):
+    """
+    Invoke --decide with CC hook JSON.
+
+    Appends an assistant turn (last_asst_text) to the transcript before passing
+    to --decide, since that mode extracts last-assistant-text from the file.
+
+    sentinel=True creates /tmp/claude-tests-ran-<session_id> (verified state).
+    """
+    merged_env = dict(os.environ)
+    if env:
+        merged_env.update(env)
+
+    sentinel_path = f'/tmp/claude-tests-ran-{session_id}'
+    if sentinel:
+        with open(sentinel_path, 'w') as sf:
+            sf.write('1')
+    elif os.path.exists(sentinel_path):
+        os.unlink(sentinel_path)
+
+    full_transcript = transcript + _asst(last_asst_text) + '\n'
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+        f.write(full_transcript)
+        path = f.name
+    try:
+        hook_json = json.dumps({
+            'transcript_path': path,
+            'session_id': session_id,
+            'stop_hook_active': False,
+        })
+        r = subprocess.run(['bash', SCRIPT, '--decide'],
+                           input=hook_json, capture_output=True, text=True,
+                           timeout=15, env=merged_env)
+        return r.stdout.strip()
+    finally:
+        os.unlink(path)
+        if os.path.exists(sentinel_path):
+            os.unlink(sentinel_path)
+
+
+# ---------------------------------------------------------------------------
+# godspeed_status tests
+# ---------------------------------------------------------------------------
+
+class TestGodspeedStatus(unittest.TestCase):
+
+    def test_unarmed_no_godspeed(self):
+        """No godspeed in transcript → UNARMED."""
+        t = _make(_user("please do the thing"), _asst("sure"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_unarmed_assistant_echo(self):
+        """
+        godspeed appears only in an assistant turn → UNARMED.
+
+        This is the 'assistant echo' guard: if an assistant turn says
+        "I understand, godspeed!" that must not arm the mandate.  Only
+        type=='user' turns count.
+        """
+        t = _make(
+            _asst("The user said godspeed, so I'll proceed autonomously."),
+            _user("yes, continue"),
+        )
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_armed_most_recent_turn(self):
+        """godspeed in most-recent user turn → ARMED 0."""
+        t = _make(_user("godspeed"), _asst("proceeding"))
+        result = run_eval(t)
+        self.assertTrue(result.startswith("ARMED"), f"Expected ARMED, got: {result}")
+        self.assertEqual(result.split()[1], "0")
+
+    def test_armed_d_counts_user_turns_only(self):
+        """
+        d counts user turns since godspeed, excluding assistant entries.
+
+        3 user turns after godspeed → ARMED 3 (N=10 to keep the window manageable).
+        """
+        t = _make(
+            _user("godspeed"),
+            _asst("ok"),
+            _user("step 1"),
+            _user("step 2"),
+            _user("step 3"),
+        )
+        result = run_eval(t, env={'GODSPEED_WINDOW': '10'})
+        self.assertTrue(result.startswith("ARMED 3"), f"Expected ARMED 3, got: {result}")
+
+    def test_halted(self):
+        """HALT! in a user turn newer than godspeed → HALTED."""
+        t = _make(
+            _user("godspeed"),
+            _asst("running"),
+            _user("HALT!"),
+        )
+        self.assertEqual(run_eval(t), "HALTED")
+
+    def test_aged_out(self):
+        """godspeed more than N user turns ago → UNARMED (aged out)."""
+        lines = [_user("godspeed")] + [_user(f"turn {i}") for i in range(12)]
+        t = _make(*lines)
+        self.assertEqual(run_eval(t, env={'GODSPEED_WINDOW': '10'}), "UNARMED")
+
+    def test_tool_use_entries_dont_inflate_d(self):
+        """
+        Assistant tool_use entries (type=='assistant') are excluded from $user_turns.
+
+        After godspeed: 5 rounds of (tool_use + assistant-text), then one user turn.
+        d should be 1 — only user turns count, not tool interleaving.
+        """
+        lines = [_user("godspeed")]
+        for _ in range(5):
+            lines.append(_tool_use())
+            lines.append(_asst("processing"))
+        lines.append(_user("are we there yet?"))
+        t = _make(*lines)
+        result = run_eval(t, env={'GODSPEED_WINDOW': '10'})
+        self.assertTrue(result.startswith("ARMED"), f"Expected ARMED, got: {result}")
+        d = int(result.split()[1])
+        self.assertEqual(d, 1, f"Expected d=1 (1 user turn after godspeed), got d={d}")
+
+
+# ---------------------------------------------------------------------------
+# godspeed_decision tests
+# ---------------------------------------------------------------------------
+
+class TestGodspeedDecision(unittest.TestCase):
+
+    def test_unarmed_noop(self):
+        """No mandate active → NOOP (hook stands down)."""
+        t = _make(_user("please fix the login page"))
+        result = run_decide(t, "I'll look into it.")
+        self.assertEqual(result, "NOOP")
+
+    def test_halted_noop(self):
+        """HALT! cancels mandate → NOOP."""
+        t = _make(_user("godspeed"), _asst("running"), _user("HALT!"))
+        result = run_decide(t, "stopping now")
+        self.assertEqual(result, "NOOP")
+
+    def test_fresh_mandate_go_unverified(self):
+        """
+        d=0, bar=0%, unverified=40% → GO.
+
+        At d=0 the bar is 0% and any confidence clears it immediately.
+        """
+        t = _make(_user("godspeed"))
+        result = run_decide(t, "Let me proceed with the next step.")
+        self.assertEqual(result, "GO")
+
+    def test_fresh_mandate_go_verified(self):
+        """d=0, verified → GO."""
+        t = _make(_user("godspeed"))
+        result = run_decide(t, "Continuing.", sentinel=True)
+        self.assertEqual(result, "GO")
+
+    def test_mid_mandate_ask_unverified(self):
+        """
+        d=6, N=10 → bar=60%, unverified=40% < 60% → ASK.
+
+        Mandate is active but confidence hasn't cleared the rising bar.
+        """
+        lines = [_user("godspeed")] + [_user(f"step {i}") for i in range(6)]
+        t = _make(*lines)
+        result = run_decide(t, "I'll continue.", env={'GODSPEED_WINDOW': '10'})
+        self.assertTrue(result.startswith("ASK"), f"Expected ASK, got: {result}")
+
+    def test_mid_mandate_go_verified(self):
+        """
+        d=6, N=10 → bar=60%, verified=80% ≥ 60% → GO.
+
+        Same position as above but test sentinel present — confidence clears bar.
+        """
+        lines = [_user("godspeed")] + [_user(f"step {i}") for i in range(6)]
+        t = _make(*lines)
+        result = run_decide(t, "Proceeding.", env={'GODSPEED_WINDOW': '10'}, sentinel=True)
+        self.assertEqual(result, "GO")
+
+    def test_ask_output_fields(self):
+        """
+        ASK line carries exactly 4 space-separated tokens: ASK <d> <bar_pct> <supplied_pct>.
+        Values must be arithmetically correct.
+        """
+        lines = [_user("godspeed")] + [_user(f"step {i}") for i in range(6)]
+        t = _make(*lines)
+        result = run_decide(t, "Moving on.", env={'GODSPEED_WINDOW': '10'})
+        parts = result.split()
+        self.assertEqual(parts[0], "ASK")
+        self.assertEqual(len(parts), 4, f"Expected 'ASK d bar supplied', got: {result!r}")
+        d, bar, supplied = int(parts[1]), int(parts[2]), int(parts[3])
+        self.assertEqual(d, 6)
+        self.assertEqual(bar, 60)   # 6*100//10
+        self.assertEqual(supplied, 40)   # GODSPEED_UNVERIFIED_CONFIDENCE default
+
+    def test_gated_axis_stop_with_mandate(self):
+        """
+        Prod-axis keyword in last assistant turn → STOP even under an active mandate.
+
+        The gated-axis check fires before the mandate math — mandate does NOT
+        override the ABSOLUTE prod rule.
+        """
+        t = _make(_user("godspeed"))
+        result = run_decide(t, "I'm about to deploy to production.")
+        self.assertEqual(result, "STOP")
+
+    def test_gated_axis_stop_no_mandate(self):
+        """Prod-axis fires even without any mandate (UNARMED state)."""
+        t = _make(_user("please fix the login page"))
+        result = run_decide(t, "Let me push this to production.")
+        self.assertEqual(result, "STOP")
+
+    def test_assistant_echo_no_arm(self):
+        """
+        godspeed in an assistant turn (echo) → no mandate → NOOP.
+
+        This is the decision-layer counterpart of TestGodspeedStatus.test_unarmed_assistant_echo.
+        """
+        t = _make(
+            _asst("The user said godspeed, I will act autonomously."),
+            _user("continue with the task"),
+        )
+        result = run_decide(t, "I'll keep going.")
+        self.assertEqual(result, "NOOP")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Replaces the fuzzy-regex permission-ask detector in `stop-action-bias-detector.sh` with an observable-state decision model keyed on a `godspeed` keyword in user turns. Eliminates the false-positive stop-hook storms during long autonomous tasks.

## Changes

- **NEW `scripts/godspeed-lookback.sh`** — sourced library: `godspeed_status` (arm/halt/unarmed scan), `godspeed_decision` (GO/ASK/STOP/NOOP), `_godspeed_notify` (vox + Discord `#call-4-bj`). Standalone `--demo`/`--eval`/`--decide` modes for debugging.
- **REWRITTEN `scripts/stop-action-bias-detector.sh`** — sources the library; implements the full mandate model with loop guards on STOP and ASK paths.
- **UPDATED `scripts/precheck-asking-detector.sh`** — ARMED path now exits 0 (stop-action-bias-detector owns mandate decisions); UNARMED/HALTED retains the narrow precheck-specific regex.
- **NEW `tests/test_godspeed.py`** — 17 unit tests covering status (ARMED/HALTED/UNARMED/assistant-echo/tool-call-inflation) and decision (GO/ASK/STOP/NOOP/fields).
- **REWRITTEN `tests/regression/test_stop_action_bias_detector.sh`** — 24 cases documenting the new behavioral contract (UNARMED=NOOP; gated-axis=STOP regardless; ARMED+fresh=GO; loop-guard; kill-switch).

Decision model: `bar = d/N`; `supplied = 80%` (test sentinel) or `40%` (unverified); `supplied >= bar → GO`; `supplied < bar → ASK`.

## Linked Issues

Closes #818

## Test Plan

- `./scripts/ci/validate.sh` → 162 passed, 0 failed (shellcheck + shfmt + all regression tests)
- `python3 -m pytest tests/test_godspeed.py` → 17/17 passed
- `tests/regression/test_stop_action_bias_detector.sh` → 24/24 passed
- Code review findings C1+C2+I1+I2+I3+M1 all addressed before merge