### PR TITLE
feat(reorient): skill-body eviction primitive — byte-preserving .jsonl surgery (D4 #907)

### DIFF
--- a/scripts/skill-gc
+++ b/scripts/skill-gc
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""skill-gc — losslessly evict skill bodies from a Claude Code transcript (.jsonl).
+
+When an agent invokes a skill, the full SKILL.md body is injected into the
+transcript as an `isMeta` user message and then reloads from disk verbatim on
+the *next* invocation. So the body is the one part of the context that is fully
+reconstructible — evicting it reclaims context (and neutralises stale-skill
+"time bombs" on resume) without losing anything the work-state depends on.
+
+This is the reorient / skill-GC core (epic #906, story D4 #907). A model cannot
+drop skills from its own live context; this is an external, offline operation on
+a NOT-running session's transcript. See memory
+`reference_skill_body_transcript_surgery` for the proven mechanic.
+
+Guarantees (asserted by verify(), on by default):
+  * byte-preserving for valid UTF-8 transcripts — non-target lines are written
+    back unchanged (a UTF-8 round-trip is identity), and on target lines only
+    the JSON-encoded body string is replaced. It never re-serialises the whole
+    file (default json spacing would grow it and rewrite untouched lines).
+  * structural integrity — line count preserved, every line valid JSON, every
+    tool_use still paired with its tool_result.
+  * recoverable — a gzip+sha backup is written before any change.
+  * fail-closed — refuses a session that looks live OR whose liveness cannot be
+    proven (no /proc to scan), unless --force.
+
+Line indices are RAW-LINE indices throughout: the transcript is parsed into a
+list aligned 1:1 with the raw lines (blank lines -> None placeholders), so the
+parsed view and the raw/output views never diverge.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import gzip
+import hashlib
+import json
+import os
+import sys
+import time
+
+LIVE_WINDOW_SECS = 60  # a transcript touched this recently is treated as possibly-live
+
+
+# --------------------------------------------------------------------------- #
+# parsing (raw-aligned)
+# --------------------------------------------------------------------------- #
+def load_events(path: str) -> list[dict]:
+    """Non-blank events (for callers that don't need raw-line alignment)."""
+    return [json.loads(l) for l in open(path, encoding="utf-8") if l.strip()]
+
+
+def parse_aligned(raw_lines: list[str]) -> list[dict | None]:
+    """Parse into a list aligned 1:1 with raw_lines; blank lines -> None."""
+    return [json.loads(l) if l.strip() else None for l in raw_lines]
+
+
+def _content(ev: dict | None) -> list:
+    if not isinstance(ev, dict):
+        return []
+    c = ev.get("message", {}).get("content") if isinstance(ev.get("message"), dict) else None
+    return c if isinstance(c, list) else []
+
+
+# --------------------------------------------------------------------------- #
+# identification
+# --------------------------------------------------------------------------- #
+def find_skill_body_indices(events: list[dict | None]) -> dict[int, str]:
+    """Return {index: skill_name} for every skill-body message, via the
+    deterministic chain: Skill tool_use -> tool_result(uuid) -> isMeta user-text
+    whose parentUuid == that tool_result's uuid. Indices are into `events` (pass
+    a raw-aligned list to get raw-line indices). None entries are skipped, and
+    None uuids/skill names are never used as keys (guards a false-eviction hole)."""
+    skill_use = {
+        b["id"]: b.get("input", {}).get("skill")
+        for ev in events
+        for b in _content(ev)
+        if b.get("type") == "tool_use" and b.get("name") == "Skill" and b.get("id")
+    }
+    result_uuid = {
+        ev.get("uuid"): skill_use[b["tool_use_id"]]
+        for ev in events
+        for b in _content(ev)
+        if b.get("type") == "tool_result"
+        and b.get("tool_use_id") in skill_use
+        and ev.get("uuid") is not None
+    }
+    bodies: dict[int, str] = {}
+    for i, ev in enumerate(events):
+        if (
+            isinstance(ev, dict)
+            and ev.get("type") == "user"
+            and ev.get("isMeta") is True
+            and ev.get("parentUuid") is not None
+            and ev.get("parentUuid") in result_uuid
+        ):
+            c = ev.get("message", {}).get("content")
+            if isinstance(c, list) and len(c) == 1 and c[0].get("type") == "text":
+                bodies[i] = result_uuid[ev["parentUuid"]]
+    return bodies
+
+
+def stub_text(skill: str, n: int) -> str:
+    return (
+        f"[skill body evicted for context GC — skill={skill}, was {n} chars. "
+        f"The current version reloads automatically the next time /{skill} is invoked.]"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# safety
+# --------------------------------------------------------------------------- #
+def session_liveness(path: str) -> str:
+    """Return 'live' | 'idle' | 'unknown'. Fail-closed: callers must treat both
+    'live' and 'unknown' as do-not-touch (unless forced).
+
+    Strong signal: a process holds the transcript fd open (Linux /proc scan).
+    Recency signal: modified within LIVE_WINDOW_SECS. When /proc is unavailable
+    (non-Linux), the strong signal is absent and an old-but-idle live session is
+    indistinguishable from a stopped one, so we return 'unknown' rather than
+    pretending mtime alone proves safety."""
+    ap = os.path.realpath(path)
+    proc = os.path.isdir("/proc")
+    if proc:
+        for fd in glob.glob("/proc/[0-9]*/fd/*"):
+            try:
+                if os.path.realpath(fd) == ap:
+                    return "live"
+            except OSError:
+                continue
+    try:
+        if time.time() - os.path.getmtime(path) < LIVE_WINDOW_SECS:
+            return "live"
+    except OSError:
+        return "unknown"
+    return "idle" if proc else "unknown"
+
+
+def backup(path: str, backup_dir: str | None) -> str:
+    data = open(path, "rb").read()
+    sha8 = hashlib.sha256(data).hexdigest()[:8]
+    bdir = backup_dir or os.path.join(os.path.dirname(os.path.abspath(path)), "transcript-backups")
+    os.makedirs(bdir, exist_ok=True)
+    base = os.path.basename(path)
+    base = base[:-6] if base.endswith(".jsonl") else base
+    bak = os.path.join(bdir, f"{base}.{sha8}.jsonl.gz")
+    with gzip.open(bak, "wb") as f:
+        f.write(data)
+    if gzip.open(bak, "rb").read() != data:
+        raise RuntimeError(f"backup verification failed: {bak}")
+    return bak
+
+
+# --------------------------------------------------------------------------- #
+# surgery (byte-preserving, raw-aligned)
+# --------------------------------------------------------------------------- #
+def evict(path: str, only_skills: set[str] | None = None) -> tuple[list[str], dict[int, str], int]:
+    """Return (new_raw_lines, targets, reclaimed_chars) WITHOUT writing. Non-target
+    lines are the original raw lines; target lines have only the body string swapped.
+    All indices are raw-line indices (parse is aligned 1:1 with raw)."""
+    raw = open(path, encoding="utf-8").read().splitlines(keepends=True)
+    events = parse_aligned(raw)  # aligned 1:1 with raw
+    targets = find_skill_body_indices(events)
+    if only_skills is not None:
+        targets = {i: s for i, s in targets.items() if s in only_skills}
+
+    out = list(raw)
+    reclaimed = 0
+    failed = []
+    for i, skill in targets.items():
+        body = events[i]["message"]["content"][0]["text"]
+        new = stub_text(skill, len(body))
+        for ensure_ascii in (False, True):
+            enc = json.dumps(body, ensure_ascii=ensure_ascii)
+            if enc in raw[i]:
+                out[i] = raw[i].replace(enc, json.dumps(new, ensure_ascii=ensure_ascii), 1)
+                reclaimed += len(body) - len(new)
+                break
+        else:
+            failed.append((i, skill))
+    if failed:
+        raise RuntimeError(f"could not locate body string on lines {failed} — aborting (no write)")
+    return out, targets, reclaimed
+
+
+def _pairs(events: list[dict | None]) -> tuple[set, set]:
+    uses, results = set(), set()
+    for ev in events:
+        for b in _content(ev):
+            if b.get("type") == "tool_use":
+                uses.add(b.get("id"))
+            if b.get("type") == "tool_result":
+                results.add(b.get("tool_use_id"))
+    return uses, results
+
+
+def verify(orig_path: str, out_lines: list[str], targets: dict[int, str]) -> list[str]:
+    """Return a list of failures ([] == clean). Compares raw-aligned lines."""
+    o_raw = open(orig_path, encoding="utf-8").read().splitlines(keepends=True)
+    fails = []
+    if len(o_raw) != len(out_lines):
+        fails.append(f"line count changed {len(o_raw)} -> {len(out_lines)}")
+    drift = [
+        i for i in range(min(len(o_raw), len(out_lines)))
+        if i not in targets and o_raw[i] != out_lines[i]
+    ]
+    if drift:
+        fails.append(f"non-target lines changed: {drift[:10]}")
+    try:
+        n_events = parse_aligned(out_lines)
+    except Exception as e:  # noqa: BLE001
+        return fails + [f"output has malformed JSON: {e}"]
+    if _pairs(parse_aligned(o_raw)) != _pairs(n_events):
+        fails.append("tool_use/tool_result pairing changed")
+    return fails
+
+
+def write_atomic(path: str, lines: list[str]) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write("".join(lines))
+        f.flush()
+        os.fsync(f.fileno())  # durable before the atomic rename
+    os.replace(tmp, path)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Evict skill bodies from a Claude Code transcript.")
+    ap.add_argument("transcript", help="path to the session .jsonl")
+    ap.add_argument("--apply", action="store_true", help="write changes (default: dry-run)")
+    ap.add_argument("--skills", help="comma-separated subset of skills to evict (default: all)")
+    ap.add_argument("--backup-dir", help="where to write the gz backup (default: <dir>/transcript-backups)")
+    ap.add_argument("--force", action="store_true", help="override the live-session refusal (DANGEROUS)")
+    ap.add_argument("--json", action="store_true", help="machine-readable report on stdout")
+    args = ap.parse_args(argv)
+
+    path = args.transcript
+    if not os.path.isfile(path):
+        print(f"skill-gc: no such transcript: {path}", file=sys.stderr)
+        return 2
+
+    only = set(s.strip() for s in args.skills.split(",")) if args.skills else None
+
+    if args.apply and not args.force:
+        state = session_liveness(path)
+        if state == "live":
+            print(f"skill-gc: REFUSING — {path} looks live (a process holds it open, or it was "
+                  f"modified <{LIVE_WINDOW_SECS}s ago). Stop the session, or pass --force if certain.",
+                  file=sys.stderr)
+            return 3
+        if state == "unknown":
+            print(f"skill-gc: REFUSING — cannot prove {path} is not live (no /proc fd scan on this "
+                  f"platform, or mtime unreadable). Stop the session and retry, or pass --force.",
+                  file=sys.stderr)
+            return 3
+
+    out_lines, targets, reclaimed = evict(path, only)
+    fails = verify(path, out_lines, targets)
+    if fails:
+        print("skill-gc: verification FAILED — no write:\n  " + "\n  ".join(fails), file=sys.stderr)
+        return 4
+
+    report = {
+        "transcript": path,
+        "targets": {int(i): s for i, s in targets.items()},
+        "skills": sorted(set(targets.values())),
+        "reclaimed_chars": reclaimed,
+        "reclaimed_tokens_est": reclaimed // 4,
+        "applied": False,
+        "backup": None,
+    }
+
+    if args.apply and targets:
+        # backup reads the file again; under --force on a live session the file could
+        # have changed since evict() read it — acceptable only because --force is opt-in.
+        report["backup"] = backup(path, args.backup_dir)
+        write_atomic(path, out_lines)
+        report["applied"] = True
+
+    if args.json:
+        print(json.dumps(report))
+    else:
+        verb = "evicted" if report["applied"] else "would evict"
+        print(f"skill-gc: {verb} {len(targets)} skill body(ies) {report['skills']} from {path}")
+        print(f"  reclaimed ~{reclaimed} chars (~{reclaimed // 4} tokens); verification clean")
+        if report["backup"]:
+            print(f"  backup: {report['backup']}")
+        elif not args.apply and targets:
+            print("  (dry-run — pass --apply to write; a gz backup is made first)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_skill_gc.py
+++ b/tests/test_skill_gc.py
@@ -1,0 +1,228 @@
+"""Tests for scripts/skill-gc — byte-preserving skill-body eviction (epic #906, D4 #907).
+
+Loads the no-extension script via SourceFileLoader (repo convention, cf.
+tests/test_discord_status.py), builds synthetic transcripts containing a real
+Skill tool_use -> tool_result -> isMeta body chain, and asserts the eviction is
+lossless, byte-preserving, structurally intact, and fail-closed on live sessions.
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.machinery
+import importlib.util
+import json
+import os
+import time
+
+import pytest
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "skill-gc")
+_loader = importlib.machinery.SourceFileLoader("skill_gc", _SCRIPT)
+_spec = importlib.util.spec_from_file_location("skill_gc", _SCRIPT, loader=_loader)
+sg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sg)
+
+
+# --------------------------------------------------------------------------- #
+# fixture builders
+# --------------------------------------------------------------------------- #
+def _body(skill: str, extra: str = "") -> str:
+    return f"SKILL BODY START [{skill}]{extra} — " + ("procedure line. " * 200) + " — SKILL BODY END"
+
+
+def _invocation(skill: str, suffix: str, parent: str) -> list[dict]:
+    """A Skill tool_use -> tool_result -> isMeta body triple, uniquely id'd by suffix."""
+    return [
+        {"type": "assistant", "uuid": f"A{suffix}", "parentUuid": parent,
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": f"toolu_{suffix}", "name": "Skill", "input": {"skill": skill}}]}},
+        {"type": "user", "uuid": f"R{suffix}", "parentUuid": f"A{suffix}",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": f"toolu_{suffix}", "content": f"Launching skill: {skill}"}]}},
+        {"type": "user", "uuid": f"B{suffix}", "parentUuid": f"R{suffix}", "isMeta": True,
+         "message": {"role": "user", "content": [{"type": "text", "text": _body(skill)}]}},
+    ]
+
+
+def _events() -> list[dict]:
+    return [
+        {"type": "user", "uuid": "U0", "parentUuid": None,
+         "message": {"role": "user", "content": [{"type": "text", "text": "please run precheck"}]}},
+        *_invocation("precheck", "A", "U0"),
+        {"type": "assistant", "uuid": "W4", "parentUuid": "BA",
+         "message": {"role": "assistant", "content": [{"type": "text", "text": "Running precheck step 1."}]}},
+        # a NON-skill tool pair — must remain paired and untouched
+        {"type": "assistant", "uuid": "W5", "parentUuid": "W4",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "toolu_B", "name": "Bash", "input": {"command": "ls"}}]}},
+        {"type": "user", "uuid": "W6", "parentUuid": "W5",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "toolu_B", "content": "file.txt"}]}},
+    ]
+
+
+def _write(events, path, ensure_ascii=True, blank_after=None):
+    lines = []
+    for idx, e in enumerate(events):
+        lines.append(json.dumps(e, separators=(",", ":"), ensure_ascii=ensure_ascii) + "\n")
+        if blank_after is not None and idx == blank_after:
+            lines.append("\n")  # a blank line to desync event-index vs raw-index
+    path.write_text("".join(lines), encoding="utf-8")
+    old = time.time() - 3600
+    os.utime(path, (old, old))  # look NOT live so --apply is allowed
+    return str(path)
+
+
+@pytest.fixture
+def transcript(tmp_path):
+    return _write(_events(), tmp_path / "sess.jsonl")
+
+
+# --------------------------------------------------------------------------- #
+def test_identify_chain(transcript):
+    targets = sg.find_skill_body_indices(sg.parse_aligned(
+        open(transcript, encoding="utf-8").read().splitlines(keepends=True)))
+    assert targets == {3: "precheck"}  # raw index of the body line, nothing else
+
+
+def test_byte_preserving_and_shrinks(transcript):
+    orig = open(transcript, encoding="utf-8").read().splitlines(keepends=True)
+    out, targets, reclaimed = sg.evict(transcript)
+    assert set(targets) == {3}
+    assert reclaimed > 0
+    for i in range(len(orig)):
+        if i not in targets:
+            assert out[i] == orig[i], f"non-target line {i} changed"
+    assert len("".join(out)) < len("".join(orig))
+    assert "SKILL BODY START" not in "".join(out)
+    assert "evicted for context GC" in out[3]
+
+
+def test_ensure_ascii_false_unicode_body(tmp_path):
+    """Real CC transcripts store raw UTF-8 (ensure_ascii=False). The swap's
+    ensure_ascii=False branch must find + evict a unicode body."""
+    evs = _events()
+    evs[3]["message"]["content"][0]["text"] = "БODY — em—dash 世界 " + ("x " * 300)
+    p = _write(evs, tmp_path / "u.jsonl", ensure_ascii=False)
+    orig = open(p, encoding="utf-8").read().splitlines(keepends=True)
+    out, targets, reclaimed = sg.evict(p)
+    assert set(targets) == {3} and reclaimed > 0
+    assert "em—dash 世界" not in "".join(out)
+    assert sg.verify(p, out, targets) == []
+    for i in range(len(orig)):
+        if i not in targets:
+            assert out[i] == orig[i]
+
+
+def test_blank_line_before_target_stays_aligned(tmp_path):
+    """A blank line before the body desyncs event-index vs raw-index unless
+    parsing is raw-aligned. Body must still be found at its RAW index (finding #1)."""
+    p = _write(_events(), tmp_path / "blank.jsonl", blank_after=1)  # blank after line 1
+    out, targets, reclaimed = sg.evict(p)
+    assert list(targets.values()) == ["precheck"]
+    (idx,) = targets
+    assert out[idx].strip() != "" and "evicted for context GC" in out[idx]
+    assert reclaimed > 0
+    assert sg.verify(p, out, targets) == []
+
+
+def test_duplicate_skill_invocations(tmp_path):
+    evs = [
+        {"type": "user", "uuid": "U0", "parentUuid": None,
+         "message": {"role": "user", "content": [{"type": "text", "text": "go"}]}},
+        *_invocation("precheck", "A", "U0"),
+        *_invocation("precheck", "C", "BA"),  # same skill again
+    ]
+    p = _write(evs, tmp_path / "dup.jsonl")
+    out, targets, _ = sg.evict(p)
+    assert sorted(targets.values()) == ["precheck", "precheck"]  # both bodies evicted
+    assert "SKILL BODY START" not in "".join(out)
+    assert sg.verify(p, out, targets) == []
+
+
+def test_structural_integrity(transcript):
+    out, targets, _ = sg.evict(transcript)
+    assert sg.verify(transcript, out, targets) == []
+    raw = open(transcript, encoding="utf-8").read().splitlines(keepends=True)
+    assert sg._pairs(sg.parse_aligned(raw)) == sg._pairs(sg.parse_aligned(out))
+
+
+def test_verify_catches_drift(transcript):
+    """Mutation-test: a non-target line drift MUST be flagged."""
+    out, targets, _ = sg.evict(transcript)
+    assert sg.verify(transcript, out, targets) == []
+    tampered = list(out)
+    tampered[0] = tampered[0].rstrip("\n") + " \n"
+    assert any("non-target" in f for f in sg.verify(transcript, tampered, targets))
+
+
+def test_verify_catches_malformed_output(transcript):
+    """Mutation-test: a target line corrupted to invalid JSON MUST be flagged."""
+    out, targets, _ = sg.evict(transcript)
+    tampered = list(out)
+    (idx,) = targets
+    tampered[idx] = "{not json\n"
+    fails = sg.verify(transcript, tampered, targets)
+    assert any("malformed JSON" in f for f in fails), fails
+
+
+def test_none_uuid_does_not_false_evict(tmp_path):
+    """A tool_result lacking a uuid must not make a root isMeta message (parentUuid None)
+    a false target."""
+    evs = [
+        {"type": "user", "uuid": None, "parentUuid": None, "isMeta": True,
+         "message": {"role": "user", "content": [{"type": "text", "text": "some meta " + "z" * 400}]}},
+        {"type": "assistant", "uuid": "A1", "parentUuid": None,
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "toolu_A", "name": "Skill", "input": {"skill": "engage"}}]}},
+        # tool_result WITHOUT a uuid
+        {"type": "user", "parentUuid": "A1",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "toolu_A", "content": "Launching skill: engage"}]}},
+    ]
+    p = _write(evs, tmp_path / "none.jsonl")
+    _, targets, _ = sg.evict(p)
+    assert targets == {}  # nothing evicted; the root isMeta message is NOT a false target
+
+
+def test_only_skills_subset(transcript):
+    _, targets, _ = sg.evict(transcript, only_skills={"nonexistent"})
+    assert targets == {}
+
+
+def test_backup_roundtrips(transcript, tmp_path):
+    data = open(transcript, "rb").read()
+    bak = sg.backup(transcript, str(tmp_path / "bk"))
+    assert bak.endswith(".jsonl.gz")
+    assert gzip.open(bak, "rb").read() == data
+
+
+def test_apply_writes_and_backs_up(transcript, tmp_path):
+    bdir = str(tmp_path / "bk")
+    assert sg.main([transcript, "--apply", "--backup-dir", bdir]) == 0
+    assert "SKILL BODY START" not in open(transcript, encoding="utf-8").read()
+    assert any(f.endswith(".jsonl.gz") for f in os.listdir(bdir))
+
+
+def test_dry_run_does_not_write(transcript):
+    before = open(transcript, "rb").read()
+    assert sg.main([transcript]) == 0
+    assert open(transcript, "rb").read() == before
+
+
+def test_refuses_live_session_by_mtime(transcript):
+    now = time.time()
+    os.utime(transcript, (now, now))  # fresh mtime => live
+    before = open(transcript, "rb").read()
+    assert sg.main([transcript, "--apply"]) == 3
+    assert open(transcript, "rb").read() == before
+    assert sg.main([transcript, "--apply", "--force"]) == 0  # --force overrides
+
+
+@pytest.mark.skipif(not os.path.isdir("/proc"), reason="fd-open liveness needs /proc")
+def test_detects_open_fd_as_live(transcript):
+    os.utime(transcript, (time.time() - 3600, time.time() - 3600))  # old mtime
+    assert sg.session_liveness(transcript) == "idle"  # old + not held
+    with open(transcript):  # hold an fd open
+        assert sg.session_liveness(transcript) == "live"


