### PR TITLE
feat(freshness): SessionStart warn hook + install change-manifest stamp (D1 #908)

### DIFF
--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -107,6 +107,26 @@
             "command": "~/.local/bin/flightdeck-session-emit.sh open"
           }
         ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "_comment": "Context-freshness warn (cc-workflow#908) — its OWN startup group, not merged into FlightDeck's, so merge_settings' group-signature union can't append-and-duplicate the FlightDeck hook on already-provisioned hosts. Self-filters fresh startups via the first-event timestamp. Fire-and-forget, exit 0.",
+            "type": "command",
+            "command": "~/.claude/scripts/hooks/workflow/context-freshness-warn.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "_comment": "Context-freshness warn (cc-workflow#908) — see the startup matcher.",
+            "type": "command",
+            "command": "~/.claude/scripts/hooks/workflow/context-freshness-warn.sh"
+          }
+        ]
       }
     ],
     "PreCompact": [

--- a/install
+++ b/install
@@ -1570,6 +1570,13 @@ if [[ "$DRY_RUN" == true ]]; then
 	echo "Dry run complete. No files were modified."
 else
 	echo "Installation complete."
+	# Record what this install laid down, for the context-freshness warn hook (#908):
+	# install time + repo sha + which skills changed, so a resumed session whose
+	# context predates this stamp can be told it is stale (and which skills went stale).
+	if [[ -x "$REPO_DIR/scripts/write-install-stamp" ]]; then
+		"$REPO_DIR/scripts/write-install-stamp" --repo "$REPO_DIR" --claude-dir "$CLAUDE_DIR" \
+			|| warn "context-freshness install stamp reported issues (non-fatal)"
+	fi
 fi
 
 # --- Dependency check (via check-deps.sh) ------------------------------------

--- a/scripts/hooks/workflow/context-freshness-warn.sh
+++ b/scripts/hooks/workflow/context-freshness-warn.sh
@@ -25,18 +25,22 @@ INPUT=$(cat 2>/dev/null || true)
 jqget() { printf '%s' "$INPUT" | jq -r "$1 // empty" 2>/dev/null || true; }
 
 SOURCE=$(jqget '.source')
-CWD=$(jqget '.cwd'); CWD="${CWD:-$(pwd)}"
+CWD=$(jqget '.cwd')
+CWD="${CWD:-$(pwd)}"
 TRANS=$(jqget '.transcript_path')
 
 # clear/compact are explicitly-fresh contexts (handled by other hooks); skip them.
 case "$SOURCE" in
-	clear | compact) exit 0 ;;
+clear | compact) exit 0 ;;
 esac
 
 # Prefer a project-local stamp (from a --local install), else the global one.
 STAMP=""
 for cand in "$CWD/.claude/.last-kit-install" "$HOME/.claude/.last-kit-install"; do
-	if [[ -f "$cand" ]]; then STAMP="$cand"; break; fi
+	if [[ -f "$cand" ]]; then
+		STAMP="$cand"
+		break
+	fi
 done
 [[ -n "$STAMP" ]] || exit 0
 INSTALLED_EPOCH=$(jq -r '.installed_at_epoch // empty' "$STAMP" 2>/dev/null || true)

