### PR TITLE
feat(flightdeck): P0+P1 emit layer — schema, buffer/shipper, state+workflow+session tees

### DIFF
--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -97,6 +97,16 @@
             "command": "~/.claude/scripts/hooks/workflow/reseed-revive.sh"
           }
         ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "_comment": "FlightDeck session-open emit (cc-workflow#857 / S1.7). Fire-and-forget: emits a session activity_start event to the durable buffer + ingest, never blocks, always exits 0.",
+            "type": "command",
+            "command": "~/.local/bin/flightdeck-session-emit.sh open"
+          }
+        ]
       }
     ],
     "PreCompact": [
@@ -148,6 +158,28 @@
             "_comment": "Inter-wave stall-guard for active /wavemachine campaigns (cc-workflow#736, async-aware interim). In the dynamic-workflows model (migration §5) the per-wave Workflow runs ASYNC: the driver launches it, ends its turn, and is re-invoked on the completion verdict. So this guard reads current_action.action and NO-OPs on a legitimate async await (awaiting-verdict), a human pause (hold), or an in-progress promotion (promoting) — it blocks ONLY a genuinely-synchronous gap (wavemachine_active=true with the driver in a launch/idle-shaped action but the turn ending without the next launch). Supersedes the legacy synchronous '/nextwave auto again' reason. Full retire of the wavemachine_active plumbing is deferred to #751. Validated 2026-05-05 in blueshift-cue Plan #179. See lesson_stop_hook_with_block.md and skills/wavemachine/SKILL.md (stall-guard contract).",
             "type": "command",
             "command": "state=\"${CLAUDE_PROJECT_DIR:-.}/.claude/status/state.json\"; [ -f \"$state\" ] || exit 0; active=$(jq -r '.wavemachine_active // false' \"$state\" 2>/dev/null); [ \"$active\" = \"true\" ] || exit 0; action=$(jq -r '.current_action.action // \"\"' \"$state\" 2>/dev/null); case \"$action\" in awaiting-verdict|hold|promoting) exit 0 ;; esac; printf '{\"decision\":\"block\",\"reason\":\"/wavemachine is active and the campaign has not reached a terminal exit. The turn ended without launching the next per-wave Workflow and without entering a legitimate async-await (awaiting-verdict), human-pause (hold), or promotion (promoting) state. If a wave is pending, advance the campaign loop now: write the coarse status (wave-status awaiting-verdict <waveId>) in the SAME tool-use block as the per-wave Workflow launch, then end the turn to await the async verdict. If all waves are promoted, take the success exit and run wave-status wavemachine-stop. Do NOT stall — emit the next tool call now.\"}'"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "_comment": "FlightDeck session-idle emit (cc-workflow#857 / S1.7). Fire-and-forget heartbeat: emits a session 'idle' step when a turn ends. Never blocks, always exits 0, never emits a block decision.",
+            "type": "command",
+            "command": "~/.local/bin/flightdeck-session-emit.sh idle"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "_comment": "FlightDeck session-close emit (cc-workflow#857 / S1.7). Fire-and-forget: emits a session activity_end event when the session ends. Never blocks, always exits 0.",
+            "type": "command",
+            "command": "~/.local/bin/flightdeck-session-emit.sh close"
           }
         ]
       }

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -25,6 +25,16 @@ set -euo pipefail
 # decision logic (block/pass) is unaffected. (cc-workflow#818)
 export GODSPEED_NOTIFY_DISABLED=1
 
+# Isolate the FlightDeck emit buffer for the whole suite. Several regression tests
+# (e.g. test_wave_engine_e2e_smoke.sh) drive the REAL wave-status CLI, whose
+# mutators now emit a FlightDeck event per mutation (cc-workflow#855). Without this
+# those emits would append to the operator's real ~/.claude/status/events.jsonl.
+# Redirect to a throwaway file and leave the ingest URL unset (buffer-only, no
+# POST). Mirrors tests/conftest.py's autouse isolation for the pytest side.
+FLIGHTDECK_EVENTS_PATH="$(mktemp -u -t flightdeck-validate-events.XXXXXX.jsonl)"
+export FLIGHTDECK_EVENTS_PATH
+unset FLIGHTDECK_INGEST_URL
+
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 PASS=0
 FAIL=0

--- a/scripts/flightdeck-session-emit.sh
+++ b/scripts/flightdeck-session-emit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# flightdeck-session-emit.sh — emit a FlightDeck session-lifecycle event (S1.7 / #857).
+#
+# Wired as SessionStart / Stop / SessionEnd hooks in config/settings.template.json.
+# Emits session open / idle / close as a FlightDeck event via the emit CLI, so the
+# operator sees live agent sessions on the deck (no agent in the reporting path).
+#
+# Fire-and-forget: it ALWAYS exits 0 (a hook must never fail a turn) and never
+# blocks the session (emit ships in a background thread; unset FLIGHTDECK_INGEST_URL
+# ⇒ buffer-only). Claude Code passes the hook JSON on stdin; session_id is read
+# from it best-effort.
+#
+# Usage: flightdeck-session-emit.sh [open|idle|close]   (default: idle)
+
+set -uo pipefail
+
+phase="${1:-idle}"
+
+# Session phase → event kind.
+case "$phase" in
+open) kind="activity_start" ;;
+close) kind="activity_end" ;;
+idle | *) kind="step" ;;
+esac
+
+# Best-effort session id: hook stdin JSON (.session_id) → env → cwd basename.
+session=""
+if [ ! -t 0 ]; then
+	payload="$(cat 2>/dev/null || true)"
+	if [ -n "$payload" ] && command -v jq >/dev/null 2>&1; then
+		session="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null || true)"
+	fi
+fi
+if [ -z "$session" ]; then
+	session="${FLIGHTDECK_SESSION_ID:-${CLAUDE_SESSION_ID:-$(basename "$PWD")}}"
+fi
+
+activity="session:${session}"
+host="$(hostname 2>/dev/null || echo unknown)"
+
+# Locate the emit CLI. FLIGHTDECK_EMIT_CMD overrides (DI-seam for tests / a
+# pinned interpreter); else the installed console command; else the module.
+emit_event() {
+	if [ -n "${FLIGHTDECK_EMIT_CMD:-}" ]; then
+		# shellcheck disable=SC2086 # intentional word-split of the command prefix
+		$FLIGHTDECK_EMIT_CMD "$@"
+	elif command -v wave-status >/dev/null 2>&1; then
+		wave-status emit "$@"
+	else
+		python3 -m wave_status.events.emit "$@"
+	fi
+}
+
+emit_event "$kind" \
+	--activity-id "$activity" \
+	--agent "$host" \
+	--phase "session" \
+	--label "session-${phase}" >/dev/null 2>&1 || true
+
+exit 0

