### PR TITLE
feat(reorient): reorient <agent> — proactive single-agent re-orientation (D2 #909)

### DIFF
--- a/scripts/reorient
+++ b/scripts/reorient
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""reorient — proactively re-orient a STOPPED agent ahead of resume (epic #906, D2 #909).
+
+A resumed session carries stale skill bodies frozen in its transcript even though
+on-disk skills and MCP binaries have refreshed. The SessionStart warn hook (D1)
+flags that at resume time — but that pays the reorientation cost at the exact
+moment you want the agent. `reorient` does it *ahead* of need, in the background:
+it evicts the stale skill bodies now (via skill-gc — byte-preserving, backed up,
+fail-closed on a live session) so the next resume is already clean, and it emits a
+delta-brief of what changed while the session slept.
+
+Objective INVERTS reseed: preserve work-state fidelity, size is only a guardrail.
+It never re-authors the work-state — it refreshes the (reconstructible) skill layer
+and reports the delta. See memory `reference_skill_body_transcript_surgery`.
+
+Usage:
+  reorient <target> [--dry-run] [--json]
+    <target>: a session .jsonl, OR a ~/.claude/projects/<encoded> directory
+              (the latest session in it is chosen).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import glob
+import json
+import os
+import subprocess
+import sys
+from shutil import which
+
+
+def find_skill_gc() -> str | None:
+    """The co-located sibling FIRST, then PATH. reorient and skill-gc are
+    co-developed and share a JSON-report contract, so reorient must pair with its
+    OWN version — sibling-first guarantees that both from-repo (scripts/reorient +
+    scripts/skill-gc) and installed (both symlinked into the same bin dir). PATH-first
+    would let a repo-copy reorient silently drive a stale installed skill-gc
+    (see memory `lesson_live_binary_not_repo_source`)."""
+    cand = os.path.join(os.path.dirname(os.path.abspath(__file__)), "skill-gc")
+    if os.path.isfile(cand):
+        return cand
+    return which("skill-gc")
+
+
+def pick_transcript(target: str) -> str | None:
+    """The transcript itself, or the newest .jsonl in a projects directory."""
+    if os.path.isfile(target) and target.endswith(".jsonl"):
+        return target
+    if os.path.isdir(target):
+        js = glob.glob(os.path.join(target, "*.jsonl"))
+        return max(js, key=os.path.getmtime) if js else None
+    return None
+
+
+def first_timestamp_epoch(transcript: str) -> int | None:
+    """Epoch of the first record carrying a top-level timestamp (session start).
+    Skips unparseable/partial lines rather than aborting the scan on the first one —
+    otherwise a single bad line before the first timestamp would mislabel a predating
+    session as 'current' in the delta-brief."""
+    try:
+        fh = open(transcript, encoding="utf-8")
+    except OSError:
+        return None
+    with fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            try:
+                ev = json.loads(line)
+                ts = ev.get("timestamp")
+                if ts:
+                    return int(datetime.datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp())
+            except ValueError:
+                continue
+    return None
+
+
+def load_stamp(claude_dir: str) -> dict | None:
+    try:
+        return json.load(open(os.path.join(claude_dir, ".last-kit-install")))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def delta_brief(transcript: str, claude_dir: str) -> dict:
+    """What changed under this session while it slept (from the install stamp)."""
+    stamp = load_stamp(claude_dir)
+    if not stamp:
+        return {"stamp": False}
+    sess = first_timestamp_epoch(transcript)
+    installed = stamp.get("installed_at_epoch")
+    predates = bool(sess and installed and sess < installed)
+    return {
+        "stamp": True,
+        "predates_install": predates,
+        "installed_at": stamp.get("installed_at"),
+        "repo_sha": (stamp.get("repo_sha") or "")[:9],
+        "changed_skills": stamp.get("changed_skills", []) if predates else [],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Re-orient a stopped agent by evicting stale skill bodies.")
+    ap.add_argument("target", help="a session .jsonl, or a ~/.claude/projects/<encoded> directory")
+    ap.add_argument("--apply", action="store_true", help="write changes (default: dry-run report)")
+    ap.add_argument("--json", action="store_true", help="machine-readable report")
+    args = ap.parse_args(argv)
+
+    sgc = find_skill_gc()
+    if not sgc:
+        print("reorient: skill-gc not found on PATH or alongside this script", file=sys.stderr)
+        return 2
+    transcript = pick_transcript(args.target)
+    if not transcript:
+        print(f"reorient: no session transcript found at {args.target}", file=sys.stderr)
+        return 2
+
+    # skill-gc does the byte-preserving eviction, the backup, and the fail-closed
+    # live-session refusal — reorient inherits all of that. Note: skill-gc only checks
+    # liveness under --apply, so a dry-run reads the transcript without the liveness gate;
+    # it never writes, but a mid-write live tail can raise on partial JSON (surfaced as a
+    # non-zero rc + stderr, contained per-target by the D3 fan-out's isolation).
+    cmd = [sys.executable, sgc, transcript, "--json"] + (["--apply"] if args.apply else [])
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        # e.g. skill-gc refused because the session looks live (rc 3) — surface it.
+        sys.stderr.write(r.stderr or f"reorient: skill-gc exited {r.returncode}\n")
+        return r.returncode
+    gc_report = json.loads(r.stdout) if r.stdout.strip() else {}
+
+    brief = delta_brief(transcript, os.path.expanduser("~/.claude"))
+    report = {"transcript": transcript, "eviction": gc_report, "delta": brief, "applied": gc_report.get("applied", False)}
+
+    if args.json:
+        print(json.dumps(report))
+    else:
+        verb = "reoriented" if report["applied"] else "would reorient"
+        skills = gc_report.get("skills", [])
+        print(f"reorient: {verb} {transcript}")
+        print(f"  evicted {len(skills)} skill body(ies) {skills}, "
+              f"~{gc_report.get('reclaimed_tokens_est', 0)} tokens reclaimed")
+        if gc_report.get("backup"):
+            print(f"  backup: {gc_report['backup']}")
+        if brief.get("predates_install"):
+            print(f"  ⚠ this session predates the last install ({brief['installed_at']}, "
+                  f"cc-workflow {brief['repo_sha']})")
+            if brief["changed_skills"]:
+                print(f"    skills changed then: {', '.join(brief['changed_skills'])}")
+        elif brief.get("stamp"):
+            print("  session is current with the last install")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reorient.py
+++ b/tests/test_reorient.py
@@ -1,0 +1,132 @@
+"""Tests for scripts/reorient (epic #906, D2 #909) — proactive re-orientation of a
+stopped agent. Drives the real skill-gc via subprocess, so it exercises the full
+evict + backup + fail-closed-on-live chain end to end.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import time
+
+import pytest
+
+_HERE = os.path.dirname(__file__)
+_SCRIPT = os.path.join(_HERE, "..", "scripts", "reorient")
+_loader = importlib.machinery.SourceFileLoader("reorient", _SCRIPT)
+_spec = importlib.util.spec_from_file_location("reorient", _SCRIPT, loader=_loader)
+ro = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ro)
+
+BODY = "SKILL BODY START — " + ("line. " * 200) + " — SKILL BODY END"
+
+
+def _make_transcript(path, *, first_ts="2020-01-01T00:00:00.000Z", stale_mtime=True):
+    events = [
+        {"type": "user", "uuid": "U0", "parentUuid": None, "timestamp": first_ts,
+         "message": {"role": "user", "content": [{"type": "text", "text": "run precheck"}]}},
+        {"type": "assistant", "uuid": "U1", "parentUuid": "U0", "timestamp": first_ts,
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "toolu_A", "name": "Skill", "input": {"skill": "precheck"}}]}},
+        {"type": "user", "uuid": "U2", "parentUuid": "U1", "timestamp": first_ts,
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "toolu_A", "content": "Launching skill: precheck"}]}},
+        {"type": "user", "uuid": "U3", "parentUuid": "U2", "isMeta": True, "timestamp": first_ts,
+         "message": {"role": "user", "content": [{"type": "text", "text": BODY}]}},
+    ]
+    with open(path, "w") as f:
+        for e in events:
+            f.write(json.dumps(e, separators=(",", ":")) + "\n")
+    if stale_mtime:
+        old = time.time() - 3600
+        os.utime(path, (old, old))
+    return str(path)
+
+
+def _stamp(claude_dir, *, install_epoch, changed=("precheck", "nextwave")):
+    os.makedirs(claude_dir, exist_ok=True)
+    json.dump({"installed_at": "2026-07-18T00:00:00Z", "installed_at_epoch": install_epoch,
+               "repo_sha": "abcdef1234567890", "changed_skills": list(changed)},
+              open(os.path.join(claude_dir, ".last-kit-install"), "w"))
+
+
+# --------------------------------------------------------------------------- #
+def test_pick_transcript_file_and_dir(tmp_path):
+    t = _make_transcript(str(tmp_path / "a.jsonl"))
+    assert ro.pick_transcript(t) == t
+    # dir: newest of two
+    d = tmp_path / "proj"; d.mkdir()
+    old = _make_transcript(str(d / "old.jsonl"))
+    time.sleep(0.01)
+    new = _make_transcript(str(d / "new.jsonl"), stale_mtime=False)
+    assert ro.pick_transcript(str(d)) == new
+    assert ro.pick_transcript(str(tmp_path / "nope")) is None
+
+
+def test_find_skill_gc_prefers_sibling():
+    """reorient must resolve its co-located skill-gc (the repo sibling here), not a
+    PATH-installed copy — otherwise the tests validate the wrong skill-gc."""
+    resolved = ro.find_skill_gc()
+    assert resolved is not None
+    assert os.path.basename(resolved) == "skill-gc"
+    assert os.path.realpath(resolved) == os.path.realpath(
+        os.path.join(_HERE, "..", "scripts", "skill-gc"))
+
+
+def test_first_timestamp_epoch(tmp_path):
+    t = _make_transcript(str(tmp_path / "a.jsonl"), first_ts="2020-01-01T00:00:00.000Z")
+    assert ro.first_timestamp_epoch(t) == 1_577_836_800  # 2020-01-01 UTC
+
+
+def test_first_timestamp_skips_malformed_lines(tmp_path):
+    """A partial/garbage line before the first timestamped record must not abort the scan."""
+    p = tmp_path / "m.jsonl"
+    with open(p, "w") as f:
+        f.write("{ this is not valid json\n")
+        f.write(json.dumps({"type": "mode", "mode": "normal"}) + "\n")  # no timestamp
+        f.write(json.dumps({"type": "user", "timestamp": "2020-01-01T00:00:00.000Z"}) + "\n")
+    assert ro.first_timestamp_epoch(str(p)) == 1_577_836_800
+
+
+def test_delta_brief_predates_install(tmp_path):
+    t = _make_transcript(str(tmp_path / "a.jsonl"), first_ts="2020-01-01T00:00:00.000Z")
+    cdir = tmp_path / "claude"; _stamp(str(cdir), install_epoch=1_700_000_000)
+    b = ro.delta_brief(t, str(cdir))
+    assert b["predates_install"] is True
+    assert b["changed_skills"] == ["precheck", "nextwave"]
+
+
+def test_delta_brief_current_session(tmp_path):
+    t = _make_transcript(str(tmp_path / "a.jsonl"), first_ts="2099-01-01T00:00:00.000Z")
+    cdir = tmp_path / "claude"; _stamp(str(cdir), install_epoch=1_700_000_000)
+    b = ro.delta_brief(t, str(cdir))
+    assert b["predates_install"] is False and b["changed_skills"] == []
+
+
+def test_reorient_evicts_stopped_session(tmp_path, monkeypatch):
+    home = tmp_path / "home"; _stamp(str(home / ".claude"), install_epoch=1_700_000_000)
+    monkeypatch.setenv("HOME", str(home))
+    (tmp_path / "proj").mkdir()
+    t = _make_transcript(str(tmp_path / "proj" / "s.jsonl"))
+    rc = ro.main([t, "--json"])  # dry-run first
+    assert rc == 0
+    assert "SKILL BODY START" in open(t).read()  # dry-run did not write
+    rc = ro.main([t, "--apply", "--json"])
+    assert rc == 0
+    assert "SKILL BODY START" not in open(t).read()  # body evicted
+    assert os.path.isdir(os.path.join(os.path.dirname(t), "transcript-backups"))
+
+
+def test_reorient_refuses_live_session(tmp_path):
+    t = _make_transcript(str(tmp_path / "live.jsonl"), stale_mtime=False)  # fresh mtime => live
+    now = time.time(); os.utime(t, (now, now))
+    before = open(t).read()
+    rc = ro.main([t, "--apply"])
+    assert rc == 3  # skill-gc's fail-closed refusal propagates
+    assert open(t).read() == before  # nothing written
+
+
+def test_reorient_missing_target(tmp_path):
+    assert ro.main([str(tmp_path / "nothing")]) == 2


### PR DESCRIPTION
## Summary

**D2** — `reorient` re-orients a *stopped* agent ahead of resume, so the first resume doesn't pay the reorientation latency the D1 warn-hook would otherwise trigger at the worst moment. It evicts the stale skill bodies now (via the merged `skill-gc`) so the next resume is already clean, and emits a delta-brief of what changed while the session slept.

## Changes

- **`scripts/reorient`** — resolves a target (session `.jsonl`, or newest session in a `~/.claude/projects/<encoded>` dir) and delegates the byte-preserving eviction to `skill-gc` via subprocess, **inheriting its gz backup and fail-closed live-session refusal** (reorient has no independent transcript-write path). Emits a delta-brief from `~/.claude/.last-kit-install` (predates-install + changed skills). Default dry-run; `--apply` writes. `skill-gc` resolved **sibling-first** so reorient always pairs with its own co-developed version. First-timestamp scan skips malformed lines.

## Linked Issues

Closes #909
Part of #906

## Test Plan

- `pytest tests/test_reorient.py` → **9/9** (subprocess end-to-end through the real skill-gc, sibling-pinned)
- **`validate.sh` → 178 passed, 0 failed** (full CI gate incl. shfmt/shellcheck/py_compile, run locally)
- CLI dry-run + `--apply` on a real transcript: evicts engage+precheck (~3,874 tokens), gz backup written
- Code review (opus): confirmed no independent write path; 1 important (sibling-first resolution + test hermeticity) + 2 minor, **all fixed**
- trivy 0 HIGH/CRITICAL (no deps added)