--- a/scripts/hooks/workflow/context-freshness-warn.sh
+++ b/scripts/hooks/workflow/context-freshness-warn.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# context-freshness-warn.sh — CC SessionStart hook (matchers: "resume", "startup").
+#
+# Warns when a session's context PREDATES the last kit install. On `claude
+# --continue`/`--resume`, the MCP binaries and on-disk skills refresh, but the
+# skill BODIES already baked into the transcript do NOT — so a resumed agent can
+# act on stale, pre-install skill instructions (e.g. a superseded gate check).
+# This surfaces that so the agent re-invokes the skill (reloading the current
+# body) or reorients before doing wave/gate work.
+#
+# Contract (CC SessionStart hook):
+#   stdin:  JSON with .session_id, .transcript_path, .cwd, .source
+#   stdout: injected as a system-reminder into the fresh agent context
+#   exit:   ALWAYS 0 (fire-and-forget; never block session start)
+#
+# Staleness = the session's first genuinely-timestamped event is earlier than the
+# `installed_at_epoch` in the last-install stamp (written by
+# scripts/write-install-stamp at the end of ./install). Fresh startups
+# self-filter: their first timestamped event is "now" > install, so nothing fires.
+#
+# Epic #906, story D1 #908.
+set -u
+
+INPUT=$(cat 2>/dev/null || true)
+jqget() { printf '%s' "$INPUT" | jq -r "$1 // empty" 2>/dev/null || true; }
+
+SOURCE=$(jqget '.source')
+CWD=$(jqget '.cwd'); CWD="${CWD:-$(pwd)}"
+TRANS=$(jqget '.transcript_path')
+
+# clear/compact are explicitly-fresh contexts (handled by other hooks); skip them.
+case "$SOURCE" in
+	clear | compact) exit 0 ;;
+esac
+
+# Prefer a project-local stamp (from a --local install), else the global one.
+STAMP=""
+for cand in "$CWD/.claude/.last-kit-install" "$HOME/.claude/.last-kit-install"; do
+	if [[ -f "$cand" ]]; then STAMP="$cand"; break; fi
+done
+[[ -n "$STAMP" ]] || exit 0
+INSTALLED_EPOCH=$(jq -r '.installed_at_epoch // empty' "$STAMP" 2>/dev/null || true)
+[[ -n "$INSTALLED_EPOCH" ]] || exit 0
+
+# The transcript path comes from stdin (never reconstructed — CC's project-dir
+# encoding replaces '/', '.', ':' and more with '-', which a naive rebuild misses).
+[[ -n "$TRANS" && -f "$TRANS" ]] || exit 0
+
+# Session start = the FIRST record carrying a top-level timestamp. Early CC records
+# (custom-title, mode, queue-operation preamble) may have none, so line 1 is NOT a
+# reliable source — scan for the first that does.
+FIRST_TS=$(jq -r 'select(.timestamp) | .timestamp' "$TRANS" 2>/dev/null | head -n 1)
+[[ -n "$FIRST_TS" ]] || exit 0
+SESSION_EPOCH=$(python3 -c "import sys,datetime; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$FIRST_TS" 2>/dev/null || echo 0)
+
+if [[ "$SESSION_EPOCH" -gt 0 && "$SESSION_EPOCH" -lt "$INSTALLED_EPOCH" ]]; then
+	INSTALLED_AT=$(jq -r '.installed_at // "?"' "$STAMP" 2>/dev/null || echo "?")
+	SHA=$(jq -r '.repo_sha // "?"' "$STAMP" 2>/dev/null | cut -c1-9)
+	CHANGED=$(jq -r '(.changed_skills // []) | join(", ")' "$STAMP" 2>/dev/null || true)
+	printf '[CONTEXT FRESHNESS WARNING] This session began before the last kit install (%s, cc-workflow %s). Skill bodies frozen in your transcript may be STALE — on-disk skills and MCP binaries have refreshed, but the instructions captured in your context have not. Before any wave/gate/precheck work, re-invoke the relevant skill (it reloads the current version) or run /reseed / reorient to flush stale skill text.' \
+		"$INSTALLED_AT" "$SHA"
+	[[ -n "$CHANGED" ]] && printf ' Skills changed in that install: %s.' "$CHANGED"
+	printf '\n'
+fi
+exit 0