--- a/skills/nextwave/per-wave-workflow.bundled.js
+++ b/skills/nextwave/per-wave-workflow.bundled.js
@@ -1108,6 +1108,39 @@ const PERSIST_RESULT = {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// FlightDeck runtime tee (S1.6 / #856). Emit phase/step (+ a token-metric STUB)
+// at each spine agent() node, for the operator's FlightDeck. HARD CONSTRAINT
+// (TC-2): the Workflow SCRIPT does NO file-I/O and NO Date/Math.random — so these
+// helpers are PURE STRING BUILDERS; the actual emit runs INSIDE the agent as a
+// fire-and-forget `wave-status emit` Bash call NAMED IN THE PROMPT, never in the
+// script body. Node latency is derived downstream from consecutive step
+// timestamps (Dev Spec S2.3 — FREE); per-node TOKEN usage is gated on #853 and
+// emitted here ONLY as an explicit null stub (R-19 — never a fabricated number).
+// Applied to the SPINE nodes (rehydrate / plan / reconcile / open-pr / promote);
+// per-node teeing of the parallel workers + the 4 trust signals co-delivers with
+// the #853 token instrumentation (those trust/merge-critical prompts stay
+// untouched here).
+function flightdeckTee(opts) {
+  const ph = (opts && opts.phase) || ''
+  const label = (opts && opts.label) || ''
+  return [
+    ``,
+    `── FlightDeck telemetry (fire-and-forget; do NOT report on it and do NOT let it affect your task) ──`,
+    `As a side action, run these best-effort commands ONCE, ignore any error, then proceed with your real task:`,
+    `  wave-status emit step --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}' || true`,
+    `  # SEAM #853: per-node token usage is not yet available — emit the token metric with NO value (an honest null stub), never a fabricated number.`,
+    `  wave-status emit metric --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --metric tokens --label '${label}' || true`,
+  ].join('\n')
+}
+
+// teeAgent(prompt, opts): run a real agent() node with the FlightDeck tee appended
+// to its prompt. PURE delegation — string concat + the runtime `agent`; no I/O, no
+// Date. Returns agent()'s promise so any existing `.catch(...)` still chains.
+function teeAgent(prompt, opts) {
+  return agent(prompt + '\n' + flightdeckTee(opts), opts)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // SEAM STUBS — return obvious placeholders. The foundational wave-2 issues
 // replace each body with the real sdlc-server-backed implementation. The exact
 // function names + return shapes here ARE the interface contract (see SEAMS.md).
@@ -1122,7 +1155,7 @@ const PERSIST_RESULT = {
 // (see the `Object.fromEntries(... Number(k) ...)` seed below). The pure read-back logic is
 // resume.js parseRehydrate (unit-tested); the agent is the file read the script can't do itself.
 async function rehydrate() {
-  const seed = await agent(
+  const seed = await teeAgent(
     rehydratePrompt({ waveId: WAVE_ID, allIssues: ALL_ISSUES, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
     { label: 'rehydrate', phase: 'Rehydrate', schema: REHYDRATE, agentType: 'general-purpose' },
   ).catch((e) => {
@@ -1407,7 +1440,7 @@ while (true) {
   if (budget.total && budgetRemaining() < COST_FLOOR) { halt = 'cost'; break } // stop before the ceiling
 
   // ── PLAN next group from CURRENT state (Prime; judgment) ──
-  const plan = await agent(primePlanPrompt(merged, pending, lastRework), {
+  const plan = await teeAgent(primePlanPrompt(merged, pending, lastRework), {
     label: `plan:${groupsRunBase + groupsRun.length + 1}`,
     phase: 'Flight loop',
     schema: NEXTGROUP,
@@ -1448,7 +1481,7 @@ while (true) {
   const implemented = built.filter((w) => w.status === 'implemented' || w.status === 'already-present')
 
   // ── MERGE + RECONCILE (Prime(post-flight) — the ONLY cross-flight view) ──
-  const rec = await agent(primeReconcilePrompt(implemented, merged), {
+  const rec = await teeAgent(primeReconcilePrompt(implemented, merged), {
     label: `merge:${groupsRunBase + groupsRun.length + 1}`,
     phase: 'Flight loop',
     schema: RECONCILE,
@@ -1506,7 +1539,7 @@ if (!halt && pending.size === 0) {
   // PR here gives the CI signal a real pipeline AND prevents a green CI from auto-merging before
   // the gate has weighed all four signals. If the PR can't be opened (kahuna branch/artifacts
   // missing), the gate HOLDs — we cannot prove a wave we cannot even PR (conservative, §3.4).
-  const prOpen = await agent(
+  const prOpen = await teeAgent(
     openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
     { label: 'gate:open-pr', phase: 'Trust gate', schema: OPEN_PR_RESULT, agentType: 'general-purpose' },
   ).catch((e) => {
@@ -1599,7 +1632,7 @@ if (gate.verdict === 'PASS') {
     // marks THAT SAME PR ready and pr_merge(skip_train:true) lands it (commutativity already proved
     // skip_train safe); the kahuna branch is deleted. It never opens a second PR. The script can't
     // call MCP/CLI directly (§3.3) — the promote agent does it.
-    const promo = await agent(
+    const promo = await teeAgent(
       promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
       { label: 'promote', phase: 'Promote', schema: PROMOTE_RESULT, agentType: 'general-purpose' },
     ).catch((e) => {

--- a/skills/nextwave/per-wave-workflow.js
+++ b/skills/nextwave/per-wave-workflow.js
@@ -268,6 +268,39 @@ const PERSIST_RESULT = {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// FlightDeck runtime tee (S1.6 / #856). Emit phase/step (+ a token-metric STUB)
+// at each spine agent() node, for the operator's FlightDeck. HARD CONSTRAINT
+// (TC-2): the Workflow SCRIPT does NO file-I/O and NO Date/Math.random — so these
+// helpers are PURE STRING BUILDERS; the actual emit runs INSIDE the agent as a
+// fire-and-forget `wave-status emit` Bash call NAMED IN THE PROMPT, never in the
+// script body. Node latency is derived downstream from consecutive step
+// timestamps (Dev Spec S2.3 — FREE); per-node TOKEN usage is gated on #853 and
+// emitted here ONLY as an explicit null stub (R-19 — never a fabricated number).
+// Applied to the SPINE nodes (rehydrate / plan / reconcile / open-pr / promote);
+// per-node teeing of the parallel workers + the 4 trust signals co-delivers with
+// the #853 token instrumentation (those trust/merge-critical prompts stay
+// untouched here).
+function flightdeckTee(opts) {
+  const ph = (opts && opts.phase) || ''
+  const label = (opts && opts.label) || ''
+  return [
+    ``,
+    `── FlightDeck telemetry (fire-and-forget; do NOT report on it and do NOT let it affect your task) ──`,
+    `As a side action, run these best-effort commands ONCE, ignore any error, then proceed with your real task:`,
+    `  wave-status emit step --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}' || true`,
+    `  # SEAM #853: per-node token usage is not yet available — emit the token metric with NO value (an honest null stub), never a fabricated number.`,
+    `  wave-status emit metric --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --metric tokens --label '${label}' || true`,
+  ].join('\n')
+}
+
+// teeAgent(prompt, opts): run a real agent() node with the FlightDeck tee appended
+// to its prompt. PURE delegation — string concat + the runtime `agent`; no I/O, no
+// Date. Returns agent()'s promise so any existing `.catch(...)` still chains.
+function teeAgent(prompt, opts) {
+  return agent(prompt + '\n' + flightdeckTee(opts), opts)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // SEAM STUBS — return obvious placeholders. The foundational wave-2 issues
 // replace each body with the real sdlc-server-backed implementation. The exact
 // function names + return shapes here ARE the interface contract (see SEAMS.md).
@@ -282,7 +315,7 @@ const PERSIST_RESULT = {
 // (see the `Object.fromEntries(... Number(k) ...)` seed below). The pure read-back logic is
 // resume.js parseRehydrate (unit-tested); the agent is the file read the script can't do itself.
 async function rehydrate() {
-  const seed = await agent(
+  const seed = await teeAgent(
     rehydratePrompt({ waveId: WAVE_ID, allIssues: ALL_ISSUES, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
     { label: 'rehydrate', phase: 'Rehydrate', schema: REHYDRATE, agentType: 'general-purpose' },
   ).catch((e) => {
@@ -567,7 +600,7 @@ while (true) {
   if (budget.total && budgetRemaining() < COST_FLOOR) { halt = 'cost'; break } // stop before the ceiling
 
   // ── PLAN next group from CURRENT state (Prime; judgment) ──
-  const plan = await agent(primePlanPrompt(merged, pending, lastRework), {
+  const plan = await teeAgent(primePlanPrompt(merged, pending, lastRework), {
     label: `plan:${groupsRunBase + groupsRun.length + 1}`,
     phase: 'Flight loop',
     schema: NEXTGROUP,
@@ -608,7 +641,7 @@ while (true) {
   const implemented = built.filter((w) => w.status === 'implemented' || w.status === 'already-present')
 
   // ── MERGE + RECONCILE (Prime(post-flight) — the ONLY cross-flight view) ──
-  const rec = await agent(primeReconcilePrompt(implemented, merged), {
+  const rec = await teeAgent(primeReconcilePrompt(implemented, merged), {
     label: `merge:${groupsRunBase + groupsRun.length + 1}`,
     phase: 'Flight loop',
     schema: RECONCILE,
@@ -666,7 +699,7 @@ if (!halt && pending.size === 0) {
   // PR here gives the CI signal a real pipeline AND prevents a green CI from auto-merging before
   // the gate has weighed all four signals. If the PR can't be opened (kahuna branch/artifacts
   // missing), the gate HOLDs — we cannot prove a wave we cannot even PR (conservative, §3.4).
-  const prOpen = await agent(
+  const prOpen = await teeAgent(
     openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
     { label: 'gate:open-pr', phase: 'Trust gate', schema: OPEN_PR_RESULT, agentType: 'general-purpose' },
   ).catch((e) => {
@@ -759,7 +792,7 @@ if (gate.verdict === 'PASS') {
     // marks THAT SAME PR ready and pr_merge(skip_train:true) lands it (commutativity already proved
     // skip_train safe); the kahuna branch is deleted. It never opens a second PR. The script can't
     // call MCP/CLI directly (§3.3) — the promote agent does it.
-    const promo = await agent(
+    const promo = await teeAgent(
       promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
       { label: 'promote', phase: 'Promote', schema: PROMOTE_RESULT, agentType: 'general-purpose' },
     ).catch((e) => {

--- a/src/wave_status/__main__.py
+++ b/src/wave_status/__main__.py
@@ -357,6 +357,18 @@ def _cmd_wavemachine_stop(args: argparse.Namespace) -> None:
     _print_envelope(result)
 
 
+def _cmd_emit(args: argparse.Namespace) -> None:
+    """Handle ``emit <kind> [opts…]`` — emit one FlightDeck event.
+
+    Delegates verbatim to the events emit CLI (single source of truth for the
+    option surface). Fire-and-forget: it buffers + non-blocking-ships and never
+    regenerates the dashboard.
+    """
+    from wave_status.events.emit import main as emit_main
+
+    emit_main(args.emit_args)
+
+
 def _cmd_show(args: argparse.Namespace) -> None:
     """Handle ``show`` — print summary, NO dashboard regen.
 
@@ -671,6 +683,20 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Clear wavemachine_active (call from worker on abort or clean exit)",
     )
     p_wst.set_defaults(func=_cmd_wavemachine_stop)
+
+    # emit — FlightDeck event emit (buffer + fire-and-forget ingest, #863).
+    # REMAINDER captures the full emit option surface so the emit CLI stays the
+    # single source of truth (see: python -m wave_status.events.emit -h).
+    p_em = sub.add_parser(
+        "emit",
+        help="Emit one FlightDeck event to the durable buffer + ingest",
+    )
+    p_em.add_argument(
+        "emit_args",
+        nargs=argparse.REMAINDER,
+        help="<kind> [--wave …] [--metric …] … (see the emit CLI -h)",
+    )
+    p_em.set_defaults(func=_cmd_emit)
 
     # show
     p_sh = sub.add_parser("show", help="Print status summary (read-only)")

--- a/src/wave_status/events/__init__.py
+++ b/src/wave_status/events/__init__.py
@@ -1,0 +1,249 @@
+"""FlightDeck event contract — typed constants + stdlib validation (S0.1 / #860).
+
+This package is the lowest-deterministic-layer emit contract for FlightDeck
+(Dev Spec §5.1, TC-4). ``schema.json`` (sibling file) is the versioned,
+language-neutral contract that BOTH the Python emitter (:mod:`wave_status.events.emit`)
+and the TypeScript ingest service validate against — schema, not shared code.
+
+This module mirrors that schema as typed Python constants and provides a
+**stdlib-only** validator (no ``jsonschema`` dependency — CT-01 / TC-1), so the
+emit hot path stays dependency-free. ``test_event_schema.py`` pins the Python
+constants against the ``schema.json`` enums so the two never drift.
+
+Design note (#853 token gate): the ``metric`` kind carries a ``value`` that may
+be ``None`` — a seamed-absent metric (the token cell stubs until #853 lands;
+R-19/TC-7: never fabricated, explicitly absent).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "EVENT_KINDS",
+    "CONCERN_KINDS",
+    "CONCERN_SOURCES",
+    "SCOPE_TAGS",
+    "ACTION_TO_KIND",
+    "now_iso",
+    "kind_for_action",
+    "build_event",
+    "validate_event",
+    "load_schema",
+    "EventValidationError",
+]
+
+# ---------------------------------------------------------------------------
+# The contract — kept in lockstep with schema.json ($defs). test_event_schema
+# asserts these equal the schema enums.
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION = 1
+
+#: The eight deterministic event kinds.
+EVENT_KINDS: tuple[str, ...] = (
+    "activity_start",
+    "phase",
+    "step",
+    "metric",
+    "concern",
+    "blocked_on_human",
+    "ci_wait",
+    "activity_end",
+)
+
+#: The six concern categories (kind == "concern").
+CONCERN_KINDS: tuple[str, ...] = (
+    "workaround",
+    "di-seam",
+    "forced-default",
+    "gate-override",
+    "self-approval",
+    "unresolved-todo",
+)
+
+#: Where a concern originated: a coded escape hatch, or an agent declaration.
+CONCERN_SOURCES: tuple[str, ...] = ("coded", "declared")
+
+#: The canonical scope-tag key set carried by every event (Dev Spec §5.1).
+SCOPE_TAGS: tuple[str, ...] = (
+    "activityId",
+    "kind",
+    "phase",
+    "wave",
+    "flight",
+    "agent",
+    "ts",
+    "logRef",
+)
+
+# ---------------------------------------------------------------------------
+# state.py action vocabulary → event kind (S0.1 → consumed by S1.2).
+#
+# Each ``current_action.action`` value that state.py writes maps to exactly one
+# event kind. ``_set_action`` uses this table so every coarse-state transition
+# emits a correctly-typed event without a per-call-site kind literal.
+# ---------------------------------------------------------------------------
+
+ACTION_TO_KIND: dict[str, str] = {
+    "idle": "step",
+    "pre-flight": "phase",
+    "planning": "phase",
+    "post-wave-review": "phase",
+    "in-flight": "step",
+    "merging": "step",
+    "waiting-on-meatbag": "blocked_on_human",
+    "waiting-ci": "ci_wait",
+    "launching": "step",
+    "awaiting-verdict": "step",
+    "promoting": "step",
+    "hold": "blocked_on_human",
+}
+
+
+class EventValidationError(ValueError):
+    """Raised by :func:`validate_event` when an event violates the contract.
+
+    A ``ValueError`` subclass so callers that already catch ``ValueError`` (the
+    emitter swallows it and buffers nothing) keep working unchanged.
+    """
+
+
+def now_iso() -> str:
+    """Return an ISO-8601 UTC timestamp (mirrors ``state._now_iso``)."""
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def kind_for_action(action: str) -> str:
+    """Map a state.py ``current_action.action`` to its event kind.
+
+    Unknown actions default to ``"step"`` — an additive-safe fallback so a new
+    action string can never make an emit raise (the emitter is fire-and-forget).
+    """
+    return ACTION_TO_KIND.get(action, "step")
+
+
+# Optional scope keys and their allowed python types (None always allowed).
+_SCOPE_TYPES: dict[str, tuple[type, ...]] = {
+    "phase": (str,),
+    "wave": (str,),
+    "flight": (str, int),
+    "agent": (str,),
+    "logRef": (str,),
+}
+
+
+def build_event(
+    kind: str,
+    *,
+    activity_id: str,
+    ts: str | None = None,
+    **fields: object,
+) -> dict:
+    """Construct a normalized, contract-shaped event dict.
+
+    Stamps ``kind``, ``activityId``, ``ts`` (defaulting to :func:`now_iso`) and
+    ``schemaVersion``. Any ``fields`` whose value is ``None`` are dropped so the
+    buffered JSONL stays compact and optional scope tags are simply absent
+    (never ``null``) — EXCEPT ``value``, which is preserved even when ``None``
+    so a seamed-absent metric (#853 token stub) round-trips honestly.
+
+    Does NOT validate — call :func:`validate_event` on the result.
+    """
+    event: dict = {
+        "kind": kind,
+        "activityId": activity_id,
+        "ts": ts or now_iso(),
+        "schemaVersion": SCHEMA_VERSION,
+    }
+    for key, val in fields.items():
+        if val is None and key != "value":
+            continue
+        event[key] = val
+    return event
+
+
+def validate_event(event: object) -> None:
+    """Validate *event* against the contract; raise :class:`EventValidationError`.
+
+    Stdlib-only, hand-rolled to mirror ``schema.json`` (no ``jsonschema`` dep).
+    Checks, in order:
+
+    - the event is a dict;
+    - ``kind`` present and in :data:`EVENT_KINDS`;
+    - ``activityId`` a non-empty str;
+    - ``ts`` a non-empty str;
+    - optional scope tags, when present and non-null, carry an allowed type;
+    - ``kind == "concern"`` ⇒ ``concernKind`` in :data:`CONCERN_KINDS` and
+      ``source`` in :data:`CONCERN_SOURCES`;
+    - ``kind == "metric"`` ⇒ ``metric`` name is a non-empty str.
+    """
+    if not isinstance(event, dict):
+        raise EventValidationError(
+            f"event must be a dict, got {type(event).__name__}"
+        )
+
+    kind = event.get("kind")
+    if kind not in EVENT_KINDS:
+        raise EventValidationError(
+            f"invalid event kind {kind!r}; must be one of {EVENT_KINDS}"
+        )
+
+    activity_id = event.get("activityId")
+    if not isinstance(activity_id, str) or not activity_id:
+        raise EventValidationError(
+            "event 'activityId' must be a non-empty string"
+        )
+
+    ts = event.get("ts")
+    if not isinstance(ts, str) or not ts:
+        raise EventValidationError("event 'ts' must be a non-empty string")
+
+    for key, allowed in _SCOPE_TYPES.items():
+        if key in event and event[key] is not None:
+            if not isinstance(event[key], allowed):
+                names = "/".join(t.__name__ for t in allowed)
+                raise EventValidationError(
+                    f"scope tag '{key}' must be {names} or absent"
+                )
+
+    if kind == "concern":
+        ck = event.get("concernKind")
+        if ck not in CONCERN_KINDS:
+            raise EventValidationError(
+                f"concern 'concernKind' must be one of {CONCERN_KINDS}, got {ck!r}"
+            )
+        src = event.get("source")
+        if src not in CONCERN_SOURCES:
+            raise EventValidationError(
+                f"concern 'source' must be one of {CONCERN_SOURCES}, got {src!r}"
+            )
+
+    if kind == "metric":
+        name = event.get("metric")
+        if not isinstance(name, str) or not name:
+            raise EventValidationError(
+                "metric event 'metric' (name) must be a non-empty string"
+            )
+
+
+def load_schema() -> dict:
+    """Load and parse the sibling ``schema.json`` contract.
+
+    Uses ``importlib.resources`` when available (works inside the zipapp), with a
+    ``__file__``-relative fallback for source-tree reads. This is the CONTRACT
+    artifact used by tests and the TS-service drift check; runtime validation
+    (:func:`validate_event`) does NOT depend on it.
+    """
+    try:
+        from importlib.resources import files
+
+        return json.loads(
+            files(__package__).joinpath("schema.json").read_text(encoding="utf-8")
+        )
+    except Exception:
+        path = Path(__file__).resolve().parent / "schema.json"
+        return json.loads(path.read_text(encoding="utf-8"))

--- a/src/wave_status/events/emit.py
+++ b/src/wave_status/events/emit.py
@@ -1,0 +1,388 @@
+"""FlightDeck emit core — durable buffer + fire-and-forget shipper (S1.1 / #863).
+
+The lowest-deterministic-layer emitter. Every state change routes through
+:func:`emit`, which:
+
+1. builds + validates the event against the S0.1 contract
+   (:mod:`wave_status.events`);
+2. atomically appends it as one JSONL line to the durable local buffer
+   (``~/.claude/status/events.jsonl`` by default) [R-01];
+3. ships it non-blocking to ``$FLIGHTDECK_INGEST_URL`` with bearer-token auth,
+   in a daemon thread, off the caller's hot path [R-02];
+4. replays unsent buffered lines in order via an offset marker when the ingest
+   endpoint recovers [R-04].
+
+**Contract: never raises to the caller.** Emit is instrumentation; a bug here
+must never break a state mutation, a Stop hook, or a Workflow node. Every public
+entrypoint swallows all exceptions (R-03). **Stdlib-only** (TC-1) — POST via
+``urllib.request``, no third-party HTTP client.
+
+DI-seams (env vars):
+
+- ``FLIGHTDECK_INGEST_URL``   — POST target. **Unset ⇒ buffer-only**, never ships,
+  never raises (R-03 default).
+- ``FLIGHTDECK_INGEST_TOKEN`` — bearer token for the ``Authorization`` header.
+- ``FLIGHTDECK_INGEST_TIMEOUT`` — POST timeout seconds (default 2).
+- ``FLIGHTDECK_EVENTS_PATH``  — override the buffer file (test isolation).
+- ``FLIGHTDECK_EMIT_DISABLED``— hard off switch (no-op emit).
+- ``FLIGHTDECK_ACTIVITY_ID`` / ``FLIGHTDECK_AGENT`` / ``FLIGHTDECK_LOG_REF`` —
+  scope defaults for :func:`emit_state_event`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import urllib.request
+from pathlib import Path
+
+from wave_status.events import build_event, validate_event
+
+__all__ = [
+    "emit",
+    "emit_state_event",
+    "ship",
+    "replay",
+    "buffer_path",
+    "activity_id_for_root",
+]
+
+# Sentinel so ``value=None`` (a seamed-absent metric, #853 token stub) is
+# distinguishable from "value not supplied".
+_UNSET = object()
+
+# Map the ergonomic snake_case emit() kwargs to the schema's camelCase keys.
+_FIELD_KEYS: dict[str, str] = {
+    "wave": "wave",
+    "phase": "phase",
+    "flight": "flight",
+    "agent": "agent",
+    "log_ref": "logRef",
+    "concern_kind": "concernKind",
+    "source": "source",
+    "metric": "metric",
+    "unit": "unit",
+    "action": "action",
+    "label": "label",
+    "detail": "detail",
+}
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+def buffer_path() -> Path:
+    """Resolve the durable buffer path (env override → default ~/.claude)."""
+    override = os.environ.get("FLIGHTDECK_EVENTS_PATH")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude" / "status" / "events.jsonl"
+
+
+def _offset_path(buffer: Path) -> Path:
+    """The offset-marker sidecar for *buffer* (records bytes already shipped)."""
+    return Path(str(buffer) + ".offset")
+
+
+def activity_id_for_root(root: object) -> str:
+    """Derive a stable ``activityId`` for a repo *root*.
+
+    ``FLIGHTDECK_ACTIVITY_ID`` wins (an operator/driver can pin one campaign id);
+    otherwise the repo directory name. Falls back to ``"unknown"`` — never raises.
+    """
+    env = os.environ.get("FLIGHTDECK_ACTIVITY_ID")
+    if env:
+        return env
+    try:
+        name = Path(str(root)).resolve().name
+        return name or "unknown"
+    except Exception:
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Buffer write (atomic append) + offset marker
+# ---------------------------------------------------------------------------
+
+def _atomic_append(buffer: Path, line: str) -> None:
+    """Append one JSONL *line* to *buffer* atomically.
+
+    Uses a single ``os.write`` to an ``O_APPEND`` fd — the kernel serializes
+    concurrent appends of a small record, so interleaved writers never tear a
+    line (POSIX ``O_APPEND`` semantics).
+    """
+    buffer.parent.mkdir(parents=True, exist_ok=True)
+    data = (line + "\n").encode("utf-8")
+    fd = os.open(str(buffer), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+
+
+def _read_offset(buffer: Path) -> int:
+    try:
+        return int(_offset_path(buffer).read_text(encoding="utf-8").strip() or "0")
+    except Exception:
+        return 0
+
+
+def _write_offset(buffer: Path, offset: int) -> None:
+    try:
+        _offset_path(buffer).write_text(str(offset), encoding="utf-8")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Shipper (fire-and-forget POST + ordered replay)
+# ---------------------------------------------------------------------------
+
+def _post(url: str, body: str) -> bool:
+    """POST *body* to *url* with optional bearer auth. True on 2xx, else False.
+
+    Never raises — a down/unreachable ingest returns False so the caller keeps
+    the event buffered (R-03).
+    """
+    token = os.environ.get("FLIGHTDECK_INGEST_TOKEN")
+    try:
+        timeout = float(os.environ.get("FLIGHTDECK_INGEST_TIMEOUT", "2"))
+    except (TypeError, ValueError):
+        timeout = 2.0
+    try:
+        req = urllib.request.Request(
+            url,
+            data=body.encode("utf-8"),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", None) or resp.getcode()
+            return 200 <= int(status) < 300
+    except Exception:
+        return False
+
+
+def ship(buffer: Path | None = None) -> int:
+    """Replay unsent buffered lines to the ingest endpoint, in order.
+
+    Reads from the offset marker to EOF; POSTs each complete line; advances the
+    offset only past a line that shipped 2xx. On the first failure it STOPS,
+    leaving the offset at the unshipped line so the next call resumes in order
+    (R-04). Returns the number of lines shipped. No-op (0) when
+    ``FLIGHTDECK_INGEST_URL`` is unset (DI-seam, R-03). Never raises.
+    """
+    url = os.environ.get("FLIGHTDECK_INGEST_URL")
+    if not url:
+        return 0
+    buf = buffer or buffer_path()
+    shipped = 0
+    try:
+        if not buf.exists():
+            return 0
+        offset = _read_offset(buf)
+        with open(buf, "r", encoding="utf-8") as f:
+            try:
+                f.seek(offset)
+            except Exception:
+                f.seek(0)
+            while True:
+                line = f.readline()
+                if not line:
+                    break
+                if not line.endswith("\n"):
+                    # Partial line (a writer is mid-append) — retry next round.
+                    break
+                stripped = line.strip()
+                if stripped and not _post(url, stripped):
+                    break  # keep offset here; ordered replay on recovery.
+                _write_offset(buf, f.tell())
+                if stripped:
+                    shipped += 1
+    except Exception:
+        return shipped
+    return shipped
+
+
+#: Alias — the spec's "replay unsent buffered lines" IS :func:`ship`.
+replay = ship
+
+
+def _ship_async(buffer: Path) -> None:
+    """Fire :func:`ship` in a daemon thread so the caller never blocks (R-02)."""
+    if not os.environ.get("FLIGHTDECK_INGEST_URL"):
+        return  # DI-seam: buffer-only, no thread.
+    try:
+        threading.Thread(
+            target=ship, args=(buffer,), daemon=True, name="flightdeck-ship"
+        ).start()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# emit — the one entrypoint
+# ---------------------------------------------------------------------------
+
+def emit(
+    kind: str,
+    *,
+    activity_id: str | None = None,
+    wave: str | None = None,
+    phase: str | None = None,
+    flight: str | int | None = None,
+    agent: str | None = None,
+    log_ref: str | None = None,
+    concern_kind: str | None = None,
+    source: str | None = None,
+    metric: str | None = None,
+    value: object = _UNSET,
+    unit: str | None = None,
+    action: str | None = None,
+    label: str | None = None,
+    detail: object = None,
+    buffer: Path | None = None,
+    ship_now: bool = True,
+) -> dict | None:
+    """Build, validate, buffer, and (non-blocking) ship one event.
+
+    Returns the event dict, or ``None`` if it could not be built/validated or
+    buffered. **Never raises** (R-01/R-03). ``value`` uses a sentinel so an
+    explicit ``value=None`` (seamed-absent metric) round-trips as JSON ``null``.
+    """
+    if os.environ.get("FLIGHTDECK_EMIT_DISABLED"):
+        return None
+
+    fields: dict[str, object] = {}
+    local = {
+        "wave": wave, "phase": phase, "flight": flight, "agent": agent,
+        "log_ref": log_ref, "concern_kind": concern_kind, "source": source,
+        "metric": metric, "unit": unit, "action": action, "label": label,
+        "detail": detail,
+    }
+    for snake, val in local.items():
+        if val is not None:
+            fields[_FIELD_KEYS[snake]] = val
+    if value is not _UNSET:
+        fields["value"] = value  # preserved even when None (token stub, R-19)
+
+    try:
+        aid = activity_id or os.environ.get("FLIGHTDECK_ACTIVITY_ID") or "unknown"
+        event = build_event(kind, activity_id=aid, **fields)
+        validate_event(event)
+    except Exception:
+        return None
+
+    buf = buffer or buffer_path()
+    try:
+        line = json.dumps(event, separators=(",", ":"), ensure_ascii=False)
+        _atomic_append(buf, line)
+    except Exception:
+        return event  # built/validated but couldn't buffer — still never raise.
+
+    if ship_now:
+        _ship_async(buf)
+    return event
+
+
+def emit_state_event(root: object, kind: str, **fields: object) -> dict | None:
+    """Convenience wrapper for state.py mutators (S1.2).
+
+    Derives ``activityId`` from *root* and picks up ``agent`` / ``log_ref`` from
+    the environment, then delegates to :func:`emit`. Never raises.
+    """
+    try:
+        return emit(
+            kind,
+            activity_id=activity_id_for_root(root),
+            agent=os.environ.get("FLIGHTDECK_AGENT"),
+            log_ref=os.environ.get("FLIGHTDECK_LOG_REF"),
+            **fields,
+        )
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI (used by the session hook S1.7 and the Workflow tee S1.6 via
+# `wave-status emit …`; also runnable as `python -m wave_status.events.emit`).
+# ---------------------------------------------------------------------------
+
+def _build_arg_fields(args) -> dict:
+    fields: dict[str, object] = {}
+    for name in (
+        "wave", "phase", "flight", "agent", "log_ref", "concern_kind",
+        "source", "metric", "unit", "action", "label", "detail",
+    ):
+        val = getattr(args, name, None)
+        if val is not None:
+            fields[name] = val
+    # For a metric, always carry `value` (None ⇒ honest seamed-absent stub).
+    if args.metric is not None:
+        if args.value is None:
+            fields["value"] = None
+        else:
+            fields["value"] = _coerce_value(args.value)
+    return fields
+
+
+def _coerce_value(raw: str) -> object:
+    for cast in (int, float):
+        try:
+            return cast(raw)
+        except (TypeError, ValueError):
+            continue
+    return raw
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``wave-status emit`` / ``python -m wave_status.events.emit``.
+
+    Emits one event and prints it as JSON. Always exits 0 — emit is
+    fire-and-forget instrumentation; a non-zero exit must never fail a hook or a
+    Workflow node.
+    """
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="wave-status emit",
+        description="Emit one FlightDeck event to the durable buffer + ingest.",
+    )
+    p.add_argument("kind", help="Event kind (activity_start|phase|step|metric|concern|blocked_on_human|ci_wait|activity_end)")
+    p.add_argument("--activity-id", dest="activity_id", default=None)
+    p.add_argument("--wave", default=None)
+    p.add_argument("--phase", default=None)
+    p.add_argument("--flight", default=None)
+    p.add_argument("--agent", default=None)
+    p.add_argument("--log-ref", dest="log_ref", default=None)
+    p.add_argument("--concern-kind", dest="concern_kind", default=None)
+    p.add_argument("--source", default=None)
+    p.add_argument("--metric", default=None, help="metric name (kind=metric)")
+    p.add_argument("--value", default=None, help="metric value; omit for a seamed-absent stub")
+    p.add_argument("--unit", default=None)
+    p.add_argument("--action", default=None)
+    p.add_argument("--label", default=None)
+    p.add_argument("--detail", default=None)
+    p.add_argument("--no-ship", dest="ship_now", action="store_false", default=True)
+    args = p.parse_args(argv)
+
+    try:
+        event = emit(
+            args.kind,
+            activity_id=args.activity_id,
+            ship_now=args.ship_now,
+            **_build_arg_fields(args),
+        )
+        if event is not None:
+            print(json.dumps(event, separators=(",", ":"), ensure_ascii=False))
+    except Exception:
+        pass  # fire-and-forget: never fail the caller.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/wave_status/events/schema.json
+++ b/src/wave_status/events/schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wave-engineering.dev/flightdeck/events/schema.json",
+  "title": "FlightDeck Event",
+  "description": "The single, versioned event contract for FlightDeck (Dev Spec TC-4 / S0.1). Every state change in the wave-pattern pipeline emits one typed, scope-tagged event against THIS schema. Both the Python emitter (src/wave_status/events/) and the TS ingest service validate against this file (schema, not shared code); it is additively versioned. The event log built from these events is the single source of truth (TC-3).",
+  "schemaVersion": 1,
+  "type": "object",
+  "required": ["kind", "activityId", "ts"],
+  "additionalProperties": true,
+  "properties": {
+    "kind": {
+      "description": "The event kind. One of the eight deterministic emit points.",
+      "$ref": "#/$defs/eventKind"
+    },
+    "activityId": {
+      "description": "Stable identifier for the campaign or float this event belongs to (one card in the UI).",
+      "type": "string",
+      "minLength": 1
+    },
+    "ts": {
+      "description": "ISO-8601 UTC timestamp (e.g. 2026-07-07T12:34:56Z).",
+      "type": "string",
+      "minLength": 1
+    },
+    "schemaVersion": {
+      "description": "The event-contract version this event was emitted against.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "phase": {
+      "description": "Scope tag: phase name/id, when known.",
+      "type": ["string", "null"]
+    },
+    "wave": {
+      "description": "Scope tag: wave id, when known.",
+      "type": ["string", "null"]
+    },
+    "flight": {
+      "description": "Scope tag: flight number/id within a wave, when known.",
+      "type": ["string", "integer", "null"]
+    },
+    "agent": {
+      "description": "Scope tag: the emitting agent identity (Dev-Name), when known.",
+      "type": ["string", "null"]
+    },
+    "logRef": {
+      "description": "Scope tag: a reference resolving to the transcript/log for this scope (the scoped log viewer keys on this).",
+      "type": ["string", "null"]
+    },
+    "action": {
+      "description": "For phase/step/blocked_on_human/ci_wait derived from a state.py current_action, the raw action string (e.g. 'planning', 'in-flight').",
+      "type": ["string", "null"]
+    },
+    "label": {
+      "description": "Human-readable short label for the event.",
+      "type": ["string", "null"]
+    },
+    "detail": {
+      "description": "Free-form detail payload (string or structured)."
+    },
+    "metric": {
+      "description": "For kind=metric, the metric name (e.g. 'latency', 'findings-velocity', 'confidence', 'tokens').",
+      "type": ["string", "null"]
+    },
+    "value": {
+      "description": "For kind=metric, the measured value. May be null for a seamed-absent metric (e.g. the #853-gated token stub — TC-7/R-19: never fabricated)."
+    },
+    "unit": {
+      "description": "For kind=metric, the unit of the value (e.g. 'ms', 'count').",
+      "type": ["string", "null"]
+    },
+    "concernKind": {
+      "description": "For kind=concern, the concern category.",
+      "$ref": "#/$defs/concernKind"
+    },
+    "source": {
+      "description": "For kind=concern, whether the concern was raised by a coded escape hatch or declared by an agent.",
+      "$ref": "#/$defs/concernSource"
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "kind": { "const": "concern" } }, "required": ["kind"] },
+      "then": { "required": ["concernKind", "source"] }
+    },
+    {
+      "if": { "properties": { "kind": { "const": "metric" } }, "required": ["kind"] },
+      "then": { "required": ["metric"] }
+    }
+  ],
+  "$defs": {
+    "eventKind": {
+      "type": "string",
+      "enum": [
+        "activity_start",
+        "phase",
+        "step",
+        "metric",
+        "concern",
+        "blocked_on_human",
+        "ci_wait",
+        "activity_end"
+      ]
+    },
+    "concernKind": {
+      "type": "string",
+      "enum": [
+        "workaround",
+        "di-seam",
+        "forced-default",
+        "gate-override",
+        "self-approval",
+        "unresolved-todo"
+      ]
+    },
+    "concernSource": {
+      "type": "string",
+      "enum": ["coded", "declared"]
+    },
+    "scopeTags": {
+      "description": "The canonical scope-tag key set carried by every event.",
+      "type": "array",
+      "const": [
+        "activityId",
+        "kind",
+        "phase",
+        "wave",
+        "flight",
+        "agent",
+        "ts",
+        "logRef"
+      ]
+    }
+  }
+}

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -1229,6 +1229,23 @@ def hold_wave(wave_id: str, root: Path, detail: str = "") -> dict:
         waves[wave_id]["hold_detail"] = detail
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    # S1.3 / #861 — coded escape hatch (ENG-1 gate-skip-but-hold). A held wave is
+    # a non-promoted terminal: the promotion gate was SKIPPED / HELD / the PASS
+    # did not land (persistTerminal('held', 'gate SKIPPED: …') routes here via the
+    # wave-status CLI). Surface it as a coded gate-override concern so it lands in
+    # FlightDeck's global concern queue (R-05/R-20). ADDITIVE — never changes the
+    # hold decision. The other coded hatches (ENG-2 forced chore-default in
+    # resume.js, ENG-6 self-approved MR in precheck/sdlc, ENG-8 kahuna pre-sync)
+    # live outside state.py and co-deliver with Story 1.5 (sdlc/nextwave).
+    _emit_event(
+        root,
+        "concern",
+        wave=wave_id,
+        concern_kind="gate-override",
+        source="coded",
+        label="wave held (non-promoted)",
+        detail=(detail or None),
+    )
     return state_data
 
 

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -18,6 +18,28 @@ from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
+# FlightDeck emit (S1.2 / #855) — ADDITIVE, fire-and-forget instrumentation.
+#
+# Every mutator below emits ONE typed, scope-tagged event AFTER its state has
+# persisted. The emit is a pure side-effect: it never changes a decision, the
+# persisted state, or control flow (if it ever did, that would be a bug in the
+# emit, not the logic). The import is guarded and ``emit_state_event`` itself
+# never raises, so a partial install (events package absent) or an emit bug can
+# never break a state mutation. See src/wave_status/events/emit.py.
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - trivial import guard
+    from wave_status.events import kind_for_action as _kind_for_action
+    from wave_status.events.emit import emit_state_event as _emit_event
+except Exception:  # pragma: no cover
+    def _emit_event(*_a, **_k):
+        return None
+
+    def _kind_for_action(_action):
+        return "step"
+
+
+# ---------------------------------------------------------------------------
 # Path helpers
 # ---------------------------------------------------------------------------
 
@@ -633,6 +655,8 @@ def init_state(plan_data: dict, root: Path, *, force: bool = False) -> None:
     # --- flights.json (empty initially) ---
     save_json(d / "flights.json", {"flights": {}})
 
+    _emit_event(root, "activity_start", wave=first_wave, label=plan_data.get("project"))
+
 
 def extend_state(plan_data: dict, root: Path) -> None:
     """Append new phases from *plan_data* to an existing plan.
@@ -784,6 +808,14 @@ def _set_action(root: Path, action: str, label: str, detail: str = "") -> dict:
     }
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root,
+        _kind_for_action(action),
+        wave=state_data.get("current_wave"),
+        action=action,
+        label=label,
+        detail=(detail or None),
+    )
     return state_data
 
 
@@ -810,6 +842,7 @@ def planning(root: Path) -> dict:
 
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(root, "phase", wave=current_wave, action="planning", label="planning")
     return state_data
 
 
@@ -909,6 +942,9 @@ def append_trajectory(root: Path, wave_id: str, entry: dict) -> dict:
     state_data["trajectory"] = traj
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root, "step", wave=wave_id, action="trajectory", label="trajectory-recorded"
+    )
     return state_data
 
 
@@ -957,6 +993,7 @@ def set_current_wave(wave_id: str, root: Path) -> dict:
     state_data["current_wave"] = wave_id
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(root, "phase", wave=wave_id, action="set-current-wave", label=wave_id)
     return state_data
 
 
@@ -1002,6 +1039,13 @@ def wavemachine_start(root: Path, launcher: str = "") -> dict:
         state_data["wavemachine_launcher"] = launcher
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root,
+        "step",
+        wave=state_data.get("current_wave"),
+        action="wavemachine-start",
+        label=(launcher or "wavemachine"),
+    )
     return state_data
 
 
@@ -1026,6 +1070,13 @@ def wavemachine_stop(root: Path) -> dict:
     state_data["current_action"] = {"action": "idle", "label": "idle", "detail": ""}
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root,
+        "activity_end",
+        wave=state_data.get("current_wave"),
+        action="wavemachine-stop",
+        label="wavemachine-stop",
+    )
     return state_data
 
 
@@ -1082,6 +1133,15 @@ def flight(n: int, root: Path) -> dict:
     }
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root,
+        "step",
+        wave=current_wave,
+        flight=n,
+        action="in-flight",
+        label=f"flight {n}",
+        detail=detail,
+    )
     return state_data
 
 
@@ -1130,6 +1190,14 @@ def flight_done(n: int, root: Path) -> dict:
     }
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root,
+        "step",
+        wave=current_wave,
+        flight=n,
+        action="merging",
+        label="merging",
+    )
     return state_data
 
 
@@ -1204,6 +1272,7 @@ def complete(root: Path, wave_id: str | None = None) -> dict:
     }
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(root, "step", wave=target, action="complete", label="promoted")
     return state_data
 
 
@@ -1279,6 +1348,13 @@ def close_issue(n: int | str, root: Path) -> dict:
     state_data["issues"][resolved]["status"] = "closed"
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root,
+        "step",
+        wave=state_data.get("current_wave"),
+        action="close-issue",
+        label=str(resolved),
+    )
     return state_data
 
 
@@ -1347,6 +1423,14 @@ def record_mr(issue: int | str, mr: str, root: Path) -> dict:
     waves[current_wave].setdefault("mr_urls", {})[resolved] = mr
     state_data["last_updated"] = _now_iso()
     save_json(d / "state.json", state_data)
+    _emit_event(
+        root,
+        "step",
+        wave=current_wave,
+        action="record-mr",
+        label=str(resolved),
+        detail=mr,
+    )
     return state_data
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,24 @@ def _run_cli_impl(
 # Fixtures
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _isolate_flightdeck_buffer(tmp_path_factory, monkeypatch):
+    """Redirect the FlightDeck emit buffer to a throwaway file for every test.
+
+    state.py mutators emit a FlightDeck event on every mutation (S1.2 / #855).
+    Without this isolation the suite would append to the real
+    ``~/.claude/status/events.jsonl`` and — if the ambient env carried an ingest
+    URL — POST during tests. Points the buffer at a unique tmp file and clears
+    the ingest env so emit is pure-buffer and offline. Tests that exercise the
+    shipper set their own ``FLIGHTDECK_*`` via ``monkeypatch`` (which wins,
+    running after this autouse fixture).
+    """
+    d = tmp_path_factory.mktemp("flightdeck-buf")
+    monkeypatch.setenv("FLIGHTDECK_EVENTS_PATH", str(d / "events.jsonl"))
+    monkeypatch.delenv("FLIGHTDECK_INGEST_URL", raising=False)
+    monkeypatch.delenv("FLIGHTDECK_INGEST_TOKEN", raising=False)
+
+
 @pytest.fixture()
 def temp_git_repo(tmp_path: Path) -> Path:
     """Create a temporary directory with ``git init`` so that

--- a/tests/test_concern_emit.py
+++ b/tests/test_concern_emit.py
@@ -1,0 +1,90 @@
+"""S1.3 / #861 — coded-concern emit at coded escape hatches (IT-02, R-05).
+
+The ONE coded escape hatch reachable from state.py is the ENG-1 gate-skip-but-hold
+landing: ``hold_wave`` marks a wave ``held`` (non-promoted terminal) when the
+promotion gate is SKIPPED/HELD or a PASS did not land. It must emit a
+``concern{source:'coded', concernKind:'gate-override'}``.
+
+The remaining coded hatches live OUTSIDE state.py and co-deliver with Story 1.5
+(deferred here — sdlc/nextwave repo work):
+  - ENG-2 forced chore-default  → skills/nextwave/resume.js deriveBranchType
+    (a bundled Workflow helper; TC-2 forbids in-script fs, so it must emit from
+    an agent() prompt / post-node hook).
+  - ENG-6 self-approved MR       → skills/precheck + sdlc pr_merge
+    ([AUTO-APPROVED: kahuna sandbox] sentinel path).
+  - ENG-8 kahuna pre-sync        → sdlc/nextwave (no state.py landing).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from wave_status import state
+
+
+def _buf() -> Path:
+    return Path(os.environ["FLIGHTDECK_EVENTS_PATH"])
+
+
+def _events() -> list[dict]:
+    p = _buf()
+    if not p.exists():
+        return []
+    return [json.loads(x) for x in p.read_text(encoding="utf-8").splitlines() if x.strip()]
+
+
+def _clear() -> None:
+    p = _buf()
+    if p.exists():
+        p.write_text("", encoding="utf-8")
+
+
+@pytest.fixture()
+def inited(temp_git_repo, sample_plan) -> Path:
+    state.init_state(sample_plan, temp_git_repo)
+    _clear()
+    return temp_git_repo
+
+
+class TestEng1HoldWaveConcern:
+    def test_hold_wave_emits_coded_gate_override_concern(self, inited):
+        state.hold_wave("wave-1", inited, detail="gate SKIPPED: loop did not converge")
+        evs = _events()
+        assert len(evs) == 1
+        ev = evs[0]
+        assert ev["kind"] == "concern"
+        assert ev["concernKind"] == "gate-override"
+        assert ev["source"] == "coded"
+        assert ev["wave"] == "wave-1"
+        assert "SKIPPED" in ev["detail"]
+
+    def test_hold_wave_concern_without_detail(self, inited):
+        state.hold_wave("wave-1", inited)
+        ev = _events()[0]
+        assert ev["kind"] == "concern"
+        assert ev["concernKind"] == "gate-override"
+        assert ev["source"] == "coded"
+        # detail absent (None dropped), never null
+        assert "detail" not in ev
+
+    def test_hold_wave_still_holds_and_does_not_advance(self, inited):
+        # Additive: the concern emit must not change the hold semantics — wave
+        # goes 'held', current_wave does NOT advance (ENG-1 contract).
+        before = state.load_json(state.status_dir(inited) / "state.json")
+        assert before["current_wave"] == "wave-1"
+        state.hold_wave("wave-1", inited, detail="reconcile-blocked")
+        after = state.load_json(state.status_dir(inited) / "state.json")
+        assert after["waves"]["wave-1"]["status"] == "held"
+        assert after["current_wave"] == "wave-1"  # unchanged
+
+    def test_raising_emitter_does_not_break_hold(self, inited, monkeypatch):
+        import wave_status.events.emit as emit_mod
+
+        monkeypatch.setattr(emit_mod, "emit", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        # hold_wave must still succeed and persist despite a raising emitter.
+        result = state.hold_wave("wave-1", inited, detail="x")
+        assert result["waves"]["wave-1"]["status"] == "held"

--- a/tests/test_event_schema.py
+++ b/tests/test_event_schema.py
@@ -1,0 +1,170 @@
+"""S0.1 / #860 — the shared event schema + typed constants.
+
+Verifies:
+- ``schema.json`` parses and its ``$defs`` enums equal the Python constants
+  (the two never drift — TC-4);
+- a sample payload for every one of the 8 event kinds validates;
+- every state.py action maps to a valid event kind (the S1.2 action→kind table);
+- the concern/metric conditional requirements are enforced;
+- malformed events are rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wave_status.events import (
+    ACTION_TO_KIND,
+    CONCERN_KINDS,
+    CONCERN_SOURCES,
+    EVENT_KINDS,
+    EventValidationError,
+    build_event,
+    kind_for_action,
+    load_schema,
+    validate_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# schema.json ↔ constants drift
+# ---------------------------------------------------------------------------
+
+class TestSchemaConstantsInSync:
+    def test_schema_parses(self):
+        schema = load_schema()
+        assert schema["title"] == "FlightDeck Event"
+        assert schema["schemaVersion"] == 1
+
+    def test_event_kind_enum_matches_constant(self):
+        schema = load_schema()
+        assert tuple(schema["$defs"]["eventKind"]["enum"]) == EVENT_KINDS
+
+    def test_concern_kind_enum_matches_constant(self):
+        schema = load_schema()
+        assert tuple(schema["$defs"]["concernKind"]["enum"]) == CONCERN_KINDS
+
+    def test_concern_source_enum_matches_constant(self):
+        schema = load_schema()
+        assert tuple(schema["$defs"]["concernSource"]["enum"]) == CONCERN_SOURCES
+
+    def test_required_top_level_keys(self):
+        schema = load_schema()
+        assert set(schema["required"]) == {"kind", "activityId", "ts"}
+
+    def test_eight_event_kinds(self):
+        assert len(EVENT_KINDS) == 8
+        assert EVENT_KINDS == (
+            "activity_start",
+            "phase",
+            "step",
+            "metric",
+            "concern",
+            "blocked_on_human",
+            "ci_wait",
+            "activity_end",
+        )
+
+    def test_six_concern_kinds(self):
+        assert set(CONCERN_KINDS) == {
+            "workaround",
+            "di-seam",
+            "forced-default",
+            "gate-override",
+            "self-approval",
+            "unresolved-todo",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Every kind's sample payload validates
+# ---------------------------------------------------------------------------
+
+def _sample_for(kind: str) -> dict:
+    extra: dict = {}
+    if kind == "concern":
+        extra = {"concernKind": "workaround", "source": "coded"}
+    elif kind == "metric":
+        extra = {"metric": "latency", "value": 1234, "unit": "ms"}
+    return build_event(kind, activity_id="campaign-x", wave="wave-1", **extra)
+
+
+class TestEveryKindValidates:
+    @pytest.mark.parametrize("kind", EVENT_KINDS)
+    def test_kind_sample_validates(self, kind):
+        validate_event(_sample_for(kind))
+
+    def test_build_event_stamps_defaults(self):
+        ev = build_event("step", activity_id="a")
+        assert ev["kind"] == "step"
+        assert ev["activityId"] == "a"
+        assert ev["ts"]  # non-empty
+        assert ev["schemaVersion"] == 1
+
+    def test_build_event_drops_none_scope_but_keeps_metric_value(self):
+        ev = build_event("metric", activity_id="a", metric="tokens", value=None, wave=None)
+        assert "wave" not in ev  # None scope dropped
+        assert "value" in ev and ev["value"] is None  # seamed-absent metric preserved
+
+
+# ---------------------------------------------------------------------------
+# action → kind mapping (feeds S1.2)
+# ---------------------------------------------------------------------------
+
+class TestActionToKind:
+    @pytest.mark.parametrize("action,kind", list(ACTION_TO_KIND.items()))
+    def test_every_action_maps_to_valid_kind(self, action, kind):
+        assert kind in EVENT_KINDS
+
+    def test_state_action_vocabulary_covered(self):
+        # The current_action.action strings state.py can write.
+        vocab = {
+            "idle", "pre-flight", "planning", "post-wave-review", "in-flight",
+            "merging", "waiting-on-meatbag", "waiting-ci", "launching",
+            "awaiting-verdict", "promoting", "hold",
+        }
+        assert vocab <= set(ACTION_TO_KIND)
+
+    def test_unknown_action_defaults_to_step(self):
+        assert kind_for_action("brand-new-action") == "step"
+
+
+# ---------------------------------------------------------------------------
+# Rejection paths
+# ---------------------------------------------------------------------------
+
+class TestRejection:
+    def test_bad_kind_rejected(self):
+        with pytest.raises(EventValidationError):
+            validate_event({"kind": "nope", "activityId": "a", "ts": "t"})
+
+    def test_missing_activity_id_rejected(self):
+        with pytest.raises(EventValidationError):
+            validate_event({"kind": "step", "ts": "t"})
+
+    def test_missing_ts_rejected(self):
+        with pytest.raises(EventValidationError):
+            validate_event({"kind": "step", "activityId": "a"})
+
+    def test_concern_without_concern_kind_rejected(self):
+        ev = build_event("concern", activity_id="a", source="coded")
+        with pytest.raises(EventValidationError):
+            validate_event(ev)
+
+    def test_concern_bad_source_rejected(self):
+        ev = build_event("concern", activity_id="a", concernKind="workaround", source="bogus")
+        with pytest.raises(EventValidationError):
+            validate_event(ev)
+
+    def test_metric_without_name_rejected(self):
+        ev = build_event("metric", activity_id="a", value=1)
+        with pytest.raises(EventValidationError):
+            validate_event(ev)
+
+    def test_non_dict_rejected(self):
+        with pytest.raises(EventValidationError):
+            validate_event("not-an-event")
+
+    def test_bad_scope_type_rejected(self):
+        with pytest.raises(EventValidationError):
+            validate_event({"kind": "step", "activityId": "a", "ts": "t", "wave": 123})

--- a/tests/test_events_emit.py
+++ b/tests/test_events_emit.py
@@ -1,0 +1,282 @@
+"""S1.1 / #863 — emit() + durable buffer + fire-and-forget shipper + replay.
+
+Covers R-01 (durable atomic append), R-02 (non-blocking POST when URL set),
+R-03 (ingest-down never raises, buffer-only when URL unset), R-04 (ordered
+replay via offset marker), and the emit CLI surface used by S1.6/S1.7.
+
+Stdlib-only mock ingest (http.server) — no third-party HTTP fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from wave_status.events import emit as emit_mod
+from wave_status.events.emit import buffer_path, emit, ship
+
+
+# ---------------------------------------------------------------------------
+# Mock ingest server (stdlib)
+# ---------------------------------------------------------------------------
+
+class _CaptureServer:
+    """A tiny HTTP server capturing POSTed bodies + auth headers.
+
+    ``received`` holds ``(path, body_dict_or_str, auth_header)`` tuples in
+    arrival order. ``status`` is the code it returns (default 202).
+    """
+
+    def __init__(self, status: int = 202, port: int = 0):
+        self.received: list[tuple] = []
+        self.status = status
+        captured = self.received
+        status_code = self.status
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *a):  # silence
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                raw = self.rfile.read(length).decode("utf-8") if length else ""
+                try:
+                    body = json.loads(raw)
+                except Exception:
+                    body = raw
+                captured.append((self.path, body, self.headers.get("Authorization")))
+                self.send_response(status_code)
+                self.end_headers()
+
+        self._server = HTTPServer(("127.0.0.1", port), Handler)
+        self.port = self._server.server_address[1]
+        self.url = f"http://127.0.0.1:{self.port}/ingest"
+        self._thread: threading.Thread | None = None
+
+    def start(self):
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self):
+        try:
+            self._server.shutdown()
+        finally:
+            self._server.server_close()
+
+    def wait_for(self, n: int, timeout: float = 3.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if len(self.received) >= n:
+                return True
+            time.sleep(0.02)
+        return False
+
+
+@pytest.fixture()
+def buf(tmp_path, monkeypatch) -> Path:
+    """A dedicated buffer file for the shipper tests (URL still unset here)."""
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv("FLIGHTDECK_EVENTS_PATH", str(path))
+    monkeypatch.delenv("FLIGHTDECK_INGEST_URL", raising=False)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# R-01 — durable atomic append
+# ---------------------------------------------------------------------------
+
+class TestBufferAppend:
+    def test_emit_atomic_append_writes_one_jsonl_line(self, buf):
+        ev = emit("step", activity_id="camp-1", wave="wave-1", label="planning")
+        assert ev is not None
+        lines = buf.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        got = json.loads(lines[0])
+        assert got["kind"] == "step"
+        assert got["activityId"] == "camp-1"
+        assert got["wave"] == "wave-1"
+        assert got["ts"]
+
+    def test_multiple_emits_append(self, buf):
+        emit("step", activity_id="c", wave="w")
+        emit("phase", activity_id="c", wave="w")
+        emit("activity_end", activity_id="c")
+        lines = buf.read_text(encoding="utf-8").splitlines()
+        assert [json.loads(x)["kind"] for x in lines] == ["step", "phase", "activity_end"]
+
+    def test_none_scope_tags_absent_not_null(self, buf):
+        emit("step", activity_id="c")  # no wave/phase/etc
+        got = json.loads(buf.read_text(encoding="utf-8").splitlines()[0])
+        assert "wave" not in got and "phase" not in got
+
+    def test_metric_value_none_preserved(self, buf):
+        emit("metric", activity_id="c", metric="tokens", value=None)  # #853 stub
+        got = json.loads(buf.read_text(encoding="utf-8").splitlines()[0])
+        assert got["metric"] == "tokens"
+        assert got["value"] is None
+
+
+# ---------------------------------------------------------------------------
+# R-03 — never raise; buffer-only when URL unset
+# ---------------------------------------------------------------------------
+
+class TestNeverRaises:
+    def test_buffer_only_when_url_unset(self, buf):
+        ev = emit("step", activity_id="c")
+        assert ev is not None
+        assert ship(buf) == 0  # no URL ⇒ shipper no-ops (DI-seam)
+        assert buf.exists()
+
+    def test_invalid_event_returns_none_no_raise(self, buf):
+        assert emit("not-a-kind", activity_id="c") is None
+        # nothing buffered
+        assert not buf.exists() or buf.read_text() == ""
+
+    def test_concern_missing_fields_returns_none(self, buf):
+        assert emit("concern", activity_id="c") is None  # concernKind/source missing
+
+    def test_disabled_switch_noops(self, buf, monkeypatch):
+        monkeypatch.setenv("FLIGHTDECK_EMIT_DISABLED", "1")
+        assert emit("step", activity_id="c") is None
+        assert not buf.exists()
+
+    def test_emit_state_event_never_raises(self, buf):
+        # Bad kind, but the wrapper still must not raise.
+        assert emit_mod.emit_state_event("/some/root", "bogus-kind") is None
+
+
+# ---------------------------------------------------------------------------
+# R-02 / IT-09 — non-blocking POST when URL set
+# ---------------------------------------------------------------------------
+
+class TestNonBlockingShip:
+    def test_post_nonblocking_when_url_set(self, buf, monkeypatch):
+        server = _CaptureServer().start()
+        try:
+            monkeypatch.setenv("FLIGHTDECK_INGEST_URL", server.url)
+            monkeypatch.setenv("FLIGHTDECK_INGEST_TOKEN", "sekret")
+            ev = emit("step", activity_id="camp-1", wave="w")  # ship_now default
+            assert ev is not None  # returns immediately, does not block on POST
+            assert server.wait_for(1), "event was not POSTed"
+            path, body, auth = server.received[0]
+            assert path == "/ingest"
+            assert body["kind"] == "step"
+            assert auth == "Bearer sekret"
+        finally:
+            server.stop()
+
+
+# ---------------------------------------------------------------------------
+# R-04 — ordered replay via offset marker + resilience
+# ---------------------------------------------------------------------------
+
+class TestReplayAndResilience:
+    def test_replay_resends_unsent_in_order(self, buf, monkeypatch):
+        # Buffer two events with the URL unset (no auto-ship).
+        emit("step", activity_id="c", wave="w1", ship_now=False)
+        emit("step", activity_id="c", wave="w2", ship_now=False)
+
+        server = _CaptureServer().start()
+        try:
+            monkeypatch.setenv("FLIGHTDECK_INGEST_URL", server.url)
+            assert ship(buf) == 2
+            assert server.wait_for(2)
+            waves = [b["wave"] for (_p, b, _a) in server.received]
+            assert waves == ["w1", "w2"]  # ordered
+            # Offset advanced — a second ship sends nothing new.
+            assert ship(buf) == 0
+        finally:
+            server.stop()
+
+    def test_ingest_down_then_recover(self, buf, monkeypatch):
+        # Start a server to claim a port, then stop it → that port is closed.
+        dead = _CaptureServer().start()
+        port = dead.port
+        dead.stop()
+        url = f"http://127.0.0.1:{port}/ingest"
+        monkeypatch.setenv("FLIGHTDECK_INGEST_URL", url)
+
+        emit("step", activity_id="c", wave="w1", ship_now=False)
+        emit("step", activity_id="c", wave="w2", ship_now=False)
+        # Ingest down → ship fails, buffers retained, offset unchanged, no raise.
+        assert ship(buf) == 0
+
+        # Recover on the same port.
+        live = _CaptureServer(port=port).start()
+        try:
+            assert ship(buf) == 2  # ordered replay on recovery
+            assert live.wait_for(2)
+            assert [b["wave"] for (_p, b, _a) in live.received] == ["w1", "w2"]
+        finally:
+            live.stop()
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (used by the session hook S1.7 + Workflow tee S1.6)
+# ---------------------------------------------------------------------------
+
+def _run(argv: list[str], events_path: Path):
+    env = os.environ.copy()
+    src = str(Path(__file__).resolve().parent.parent / "src")
+    env["PYTHONPATH"] = src + (os.pathsep + env.get("PYTHONPATH", "") if env.get("PYTHONPATH") else "")
+    env["FLIGHTDECK_EVENTS_PATH"] = str(events_path)
+    env.pop("FLIGHTDECK_INGEST_URL", None)
+    return subprocess.run(argv, capture_output=True, text=True, env=env)
+
+
+class TestEmitCli:
+    def test_module_cli_buffers(self, tmp_path):
+        ep = tmp_path / "events.jsonl"
+        r = _run(
+            [sys.executable, "-m", "wave_status.events.emit", "step",
+             "--activity-id", "camp-x", "--wave", "wave-1"],
+            ep,
+        )
+        assert r.returncode == 0, r.stderr
+        got = json.loads(ep.read_text(encoding="utf-8").splitlines()[0])
+        assert got["kind"] == "step" and got["wave"] == "wave-1"
+
+    def test_wave_status_emit_subcommand(self, tmp_path):
+        ep = tmp_path / "events.jsonl"
+        r = _run(
+            [sys.executable, "-m", "wave_status", "emit", "concern",
+             "--activity-id", "camp-x", "--concern-kind", "gate-override",
+             "--source", "coded", "--wave", "wave-2"],
+            ep,
+        )
+        assert r.returncode == 0, r.stderr
+        got = json.loads(ep.read_text(encoding="utf-8").splitlines()[0])
+        assert got["kind"] == "concern"
+        assert got["concernKind"] == "gate-override"
+        assert got["source"] == "coded"
+
+    def test_metric_stub_value_null_via_cli(self, tmp_path):
+        ep = tmp_path / "events.jsonl"
+        # No --value ⇒ honest seamed-absent token stub (value: null).
+        r = _run(
+            [sys.executable, "-m", "wave_status", "emit", "metric",
+             "--activity-id", "c", "--metric", "tokens"],
+            ep,
+        )
+        assert r.returncode == 0, r.stderr
+        got = json.loads(ep.read_text(encoding="utf-8").splitlines()[0])
+        assert got["metric"] == "tokens" and got["value"] is None
+
+    def test_cli_bad_kind_exits_zero_no_buffer(self, tmp_path):
+        ep = tmp_path / "events.jsonl"
+        r = _run(
+            [sys.executable, "-m", "wave_status", "emit", "bogus",
+             "--activity-id", "c"],
+            ep,
+        )
+        assert r.returncode == 0  # fire-and-forget: never fail the caller
+        assert not ep.exists() or ep.read_text() == ""

--- a/tests/test_per_wave_workflow_tee.py
+++ b/tests/test_per_wave_workflow_tee.py
@@ -1,0 +1,141 @@
+"""S1.6 / #856 — Workflow-runtime FlightDeck tee.
+
+Asserts the per-wave Workflow emits phase/step (+ a token-metric STUB) at each
+spine agent() node, WITHOUT violating TC-2 (no fs/Date/Math.random in the
+Workflow SCRIPT body — the emit rides the agent() prompt), and that the token
+metric is a clearly-marked #853 stub (R-19). Also confirms the committed bundle
+is in sync + valid JS.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_NW = Path(__file__).resolve().parent.parent / "skills" / "nextwave"
+_SRC = _NW / "per-wave-workflow.js"
+_BUNDLE = _NW / "per-wave-workflow.bundled.js"
+
+_HAS_NODE = shutil.which("node") is not None
+
+
+@pytest.fixture(scope="module")
+def src() -> str:
+    return _SRC.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def bundle() -> str:
+    return _BUNDLE.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers exist and delegate
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_flightdeck_tee_defined(self, src):
+        assert "function flightdeckTee(opts)" in src
+
+    def test_tee_agent_defined_and_delegates(self, src):
+        assert "function teeAgent(prompt, opts)" in src
+        # PURE delegation to the runtime agent(), appending the tee to the prompt.
+        assert "return agent(prompt + '\\n' + flightdeckTee(opts), opts)" in src
+
+
+# ---------------------------------------------------------------------------
+# Phase/step + token stub per node
+# ---------------------------------------------------------------------------
+
+class TestEmitInstructions:
+    def test_emits_step_scoped_by_phase_and_label(self, src):
+        assert "wave-status emit step --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}'" in src
+
+    def test_token_metric_is_a_seamed_null_stub(self, src):
+        # A metric named tokens, with NO --value ⇒ null (honest stub), marked #853.
+        assert "wave-status emit metric" in src
+        assert "--metric tokens" in src
+        assert "SEAM #853" in src
+        # The token metric line must NOT carry a fabricated --value.
+        metric_line = next(
+            ln for ln in src.splitlines()
+            if "wave-status emit metric" in ln and "--metric tokens" in ln
+        )
+        assert "--value" not in metric_line
+
+    def test_tee_is_fire_and_forget(self, src):
+        assert "fire-and-forget" in src
+        assert "|| true" in src  # emit failures are swallowed in the prompt
+
+
+# ---------------------------------------------------------------------------
+# Spine nodes teed; trust-critical nodes intentionally NOT teed
+# ---------------------------------------------------------------------------
+
+class TestNodeCoverage:
+    def test_five_spine_nodes_teed(self, src):
+        assert src.count("await teeAgent(") == 5
+
+    @pytest.mark.parametrize("anchor", [
+        "const seed = await teeAgent(",                         # rehydrate
+        "const plan = await teeAgent(primePlanPrompt(",         # plan
+        "const rec = await teeAgent(primeReconcilePrompt(",     # reconcile
+        "const prOpen = await teeAgent(",                       # gate open-pr
+        "const promo = await teeAgent(",                        # promote
+    ])
+    def test_spine_node_uses_tee(self, src, anchor):
+        assert anchor in src
+
+    def test_parallel_workers_and_trust_signals_not_teed(self, src):
+        # The code-writing workers + the 4 trust signals stay untouched here
+        # (their per-node token tee co-delivers with #853).
+        assert "teeAgent(workerPrompt(" not in src
+        assert "teeAgent(commutativitySignalPrompt(" not in src
+        assert "teeAgent(ciSignalPrompt(" not in src
+        assert "teeAgent(reviewSignalPrompt(" not in src
+        assert "teeAgent(trivySignalPrompt(" not in src
+
+
+# ---------------------------------------------------------------------------
+# TC-2 — no fs/Date/Math.random introduced into the Workflow SCRIPT body
+# ---------------------------------------------------------------------------
+
+def _code_only(js: str) -> str:
+    """Strip /* */ block comments and full-line // comments so the TC-2 check
+    tests executable code, not prose (our own seam comment names the primitives)."""
+    import re
+
+    js = re.sub(r"/\*.*?\*/", "", js, flags=re.DOTALL)
+    return "\n".join(
+        ln for ln in js.splitlines() if not ln.lstrip().startswith("//")
+    )
+
+
+class TestTC2NoForbiddenPrimitives:
+    @pytest.mark.parametrize("banned", ["new Date", "Date.now", "Math.random", "readFileSync", "writeFileSync", "require(", "fs."])
+    def test_script_body_free_of_banned_primitive(self, src, banned):
+        code = _code_only(src)
+        assert banned not in code, f"TC-2 violation: workflow script uses {banned!r}"
+
+
+# ---------------------------------------------------------------------------
+# Committed bundle is in sync + valid
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node not available")
+class TestBundle:
+    def test_bundle_in_sync(self):
+        r = subprocess.run(["node", str(_NW / "bundle.mjs"), "--check"], capture_output=True, text=True)
+        assert r.returncode == 0, f"bundle stale — run node bundle.mjs\n{r.stdout}\n{r.stderr}"
+
+    def test_bundle_valid_js(self):
+        r = subprocess.run(["node", "--check", str(_BUNDLE)], capture_output=True, text=True)
+        assert r.returncode == 0, r.stderr
+
+    def test_bundle_carries_five_tees(self, bundle):
+        assert bundle.count("await teeAgent(") == 5
+        assert "FlightDeck telemetry" in bundle
+        assert "SEAM #853" in bundle

--- a/tests/test_session_hook_emit.py
+++ b/tests/test_session_hook_emit.py
@@ -1,0 +1,133 @@
+"""S1.7 / #857 — session hook: settings wiring + flightdeck-session-emit.sh.
+
+Verifies the Stop / SessionEnd / SessionStart hooks are wired in
+config/settings.template.json and that scripts/flightdeck-session-emit.sh emits
+a correctly-typed session event for each phase (open/idle/close), fire-and-forget
+(always exit 0, buffer-only offline).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO / "scripts" / "flightdeck-session-emit.sh"
+_SETTINGS = _REPO / "config" / "settings.template.json"
+_SRC = str(_REPO / "src")
+
+
+def _run(phase: str, events_path: Path, stdin: str = ""):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = _SRC + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    env["FLIGHTDECK_EVENTS_PATH"] = str(events_path)
+    env["FLIGHTDECK_EMIT_CMD"] = "python3 -m wave_status.events.emit"
+    env["FLIGHTDECK_SESSION_ID"] = "sess-abc"
+    env.pop("FLIGHTDECK_INGEST_URL", None)
+    return subprocess.run(
+        ["bash", str(_SCRIPT), phase],
+        input=stdin, capture_output=True, text=True, env=env,
+    )
+
+
+def _last_event(events_path: Path) -> dict:
+    lines = events_path.read_text(encoding="utf-8").splitlines()
+    return json.loads(lines[-1])
+
+
+class TestScriptEmits:
+    @pytest.mark.parametrize(
+        "phase,kind",
+        [("open", "activity_start"), ("idle", "step"), ("close", "activity_end")],
+    )
+    def test_phase_maps_to_kind(self, tmp_path, phase, kind):
+        ep = tmp_path / "events.jsonl"
+        r = _run(phase, ep)
+        assert r.returncode == 0, r.stderr
+        ev = _last_event(ep)
+        assert ev["kind"] == kind
+        assert ev["activityId"] == "session:sess-abc"
+        assert ev["label"] == f"session-{phase}"
+        assert ev["phase"] == "session"
+
+    def test_default_phase_is_idle(self, tmp_path):
+        ep = tmp_path / "events.jsonl"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _SRC
+        env["FLIGHTDECK_EVENTS_PATH"] = str(ep)
+        env["FLIGHTDECK_EMIT_CMD"] = "python3 -m wave_status.events.emit"
+        env["FLIGHTDECK_SESSION_ID"] = "s"
+        env.pop("FLIGHTDECK_INGEST_URL", None)
+        r = subprocess.run(["bash", str(_SCRIPT)], input="", capture_output=True, text=True, env=env)
+        assert r.returncode == 0
+        assert _last_event(ep)["kind"] == "step"
+
+    def test_session_id_from_stdin_json(self, tmp_path):
+        ep = tmp_path / "events.jsonl"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _SRC
+        env["FLIGHTDECK_EVENTS_PATH"] = str(ep)
+        env["FLIGHTDECK_EMIT_CMD"] = "python3 -m wave_status.events.emit"
+        env.pop("FLIGHTDECK_SESSION_ID", None)
+        env.pop("FLIGHTDECK_INGEST_URL", None)
+        # Claude Code passes the hook payload as JSON on stdin.
+        payload = json.dumps({"session_id": "from-stdin", "hook_event_name": "Stop"})
+        r = subprocess.run(
+            ["bash", str(_SCRIPT), "idle"],
+            input=payload, capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0
+        # jq may or may not be installed; if present the stdin id wins.
+        act = _last_event(ep)["activityId"]
+        if _has_jq():
+            assert act == "session:from-stdin"
+        else:
+            assert act.startswith("session:")
+
+    def test_always_exits_zero_even_on_emit_failure(self, tmp_path):
+        ep = tmp_path / "events.jsonl"
+        env = os.environ.copy()
+        env["FLIGHTDECK_EVENTS_PATH"] = str(ep)
+        env["FLIGHTDECK_EMIT_CMD"] = "false"  # force the emit command to fail
+        env["FLIGHTDECK_SESSION_ID"] = "s"
+        env.pop("FLIGHTDECK_INGEST_URL", None)
+        r = subprocess.run(["bash", str(_SCRIPT), "idle"], input="", capture_output=True, text=True, env=env)
+        assert r.returncode == 0  # fire-and-forget: a hook must never fail a turn
+
+
+def _has_jq() -> bool:
+    from shutil import which
+    return which("jq") is not None
+
+
+class TestSettingsWiring:
+    def _hooks(self) -> dict:
+        return json.loads(_SETTINGS.read_text(encoding="utf-8"))["hooks"]
+
+    def _commands(self, event: str) -> list[str]:
+        cmds: list[str] = []
+        for block in self._hooks().get(event, []):
+            for h in block.get("hooks", []):
+                cmds.append(h.get("command", ""))
+        return cmds
+
+    def test_stop_wires_idle(self):
+        assert any("flightdeck-session-emit.sh idle" in c for c in self._commands("Stop"))
+
+    def test_session_end_wires_close(self):
+        assert any("flightdeck-session-emit.sh close" in c for c in self._commands("SessionEnd"))
+
+    def test_session_start_wires_open(self):
+        assert any("flightdeck-session-emit.sh open" in c for c in self._commands("SessionStart"))
+
+    def test_existing_stop_hooks_preserved(self):
+        # Additive: the precheck-asking + stop-action-bias + stall-guard hooks
+        # must remain wired (we only appended).
+        cmds = " ".join(self._commands("Stop"))
+        assert "precheck-asking-detector.sh" in cmds
+        assert "stop-action-bias-detector.sh" in cmds
+        assert "wavemachine_active" in cmds  # the stall-guard inline command

--- a/tests/test_state_emit_integration.py
+++ b/tests/test_state_emit_integration.py
@@ -1,0 +1,216 @@
+"""S1.2 / #855 — every state.py mutator emits one typed, scoped event (IT-01).
+
+Drives each instrumented mutator in-process and asserts it appends EXACTLY one
+FlightDeck event of the expected kind, correctly scoped. Also proves the
+instrumentation is purely additive: a raising emitter never breaks a mutation
+(the mutation still persists state.json), and no mutator changes its return /
+persistence behavior.
+
+The autouse ``_isolate_flightdeck_buffer`` fixture (conftest) points the emit
+buffer at a per-test tmp file and clears the ingest env, so these run offline.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from wave_status import state
+
+
+# ---------------------------------------------------------------------------
+# Buffer helpers (reads the tmp buffer the autouse fixture configured)
+# ---------------------------------------------------------------------------
+
+def _buf() -> Path:
+    return Path(os.environ["FLIGHTDECK_EVENTS_PATH"])
+
+
+def _events() -> list[dict]:
+    p = _buf()
+    if not p.exists():
+        return []
+    return [json.loads(x) for x in p.read_text(encoding="utf-8").splitlines() if x.strip()]
+
+
+def _clear() -> None:
+    p = _buf()
+    if p.exists():
+        p.write_text("", encoding="utf-8")
+    off = Path(str(p) + ".offset")
+    if off.exists():
+        off.unlink()
+
+
+@pytest.fixture()
+def inited(temp_git_repo, sample_plan) -> Path:
+    """A git repo with an initialized plan; buffer cleared post-init."""
+    state.init_state(sample_plan, temp_git_repo)
+    _clear()
+    return temp_git_repo
+
+
+def _one(kind: str) -> dict:
+    evs = _events()
+    assert len(evs) == 1, f"expected exactly one event, got {len(evs)}: {evs}"
+    assert evs[0]["kind"] == kind, f"expected kind {kind}, got {evs[0]['kind']}"
+    assert evs[0]["activityId"]
+    assert evs[0]["ts"]
+    assert evs[0]["schemaVersion"] == 1
+    return evs[0]
+
+
+# ---------------------------------------------------------------------------
+# One event per mutation, correctly typed + scoped
+# ---------------------------------------------------------------------------
+
+class TestOneEventPerMutation:
+    def test_init_state_activity_start(self, temp_git_repo, sample_plan):
+        state.init_state(sample_plan, temp_git_repo)
+        ev = _one("activity_start")
+        assert ev["wave"] == "wave-1"
+
+    def test_planning_phase(self, inited):
+        state.planning(inited)
+        ev = _one("phase")
+        assert ev["wave"] == "wave-1"
+        assert ev["action"] == "planning"
+
+    def test_preflight_phase_via_set_action(self, inited):
+        state.preflight(inited)
+        ev = _one("phase")
+        assert ev["action"] == "pre-flight"
+
+    def test_review_phase_via_set_action(self, inited):
+        state.review(inited)
+        ev = _one("phase")
+        assert ev["action"] == "post-wave-review"
+
+    def test_waiting_blocked_on_human(self, inited):
+        state.waiting(inited, "need a human")
+        ev = _one("blocked_on_human")
+        assert ev["action"] == "waiting-on-meatbag"
+
+    def test_hold_blocked_on_human(self, inited):
+        state.hold(inited, "adjudicating")
+        ev = _one("blocked_on_human")
+        assert ev["action"] == "hold"
+
+    def test_waiting_ci(self, inited):
+        state.waiting_ci(inited, "run 123")
+        ev = _one("ci_wait")
+        assert ev["action"] == "waiting-ci"
+
+    def test_promoting_step(self, inited):
+        state.promoting(inited, "wave-1")
+        ev = _one("step")
+        assert ev["action"] == "promoting"
+
+    def test_launching_step(self, inited):
+        state.launching(inited, "wave-1")
+        ev = _one("step")
+        assert ev["action"] == "launching"
+
+    def test_awaiting_verdict_step(self, inited):
+        state.awaiting_verdict(inited, "wave-1")
+        ev = _one("step")
+        assert ev["action"] == "awaiting-verdict"
+
+    def test_flight_step(self, inited, sample_flights):
+        state.store_flight_plan(sample_flights, inited)
+        _clear()  # store_flight_plan is not instrumented; isolate the flight event
+        state.flight(1, inited)
+        ev = _one("step")
+        assert ev["wave"] == "wave-1"
+        assert ev["flight"] == 1
+        assert ev["action"] == "in-flight"
+
+    def test_flight_done_step(self, inited, sample_flights):
+        state.store_flight_plan(sample_flights, inited)
+        state.flight(1, inited)
+        _clear()
+        state.flight_done(1, inited)
+        ev = _one("step")
+        assert ev["flight"] == 1
+        assert ev["action"] == "merging"
+
+    def test_complete_step(self, inited):
+        state.complete(inited)
+        ev = _one("step")
+        assert ev["wave"] == "wave-1"
+        assert ev["action"] == "complete"
+        assert ev["label"] == "promoted"
+
+    def test_close_issue_step(self, inited):
+        state.close_issue(13, inited)
+        ev = _one("step")
+        assert ev["action"] == "close-issue"
+
+    def test_record_mr_step(self, inited):
+        state.record_mr(13, "#99", inited)
+        ev = _one("step")
+        assert ev["wave"] == "wave-1"
+        assert ev["action"] == "record-mr"
+        assert ev["detail"] == "#99"
+
+    def test_append_trajectory_step(self, inited):
+        state.append_trajectory(inited, "wave-1", {"verdict": "PASS"})
+        ev = _one("step")
+        assert ev["wave"] == "wave-1"
+        assert ev["action"] == "trajectory"
+
+    def test_set_current_wave_phase(self, inited):
+        state.set_current_wave("wave-2", inited)
+        ev = _one("phase")
+        assert ev["wave"] == "wave-2"
+        assert ev["action"] == "set-current-wave"
+
+    def test_wavemachine_start_step(self, inited):
+        state.wavemachine_start(inited, launcher="agent-x")
+        ev = _one("step")
+        assert ev["action"] == "wavemachine-start"
+
+    def test_wavemachine_stop_activity_end(self, inited):
+        state.wavemachine_start(inited)
+        _clear()
+        state.wavemachine_stop(inited)
+        ev = _one("activity_end")
+        assert ev["action"] == "wavemachine-stop"
+
+
+# ---------------------------------------------------------------------------
+# Additive safety: instrumentation never alters the mutation
+# ---------------------------------------------------------------------------
+
+class TestAdditiveSafety:
+    def test_activity_id_stable_across_campaign(self, inited):
+        state.planning(inited)
+        state.close_issue(13, inited)
+        state.complete(inited)
+        ids = {e["activityId"] for e in _events()}
+        assert len(ids) == 1  # one campaign → one stable activityId
+
+    def test_raising_emitter_does_not_break_mutation(self, inited, monkeypatch):
+        # Force the underlying emit() to raise; emit_state_event must swallow it
+        # (R-03) and the mutation must still persist state.json unchanged.
+        import wave_status.events.emit as emit_mod
+
+        def _boom(*a, **k):
+            raise RuntimeError("ingest exploded")
+
+        monkeypatch.setattr(emit_mod, "emit", _boom)
+
+        result = state.planning(inited)  # must not raise
+        assert result["current_action"]["action"] == "planning"
+        # state.json persisted the planning transition despite the emit blowing up
+        d = state.status_dir(inited)
+        persisted = state.load_json(d / "state.json")
+        assert persisted["waves"]["wave-1"]["status"] == "in_progress"
+
+    def test_no_extra_stdout_from_mutation(self, inited, capsys):
+        state.planning(inited)
+        out = capsys.readouterr()
+        assert out.out == "" and out.err == ""


### PR DESCRIPTION
## Summary

FlightDeck Phase 0 + Phase 1 (the claudecode-workflow-repo portion): emit a typed, scope-tagged event at the lowest deterministic layer on every state change, to a durable buffer (`~/.claude/status/events.jsonl`) with a fire-and-forget POST to the FlightDeck ingest. **No agent is in the reporting path.** This is the emit layer only — the container service, UI, watcher, and cutover (P2–P5) are separate work; nothing here deploys or touches any Swarm/prod manifest.

DRAFT for human review — do not merge. See `docs/flightdeck-devspec.md` and Plan #854.

## Changes

- **S0.1 / #860** — NEW `src/wave_status/events/schema.json` (the one versioned event contract) + `__init__.py` (typed constants `EVENT_KINDS`/`CONCERN_KINDS`/`CONCERN_SOURCES`/`SCOPE_TAGS`, the `state.py` action→kind map, and a **stdlib-only** `validate_event`/`build_event`; no `jsonschema` dep — CT-01).
- **S1.1 / #863** — NEW `src/wave_status/events/emit.py`: validate → atomic append to the durable buffer → non-blocking bearer-auth POST to `$FLIGHTDECK_INGEST_URL` in a daemon thread → ordered offset-marker replay on recovery. **Never raises** into a caller (R-03). DI-seam: URL unset ⇒ buffer-only. A `wave-status emit` CLI for the hook + Workflow tee.
- **S1.2 / #855** — thread `emit()` into every `state.py` mutator (`_set_action`, `planning`, `flight`, `flight_done`, `complete`, `close_issue`, `record_mr`, `append_trajectory`, `init_state`, `set_current_wave`, `wavemachine_start/stop`). **ADDITIVE ONLY** — one emit per mutation after persist; no decision/persistence/control-flow change.
- **S1.3 / #861** — coded-concern emit at the ENG-1 gate-skip hatch (`hold_wave` → `concern{source:coded, concernKind:gate-override}`).
- **S1.6 / #856** — Workflow-runtime tee: pure string-builders `flightdeckTee`/`teeAgent` emit phase/step (+ a `#853`-gated token null-stub) at the 5 spine agent() nodes via the agent prompt. **TC-2**: no fs/`Date`/`Math.random` in the Workflow script body. Bundle rebuilt + in sync.
- **S1.7 / #857** — NEW `scripts/flightdeck-session-emit.sh` (session open/idle/close) wired as SessionStart/Stop/SessionEnd hooks in `config/settings.template.json`.

## Deferred (not in this PR)

- **#862 / #865** — the TS emit helper + non-CLI sdlc handler wiring live in `mcp-server-sdlc` (a different repo, busy on another branch).
- **#858** — lazyriver leg-agent emit parity is **blocked on #852** (sequence after it lands).
- The coded hatches ENG-2 (forced chore-default, `resume.js`), ENG-6 (self-approved MR, precheck/sdlc), ENG-8 (kahuna pre-sync) live outside `state.py` and **co-deliver with #865/S1.5**; only the state.py-reachable ENG-1 hatch is emitted here.
- Per-node teeing of the parallel workers + the 4 trust signals is intentionally left out (those trust/merge-critical prompts stay untouched; their per-node token tee co-delivers with **#853**).

## Linked Issues

Closes #860
Closes #863
Closes #855
Closes #861
Closes #856
Closes #857

## Test Plan

Run per story + full-suite gate (all local, `GODSPEED_NOTIFY_DISABLED`-muzzled):

- `tests/test_event_schema.py` (39) — every kind validates; schema enums == constants (no drift).
- `tests/test_events_emit.py` (16) — atomic append, buffer-only, never-raise, non-blocking POST + bearer (IT-09), ordered replay, ingest-down-then-recover (stdlib mock ingest), CLI.
- `tests/test_state_emit_integration.py` (IT-01) — one correctly-typed/scoped event per mutation; raising emitter never breaks a mutation.
- `tests/test_concern_emit.py` — ENG-1 hatch coded concern; hold non-advance unchanged.
- `tests/test_per_wave_workflow_tee.py` (22) — spine tee, token null-stub + `#853` seam, TC-2 clean, bundle in sync + valid.
- `tests/test_session_hook_emit.py` (10) — phase→kind, stdin session_id, always-exit-0, settings wiring.
- **Full suite:** `pytest tests/` → 1462+ passed, 0 failed (see run). `./scripts/ci/validate.sh` → 171 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUmiaud1v3c8zWbZrBp1Ar