### PR TITLE
chore(prepwaves): add per-wave dispatch classification (Story 1.1)

### DIFF
--- a/skills/prepwaves/SKILL.md
+++ b/skills/prepwaves/SKILL.md
@@ -65,14 +65,27 @@ Bound by WAVE_AXIOMS 1 and 10 (`WAVE_AXIOMS.md` at the repo root). `/prepwaves` 
 4. **Compute waves.** Call `wave_compute(epic_ref)` (param name is historical — pass the Plan's issue ref) to get the topologically-sorted wave plan, then `wave_topology(...)` to classify. Present the wave plan (waves, issues, dependency chain, branch naming `feature/<N>-<desc>`).
 
    **Single-repo-per-wave validator (Axiom 10).** After computing waves, resolve every issue in each wave to its `owner/repo` (per-issue `repo`, else plan-level `repo`, else the project repo). If any single wave's issues span **more than one** distinct repo, **STOP and refuse** — name the offending wave and its conflicting repos, and tell the planner to split it into serial single-repo phases (expand-contract), never one straddling wave (there is no atomic two-remote promotion). A *phase* may still span repos across its waves (`cross_repo: true`, step 5) — the invariant is per-wave, not per-phase.
+
+   **4.A — Dispatch classification.** After the `wave_topology` call returns, annotate **each** wave with a `dispatch` field that tells `/nextwave` how its flights may execute: `fan` (flights run concurrently), `serialize` (flights run one at a time), or `serialize-preferred` (serialize by default, may fan only if the operator opts in). Apply this four-rule table per wave — *width* is the number of flights (issues) in the wave:
+
+   | Rule | Condition | `dispatch` |
+   |---|---|---|
+   | 1 | Width = 1 | `serialize` |
+   | 2 | Width > 1, **any** intra-wave dependency edge between its flights | `serialize` — **hard gate** (F-8 class); a dep edge inside a wave can never be overridden to `fan` |
+   | 3 | Width > 1, all flights independent, work is **mechanical** (no cross-flight learning to share) | `fan` |
+   | 4 | Width > 1, all flights independent, work has **learning potential** (a lesson from one flight would sharpen another) | `serialize-preferred` |
+
+   **Asymmetric bias — default is `serialize`.** The two misclassifications are not equally costly. A **wrong `serialize`** costs only wall-clock: the wave still lands, just slower. A **wrong `fan`** can *kill the wave*: flights that were not actually independent corrupt each other's work and the whole wave must be re-run. So when a wave is ambiguous, bias toward `serialize` — **wrong serialize = wall-clock cost; wrong fan = wave kill; default is serialize.** Rule 2 (intra-wave dep edge) is a hard gate, not a bias — it is never overridable to `fan`.
+
+   Embed the resolved value on each wave in the plan JSON as `dispatch: <fan|serialize|serialize-preferred>` (it round-trips through `wave_init` — see step 7).
 5. **Cross-repo detection.** For each Phase about to be persisted, walk every sub-issue's ref. Resolve each ref's `owner/repo` (per-issue `repo` field, else plan-level `repo`, else the orchestrator's current project repo). Collect distinct repo slugs that differ from the orchestrator's project repo. If the set is non-empty, set `cross_repo: true` and `target_repos: [<slug>, ...]` on that Phase in the plan JSON. Single-repo Phases leave both fields unset. Cheap — no extra LLM calls; pure walk over refs already in `wave_compute`'s output.
 6. **Approval gate.** Before presenting the plan for approval, verify the current branch:
    - Resolve the project's protected branch: read `## Branching` from `.claude-project.md` in the repo root; if the file is absent or the field is missing, default to `main`/`master`.
    - Run `git rev-parse --abbrev-ref HEAD`.
    - If the result is **not** the protected branch or a branch matching `^release/`, **STOP and refuse approval**: report the current branch and tell the user to check out the project's protected branch first. Feature branches cut from a wrong base target the wrong upstream — this must be correct before the plan is locked in.
-   - Once the branch check passes, present the wave plan and wait for explicit user approval. Iterate on the plan here — not during `/nextwave`.
+   - Once the branch check passes, present the wave plan — including **each wave's `dispatch` classification** (`fan` / `serialize` / `serialize-preferred`) from step 4.A alongside its issues and dependency chain — and wait for explicit user approval. Surfacing `dispatch` at the gate lets the operator veto a `fan` before the plan locks in. Iterate on the plan here — not during `/nextwave`.
 
-7. **Persist.** Call `wave_init(plan_json)` — the tool auto-detects existing plans and uses extend mode, preserving completed waves. Use Phase-prefixed wave IDs (e.g., `wave-2a`) to avoid collisions when extending. Cross-repo fields (`cross_repo`, `target_repos`) round-trip without modification (the underlying `wave-status init` writes the plan dict verbatim to `phases-waves.json`).
+7. **Persist.** Call `wave_init(plan_json)` — the tool auto-detects existing plans and uses extend mode, preserving completed waves. Use Phase-prefixed wave IDs (e.g., `wave-2a`) to avoid collisions when extending. Cross-repo fields (`cross_repo`, `target_repos`) round-trip without modification (the underlying `wave-status init` writes the plan dict verbatim to `phases-waves.json`). The per-wave `dispatch` field (step 4.A) is round-trippable the same way — `wave_init` persists it verbatim onto each wave in `phases-waves.json`, and `/nextwave` reads it back at execution time. A wave (or an older `phases-waves.json`) that carries **no** `dispatch` field is treated as `serialize` by `/nextwave` — a backward-compatible default, so plans written before this field existed still execute correctly.
 
    **Commit the plan file (required).** After `wave_init` returns, check whether `.claude/status/phases-waves.json` appears in `git status --porcelain` output. If it does (the file is tracked or newly added), commit it:
    ```


### PR DESCRIPTION
## Summary
Wave wave-1a flight for issue #823. Adds per-wave `dispatch` classification (`fan` / `serialize` / `serialize-preferred`) to `/prepwaves` so `/nextwave` knows how each wave's flights may execute.

## Changes
- New step 4.A in `skills/prepwaves/SKILL.md`: four-rule dispatch table (width=1 → serialize; intra-wave dep edge → serialize hard gate; independent+mechanical → fan; independent+learning → serialize-preferred).
- Asymmetric bias documented: wrong-serialize costs wall-clock, wrong-fan can kill a wave → default serialize.
- Step 6 approval gate surfaces each wave's `dispatch` so the operator can veto a `fan` before lock-in.
- Step 7 persistence: `dispatch` round-trips through `wave_init`; missing field defaults to `serialize` (backward compatible).

## Linked Issues
Closes #823

## Test Plan
- `commutativity_verify` (single-target, base `kahuna/822-executor-model`): STRONG.
- `scripts/ci/validate.sh` (shellcheck/shfmt/py-compile/SKILL frontmatter) and `scripts/ci/test.sh` (pytest) run locally against the merged state.
- Documentation-only change to one Markdown skill file; no code interface touched.