### PR TITLE
docs(lazyriver): finalize README skills-table entry (#827)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Key features:
 | ibm | `/ibm` | Issue-Branch-PR/MR workflow reminder |
 | issue | `/issue` | Create structured issues (feature, bug, chore, docs, epic) with templates and labels |
 | jfail | `/jfail` | CI job/workflow failure analysis |
-| lazyriver | `/lazyriver` | Goal-seek loop — probe/judge/steer to a plan, upstream of `/devspec` (placeholder — Plan #822 Phase 2) |
+| lazyriver | `/lazyriver` | Goal-seek loop — probe, judge sufficiency, steer, journal until sufficient; escalation-corded; emits a plan (to `/devspec`) or a direct answer |
 | man | `/man` | Display usage information for any installed skill |
 | mmr | `/mmr` | Merge a PR/MR with squash |
 | multithread | `/multithread` | Parallelize discussion/work over independent items (placeholder — Plan #822 Phase 3) |


### PR DESCRIPTION
## Summary
Wave wave-2b flight for issue #827. Replaces the placeholder lazyriver skills-table entry in README.md with its finalized description (goal-seek loop: probe, judge sufficiency, steer, journal; escalation-corded; emits a plan to `/devspec` or a direct answer).

## Changes
- README.md: lazyriver row updated from `(placeholder — Plan #822 Phase 2)` to the real Story 2.2 description.

## Linked Issues
Refs #827 (closure handled by the wave loop on integration).

## Test Plan
- Docs-only, single-line change; no runtime surface.
- commutativity_verify (single-target, base kahuna/822-executor-model): STRONG.
- Full pytest suite run at integration reconcile.