### PR TITLE
chore(vox): flock playback mutex + upstream #881 speaker-id hotpatch

### DIFF
--- a/scripts/vox
+++ b/scripts/vox
@@ -95,6 +95,104 @@ resolve_player() {
 	return 0
 }
 
+# --- Resolve speaker identity -------------------------------------------------
+# Who is announcing? Walk up the process tree from vox's parent to the owning
+# `claude --session-id <uuid>` process, take its cwd, and resolve
+# <cwd>/.claude/agent-identity.json -> dev_name. Fallbacks: short session id,
+# then the caller PID. Defensive throughout so a failed lookup never breaks vox.
+resolve_speaker() {
+	local name="" sid="" pid cmd cwd d hop=0
+	local have_jq=0
+	command -v jq >/dev/null 2>&1 && have_jq=1
+
+	# name_from_cwd DIR : echo dev_name from the nearest ancestor dir carrying
+	# .claude/agent-identity.json, walking up from DIR. Empty if none.
+	name_from_cwd() {
+		local d="$1"
+		((have_jq)) || return 0
+		while [[ -n "$d" && "$d" != "/" ]]; do
+			if [[ -f "$d/.claude/agent-identity.json" ]]; then
+				jq -r '.dev_name // empty' "$d/.claude/agent-identity.json" 2>/dev/null || true
+				return 0
+			fi
+			d="$(dirname "$d")"
+		done
+	}
+
+	# 1) Primary: vox's own cwd (agents invoke it from their project root).
+	name="$(name_from_cwd "$PWD")" || name=""
+
+	# 2) Walk the process tree: capture a session id (for the fallback label) and,
+	#    if cwd gave no name, try each ancestor's cwd (catches the session's dir
+	#    even if the agent cd'd elsewhere).
+	pid="${PPID:-0}"
+	while [[ "$pid" =~ ^[0-9]+$ ]] && ((pid > 1)) && ((hop < 14)); do
+		hop=$((hop + 1))
+		cmd="$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null)" || cmd=""
+		if [[ -z "$sid" && "$cmd" == *"--session-id"* ]]; then
+			sid="$(printf '%s ' "$cmd" | sed -n 's/.*--session-id[= ]\([0-9a-fA-F-]\{36\}\).*/\1/p')" || sid=""
+		fi
+		if [[ -z "$name" ]]; then
+			cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null)" || cwd=""
+			if [[ -n "$cwd" ]]; then
+				name="$(name_from_cwd "$cwd")"
+			fi
+		fi
+		[[ -n "$name" && -n "$sid" ]] && break
+		pid="$(awk '/^PPid:/{print $2; exit}' "/proc/$pid/status" 2>/dev/null)" || pid=""
+		[[ -n "$pid" ]] || break
+	done
+
+	if [[ -n "$name" ]]; then
+		printf '%s' "$name"
+	elif [[ -n "$sid" ]]; then
+		printf 'session %s' "${sid:0:8}"
+	else
+		printf 'pid %s' "${PPID:-unknown}"
+	fi
+}
+
+# --- Provenance log -----------------------------------------------------------
+# Append one JSON line per announcement to ~/.claude/logs/vox.jsonl, capturing
+# the caller's lineage AT CALL TIME (parent cmdline + cwd + a 6-deep ancestor
+# cmdline chain) — so a fire-and-exit caller is still traceable after it's gone.
+# VOX_NO_LOG=1 to skip. Best-effort; never breaks vox.
+vox_log() {
+	if [[ "${VOX_NO_LOG:-0}" == "1" ]]; then return 0; fi
+	command -v jq >/dev/null 2>&1 || return 0
+	local logdir="$HOME/.claude/logs" logf ts ppid pcmd pcwd pid hop cmd chainjson
+	local -a chain=()
+	logf="$logdir/vox.jsonl"
+	mkdir -p "$logdir" 2>/dev/null || return 0
+	ts="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || true)"
+	ppid="${PPID:-0}"
+	[[ "$ppid" =~ ^[0-9]+$ ]] || ppid=0
+	pcmd="$(tr '\0' ' ' <"/proc/$ppid/cmdline" 2>/dev/null || true)"
+	pcmd="${pcmd% }"
+	pcwd="$(readlink "/proc/$ppid/cwd" 2>/dev/null || true)"
+	pid="$ppid"
+	hop=0
+	while [[ "$pid" =~ ^[0-9]+$ ]] && ((pid > 1)) && ((hop < 6)); do
+		hop=$((hop + 1))
+		cmd="$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)"
+		cmd="${cmd% }"
+		if [[ -n "$cmd" ]]; then
+			chain+=("$cmd")
+		fi
+		pid="$(awk '/^PPid:/{print $2; exit}' "/proc/$pid/status" 2>/dev/null || true)"
+		[[ -n "$pid" ]] || break
+	done
+	chainjson='[]'
+	if ((${#chain[@]})); then
+		chainjson="$(printf '%s\n' "${chain[@]}" | jq -R . | jq -sc . 2>/dev/null || echo '[]')"
+	fi
+	jq -cn --arg ts "$ts" --arg sp "${1:-}" --arg txt "${2:0:240}" \
+		--argjson ppid "$ppid" --arg caller "$pcmd" --arg cwd "$pcwd" --argjson chain "$chainjson" \
+		'{ts:$ts, speaker:$sp, ppid:$ppid, cwd:$cwd, caller:$caller, chain:$chain, text:$txt}' \
+		>>"$logf" 2>/dev/null || true
+	return 0
+}
+
 # --- Usage / help -------------------------------------------------------------
 
 usage() {
@@ -257,6 +355,16 @@ if [[ -z "${TEXT//[$' \t\n\r']/}" ]]; then
 	exit 1
 fi
 
+# --- Identify + log the caller, then sign off ---------------------------------
+# Resolve who is speaking, LOG the call with full caller lineage (captured now so
+# a fire-and-exit caller is still traceable), then append the speaker to the
+# spoken text. VOX_NO_SIGNOFF=1 skips the sign-off; VOX_NO_LOG=1 skips the log.
+SPEAKER="$(resolve_speaker 2>/dev/null)" || SPEAKER=""
+vox_log "$SPEAKER" "$TEXT" || true
+if [[ "${VOX_NO_SIGNOFF:-0}" != "1" && -n "$SPEAKER" ]]; then
+	TEXT="${TEXT}. This is ${SPEAKER}."
+fi
+
 # --- Resolve + invoke provider ------------------------------------------------
 
 PROVIDER="$(resolve_provider)" || exit 1
@@ -310,6 +418,18 @@ prepend_wake_noise "$audio_out"
 
 # --- Resolve + invoke player --------------------------------------------------
 
+# Serialize audio playback so concurrent agents don't talk over each other (#895).
+# flock is util-linux and absent on stock macOS; when it's missing, play directly
+# (no mutex, but no breakage on a supported platform).
+VOX_LOCK="${VOX_LOCK:-${TMPDIR:-/tmp}/vox-speak.lock}"
+vox_play() {
+	if command -v flock >/dev/null 2>&1; then
+		flock "$VOX_LOCK" "$@"
+	else
+		"$@"
+	fi
+}
+
 PLAYER=$(resolve_player)
 if [[ -z "$PLAYER" ]]; then
 	echo "Error: no audio player found. Set \$VOX_PLAYER, symlink ~/.config/vox/player, or install aplay/paplay/afplay/ffplay." >&2
@@ -322,10 +442,10 @@ if $BACKGROUND; then
 	(
 		trap 'rm -f "$bgfile"' EXIT
 		# shellcheck disable=SC2086
-		timeout 60 $PLAYER "$bgfile" || true
+		vox_play timeout -k 5 60 $PLAYER "$bgfile" || true
 	) &>/dev/null &
 	disown
 else
 	# shellcheck disable=SC2086
-	$PLAYER "$audio_out"
+	vox_play $PLAYER "$audio_out"
 fi

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -178,6 +178,7 @@ def test_resolution_falls_back_to_bundled_silent(env, tmp_path):
 
 def test_provider_receives_text_as_argv(env, echo_stdin_provider, tmp_path):
     env["VOX_PROVIDER"] = str(echo_stdin_provider)
+    env["VOX_NO_SIGNOFF"] = "1"
     out = tmp_path / "out.wav"
     r = _run([str(VOX), "--output", str(out), "hello world"], env=env)
     assert r.returncode == 0, r.stderr
@@ -187,10 +188,22 @@ def test_provider_receives_text_as_argv(env, echo_stdin_provider, tmp_path):
 def test_stdin_message_round_trips(env, echo_stdin_provider, tmp_path):
     """Text piped via stdin round-trips through vox → provider."""
     env["VOX_PROVIDER"] = str(echo_stdin_provider)
+    env["VOX_NO_SIGNOFF"] = "1"
     out = tmp_path / "out.wav"
     r = _run([str(VOX), "--output", str(out)], env=env, stdin="piped-message")
     assert r.returncode == 0, r.stderr
     assert out.read_text() == "piped-message"
+
+
+def test_signoff_appended_when_enabled(env, echo_stdin_provider, tmp_path):
+    """Without VOX_NO_SIGNOFF, vox appends '. This is <speaker>.' to the text."""
+    env["VOX_PROVIDER"] = str(echo_stdin_provider)
+    out = tmp_path / "out.wav"
+    r = _run([str(VOX), "--output", str(out), "hello"], env=env)
+    assert r.returncode == 0, r.stderr
+    text = out.read_text()
+    assert text.startswith("hello")
+    assert "This is " in text
 
 
 def test_provider_failure_surfaces_error(env, failing_provider, tmp_path):


### PR DESCRIPTION
## Summary

Serializes `vox` audio playback with a host-local `flock` mutex so concurrent agents speak one at a time instead of talking over each other. In the same change, upstreams the long-drifted #881 speaker-identity hotpatch from the installed copy into the repo source, so `scripts/vox` finally matches what's actually installed.

## Changes

- **Mutex (#895):** a portable `vox_play` wrapper wraps both the foreground and `--bg` players in `flock "$VOX_LOCK" …`; falls back to direct playback where `flock` is absent (stock macOS — a supported target), and bounds the `--bg` player with `timeout -k 5`.
- **Upstream #881:** brings `resolve_speaker()`, `vox_log()` provenance logging, and the caller sign-off into `scripts/vox` (they were field-proven live but never committed).
- **Tests:** `test_vox.py` — two text round-trip tests opt out of the sign-off via `VOX_NO_SIGNOFF=1`; new `test_signoff_appended_when_enabled` covers the sign-off.
- Lint clean-up on the upstreamed code (SC2015 → `if/then`, `shfmt`).

## Linked Issues

Closes #895
Closes #881

## Test Plan

- `validate.sh` — **173/173**, exit 0.
- `shellcheck -x scripts/vox` clean; `shfmt -d scripts/vox` no diff.
- `python3 -m pytest tests/test_vox.py` — **31 passed** (incl. new sign-off test).
- Live serialization verified: two concurrent voxes take ~2–3s (serialized), not ~1s; happy path exits 0; portable fallback confirmed (guarded on `command -v flock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUmiaud1v3c8zWbZrBp1Ar