### PR TITLE
fix(mmr): CI gate default-deny with escalation — allowlist at both layers

### DIFF
--- a/skills/mmr/SKILL.md
+++ b/skills/mmr/SKILL.md
@@ -27,7 +27,41 @@ Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix)
 
 1. `pr_status(number)` → require `state == "open"`; inspect `checks.summary`. **Then guard the merge target:** call `branch_guard({ role: "target", branch: <PR/MR target from pr_status> })`; on `verdict == "warn"` **STOP** and surface `reason` — you are about to merge into a **protected** branch that is neither the live default nor a `kahuna/*` sandbox integration branch. Silent for the live default and `kahuna/*` targets. *(Transition fallback until `branch_guard` is deployed (#465): resolve the live default inline via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` / GitLab `glab api "projects/:id" --jq .default_branch` and STOP if the target is neither the live default nor matches `^kahuna/[0-9]+-`. The degraded path can't query host protection, so it errs toward stopping on any non-default, non-sandbox target — safe, and rare in this trunk-based flow.)*
 2. If `checks.summary == "pending"` → `pr_wait_ci(number, poll_interval_sec: 30, timeout_sec: 1800)`. On `timed_out` ask whether to wait longer. On `failed` STOP.
-3. If `checks.summary == "has_failures"` → STOP and report. Do NOT merge with failing checks.
+3. **DEFAULT-DENY — merge only on an explicit pass.** Proceed **only** if `checks.summary == "all_passed"`. **Any other value STOPs**, including values that do not exist yet.
+
+   This is deliberately an allowlist. The previous form blocked on `has_failures` and merged on everything else, which meant an unrecognised summary read as permission. That is how this gate was **inert on GitHub for its entire life**: `gh pr checks --json` does not exist on `gh 2.45.0` (the fleet version), the adapter left `summary` at its `'none'` initialiser and still returned `ok: true`, and `'none'` matched neither the `pending` branch nor the `has_failures` branch — so every GitHub merge fell straight through to step 4. The gate reported fine and did nothing. (cc-workflow#925; upstream reporting defect `mcp-server-sdlc#491`.)
+
+   **`none` is not evidence of passing — it means the query told us nothing.**
+
+   **On `none` (or any unrecognised value), do NOT stop outright — escalate to a source that works.** `pr_status` and `pr_wait_ci` do **not** share a code path, so a blind spot in one is not a blind spot in both. Measured on the same PR, same host, seconds apart (`gh 2.45.0`, **before** the `pr_status` fix in `mcp-server-sdlc#491`) —
+
+   ```
+   pr_status(32)   → checks: {total:0, passed:0, failed:0, pending:0, summary:"none"}
+   pr_wait_ci(32)  → {total:2, passed:2, failed:0, pending:0}      ← correct
+   gh pr checks 32 → lint pass, test pass                          ← agrees with pr_wait_ci
+   ```
+
+   So: call `pr_wait_ci(number)` and treat **its** result as authoritative — **as an allowlist, exactly like step 3 itself.** Proceed **only** on `status == "passed"`. **Every other status STOPs, including ones not listed here:**
+   - `passed` → proceed. *(the only value that proceeds)*
+   - `failed` → STOP.
+   - `timed_out` → STOP.
+   - `no_checks_required` → **STOP.** This one is a trap: it is a *definite, successful* verdict (`pr_wait_ci` probes once at t=0 and returns it on an empty rollup — #416), and its plain-English name reads as "nothing is wrong." **A repo with no required checks is not a repo whose checks passed.** Route it to the no-checks-configured branch below.
+   - `{ok: false}` or any error envelope → **STOP** and surface the error; do not silently continue past a gate that failed to run.
+   - anything else → **STOP.** Two independent sources unable to confirm a pass is a stop, not a shrug.
+
+   **Why this sub-list is an allowlist too (cc-workflow#925 code review):** the first draft of this fix converted the *outer* gate from a blocklist to an allowlist and then wrote the *inner* escalation as a blocklist — enumerating the statuses that stop, which silently permits every status nobody thought of. `no_checks_required` was already live and unlisted, so the escalation would have merged on it. **Fixing a defect at one layer while reproducing it at the next is the failure mode this whole section is about.** If `pr_wait_ci` ever gains a new status, it must land here as an explicit STOP before anything merges on it.
+
+   Stopping outright would have been *correct but useless* at the time this was written: `pr_status` returned `none` for **every** GitHub PR on `gh 2.45.0`, so a bare default-deny converts a silent-permit into a total merge block. Default-deny means **never proceed without an explicit pass**; it does not mean refuse to go and get one.
+
+   **Do not delete the escalation once `pr_status` is truthful.** `mcp-server-sdlc#491` fixes the GitHub instance, not the class — `#494` records the same silent-permissive shape on GitLab (`no_pipeline_data` returned with `ok: true`), still open. The escalation is written against **any** unrecognised summary precisely so it keeps working for variants nobody has named yet; narrowing it to the one value we happened to measure would rebuild the defect this section exists to close.
+
+   Once `pr_wait_ci` has stopped you — whether by `no_checks_required` or by failing to produce a verdict — distinguish the causes by hand, because they need different responses:
+   - **no checks configured on this repo** (incl. `no_checks_required`) → a human decides whether merging without CI is acceptable here;
+   - **the query failed** (unsupported flag, auth, network) → fix the query; infer nothing about the checks.
+
+   **If there is no human — HALT, do not improvise.** On a `kahuna/*` sandbox, under `/wavemachine` in `auto` mode, or with an armed `godspeed` mandate, "a human decides" has no addressee. Do **not** resolve it yourself: **do not merge**, emit a structured blocker (`wave-hold` shape on wave paths) naming the PR and the unresolved cause, and let the wave gate escalate it. An autonomous agent that reaches an underspecified branch will improvise, and improvising toward *proceed* is the exact failure this gate exists to prevent — the more so because `/precheck` lists this gate as non-bypassable *precisely because* it is the last control once the human is gone.
+
+   Verify with `gh pr checks <number>` (no `--json`) or `gh run list --branch <head>`. **Do not read a bare "no output" as a pass** — that is the same failure one layer down.
 4. `pr_diff(number)` → use the diff content (plus `git log target..source`) to draft the squash commit message.
 5. **Draft the squash commit message** (agent reasoning — this is the judgment layer):
    - Title: conventional commits `type(scope): description`
@@ -42,7 +76,8 @@ Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix)
 ## Important Rules
 
 - NEVER merge without explicit user approval
-- NEVER merge if `checks.summary == "has_failures"`
+- ONLY merge if `checks.summary == "all_passed"` — an allowlist, never a blocklist. `has_failures` blocks, and so does `none`, and so does any value not in this list. A blocklist of known-bad states silently permits every state you did not think of, which is exactly how this gate sat inert (cc-workflow#925). **But on `none`/unrecognised, escalate to `pr_wait_ci` first (step 3) — stop only if that also cannot confirm a pass.** Without that clause this rule reads as "block every GitHub merge", because `pr_status` returned `none` for every GitHub PR on `gh 2.45.0`.
+- `pr_wait_ci` is an allowlist too — proceed only on `passed`. **`no_checks_required` is a STOP**, not a pass: it means the probe found nothing to wait for, not that anything succeeded.
 - NEVER merge into a protected, non-default, non-`kahuna/*` branch — `branch_guard` STOPs this (target must be the live default or a `kahuna/*` sandbox)
 - Always squash + delete source branch
 - Squash message replaces the entire commit history — make it comprehensive

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -163,7 +163,15 @@ The detection regex is `^kahuna/[0-9]+-`. Resolve `base_branch` from the most re
 - `sandbox_context == false` (default — feature branch targeting `main`): existing behavior preserved — present checklist, notify, **STOP** and wait for `/scp` / `/scpmr` / `/scpmmr` / affirmative. This is the IT-09 negative case.
 - `sandbox_context == true` (Flight Agent on a kahuna sandbox): full checklist runs, full notifications fire, then emit the sentinel line **`[AUTO-APPROVED: kahuna sandbox]`** on stdout, then invoke `/scpmmr` with no wait. The sentinel makes the auto-approval grep-able in transcripts and Discord scrollback.
 
-**Non-bypassable items:** validation, code-reviewer (high+ findings still block), trivy scan, Discord `#precheck` post, `vox` announcement. These run in full regardless of `sandbox_context`. Only the human-approval STOP is replaced by the sentinel + auto-`/scpmmr`.
+**Non-bypassable items:** validation, code-reviewer (high+ findings still block), trivy scan, Discord `#precheck` post, `vox` announcement, **and `/mmr`'s CI gate**. These run in full regardless of `sandbox_context`. Only the human-approval STOP is replaced by the sentinel + auto-`/scpmmr`.
+
+The CI gate is listed explicitly because **the kahuna sandbox is not the only path that merges without a human.** Autonomous merging also occurs under **`/wavemachine` in `auto` mode** — its promote node performs the kahuna→protected merge with no human halt (interactive mode routes that same merge *to* a human, so the exposure is mode-specific, not skill-wide) — and under an **armed `godspeed` mandate**, whose gated-action list covers force-push, push-to-protected, terraform/kubectl/helm/docker/systemctl and prod-shaped writes but **not merges**, so an armed agent carries straight through one. In both, once the human approval is gone, the CI gate is the *last* thing between a red build and the protected branch.
+
+*(`/lazyriver` is deliberately **not** in that list. It is a `probe → journal → judge → steer` goal-seek loop that terminates by emitting a plan or an answer — it has no merge path at all. It was named here in an earlier draft and the claim was wrong; naming a skill that cannot merge costs the paragraph its credibility with exactly the reader careful enough to check.)*
+
+That gate was **inert on GitHub** until cc-workflow#925: it blocked only on `has_failures` and merged on any unrecognised summary, and `gh pr checks --json` does not exist on the fleet's `gh 2.45.0`, so the summary was always `none`. **Autonomous merge paths and a non-functioning CI gate were composing into an unguarded merge** — and the more autonomy a mode has, the more completely it was unguarded.
+
+`/mmr` step 3 is now default-deny. Do not weaken it back to a blocklist without re-reading that issue, and treat any *new* autonomous merge path as inheriting this dependency: **removing the human raises the CI gate from a second opinion to the only opinion.**
 
 ## Rules
 No diff. No commit. No skipping code-reviewer. Honesty over speed — no checking items you haven't verified. **Linting is not testing** — passing lint/typecheck does not mean code works. **`vox` is ALWAYS called** — it is NOT a fallback for disc_send failure. Both notifications happen every time.

--- a/tests/test_mmr_ci_gate.py
+++ b/tests/test_mmr_ci_gate.py
@@ -1,0 +1,284 @@
+"""Tests for skills/mmr/SKILL.md — the CI gate must be default-DENY.
+
+Why this file exists (cc-workflow#925):
+
+`/mmr`'s CI gate was inert on GitHub for its entire life. Three facts composed:
+
+  1. `gh pr checks --json` does not exist on gh 2.45.0, the fleet version.
+  2. The adapter reads results only on exitCode == 0, so `checks.summary` kept
+     its `'none'` initialiser — and the call still returned ok: true.
+  3. `/mmr` blocked on `has_failures` and waited on `pending`. Nothing required
+     a PASS.
+
+`'none'` matched neither branch, so every GitHub merge fell through to the merge
+step. The gate reported fine and did nothing.
+
+The defect is the *shape*, not the value: a blocklist of known-bad states
+silently permits every state nobody thought of. These tests pin the allowlist so
+a future edit cannot quietly restore the blocklist form.
+
+This matters more than it looks because several paths merge with **no human**:
+kahuna sandboxes (`/precheck` auto-approves), `/wavemachine`, `/lazyriver`, and
+an armed `godspeed` mandate. Removing the human raises this gate from a second
+opinion to the only opinion.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+MMR_PATH = _ROOT / "skills" / "mmr" / "SKILL.md"
+PRECHECK_PATH = _ROOT / "skills" / "precheck" / "SKILL.md"
+
+
+@pytest.fixture
+def mmr_text() -> str:
+    """Read the /mmr SKILL.md file."""
+    return MMR_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def precheck_text() -> str:
+    """Read the /precheck SKILL.md file."""
+    return PRECHECK_PATH.read_text(encoding="utf-8")
+
+
+class TestMmrCiGateIsDefaultDeny:
+    def test_gate_requires_an_explicit_pass(self, mmr_text: str) -> None:
+        """The gate must name all_passed as the condition to PROCEED.
+
+        Fails against the pre-#925 skill, which never mentioned all_passed at
+        all — it only enumerated the states that stop.
+        """
+        assert re.search(
+            r"Proceed \*\*only\*\* if `checks\.summary == \"all_passed\"`", mmr_text
+        ), (
+            "the CI gate must require an explicit passing signal; a blocklist "
+            "of failure states merges on everything it did not anticipate. "
+            "NOTE: a bare `'all_passed' in mmr_text` would pass against a skill "
+            "reading `NEVER merge if summary == \"all_passed\"` — the literal "
+            "must be pinned in its PROCEED context, not merely present"
+        )
+
+    def test_unrecognised_summary_stops(self, mmr_text: str) -> None:
+        """An unknown future value must stop, and the skill must say so.
+
+        The original defect was not that `none` was mishandled — it is that
+        ANY unenumerated value read as permission. Pinning only `none` would
+        fix the instance and leave the class.
+        """
+        assert re.search(
+            r"any other value\s+STOPs|Any other value\b.*STOP", mmr_text, re.I
+        ), "the skill must state that values outside the allowlist stop"
+
+    def test_none_is_not_treated_as_a_pass(self, mmr_text: str) -> None:
+        """`none` means the query told us nothing — never that checks passed."""
+        assert re.search(r"`?none`?\s+is not evidence of passing", mmr_text, re.I), (
+            "the skill must state explicitly that a `none` summary is an absence "
+            "of information, not a passing result"
+        )
+
+    def test_none_distinguishes_its_two_causes(self, mmr_text: str) -> None:
+        """No checks configured and a failed query need different responses.
+
+        Collapsing them is the same defect one layer down — a result that
+        cannot distinguish "checked and found nothing" from "did not look".
+        """
+        assert re.search(r"no checks configured", mmr_text, re.I), (
+            "the skill must name 'no checks configured' as one cause of `none`"
+        )
+        assert re.search(r"the query failed", mmr_text, re.I), (
+            "the skill must name 'the query failed' as the other cause of `none`"
+        )
+
+    def test_never_rule_is_an_allowlist_not_a_blocklist(self, mmr_text: str) -> None:
+        """The summary rule at the foot of the skill inherits the same defect.
+
+        Pinning step 3 alone would leave a contradicting blocklist rule in the
+        same file, and a reader consulting the rules section would get the old,
+        permissive behaviour.
+        """
+        assert re.search(r"ONLY merge if .*all_passed", mmr_text), (
+            "the rules section must be phrased as an allowlist"
+        )
+        assert not re.search(
+            r"NEVER merge if `checks\.summary == \"has_failures\"`\s*$",
+            mmr_text,
+            re.M,
+        ), (
+            "the bare blocklist rule must not survive — it permits every state "
+            "it does not enumerate"
+        )
+
+
+class TestAutonomousPathsDependOnThisGate:
+    def test_precheck_lists_the_ci_gate_as_non_bypassable(
+        self, precheck_text: str
+    ) -> None:
+        """Sandbox auto-approval must not compose with a skippable CI gate."""
+        block = re.search(
+            r"\*\*Non-bypassable items:\*\*.*?(?=\n\n)", precheck_text, re.S
+        )
+        assert block, "the non-bypassable items list is missing"
+        assert re.search(r"CI gate", block.group(0), re.I), (
+            "the CI gate must appear in the non-bypassable list; it is the last "
+            "control on any path where the human approval is removed"
+        )
+
+    def test_the_other_autonomous_paths_are_named(self, precheck_text: str) -> None:
+        """The kahuna sandbox is NOT the only path that merges without a human.
+
+        Naming only the sandbox understates the exposure — an agent reading
+        that would conclude non-sandbox work is human-gated, which is false
+        under /wavemachine's auto mode and an armed godspeed mandate.
+
+        `/lazyriver` was named here in an earlier draft and it was WRONG: it is
+        a probe→journal→judge→steer goal-seek loop with no merge path at all.
+        The first version of this test asserted its presence, which would have
+        made the suite go red the moment someone corrected the prose. **A test
+        that fails when you fix a factual error is worse than no test** — it
+        converts the documentation bug into a reason not to fix it.
+        """
+        block = re.search(
+            r"the kahuna sandbox is not the only path.*?(?=\n\n)",
+            precheck_text,
+            re.S | re.I,
+        )
+        assert block, "the autonomous-paths paragraph is missing"
+        para = block.group(0)
+
+        for mode in ("wavemachine", "godspeed"):
+            assert mode in para, (
+                f"/{mode} merges without a human and must be named IN the "
+                f"paragraph documenting the CI gate as last control — a bare "
+                f"whole-file substring check passes on any incidental mention"
+            )
+
+    def test_lazyriver_is_not_claimed_to_merge(self, precheck_text: str) -> None:
+        """Pin the correction so the wrong claim cannot come back.
+
+        Asserting absence is normally a weak test, but here the failure mode is
+        specific and recurring: `/lazyriver` reads like a wave-family skill, so
+        it is a natural thing to list alongside /wavemachine by association
+        rather than by checking. If it is reintroduced it must be as an
+        explicit exclusion, which is what the negative lookahead allows.
+        """
+        for m in re.finditer(r"lazyriver", precheck_text):
+            window = precheck_text[max(0, m.start() - 200) : m.end() + 200]
+            assert re.search(r"not\b|no merge path|deliberately", window, re.I), (
+                "/lazyriver has no merge path; it may only appear here as an "
+                "explicit exclusion, never in the list of paths that merge "
+                "without a human"
+            )
+
+
+class TestDefaultDenyDoesNotBecomeATotalBlock:
+    """Default-deny must escalate to a working source, not refuse outright.
+
+    `pr_status` returns summary 'none' for EVERY GitHub PR on gh 2.45.0, so a
+    bare "stop on anything but all_passed" converts a silent-permit into a
+    fleet-wide merge block. Measured on the same PR, seconds apart:
+
+        pr_status(32)   -> {total:0, passed:0, summary:"none"}
+        pr_wait_ci(32)  -> {total:2, passed:2, failed:0, pending:0}
+
+    They do not share a code path. Only pr_status is blind.
+    """
+
+    def test_none_escalates_to_pr_wait_ci(self, mmr_text: str) -> None:
+        assert re.search(r"do NOT stop outright", mmr_text), (
+            "on `none` the skill must escalate to a working source rather than "
+            "refusing — pr_status is blind on every GitHub PR"
+        )
+        # NOT `re.search(r"pr_wait_ci.*authoritative", mmr_text, re.S)` — with
+        # re.S the greedy `.*` spans the whole file, so it matches the mention
+        # of pr_wait_ci in the Tools Used list at the top against the word
+        # "authoritative" anywhere below, including a sentence saying it is NOT
+        # authoritative. Anchor to one line instead.
+        assert re.search(
+            r"call `pr_wait_ci\(number\)` and treat \*\*its\*\* result as authoritative",
+            mmr_text,
+        ), "pr_wait_ci must be named as the authoritative fallback, in one clause"
+
+    def test_states_why_a_bare_deny_is_useless(self, mmr_text: str) -> None:
+        """The reasoning must survive, or someone 'simplifies' it back."""
+        assert re.search(r"total merge block", mmr_text), (
+            "the skill must record that a bare default-deny blocks every merge, "
+            "so a future edit does not reintroduce it as a simplification"
+        )
+
+    def test_two_blind_sources_is_a_stop(self, mmr_text: str) -> None:
+        assert re.search(r"unable to confirm a pass is a stop", mmr_text), (
+            "if pr_wait_ci also cannot establish a result, that must STOP"
+        )
+
+    def test_escalation_is_itself_an_allowlist(self, mmr_text: str) -> None:
+        """The INNER gate must be an allowlist too — this is the one that bit.
+
+        The first version of #925 converted the outer gate (`checks.summary`)
+        from a blocklist to an allowlist and then wrote the escalation as a
+        blocklist: it enumerated the `pr_wait_ci` statuses that STOP and let
+        everything else through. `no_checks_required` was already live (#416)
+        and unlisted, so the escalation would have merged on it.
+
+        Every assertion in this file passed against that hole. That is the
+        proof that prose-substring tests pin wording rather than behaviour —
+        so this one pins the COMPLETENESS of the enumeration, which is the
+        actual failure mode, rather than the presence of a slogan.
+        """
+        assert re.search(
+            r"[Ee]very other status STOPs, including ones not listed here", mmr_text
+        ), "the pr_wait_ci escalation must be phrased as an allowlist"
+        assert re.search(r"`?no_checks_required`?\s*→\s*\*\*STOP", mmr_text), (
+            "`no_checks_required` must be named as an explicit STOP — it is a "
+            "definite, successful verdict whose plain-English name reads as "
+            "permission, so it is the value most likely to be mis-read"
+        )
+        assert re.search(r"`\{ok: false\}` or any error envelope\s*→\s*\*\*STOP", mmr_text), (
+            "an {ok:false} envelope must STOP explicitly; 'report and suggest' "
+            "is not a stop, and it is the softest link in a default-deny gate"
+        )
+
+    def test_no_human_branch_halts_rather_than_improvising(self, mmr_text: str) -> None:
+        """'A human decides' has no addressee on the autonomous paths.
+
+        /precheck lists this gate as non-bypassable precisely because it is the
+        last control once the human is gone — so the branch that defers TO a
+        human must say what happens when there isn't one. An underspecified
+        branch is where an autonomous agent improvises, and improvising toward
+        'proceed' is the failure the whole gate exists to prevent.
+        """
+        assert re.search(r"If there is no human — HALT", mmr_text), (
+            "the skill must define the no-human case explicitly rather than "
+            "leaving 'a human decides' as the terminal instruction"
+        )
+        assert re.search(r"wave-hold", mmr_text), (
+            "the halt must emit a structured blocker the wave gate can "
+            "escalate, not merely stop"
+        )
+
+    def test_escalation_survives_the_upstream_fix(self, mmr_text: str) -> None:
+        """The escalation must not be deleted when `pr_status` becomes truthful.
+
+        `mcp-server-sdlc#491` (PR #495) makes GitHub's `pr_status` report real
+        results, which makes the escalation branch *look* like dead code. It is
+        not: #494 records the identical silent-permissive shape on GitLab —
+        `no_pipeline_data` returned with `ok: true` — and it is still open.
+
+        This is the instance-vs-class distinction the whole file is about, one
+        layer up: fixing the reporter we measured does not fix reporters we
+        have not measured. The escalation is written against ANY unrecognised
+        summary so it covers variants nobody has named yet, and narrowing it to
+        the value we happened to observe would restore the blocklist shape.
+        """
+        assert re.search(r"[Dd]o not delete the escalation", mmr_text), (
+            "the skill must warn against removing the escalation once the "
+            "upstream reporter is fixed — it reads as dead code and is not"
+        )
+        assert "#494" in mmr_text, (
+            "the skill must cite the still-open GitLab variant; without a live "
+            "counter-example the warning is an assertion a future editor can "
+            "reasonably dismiss"
+        )


### PR DESCRIPTION
## Summary

`/mmr`'s CI gate was default-ALLOW and had been **inert on GitHub for its entire life** — every GitHub merge fell through it ungated. This makes it default-DENY at both layers, with an escalation so that default-deny doesn't become a fleet-wide total merge block.

## Changes

**The original defect.** Three facts composed: `gh pr checks --json` does not exist on `gh 2.45.0` (the fleet version); the adapter reads results only on `exitCode == 0`, so `checks.summary` kept its `'none'` initialiser **and the call still returned `ok: true`**; and the skill blocked on `has_failures` while waiting on `pending`. `'none'` matched neither branch, so every GitHub merge reached the merge step. The gate reported fine and did nothing.

The defect is the **shape**, not the value: a blocklist of known-bad states silently permits every state nobody thought of.

- **Step 3 is now an allowlist** — proceed only on `checks.summary == "all_passed"`.
- **With escalation, because a bare default-deny is useless.** `pr_status` returned `none` for *every* GitHub PR on gh 2.45.0, so refusing outright converts a silent-permit into a total merge block. On an unrecognised value the skill calls `pr_wait_ci` — which does not share a code path and is not blind — and treats it as authoritative. Two independent sources unable to confirm a pass is a stop, not a shrug.
- **The inner gate is an allowlist too.** Code review caught that the first draft fixed the outer gate and **rebuilt the same defect one layer down**: the escalation enumerated the `pr_wait_ci` statuses that STOP, silently permitting any status not listed. `no_checks_required` (#416) was already live, unlisted, and its plain-English name reads as permission — `/mmr` would have merged on it, and **every test written for this change passed against that hole.**
- **Explicit STOP on `{ok:false}`** — "report and suggest" is not a stop, and it was the softest link in a default-deny gate.
- **A HALT branch for no-human contexts** (kahuna sandbox, `/wavemachine` auto, armed `godspeed`), where "a human decides" has no addressee. An underspecified branch is where an autonomous agent improvises, and improvising toward *proceed* is the failure this gate exists to prevent.
- **Removes the `/lazyriver` claim** — it is a probe→journal→judge→steer loop with **no merge path**. The original test asserted its presence, which would have gone red the moment someone corrected the prose; a test that fails when you fix a factual error is worse than no test.

## Linked Issues

Closes #925

Upstream, now merged: `mcp-server-sdlc#491` (PR #495) makes `pr_status` truthful. The escalation is deliberately **kept** — `#494` records the same silent-permissive shape on GitLab (`no_pipeline_data` with `ok:true`), still open. Fixing the reporter we measured does not fix reporters we have not.

## Test Plan

Actually run, on the current tree:

```
validate.sh   179 passed / 0 failed          (exit 0, re-run after review fixes)
pytest        1614 passed, 4 skipped, 64 xfailed, 2 xpassed   (8m47s)
gate tests    14 pass on the fix
              13 of 14 RED against HEAD — verified in an isolated copy,
              working tree untouched
```

**Known limitation, deferred.** The suite asserts on SKILL.md prose via regex, so it pins *wording* rather than *behaviour* — proven by the fact that it passed against the `no_checks_required` hole above. Two near-vacuous assertions are now anchored (a greedy `.*` under `re.S` spanned the whole file, matching "authoritative" anywhere). The structural fix — extracting the decision table into data the skill renders and the test asserts over — is a separate change.

**trivy: zero manifests parsed.** cc-workflow has no dependency lockfile, so nothing was scanned. Recorded as `[NO MANIFESTS — nothing scanned]`, **not** as a pass — a pass over an empty denominator is the same shape as the gate this PR fixes. Verified trivy 0.69.3 works where manifests exist (`mcp-server-sdlc` → 1 manifest, 3 HIGH).
