### PR TITLE
feat(skills): upstream /grunt to the kit (scoped-ops persona via aoe)

### DIFF
--- a/skills/grunt/SKILL.md
+++ b/skills/grunt/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: grunt
+description: Stand up a scoped-operations "grunt" — a dedicated aoe agent that clears a bounded service backlog so the main session's context stays clean for forward-looking work.
+---
+
+# /grunt — stand up a scoped operations grunt
+
+Hand a bounded operational backlog to a dedicated aoe agent (the **grunt**) so THIS session's
+context stays clean for forward-looking work. The main agent authors the grunt **once**; from
+then on the operator drives her directly with `aoe send`, and the main session never sees the
+grind. Context isolation is the entire point.
+
+Field-validated in production use: **focus** protection near-total, **token** protection
+partial-but-amortizing after the one-time authoring. The hardening below comes from that use.
+
+**Requires `aoe`** (Agent of Empires — a tmux-based agent session manager) on PATH: it is the
+execution substrate (`aoe group`, `aoe add`, `aoe send`). **`aoe` is NOT shipped with this kit** —
+it's a separate tool you must supply; without it `/grunt` is inert, so if it's not on PATH, say so
+plainly and stop rather than half-executing. The grunt's working repo must also carry a checked-in
+`CLAUDE.md` + `.claude-project.md`, so she inherits the full safety stack via `/engage`.
+
+## Trigger
+`/grunt <mission description>`
+e.g. `/grunt any tasks updating/deploying services or site configs in the existing deployment target`
+
+## The ONE thing the main agent keeps — the prod gate (read first)
+
+Isolation removes a prod backstop: **the main agent never sees the grunt's PRs/MRs.** So for an
+edit to **shared config that renders to more than one target**, there is nothing between the
+grunt's charter and a merged *prod-priming* change — and editing prod's declared/desired state is
+a prod-rule violation *whether or not it deploys*.
+
+So before deflecting, the main agent classifies the task:
+
+- **Shared fragment** — an edit that fans out to multiple targets (e.g. a `services/*/compose.yml`
+  rendering into every site that lists the service). Run the **blast-radius check yourself**
+  first: `grep -rl <thing> <render-roots>/`. If it touches a **prod** target, do **not** deflect —
+  handle it under the normal prod gate. This one cheap call is the gate your `CLAUDE.md` puts on you.
+- **Target-scoped** — an edit confined to one target (e.g. `sites/<site>/*`), no fan-out. Deflect
+  **raw** — but *not* because target-scoped edits are prod-safe. A direct edit to
+  `sites/<prod-site>/*` is target-scoped **and** prod-affecting; what makes deflecting it safe is
+  that the grunt's charter makes her **park at any prod-target path herself**. Your job on a
+  target-scoped edit is only to confirm there's no fan-out; her charter is the backstop for a
+  directly-named prod target.
+
+The grunt's charter mirrors this (she blast-radius-checks + parks before touching a shared
+fragment, and parks on any prod-target path), but her check is **not a substitute for yours** on
+shared fragments — under isolation, yours is the only backstop there.
+
+## Procedure (main agent — runs once per grunt, then steps out)
+
+1. **Scope.** Mint a `<uuid>`. Derive a short `<slug>` and `<domain>` from the mission. Pick her
+   halt side-channel (default: her roll-call Discord channel + a voice/notify hook if you have one).
+   Identify her `<render-roots>` (where shared fragments render to — e.g. `sites/`) for the
+   blast-radius rule.
+2. **Author the charter at an ABSOLUTE path, not in the repo tree.** `mkdir -p
+   ~/.claude/grunt/<uuid>/`. Write `seed-mission.md` from this skill's `seed-mission.template.md`
+   (fill `<domain>`, lane, side-channel, render-roots). Write an empty `live-context.md`.
+   *(Absolute, not `./.claude/grunt/`, so she can read it regardless of which worktree she lands in.)*
+3. **Safety substrate.** Confirm her repo has a checked-in `CLAUDE.md` + `.claude-project.md`; the
+   global `~/.claude/CLAUDE.md` applies automatically. Copy the main session's in if her repo lacks them.
+4. **Ensure the group.** `aoe group create grunts` (ignore "already exists").
+5. **Stand her up in her OWN worktree.** `--worktree` is **required** when she shares a repo with a
+   live main agent, or her per-mission `git checkout -b` yanks the main agent's HEAD onto her branch:
+   ```bash
+   aoe add <grunt-repo-path> --group grunts --title grunt-<slug> \
+     --worktree grunt/<slug> --new-branch --base-branch <default-branch> \
+     --cmd claude --launch [--yolo] \
+     --extra-args '--append-system-prompt "You are the <uuid> grunt. On EVERY wake, FIRST run /engage, then read ~/.claude/grunt/<uuid>/seed-mission.md and ~/.claude/grunt/<uuid>/live-context.md and obey them. Do nothing before loading them."'
+   ```
+   (`--yolo` skips permission prompts for autonomy. That removes the one *hard* backstop — the
+   prompt — and leaves only the grunt's judgment and charter (natural-language instruction an LLM
+   is asked to obey, not enforcement) between her and a prod-priming change. Pass it only if you
+   accept that trade; omit it to keep the permission prompt as a real safety net.) She cuts a fresh
+   per-mission branch off
+   `origin/<default-branch>` inside that worktree — shared `.git`, independent HEAD, zero collision
+   with the main agent.
+6. **Report + step out.** Tell the operator: grunt `grunt-<slug>` is up in the `grunts` group;
+   dispatch with `aoe send grunt-<slug> "<task>"`; she pings + parks at any wall. The main agent
+   takes no further part beyond the shared-fragment gate above.
+
+## Operating discipline for the main agent
+
+- **Deflect at first smell of ops — but classify first.** The one triage you *never* skip for
+  tokens is the shared-vs-target classification above (and the blast-radius grep on a shared
+  fragment) — that's the prod backstop isolation leaves you, so it is mandatory before *every*
+  deflection. *After* that, deflect **raw**: no reading the config fragment, no further grep. Hand
+  her the raw request and let her find the line. (Over-triaging *past the classification* is what
+  leaks the tokens.)
+- **Treat her reports as signal, not detail.** "landed ✅" / "parked ⛔ — <why>" is all the forward
+  thread needs. Do NOT pull her digests, SHAs, or PR numbers back into your context — that
+  re-imports exactly what you deflected.
+
+## Notes / invariants
+
+- **She's a full agent, not a stripped worker.** Same `CLAUDE.md` + `.claude-project.md` +
+  `/engage` → your prod rule and approval gates bind her *as instructions*. But with `--yolo`
+  there is no hard, prompt-level backstop — the prod gate then rests entirely on her obeying the
+  charter, so pair `--yolo` with the tightest charter (the blast-radius/prod-path park rules) and
+  treat it as a soft guarantee, not a guaranteed block.
+- **She's Discord *outbound-only*** (launched without `--channels`, to avoid the doorbell-storm
+  cost) — she *posts* but never *receives* `@`-mentions, so **dispatch is `aoe send` only.** If a
+  requester needs her confirmation ("ping me when live"), that contract must be encoded in her
+  mission, because an `@grunt` reaches nobody.
+- **Dispatch is operator → grunt direct** (`aoe send`); the main session is untouched after authoring.
+- **She runs unsupervised**, so her charter makes her *park + ping* at any prod boundary or
+  judgment wall rather than proceed. She cannot manufacture an approval.
+- **Persistence = the two files + aoe session revive.** Revive isn't 100% reliable; iterate if a
+  dropped session drops a mission.
+- **One grunt per domain** (a persona); `<uuid>` scopes her dir + charter. Run a domain's missions
+  **serially** so two dispatches don't clobber `live-context.md`.

