### PR TITLE
fix(hooks): mute _godspeed_notify in CI + hook regression tests (#883)

### DIFF
--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Mute operator-facing hook side effects for the whole suite. Several regression
+# tests drive the real Stop hooks against gated-keyword fixtures; without this
+# every such case would fire a real vox announcement + Discord ping. The hooks'
+# decision logic (block/pass) is unaffected. (cc-workflow#818)
+export GODSPEED_NOTIFY_DISABLED=1
+
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 PASS=0
 FAIL=0

--- a/scripts/godspeed-lookback.sh
+++ b/scripts/godspeed-lookback.sh
@@ -164,6 +164,17 @@ _godspeed_notify() {
 	local d="${2:-?}"
 	local N="${GODSPEED_WINDOW:-200}"
 
+	# Operator-facing side-effect kill-switch. When set, the decision logic is
+	# still fully exercised (STOP/ASK still block); only the vox TTS and Discord
+	# post are muted. Auto-suppressed under any CI signal (non-empty $CI) so no
+	# runner needs the explicit export, plus an explicit GODSPEED_NOTIFY_DISABLED
+	# for regression tests that drive the real hook against gated-keyword fixtures
+	# — otherwise every gated test case sprays a real "gated axis detected"
+	# announcement + Discord ping at BJ. (cc-workflow#883, follow-up to #818)
+	if [[ "${GODSPEED_NOTIFY_DISABLED:-0}" == "1" || -n "${CI:-}" ]]; then
+		return 0
+	fi
+
 	# Agent identity (best-effort).
 	local identity_suffix=""
 	local identity_file=""

--- a/tests/regression/test_precheck_asking_detector.sh
+++ b/tests/regression/test_precheck_asking_detector.sh
@@ -13,6 +13,10 @@
 
 set -uo pipefail
 
+# Mute hook vox/Discord side effects — this hook sources godspeed-lookback.sh
+# and can drive _godspeed_notify; keep the suite silent for the operator.
+export GODSPEED_NOTIFY_DISABLED=1
+
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 HOOK="$REPO_DIR/scripts/precheck-asking-detector.sh"
 

--- a/tests/regression/test_stop_action_bias_detector.sh
+++ b/tests/regression/test_stop_action_bias_detector.sh
@@ -29,6 +29,11 @@
 
 set -uo pipefail
 
+# Mute the hook's real vox/Discord side effects — this test drives the real
+# hook against gated-keyword fixtures, which otherwise fire a live "gated axis
+# detected" announcement + Discord ping per case. Decision logic is unaffected.
+export GODSPEED_NOTIFY_DISABLED=1
+
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 HOOK="$REPO_DIR/scripts/stop-action-bias-detector.sh"
 


### PR DESCRIPTION
## Summary

The Stop-hook regression tests drive the real hook against gated-keyword fixtures, and `_godspeed_notify` was unstubbed — so every gated case fired a live `vox` announcement ("gated axis detected. Check the terminal.") + a Discord POST at BJ, ~10 of each per `validate.sh` run (the 2026-07-06 "mystery voice"). This adds a notify kill-switch so validation/CI are silent while the hook's block/pass decision logic stays fully exercised.

## Changes

- `scripts/godspeed-lookback.sh` — `_godspeed_notify` early-returns when `GODSPEED_NOTIFY_DISABLED=1` **or** `$CI` is non-empty (runners self-suppress; no explicit export needed on CI). Guard sits at the top of the notifier only — it does not gate the STOP/ASK decision.
- `scripts/ci/validate.sh` — exports `GODSPEED_NOTIFY_DISABLED=1` (belt-and-suspenders for local runs where `$CI` is unset).
- `tests/regression/test_stop_action_bias_detector.sh` + `test_precheck_asking_detector.sh` — export the same for standalone runs.

Block/pass decision logic is unchanged — only vox/Discord are muted.

## Linked Issues

Closes #883

## Test Plan

- `shellcheck -x` on all 4 files → clean
- `bash tests/regression/test_stop_action_bias_detector.sh` → 24 passed, 0 failed, silent
- `bash tests/regression/test_precheck_asking_detector.sh` → 18 passed, 0 failed, silent
- CI-path: `CI=1` with no explicit disable → `_godspeed_notify` early-returns (rc=0), silent
- `./scripts/ci/validate.sh` → **167 passed, 0 failed**; vox-log delta = **0** (empirically silent)
- `trivy fs` (HIGH/CRITICAL) → 0
- code review → no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)