### PR TITLE
feat(skills): kill cached default-branch; wire branch_guard guards

### DIFF
--- a/.claude-project.md
+++ b/.claude-project.md
@@ -8,7 +8,6 @@
 - **Remote:** git@github.com:Wave-Engineering/claudecode-workflow.git
 
 ## Branching
-- **Default branch:** main
 - **Merge strategy:** squash
 
 ## Status Mechanism

--- a/skills/ccfold/SKILL.md
+++ b/skills/ccfold/SKILL.md
@@ -148,10 +148,11 @@ After merging CLAUDE.md, generate or update `.claude-project.md` in the project 
 Run these commands to populate each section:
 
 1. **Platform** — `git remote get-url origin` to determine host (GitHub/GitLab) and CLI (`gh`/`glab`)
-2. **Default branch** — `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`
-3. **Existing labels** — `gh label list --limit 50 --json name,description` (GitHub) or `glab label list` (GitLab)
-4. **CI system** — Check for `.github/workflows/` (GitHub Actions) and/or `.gitlab-ci.yml` (GitLab CI)
-5. **Toolchain** — Check for `scripts/ci/validate.sh`, `scripts/ci/build.sh`, `Makefile`, `pytest`, `package.json`, etc.
+2. **Existing labels** — `gh label list --limit 50 --json name,description` (GitHub) or `glab label list` (GitLab)
+3. **CI system** — Check for `.github/workflows/` (GitHub Actions) and/or `.gitlab-ci.yml` (GitLab CI)
+4. **Toolchain** — Check for `scripts/ci/validate.sh`, `scripts/ci/build.sh`, `Makefile`, `pytest`, `package.json`, etc.
+
+> **Do NOT discover or record the default branch.** It is deliberately absent. A cached default silently goes stale when the upstream default is renamed or moved — `git symbolic-ref refs/remotes/origin/HEAD` only reads a local pointer set at clone time and never re-checks. The default branch is resolved **live** at use-time by the `branch_guard` tool; it is never written into `.claude-project.md`. See #888.
 
 ### Writing `.claude-project.md`
 
@@ -168,7 +169,6 @@ Use this template structure:
 - **Remote:** (origin URL)
 
 ## Branching
-- **Default branch:** (discovered)
 - **Merge strategy:** squash
 
 ## Status Mechanism
@@ -194,6 +194,7 @@ Use this template structure:
 
 - **If `.claude-project.md` does not exist:** Create it from scratch using the template above, populated with discovered values.
 - **If `.claude-project.md` already exists:** Preserve any content outside the auto-generated sections. Update the auto-generated sections (those between `<!-- Auto-generated -->` markers) with fresh discovery results. Manual edits in non-templated areas are kept.
+- **Strip any cached default branch (create AND update):** `.claude-project.md` must NEVER carry a `Default branch:` line. If an existing file has one (from an older template), delete it. The default is queried live at use-time via `branch_guard` — never cached — because a frozen value silently goes stale when the upstream default is renamed (see #888).
 
 ### Show the user what was written
 

--- a/skills/mmr/SKILL.md
+++ b/skills/mmr/SKILL.md
@@ -14,7 +14,8 @@ description: Merge a PR/MR with squash and source branch deletion
 Squash-merge a pull request (GitHub) or merge request (GitLab) with a detailed commit message and source branch deletion. All platform differences are handled inside the MCP tools — no inline `gh`/`glab` bash.
 
 ## Tools Used
-- `mcp__sdlc-server__pr_status` — state, merge_state, mergeable, checks summary
+- `mcp__sdlc-server__pr_status` — state, merge_state, mergeable, checks summary, target branch
+- `mcp__sdlc-server__branch_guard` — validate the merge target against the live default (protected-gated, `kahuna/*`-exempt)
 - `mcp__sdlc-server__pr_diff` — unified diff for squash message drafting
 - `mcp__sdlc-server__pr_wait_ci` — server-side block on pending checks (default 30s interval, 30min timeout)
 - `mcp__sdlc-server__pr_merge` — squash merge with auto-fallback to merge-queue on GitHub
@@ -24,7 +25,7 @@ Squash-merge a pull request (GitHub) or merge request (GitLab) with a detailed c
 
 Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix); otherwise resolve via `pr_status` on the current branch's PR or fail if none exists.
 