--- a/scripts/write-install-stamp
+++ b/scripts/write-install-stamp
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""write-install-stamp — record what the last ./install laid down, for the
+context-freshness warn hook (epic #906, story D1 #908).
+
+Writes ``<claude-dir>/.last-kit-install``: the install time, the cc-workflow HEAD
+sha, and the set of skills whose SKILL.md changed since the previous install — so
+a resumed session whose context predates this stamp can be told not just THAT it
+is stale but WHICH skills went stale.
+
+Called at the end of a successful (non-dry-run) ./install. Safe to run anytime;
+it only reads the repo's skills/ and the prior stamp.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+
+
+def skill_hashes(repo: str) -> dict[str, str]:
+    """{skill_name: sha256(SKILL.md)} for every skill in <repo>/skills/*/SKILL.md."""
+    out: dict[str, str] = {}
+    sdir = os.path.join(repo, "skills")
+    if not os.path.isdir(sdir):
+        return out
+    for name in sorted(os.listdir(sdir)):
+        p = os.path.join(sdir, name, "SKILL.md")
+        if os.path.isfile(p):
+            out[name] = hashlib.sha256(open(p, "rb").read()).hexdigest()
+    return out
+
+
+def build_stamp(repo: str, prior_skills: dict[str, str], now: datetime | None = None) -> dict:
+    now = now or datetime.now(timezone.utc)
+    skills = skill_hashes(repo)
+    changed = sorted(n for n, h in skills.items() if prior_skills.get(n) != h)
+    try:
+        sha = subprocess.run(
+            ["git", "-C", repo, "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        sha = "unknown"
+    return {
+        "installed_at": now.isoformat().replace("+00:00", "Z"),
+        "installed_at_epoch": int(now.timestamp()),
+        "repo_sha": sha,
+        "skill_count": len(skills),
+        "changed_skills": changed,          # [] on the very first install
+        "first_install": not prior_skills,
+        "skills": skills,                    # name -> sha256, basis for the next diff
+    }
+
+
+def write_stamp(repo: str, claude_dir: str) -> tuple[str, dict]:
+    stamp_path = os.path.join(claude_dir, ".last-kit-install")
+    prior: dict[str, str] = {}
+    if os.path.isfile(stamp_path):
+        try:
+            prior = json.load(open(stamp_path)).get("skills", {}) or {}
+        except (json.JSONDecodeError, OSError):
+            prior = {}
+    stamp = build_stamp(repo, prior)
+    os.makedirs(claude_dir, exist_ok=True)
+    tmp = stamp_path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(stamp, f, indent=2)
+    os.replace(tmp, stamp_path)
+    return stamp_path, stamp
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, help="the cc-workflow repo root")
+    ap.add_argument("--claude-dir", required=True, help="the ~/.claude root to stamp (or project .claude under --local)")
+    args = ap.parse_args(argv)
+    path, stamp = write_stamp(args.repo, args.claude_dir)
+    print(f"skill stamp: wrote {path} — {stamp['skill_count']} skills, "
+          f"{len(stamp['changed_skills'])} changed since last install")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_freshness_warn.py
+++ b/tests/test_freshness_warn.py
@@ -1,0 +1,168 @@
+"""Tests for D1 (#908) — the context-freshness install stamp + SessionStart warn hook.
+
+Covers scripts/write-install-stamp (imported via SourceFileLoader) and
+scripts/hooks/workflow/context-freshness-warn.sh (driven via subprocess with a
+sandboxed $HOME). Epic #906.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+
+import pytest
+
+_HERE = os.path.dirname(__file__)
+_STAMP_SCRIPT = os.path.join(_HERE, "..", "scripts", "write-install-stamp")
+_HOOK = os.path.join(_HERE, "..", "scripts", "hooks", "workflow", "context-freshness-warn.sh")
+
+_loader = importlib.machinery.SourceFileLoader("write_install_stamp", _STAMP_SCRIPT)
+_spec = importlib.util.spec_from_file_location("write_install_stamp", _STAMP_SCRIPT, loader=_loader)
+wis = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wis)
+
+
+# --------------------------------------------------------------------------- #
+# stamp writer
+# --------------------------------------------------------------------------- #
+def _make_repo(tmp_path, skills: dict[str, str]):
+    for name, body in skills.items():
+        d = tmp_path / "skills" / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(body)
+    return str(tmp_path)
+
+
+def test_skill_hashes_reads_skill_md(tmp_path):
+    repo = _make_repo(tmp_path, {"engage": "one", "precheck": "two"})
+    h = wis.skill_hashes(repo)
+    assert set(h) == {"engage", "precheck"}
+    assert h["engage"] != h["precheck"]
+
+
+def test_first_install_marks_all_changed(tmp_path):
+    repo = _make_repo(tmp_path, {"engage": "one", "precheck": "two"})
+    stamp = wis.build_stamp(repo, prior_skills={})
+    assert stamp["first_install"] is True
+    assert sorted(stamp["changed_skills"]) == ["engage", "precheck"]
+    assert stamp["skill_count"] == 2
+    assert "installed_at_epoch" in stamp and isinstance(stamp["installed_at_epoch"], int)
+
+
+def test_changed_skills_is_the_diff(tmp_path):
+    repo = _make_repo(tmp_path, {"engage": "NEW", "precheck": "same", "nextwave": "brand-new"})
+    prior = wis.skill_hashes(repo).copy()
+    # simulate the prior install: precheck unchanged, engage different, nextwave absent
+    prior["engage"] = "OLD-hash-differs"
+    del prior["nextwave"]
+    stamp = wis.build_stamp(repo, prior_skills=prior)
+    assert stamp["first_install"] is False
+    assert sorted(stamp["changed_skills"]) == ["engage", "nextwave"]  # precheck NOT listed
+
+
+def test_write_stamp_atomic_and_valid(tmp_path):
+    repo = _make_repo(tmp_path, {"engage": "one"})
+    cdir = tmp_path / "claude"
+    path, stamp = wis.write_stamp(repo, str(cdir))
+    assert os.path.isfile(path)
+    on_disk = json.load(open(path))
+    assert on_disk["skill_count"] == 1
+    assert not os.path.exists(path + ".tmp")  # temp cleaned up by rename
+
+
+# --------------------------------------------------------------------------- #
+# hook
+# --------------------------------------------------------------------------- #
+def _run_hook(stdin_obj, home):
+    return subprocess.run(
+        ["bash", _HOOK],
+        input=json.dumps(stdin_obj),
+        capture_output=True, text=True,
+        env={**os.environ, "HOME": str(home)},
+    )
+
+
+def _write_transcript(path, session_ts):
+    """A FAITHFUL transcript: CC-style preamble records with NO top-level timestamp,
+    then the first genuinely-timestamped event (regression guard for the head -n1 bug)."""
+    with open(path, "w") as f:
+        f.write(json.dumps({"type": "custom-title", "title": "x"}) + "\n")
+        f.write(json.dumps({"type": "mode", "mode": "normal"}) + "\n")
+        f.write(json.dumps({"type": "user", "timestamp": session_ts,
+                            "message": {"role": "user", "content": "hi"}}) + "\n")
+
+
+def _setup(home, *, install_epoch, session_ts, sid="sid123",
+           changed=("nextwave", "precheck"), stamp_dir=None):
+    home = str(home)
+    proj = os.path.join(home, ".claude", "projects", "encoded-proj")
+    os.makedirs(proj, exist_ok=True)
+    sdir = stamp_dir or os.path.join(home, ".claude")
+    os.makedirs(sdir, exist_ok=True)
+    json.dump(
+        {"installed_at": "2026-07-18T00:00:00Z", "installed_at_epoch": install_epoch,
+         "repo_sha": "abcdef1234567890", "changed_skills": list(changed)},
+        open(os.path.join(sdir, ".last-kit-install"), "w"),
+    )
+    trans = os.path.join(proj, f"{sid}.jsonl")
+    if session_ts is not None:
+        _write_transcript(trans, session_ts)
+    # transcript_path is provided by CC on stdin — the hook never reconstructs it.
+    return {"session_id": sid, "cwd": "/x/proj", "source": "resume", "transcript_path": trans}
+
+
+def test_hook_warns_on_stale_resume(tmp_path):
+    """Faithful transcript (timestamp on line 3, not line 1) must still warn — the
+    hook scans for the first genuinely-timestamped record."""
+    stdin = _setup(tmp_path, install_epoch=1_700_000_000, session_ts="2020-01-01T00:00:00.000Z")
+    p = _run_hook(stdin, tmp_path)
+    assert p.returncode == 0
+    assert "CONTEXT FRESHNESS WARNING" in p.stdout
+    assert "nextwave, precheck" in p.stdout  # names the changed skills
+
+
+def test_hook_silent_on_fresh_session(tmp_path):
+    stdin = _setup(tmp_path, install_epoch=1_700_000_000, session_ts="2099-01-01T00:00:00.000Z")
+    p = _run_hook(stdin, tmp_path)
+    assert p.returncode == 0 and p.stdout.strip() == ""
+
+
+def test_hook_prefers_project_local_stamp(tmp_path):
+    """A --local install stamps <cwd>/.claude; the hook must read that (not just $HOME)."""
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)  # HOME exists but has NO stamp
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    json.dump({"installed_at": "2026-07-18T00:00:00Z", "installed_at_epoch": 1_700_000_000,
+               "repo_sha": "abc", "changed_skills": ["only-local"]},
+              open(proj / ".claude" / ".last-kit-install", "w"))
+    trans = proj / "t.jsonl"
+    _write_transcript(str(trans), "2020-01-01T00:00:00.000Z")
+    stdin = {"session_id": "s", "cwd": str(proj), "source": "resume", "transcript_path": str(trans)}
+    p = _run_hook(stdin, home)
+    assert p.returncode == 0
+    assert "CONTEXT FRESHNESS WARNING" in p.stdout and "only-local" in p.stdout
+
+
+def test_hook_silent_without_stamp(tmp_path):
+    trans = tmp_path / "t.jsonl"
+    _write_transcript(str(trans), "2020-01-01T00:00:00Z")
+    p = _run_hook({"session_id": "s", "cwd": "/x/proj", "source": "resume",
+                   "transcript_path": str(trans)}, tmp_path)
+    assert p.returncode == 0 and p.stdout.strip() == ""
+
+
+def test_hook_skips_clear_and_compact(tmp_path):
+    stdin = _setup(tmp_path, install_epoch=1_700_000_000, session_ts="2020-01-01T00:00:00.000Z")
+    for src in ("clear", "compact"):
+        p = _run_hook({**stdin, "source": src}, tmp_path)
+        assert p.returncode == 0 and p.stdout.strip() == "", f"should skip source={src}"
+
+
+def test_hook_always_exits_zero_on_garbage(tmp_path):
+    p = subprocess.run(["bash", _HOOK], input="not json at all", capture_output=True,
+                       text=True, env={**os.environ, "HOME": str(tmp_path)})
+    assert p.returncode == 0


### PR DESCRIPTION
## Summary

The **ships-in-cutover safety net** (D1): when a session is resumed whose context predates the last kit install, warn that its in-transcript skill bodies may be stale. On `claude --continue`, binaries and on-disk skills refresh but the skill *bodies* frozen in the transcript do not — so a resumed agent can act on superseded skill instructions (e.g. a pre-#476 gate check). This makes that visible.

## Changes

- **`scripts/write-install-stamp`** — at the end of a successful `./install`, writes `~/.claude/.last-kit-install`: install time, cc-workflow HEAD sha, per-skill sha256, and the skills changed since the prior install (so the warn can name *what* went stale).
- **`scripts/hooks/workflow/context-freshness-warn.sh`** — SessionStart hook (`resume` + `startup`). Warns when a session's first genuinely-timestamped event predates the stamp. Reads `.transcript_path` from stdin (never reconstructs the path — CC's dir encoding maps `/ . :` all to `-`); scans for the first record with a top-level timestamp (real transcripts open with untimestamped `custom-title`/`mode` records); prefers a project-local stamp under `--local`; always exits 0.
- **`install`** — writes the stamp on success (non-fatal on failure).
- **`config/settings.template.json`** — registers the hook in its **own** `startup` group (not merged into FlightDeck's, so the settings-union can't duplicate that hook) plus a `resume` group.

## Linked Issues

Closes #908
Part of #906

## Test Plan

- `pytest tests/test_freshness_warn.py` → **10/10**, with a **CC-faithful fixture** (untimestamped preamble)
- Settings-merge test `test_install_merge_hooks_union.py` → 8/8; install/settings suite 57/57 (earlier)
- `shellcheck` clean; settings JSON valid
- **Hook verified firing on a real production transcript** (the code-review caught that the original `head -n1` approach was silently inert — real transcripts don't start with a timestamped record)
- Code review (opus): 1 critical + 3 important, **all fixed** and each covered by a test / real-data smoke
- trivy 0 HIGH/CRITICAL (no deps added)