### PR DESCRIPTION
## Summary

`scripts/skill-gc` — the proven **reorient / skill-GC core** (D4) for the dormant-agent context-freshness epic. It losslessly evicts skill bodies from a Claude Code transcript `.jsonl`, reclaiming context (and defusing stale-skill "time bombs" on `claude --continue`) without touching the irreplaceable work-state. Skill bodies reload verbatim from disk on next invocation, so eviction is recoverable by construction.

## Changes

- **`scripts/skill-gc`** — identifies skill-body messages via the deterministic chain (`Skill` tool_use → tool_result uuid → `isMeta` user-text whose `parentUuid` == that uuid) and replaces each body with a stub, **byte-preservingly**: non-target lines pass through untouched; only the JSON-encoded body substring is swapped (never a whole-file re-serialisation). Safety envelope: gz+sha backup, atomic `fsync`'d temp+rename, **fail-closed** refusal on a live-or-unprovable session (tri-state `live`/`idle`/`unknown` via `/proc` fd scan + mtime), and `verify()` (line count, JSON validity, tool_use/tool_result pairing, non-target byte-identity). Raw-line indexing throughout so parsed/raw views never diverge.
- **`tests/test_skill_gc.py`** — 15 tests including mutation-tested guards (drift + malformed-output), `ensure_ascii=False` unicode bodies (the real transcript format), blank-line raw-alignment, duplicate skills, None-key false-evict guard, and `/proc` fd-open liveness.

## Linked Issues

Closes #907
Part of #906

## Test Plan

- `python3 -m pytest tests/test_skill_gc.py` → **15/15**
- Full suite `pytest tests/` → **1521 passed, 0 failed** (post-fix)
- `py_compile` clean; trivy 0 HIGH/CRITICAL (no deps added)
- CLI run on a real 582-line transcript: correctly finds engage+precheck bodies (~3.9k reclaimable tokens), dry-run does not write
- **Round-trip proven on a live throwaway session**: invoke skill → evict → `claude --resume` loads clean, work-state recalled from memory, re-invoking the skill reloads the full current body
- Code review (opus): 2 important + minors, **all fixed** and each covered by a new test
