### PR TITLE
fix(issue): stop instructing agents to pass the label colour format label_create rejects

### DIFF
--- a/docs/phase-epic-taxonomy-devspec.md
+++ b/docs/phase-epic-taxonomy-devspec.md
@@ -100,7 +100,7 @@ This is a pure-terminology / pure-rename project. The implementation already beh
 | CT-01 | The kahuna branch lifecycle (create on Plan start, accumulate across Phases, merge once at Plan end, delete on success) MUST remain behaviorally identical. No changes to `wave_init` branch-creation logic, `wave_finalize` MR-assembly logic, or the trust-score gate's 4-signal evaluation. | This is a pure-rename project; behavior changes here would expand scope into a full pipeline redesign. KAHUNA just shipped; it works; we're touching words not wiring. |
 | CT-02 | No perpetual read-compat shim for legacy `epic_id`. Phase 2 (schema rename) ships cleanly; a one-time `sed` migration note lives in §5.B for any surprise case. | The fleet is two installations (malory + Anoushka's laptop). Both are a `./install` away from new-taxonomy-ready; neither warrants accommodation in code. See `principle_cost_asymmetry_continue_vs_exit.md` — we don't build insurance for failures that happen once. |
 | CT-03 | Platform-adapter retrofit **structural** compatibility. The sdlc-server handler signature changes (`wave_init({kahuna: {plan_id, slug}})`, `wave_finalize({plan_id, ...})`) MUST match the shape of the typed PlatformAdapter — flat-hyphenated per-method-per-platform files, no new abstraction levels, no parallel adapter tree. This is a *shape* constraint, not a *timing* constraint: if tachikoma's retrofit has not landed when Phase 2 is ready to ship, we ship on pre-retrofit handlers using the adapter shape; her retrofit absorbs them on its next pass with no structural conflict. | The platform adapter retrofit (sdlc#227) defines the adapter contract; this Plan's schema changes conform to its *shape* regardless of whether her retrofit has shipped. Conflating "must match her shape" with "must wait for her retrofit" is goldplating of coordination we don't need. |
-| CT-04 | The `type::plan` label MUST be created on every Wave-Engineering repo that participates in Plan-level tracking. Label taxonomy is `group::value` (existing convention from `lesson_repo_label_taxonomies.md`). Color matches the existing `type::epic` purple (`#5319E7`) so the two are visually grouped. | A Plan can't be filed on a repo that doesn't know the label; per-repo label drift has already burned us (see `lesson_repo_label_taxonomies.md`). Mechanical rollout, not a per-repo judgment. |
+| CT-04 | The `type::plan` label MUST be created on every Wave-Engineering repo that participates in Plan-level tracking. Label taxonomy is `group::value` (existing convention from `lesson_repo_label_taxonomies.md`). Color matches the existing `type::epic` purple (`5319E7`) so the two are visually grouped. | A Plan can't be filed on a repo that doesn't know the label; per-repo label drift has already burned us (see `lesson_repo_label_taxonomies.md`). Mechanical rollout, not a per-repo judgment. |
 | CT-05 | The optional `epic::N` label family is **purely advisory**. No pipeline tool MAY read, filter, branch on, or group by `epic::N` labels. Tests MUST assert the absence of `epic::N` reads in pipeline code paths. | The entire point of demoting "epic" to a PM-layer concept is that the pipeline stops caring. Any pipeline code that reads `epic::N` is a taxonomy leak — enforced mechanically, not by convention. |
 
 ### 2.2 Product Constraints
@@ -158,7 +158,7 @@ Requirements are grouped by theme. Every requirement must appear in at least one
 
 | ID | Type | Requirement |
 |----|------|-------------|
-| R-14 | Event-driven | When `/issue` or any Plan-creating pipeline tool needs to apply the `type::plan` label on a repo that does not yet carry that label in its taxonomy, the tool shall create the label on demand via `label_create` (sdlc-server) using the canonical color (`#5319E7`, matching `type::epic`) and description. No user-facing error unless `label_create` itself fails. |
+| R-14 | Event-driven | When `/issue` or any Plan-creating pipeline tool needs to apply the `type::plan` label on a repo that does not yet carry that label in its taxonomy, the tool shall create the label on demand via `label_create` (sdlc-server) using the canonical color (`5319E7` — bare hex, matching `type::epic`; `label_create` validates `^[0-9a-fA-F]{6}$` and rejects the `#` form) and description. No user-facing error unless `label_create` itself fails. |
 | R-15 | Event-driven | When `/issue type=plan` creates a Plan tracking issue, it shall apply the `type::plan` label and populate the issue body with the canonical Plan template (see §5 Detailed Design). |
 
 ### 3.5 Orchestrator Contract & Plan Ledger
@@ -743,7 +743,7 @@ When invoked, the skill:
    - A one-sentence Goal
    - A suggested slug (kebab-case, from the Goal)
    - An initial Scope block (in / out of scope bullets) populated as placeholders the Pair fills during `/devspec create`
-2. **Checks target repo for `type::plan` label.** If absent, calls `label_create` (sdlc-server) with canonical color `#5319E7` and description `"Plan tracking issue — top-level pipeline container"`. Label creation is idempotent. (R-14 satisfied.)
+2. **Checks target repo for `type::plan` label.** If absent, calls `label_create` (sdlc-server) with canonical color `5319E7` (bare hex — `label_create` rejects the `#` form) and description `"Plan tracking issue — top-level pipeline container"`. Label creation is idempotent. (R-14 satisfied.)
 3. **Renders the canonical Plan body** per §5.1.2's frozen-content template:
    - `<!-- PLAN-ISSUE v1 -->` marker
    - `## Goal` — populated from the prompt
@@ -762,7 +762,7 @@ When a Story is created with the `--epic N` flag:
 
 1. **Validates `N` is an open issue with `type::epic` label** on the target repo via `work_item` pre-check. If `N` doesn't exist or doesn't carry `type::epic`, fail with a clear error message directing the Pair to first create the Epic via `/issue epic <prompt>`.
 2. **Creates the Story** with both `type::feature` (or bug/chore/docs) AND `epic::N` labels. Body is the standard Story template.
-3. **Checks target repo for `epic::N` label** (the label family). If absent, calls `label_create` with color `#5319E7` (same family as `type::epic`) and description `"Story belongs to Epic #N (PM-layer thematic grouping)"`.
+3. **Checks target repo for `epic::N` label** (the label family). If absent, calls `label_create` with color `5319E7` (bare hex — `label_create` rejects the `#` form; same family as `type::epic`) and description `"Story belongs to Epic #N (PM-layer thematic grouping)"`.
 4. **Posts NO comment on the Epic issue.** The parent-child relationship is represented by the `epic::N` label alone; no explicit link comment. Pipeline doesn't read it; PMs who care can filter the Epic's board by its label.
 
 #### 5.5.5 Epic template (for reference — no change)

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -55,7 +55,7 @@ template and label family (authoritative source: `docs/phase-epic-taxonomy-devsp
 artifact the Orchestrator reads; an Epic is a PM-layer grouping the pipeline
 never reads. If you find pipeline code inspecting `type::epic` or `epic::N`,
 it's a taxonomy leak (Dev Spec R-19). The two types share label colour
-`#5319E7` because they sit in the same visual family on the project board,
+`5319E7` because they sit in the same visual family on the project board,
 not because they share any pipeline semantics.
 
 ## Wave-Pattern-Ready Output Guarantee
@@ -498,10 +498,10 @@ Two label families are created on-demand when absent from the target repo:
 
 | Label | Colour | Description | Created by |
 |-------|--------|-------------|------------|
-| `type::plan` | `#5319E7` | `"Plan tracking issue — top-level pipeline container"` | `/issue plan` invocations |
-| `epic::<N>` | `#5319E7` | `"Story belongs to Epic #N (PM-layer thematic grouping)"` (substitute `<N>`) | `/issue <story> --epic N` invocations |
+| `type::plan` | `5319E7` | `"Plan tracking issue — top-level pipeline container"` | `/issue plan` invocations |
+| `epic::<N>` | `5319E7` | `"Story belongs to Epic #N (PM-layer thematic grouping)"` (substitute `<N>`) | `/issue <story> --epic N` invocations |
 
-Both share colour `#5319E7` with `type::epic` — they sit in the same visual
+Both share colour `5319E7` with `type::epic` — they sit in the same visual
 family on the project board. This does NOT mean the pipeline treats them
 alike; the colour is cosmetic, the semantics are different.
 
@@ -566,6 +566,24 @@ Create immediately — do not ask for approval. Issues are cheap to edit and clo
 
 If `work_item` reports a missing label at create-time (race or pre-existing
 `epic::X` for a different `X`), surface the error; do not silently retry.
+
+> ### ⚠️ `work_item` does not accept `type: plan` yet
+>
+> The tool's `type` enum is `epic | story | feature | bug | chore | docs | fix | pr | mr` — **there
+> is no `plan`.** `/issue plan` therefore cannot pass `type: "plan"` today. Tracked as
+> **`mcp-server-sdlc#477`**; when it lands, pass `type: "plan"` and the correct `type::plan` label
+> is applied automatically — no workaround needed.
+>
+> **Until then, do NOT reach for `type: "epic"` as a substitute on GitHub.** `work_item` *prepends*
+> an automatic `type::<type>` label to the caller's label list, unconditionally. On **GitLab** that
+> is invisible: `type::epic` and `type::plan` share the `type::` scope key, and GitLab's scoped
+> labels are mutually exclusive, so the later `type::plan` **evicts** `type::epic`. On **GitHub**
+> there are no scoped labels — the Plan ends up carrying **both** `type::epic` *and* `type::plan`,
+> which is precisely the taxonomy leak this skill's Taxonomy Overview forbids (Dev Spec R-19).
+>
+> The workaround is safe by *accident* on GitLab and broken on GitHub. If you must create a Plan
+> before #477 lands, create it and then **verify the resulting label set** — strip any stray
+> `type::epic`.
 
 ## Batch Creation (N > 1 issues in one pass)
 
@@ -652,16 +670,20 @@ time:
 
 ## Label Colour Reference
 
-When creating labels, use these colours for consistency. **Note:** `gh` expects hex without `#` prefix; `glab` expects it with `#`. The `mcp__sdlc-server__label_create` tool handles platform translation; pass the `#`-prefixed form.
+When creating labels, use these colours for consistency.
 
-| Group | Colour (glab / label_create) | Colour (gh) |
-|-------|------------------------------|-------------|
-| `type::plan` | `#5319E7` | `5319E7` |
-| `type::epic` | `#5319E7` | `5319E7` |
-| `type::<story-subtype>` | `#0E8A16` | `0E8A16` |
-| `priority::` | `#D93F0B` | `D93F0B` |
-| `urgency::` | `#FBCA04` | `FBCA04` |
-| `size::` | `#1D76DB` | `1D76DB` |
-| `severity::` | `#B60205` | `B60205` |
-| `wave::` | `#5319E7` | `5319E7` |
-| `epic::<N>` | `#5319E7` | `5319E7` |
+> **Pass a bare 6-char hex. No `#`.** `mcp__sdlc-server__label_create` validates `color` against
+> `^[0-9a-fA-F]{6}$` and **rejects the `#`-prefixed form outright**. The tool handles any
+> platform-specific translation internally — callers never pass `#`.
+
+| Group | Colour |
+|-------|--------|
+| `type::plan` | `5319E7` |
+| `type::epic` | `5319E7` |
+| `type::<story-subtype>` | `0E8A16` |
+| `priority::` | `D93F0B` |
+| `urgency::` | `FBCA04` |
+| `size::` | `1D76DB` |
+| `severity::` | `B60205` |
+| `wave::` | `5319E7` |
+| `epic::<N>` | `5319E7` |

--- a/tests/test_issue_skill.py
+++ b/tests/test_issue_skill.py
@@ -686,3 +686,108 @@ Body.
         result = _spec_validate_structure(body)
         assert not result["valid"]
         assert "changes" in result["missing"]
+
+
+class TestLabelColourFormat:
+    """The skill's label colours must match `label_create`'s actual contract.
+
+    cc-workflow#902. The skill previously *instructed* agents to pass the
+    `#`-prefixed form ("gh expects hex without #; glab expects it with #; the
+    tool handles platform translation; pass the #-prefixed form"). That is
+    backwards: `mcp__sdlc-server__label_create` validates `color` against
+    ``^[0-9a-fA-F]{6}$`` and rejects `#RRGGBB` outright. An agent following the
+    skill as written hit the failure (deep-thought, #agent-ops 2026-07-13).
+
+    This is a doc-drifting-from-a-tool-contract bug, so the only test that can
+    catch it is one that reads the doc.
+    """
+
+    # The exact pattern label_create enforces.
+    _LABEL_CREATE_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
+
+    def test_no_hash_prefixed_colours_anywhere(self, skill_text: str) -> None:
+        # A `#`-prefixed 6-hex inside backticks reads as a value to pass.
+        offenders = re.findall(r"`#[0-9A-Fa-f]{6}`", skill_text)
+        assert not offenders, (
+            f"skill presents #-prefixed colour(s) as values to pass: {sorted(set(offenders))}. "
+            "label_create rejects them (^[0-9a-fA-F]{6}$) — use bare hex."
+        )
+
+    def test_documented_colours_satisfy_label_create(self, skill_text: str) -> None:
+        """Every colour the skill OFFERS must be one label_create would accept.
+
+        Harvest the raw token from the Colour column — do NOT pre-filter to
+        well-formed hex. Matching `([0-9A-Fa-f]{6})` first and then asserting it
+        is 6 hex chars is a tautology: a bad value like `#5319E7` or `ZZZZZZ`
+        would simply not be collected, and the test would pass while the skill
+        shipped a colour the tool rejects.
+        """
+        table = re.search(
+            r"^\| Group \| Colour \|.*?(?=\n\s*\n|\Z)",
+            skill_text,
+            re.M | re.S,
+        )
+        assert table, "Label Colour Reference table not found — did its shape change?"
+
+        rows = re.findall(r"^\|\s*`?[^|]+?`?\s*\|\s*([^|]+?)\s*\|\s*$", table.group(0), re.M)
+        colours = [c.strip().strip("`") for c in rows if c.strip().strip("`").lower() != "colour"]
+        colours = [c for c in colours if not set(c) <= {"-", ":"}]  # drop the |---| separator
+        assert colours, "no colours harvested from the table — the parse is broken, not the doc"
+
+        for colour in colours:
+            assert self._LABEL_CREATE_COLOR_RE.match(colour), (
+                f"colour {colour!r} in the Label Colour Reference would be REJECTED by "
+                f"label_create (it validates ^[0-9a-fA-F]{{6}}$ — bare hex, no '#')"
+            )
+
+    def test_states_the_no_hash_rule(self, skill_text: str) -> None:
+        assert re.search(r"[Nn]o `?#`?\.|bare 6-char hex|without.*`#`", skill_text), (
+            "skill must state that label_create takes a bare hex with no '#'"
+        )
+
+    def test_does_not_claim_platform_translation_of_the_hash(self, skill_text: str) -> None:
+        # The specific false claim that caused the bug.
+        assert "pass the `#`-prefixed form" not in skill_text, (
+            "the skill must not instruct agents to pass the #-prefixed form — label_create rejects it"
+        )
+
+
+class TestPlanTypeGapDocumented:
+    """`work_item` has no `plan` in its type enum (mcp-server-sdlc#477).
+
+    The skill must not silently imply `type: "plan"` works, and must warn that
+    the obvious `type: "epic"` workaround leaks `type::epic` on GitHub (GitLab
+    hides it via scoped-label eviction; GitHub has no scoped labels).
+    """
+
+    @staticmethod
+    def _warning_box(skill_text: str) -> str:
+        """The `work_item does not accept type: plan` blockquote, extracted.
+
+        Anchor the assertions to THIS region rather than the whole 700-line file —
+        a bare `"477" in skill_text` would be satisfied by any future issue number
+        or even a hex colour like `477ACB`, and `"scoped label"` anywhere would do.
+        """
+        m = re.search(
+            r"^> ### .*?`type: plan`.*?(?=\n(?!>)|\Z)",
+            skill_text,
+            re.M | re.S,
+        )
+        assert m, "the `work_item does not accept type: plan` warning box is missing"
+        return m.group(0)
+
+    def test_plan_enum_gap_is_flagged(self, skill_text: str) -> None:
+        box = self._warning_box(skill_text)
+        assert re.search(r"mcp-server-sdlc#477|sdlc#477", box), (
+            "the warning box must cite the tracking issue (sdlc#477) for the missing `plan` enum"
+        )
+
+    def test_epic_workaround_github_leak_is_warned(self, skill_text: str) -> None:
+        box = self._warning_box(skill_text)
+        assert re.search(r"scoped label", box, re.I), (
+            "the box must explain GitLab scoped-label eviction..."
+        )
+        assert re.search(r"GitHub", box), (
+            "...and that GitHub has NO scoped labels, so the type::epic leak is REAL there. "
+            "Without both halves the workaround reads as safe."
+        )


### PR DESCRIPTION
## Summary

`skills/issue/SKILL.md` told agents:

> "`gh` expects hex without `#` prefix; `glab` expects it with `#`. The `mcp__sdlc-server__label_create` tool handles platform translation; **pass the `#`-prefixed form.**"

**That is backwards.** `label_create` validates `color` against `^[0-9a-fA-F]{6}$` and rejects `#RRGGBB` at schema-parse, before any adapter runs. The skill did not merely carry a stale example — it *actively instructed* agents to use the one format that fails, then handed them a two-column table whose "pass this" column was the rejected form. **deep-thought** (bs) followed it and `label_create` rejected the documented `#5319E7`.

The old claim was **half-true and inverted**: the tool *does* translate, but in the other direction — the GitLab adapter **prepends the `#` itself** (`label-create-gitlab.ts`: `cmd.push('--color', \`#${args.color}\`)`), and the GitHub adapter passes bare hex through. So **bare hex is correct on both platforms**, and the `#` form was never right on either.

## Changes

- Replace the false note with the actual contract: **bare 6-char hex, no `#`.**
- **Collapse the two-column colour table to one bare-hex column.** The two columns *were* the trap — they presented the rejected format as the one to pass.
- Strip every `#`-prefixed colour from the skill.
- **`docs/phase-epic-taxonomy-devspec.md`** — the skill cites this as its authoritative source, and it still carried `#5319E7` in the exact lines specifying the `label_create` argument (R-14, §5.5.3 step 2, §5.5.4 step 3). Fixing the skill while leaving that intact would have moved the trap one hop away, not removed it.
- Document the `work_item` **`type: plan` gap** ([mcp-server-sdlc#477](https://github.com/Wave-Engineering/mcp-server-sdlc/issues/477)) and warn that the obvious `type: "epic"` workaround is **safe by accident on GitLab and a real taxonomy leak on GitHub**: `work_item` unconditionally *prepends* an auto `type::<type>` label; GitLab's scoped labels are mutually exclusive within the `type::` key, so the caller's later `type::plan` **evicts** `type::epic` — and **GitHub has no scoped labels**, so the Plan carries **both**. Dev Spec R-19 forbids precisely that.

## Tests

`TestLabelColourFormat` + `TestPlanTypeGapDocumented` in `tests/test_issue_skill.py`. A doc drifting from a tool contract can only be caught by a test that **reads the doc**.

### The colour guard was vacuous on the first pass — caught in review

```python
for colour in re.findall(r"`([0-9A-Fa-f]{6})`", skill_text):
    assert COLOR_RE.match(colour)          # tautology
```

`findall` only ever yields well-formed 6-hex, so asserting the results are 6-hex can never fail. A bad value like `#5319E7` or `ZZZZZZ` is simply **not collected** — the test would stay green while the skill shipped a colour the tool rejects. That is the same decorative-guard failure this PR exists to prevent, and I walked into it.

Rewritten to harvest the **raw token** from the Colour column so malformed values are caught rather than filtered away. Mutation-tested against both `#5319E7` and `ZZZZZZ` — **red on each**, green when restored.

## Linked Issues

Closes #902

## Test Plan

Actually run:

- `./scripts/ci/validate.sh` → **173 passed, 0 failed**
- `pytest tests/test_issue_skill.py` → 48 passed
- **Mutation-tested the colour guard** twice (`#5319E7`, `ZZZZZZ`) — fails on both, passes when restored
- Mutation-tested the false-instruction guard — restoring the original wording turns it red
- Repo-wide grep: no `#`-prefixed colour remains anywhere as a value to pass to `label_create`
- Review independently verified the GitLab adapter prepends the `#`, so bare hex does **not** break GitLab label creation
- trivy: 0 HIGH/CRITICAL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CSEY5TUixZARAmHrjYTYX