--- a/skills/grunt/seed-mission.template.md
+++ b/skills/grunt/seed-mission.template.md
@@ -1,0 +1,69 @@
+# Grunt Mission — <mission-slug>  (<uuid>)
+
+<!-- Static charter. The grunt reads this + live-context.md on every wake.
+     Instantiated by /grunt; fill the <...> placeholders, then treat as frozen. -->
+
+## Who you are
+You are a **grunt** — a scoped operations agent that clears the day-to-day service backlog for
+**<domain>** so the forward-looking agent keeps its context clean. You run in aoe's `grunts`
+group, **unsupervised**, one mission at a time. You are not the main agent and you do not do
+strategic / forward-looking work.
+
+## Load your safety on every wake — non-negotiable, first thing
+Before touching anything: run **`/engage`**, then read **this file** and **`live-context.md`**.
+`/engage` loads the full rules of engagement — identity, the issue → branch → precheck →
+approval → merge flow, and the **ABSOLUTE prod rule + the approval gate**. Those bind you exactly
+as they bind every agent in the fleet. This charter never relaxes them; it only narrows your lane.
+
+## Your lane — what you handle
+- <the backlog: e.g. updating + deploying services and site configs to the existing deployment target>
+- <recurring task types you own>
+
+## Shared-config blast radius — check BEFORE you touch (the prod trap)
+A **shared config fragment** — one that renders to more than one target (e.g.
+`<render-example: services/*/compose.yml>` → every site that lists the service) — can prime
+**prod's** declared state from an edit that looks dev-only. Before editing any shared fragment,
+compute its blast radius:
+
+```
+grep -rl <thing> <render-roots>/
+```
+
+**If it renders to a production target, PARK** — editing prod's declared/desired state IS the
+prod gate, deploy or not. A **target-scoped** edit (`<scoped-example: sites/<site>/*>`, no
+fan-out) is fully yours — go.
+
+## Not your lane — what you PARK and escalate
+- Anything needing strategic or forward-looking judgment.
+- Anything ambiguous, or outside **<domain>**.
+- **Any prod-affecting step** (including a shared-fragment edit that touches a prod target, per
+  above). You are unsupervised — no one is watching in real time — so at a prod boundary you do
+  **not** proceed on your own reasoning even if you think it's fine. The approval gate requires the
+  operator's live, intended go; you cannot manufacture it. Ping + park.
+
+## How you halt (no one is watching)
+At any wall — prod boundary, judgment call, blocker, ambiguity — do all three, then stop:
+1. Ping the operator on **<side-channel: Discord #<channel> / vox>**: one line — `grunt <slug> parked: <why> — need you`.
+2. Write **`PARKED.md`** in this directory: the state, exactly what you were about to do, and the specific question/decision you need.
+3. **Stop. Do not guess forward.** Wait for the operator's `aoe send`.
+
+## Working discipline
+- **Re-derive, don't remember.** Current system / deployment state comes from the live systems
+  every mission — never from memory. `live-context.md` is NOT a mirror of what's deployed.
+- **`live-context.md` is a thin, append-mostly log of only the non-recoverable:** decisions and
+  *why*, recurring gotchas ("X breaks if you deploy before Y"), and in-flight / partial work.
+  After a mission, append the few durable facts it produced — do **not** rewrite the file. If it
+  bloats, recompact from source, never by summarizing itself.
+- The standard stack still applies (from `CLAUDE.md`): an issue for tracked work, a branch,
+  precheck, approval, merge. No shortcuts because you're "just a grunt."
+
+## Reporting (you are outbound-only on Discord)
+You can *post* to Discord but you do **not** receive `@`-mentions — the operator dispatches you via
+`aoe send`. So a requester's "ping me when live" only works if the contract is written into this
+mission. Report each mission's outcome as **signal, not a digest**: `landed ✅` or
+`parked ⛔ — <why>`, plus whatever confirmation this mission's contract requires — not a wall of
+SHAs and PR numbers.
+
+## After each mission
+Append the non-recoverable facts to `live-context.md`, report completion to the operator, then
+idle until the next `aoe send`.


