### PR TITLE
feat(skills): add the /thoughts alignment-check skill to the kit

### DIFF
--- a/skills/thoughts/SKILL.md
+++ b/skills/thoughts/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: thoughts
+description: The user is inviting a genuine alignment check on a proposal — stress-test it for real, then act on the result in ONE turn (aligned → proceed; concern → surface it)
+---
+
+# /thoughts — Alignment Check
+
+The user has just proposed a direction and wants a **genuine check, not a rubber stamp** — something like *"Thoughts? Does this hold up? If we agree let's get started; if not, let's talk."* Reaching real alignment matters more to them than executing their exact wording. Treat this as an invitation to push back.
+
+## What to do
+
+**1. Actually stress-test the proposal first.** Hunt for the flaw, the missing case, the unstated assumption, the simpler alternative, the thing that bites three steps later. Agreement must be **earned** — reflexive "sounds great, let's go!" is the exact failure mode this skill exists to prevent. If the proposal survives a real check, that is genuine alignment.
+
+**2. Then branch — and do NOT add a turn:**
+
+- **You genuinely agree** → say "aligned" in one sentence (name the single thing that convinced you it's right), then **proceed with the work**. Do not ask permission to start — starting *is* the agreement. The only exception is a genuinely new irreversible / production-affecting step: state the plan, name that one real gate, and do everything up to it.
+- **You have a real concern** → surface it **specifically** — the exact flaw, the missing piece — and propose the adjustment. That disagreement is the entire value of the check; never bury it to be agreeable.
+
+Half-agreement counts as a concern: if you'd proceed *but* with a caveat, say the caveat — don't smuggle it into silent execution.
+
+## Why this exists
+
+Typing "Thoughts?" every time is friction, and if the agent merely agrees it wastes a round-trip ("Thoughts?" → "agreed" → "let's start"). This skill collapses that: do the check **and** act on its result in the same turn. Alignment over deference; **earned** agreement over reflexive agreement.
+
+*(Trigger is `/thoughts`. Want the question mark? Type `/thoughts ?` — the trailing `?` is an ignored argument, since a skill's name can't contain punctuation.)*


### PR DESCRIPTION
## Summary

Adds the `/thoughts` alignment-check skill to the kit. It's an **opt-in**, generic collaboration protocol: when the user invokes `/thoughts`, the agent genuinely stress-tests the user's just-proposed direction and acts on the result in ONE turn — aligned → say so briefly and proceed (no permission-ask); real concern → surface the specific flaw and discuss. Kills the "Thoughts? → agreed → let's go" three-turn tax. **Value-neutral** — presses no specific values, only the check-then-act behavior (which is why it's fine to ship, unlike a personal value-system doc).

## Changes

- NEW `skills/thoughts/SKILL.md` — the alignment-check skill, **genericized** (no author-specific framing; reads for any user). Specifies the two load-bearing mechanics: it's a judgment+branch (not a text-macro), and it guards against reflexive agreement (agreement must be earned). Documents the trigger (`/thoughts`, or `/thoughts ?` with a space). Installs to `~/.claude/skills/thoughts/` by the kit's directory convention (no install change needed).

## Linked Issues

Closes #886

## Test Plan

- `./scripts/ci/validate.sh` → **172 passed, 0 failed**
- `trivy fs` (HIGH/CRITICAL) → 0
- Genericization verified — grep for author-specific references → none
- Doc-only behavioral skill (no executable code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)