-1. `pr_status(number)` → require `state == "open"`; inspect `checks.summary`
+1. `pr_status(number)` → require `state == "open"`; inspect `checks.summary`. **Then guard the merge target:** call `branch_guard({ role: "target", branch: <PR/MR target from pr_status> })`; on `verdict == "warn"` **STOP** and surface `reason` — you are about to merge into a **protected** branch that is neither the live default nor a `kahuna/*` sandbox integration branch. Silent for the live default and `kahuna/*` targets. *(Transition fallback until `branch_guard` is deployed (#465): resolve the live default inline via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` / GitLab `glab api "projects/:id" --jq .default_branch` and STOP if the target is neither the live default nor matches `^kahuna/[0-9]+-`. The degraded path can't query host protection, so it errs toward stopping on any non-default, non-sandbox target — safe, and rare in this trunk-based flow.)*
 2. If `checks.summary == "pending"` → `pr_wait_ci(number, poll_interval_sec: 30, timeout_sec: 1800)`. On `timed_out` ask whether to wait longer. On `failed` STOP.
 3. If `checks.summary == "has_failures"` → STOP and report. Do NOT merge with failing checks.
 4. `pr_diff(number)` → use the diff content (plus `git log target..source`) to draft the squash commit message.
@@ -42,6 +43,7 @@ Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix)
 
 - NEVER merge without explicit user approval
 - NEVER merge if `checks.summary == "has_failures"`
+- NEVER merge into a protected, non-default, non-`kahuna/*` branch — `branch_guard` STOPs this (target must be the live default or a `kahuna/*` sandbox)
 - Always squash + delete source branch
 - Squash message replaces the entire commit history — make it comprehensive
 - Merge conflicts → STOP and report, do NOT attempt to resolve

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -17,6 +17,7 @@ Mandatory verification before any commit. Checks compliance, runs code review, p
 
 ## Tools Used
 - `mcp__sdlc-server__ibm` — branch/issue workflow (no protected branch; branch linked to an open issue)
+- `mcp__sdlc-server__branch_guard` — resolve the live default branch and verify the current branch's base is it (protected-gated, `kahuna/*`-exempt)
 - `mcp__sdlc-server__spec_validate_structure` — linked issue has Changes / Tests / AC
 - `mcp__disc-server__disc_send` — post approval request to `#precheck` (channel `1491195025198157834`)
 
@@ -24,6 +25,18 @@ Mandatory verification before any commit. Checks compliance, runs code review, p
 
 ### Step 1 — IBM gate (serial, hard stop)
 Call `mcp__sdlc-server__ibm` directly (no sub-agent — it's one MCP call). If it fails, stop immediately and do not proceed.
+
+### Step 1.5 — Base-branch gate (serial, hard stop)
+Call `mcp__sdlc-server__branch_guard({ role: "base" })`. It resolves the **live** default branch from the git host (never a cached `.claude-project.md` value or `origin/HEAD` — both go stale silently) and checks the branch your work is based on. Interpret the envelope:
+- `verdict == "pass"` → continue.
+- `verdict == "warn"` → **STOP** and surface `reason` verbatim. Your branch's base is a **protected** branch that is neither the live default nor a `kahuna/*` sandbox — almost always a stale or renamed base (the exact failure this gate exists to catch). Rebase onto the live default, or confirm the base is intentional, before proceeding.
+- `{ ok: false }` or any error envelope → **STOP** and surface the error; do not silently continue past a gate that failed to run.
+
+**Protected-gated:** silent when the base is unprotected (feature→feature, stacked branches) or a `kahuna/*` integration branch. Only a protected, non-default, non-sandbox base trips it.
+
+**Scope (known limit):** reliable once a PR exists (it reads the PR's base). Before a PR exists, git can't distinguish "based on a stale default" from "based on the current default, now a bit behind" without false positives, so the pre-PR case is intentionally not gated here — the PR-create and merge target guards catch the wrong-target case. (#888)
+
+**Transition fallback** — *only* until `branch_guard` is deployed on this host's sdlc-server (#465): resolve the live default inline (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, or GitLab `glab api "projects/:id" --jq .default_branch`). If an open PR exists, compare its base (`gh pr view --json baseRefName -q .baseRefName`) and STOP if that base is a protected branch that is neither the live default nor matches `^kahuna/[0-9]+-`. Delete this paragraph once `branch_guard` is universal.
 
 ### Step 2 — Parallel verification batch
 After `ibm()` passes, launch all four jobs **in a single message** as parallel Agent calls. Do NOT wait for one before starting the next — they have no data dependencies on each other.
@@ -85,7 +98,7 @@ Delegated to Job C (Haiku sub-agent) in the parallel batch. Interpret the result
 - **FINDINGS** → report each finding (package, CVE, severity, fixed version if any) as a deferred checklist item. Do NOT auto-upgrade dependencies — the user approves the codebase state at the gate. Do NOT block the gate on vulnerabilities with no available fix.
 
 ## The Checklist (full every time; a checkmark means VERIFIED by reading the codebase)
-**Context:** Project | Issue #N — title | Branch `feature/N-...` → `main`
+**Context:** Project | Issue #N — title | Branch `feature/N-...` → `<live default>`
 - [ ] Implementation (AC verified) — [ ] TODOs (searched+addressed) — [ ] Docs (reviewed+updated) — [ ] Validation (actually ran)
 - [ ] New tests (cover new code) — [ ] All tests pass (entire suite) — [ ] Scripts executed (linting is NOT testing) — [ ] Code review (high+ fixed)
 - [ ] Dependencies (trivy: 0 HIGH/CRITICAL, or exceptions documented, or [SKIPPED])
@@ -103,7 +116,7 @@ Resolve identity from `<project_root>/.claude/agent-identity.json`; fall back to
 
 **Project:** <project-name>
 **Issue:** #<N> — <title>
-**Branch:** `<type>/<N>-<slug>` → `main`
+**Branch:** `<type>/<N>-<slug>` → `<live default>`
 **Checklist:** `[codebase]` `[docs]` `[tests]` `[config]`
 **Findings:** <fixed> / <deferred> / (none)
 

--- a/skills/scp/SKILL.md
+++ b/skills/scp/SKILL.md
@@ -16,6 +16,7 @@ Git commit workflow with context awareness. Reasoning layer (commit message draf
 ## Tools Used
 
 - `mcp__sdlc-server__ibm` — branch/issue workflow gate (no protected branch; branch linked to an open issue). Handles platform detection internally.
+- `mcp__sdlc-server__branch_guard` — validate the PR target against the live default before creating (protected-gated, `kahuna/*`-exempt).
 - `mcp__sdlc-server__pr_list` — check whether a PR already exists for the current branch.
 - `mcp__sdlc-server__pr_create` — create the PR with the drafted title/body.
 
@@ -63,7 +64,8 @@ Git plumbing stays as git:
 
 Then route PR handling through MCP tools:
 4. `pr_list({head: "<current-branch>"})` — check whether a PR already exists for this branch.
-5. If the list is empty, call `pr_create({title, body, base, head, draft?})` with the drafted title/body. For `base`, use the repo's default branch (resolve once per session via `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'` and cache locally); `head` is the current branch.
+5. If the list is empty, **resolve the intended base, then validate it before creating.** The base is the **live** default branch (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name` / GitLab `glab api "projects/:id" --jq .default_branch`) unless you are intentionally targeting a non-default branch (e.g. a `kahuna/*` integration branch on a sandbox flight). Call `branch_guard({ role: "target", branch: <that resolved base> })` — passing the concrete base so the guard actually inspects it — and on `verdict == "warn"` **STOP**, surfacing `reason` (the base is a protected branch that is neither the live default nor a `kahuna/*` sandbox). On `pass`, call `pr_create({title, body, base, head, draft?})` with that validated `base` (never a cached value); `head` is the current branch.
+   - *Transition fallback until `branch_guard` is deployed (#465):* skip the tool call and **STOP** directly if the resolved `base` is neither the live default nor matches `^kahuna/[0-9]+-`. (The degraded path can't query host protection, so it errs toward stopping on any non-default, non-sandbox base — safe, and rare in this trunk-based flow.)
 6. Report the PR URL (either the pre-existing one from `pr_list` or the newly-created one from `pr_create`).
 
 ## Important Rules


### PR DESCRIPTION
## Summary

Kills the frozen `Default branch: main` in `.claude-project.md` that let an agent work four days on a stale base. The default is now resolved **live** (never cached, never `origin/HEAD`), and `branch_guard` gates every base/target: a **protected** branch that isn't the current live default — e.g. an old `release/*` when the default has moved to a newer `release/*` — stops the flow. `kahuna/*` sandboxes are exempt.

## Changes

- `ccfold`: stop discovering/writing the default branch; strip it on re-fold
- `.claude-project.md`: removed the cached line
- `precheck`: base-branch gate (`branch_guard role:base`)
- `scp`: validate the resolved base before `pr_create`
- `mmr`: validate the PR/MR target before `pr_merge`
- protected-gated + `kahuna/*` exempt; transition fallbacks (inline `gh`/`glab`) until `branch_guard` deploys fleet-wide
- de-hardcode `main` in the precheck checklist/Discord notification

## Linked Issues

Closes #888

## Test Plan

Precheck ran green: `validate.sh` 172/0, pytest 1498 passed, trivy 0 HIGH/CRITICAL, spec-validate PASS, code-review findings addressed. The `branch_guard` tool (`mcp-server-sdlc#465`, separate PR) verified: `bun test` 2355/0. Behavioral: with default `release/1.0.0`, targeting/merging `release/0.0.1` → STOP (protected, ≠ live default); targeting the live default → pass; `kahuna/*` → pass.