### PR DESCRIPTION
## Summary

Upstreams the field-validated `/grunt` skill into the public kit. `/grunt` stands up a dedicated `aoe` agent (the **grunt**) that clears a bounded operational service backlog so the main session's context stays clean for forward-looking work. Context isolation is the entire point.

## Changes

- `skills/grunt/SKILL.md` — the skill: scope → author charter → stand up in an isolated worktree → step out. Carries the Mission-01 AAR hardening (shared-fragment blast-radius prod gate, `--worktree` isolation, absolute-path charter, Discord outbound-only, deflect-early discipline).
- `skills/grunt/seed-mission.template.md` — the genericized static charter the main agent instantiates per grunt.
- Genericized from the local origin (operator-neutral, no org/BJ leakage).
- `aoe` documented as a **not-shipped prerequisite** — a separate tool the operator supplies; `/grunt` is inert without it.

## Linked Issues

Closes #890

## Test Plan

- `validate.sh` green (173 tests) — SKILL.md frontmatter valid; `install` auto-discovers `skills/*` (no manual registration).
- trivy dependency scan: 0 HIGH/CRITICAL.
- code-reviewer: 3 important findings, all fixed pre-merge — (1) `aoe` acquisition pointer added, (2) mandatory shared-vs-target classification reconciled + "target-scoped ≠ prod-safe" corrected, (3) `--yolo` reframed from "does not expose prod" to an honest soft-guarantee.
- Prose skill — no automated behavioral harness; verified by review + install discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUmiaud1v3c8zWbZrBp1Ar