### PR TITLE
fix(mmr): qualify cross-repo issue refs — bare #N resolved to the wrong issue

### DIFF
--- a/skills/mmr/SKILL.md
+++ b/skills/mmr/SKILL.md
@@ -45,7 +45,7 @@ Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix)
    - `passed` → proceed. *(the only value that proceeds)*
    - `failed` → STOP.
    - `timed_out` → STOP.
-   - `no_checks_required` → **STOP.** This one is a trap: it is a *definite, successful* verdict (`pr_wait_ci` probes once at t=0 and returns it on an empty rollup — #416), and its plain-English name reads as "nothing is wrong." **A repo with no required checks is not a repo whose checks passed.** Route it to the no-checks-configured branch below.
+   - `no_checks_required` → **STOP.** This one is a trap: it is a *definite, successful* verdict (`pr_wait_ci` probes once at t=0 and returns it on an empty rollup — `mcp-server-sdlc#416`), and its plain-English name reads as "nothing is wrong." **A repo with no required checks is not a repo whose checks passed.** Route it to the no-checks-configured branch below.
    - `{ok: false}` or any error envelope → **STOP** and surface the error; do not silently continue past a gate that failed to run.
    - anything else → **STOP.** Two independent sources unable to confirm a pass is a stop, not a shrug.
 
@@ -53,7 +53,7 @@ Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix)
 
    Stopping outright would have been *correct but useless* at the time this was written: `pr_status` returned `none` for **every** GitHub PR on `gh 2.45.0`, so a bare default-deny converts a silent-permit into a total merge block. Default-deny means **never proceed without an explicit pass**; it does not mean refuse to go and get one.
 
-   **Do not delete the escalation once `pr_status` is truthful.** `mcp-server-sdlc#491` fixes the GitHub instance, not the class — `#494` records the same silent-permissive shape on GitLab (`no_pipeline_data` returned with `ok: true`), still open. The escalation is written against **any** unrecognised summary precisely so it keeps working for variants nobody has named yet; narrowing it to the one value we happened to measure would rebuild the defect this section exists to close.
+   **Do not delete the escalation once `pr_status` is truthful.** `mcp-server-sdlc#491` fixes the GitHub instance, not the class — `mcp-server-sdlc#494` records the same silent-permissive shape on GitLab (`no_pipeline_data` returned with `ok: true`), still open. The escalation is written against **any** unrecognised summary precisely so it keeps working for variants nobody has named yet; narrowing it to the one value we happened to measure would rebuild the defect this section exists to close.
 
    Once `pr_wait_ci` has stopped you — whether by `no_checks_required` or by failing to produce a verdict — distinguish the causes by hand, because they need different responses:
    - **no checks configured on this repo** (incl. `no_checks_required`) → a human decides whether merging without CI is acceptable here;

--- a/tests/test_mmr_ci_gate.py
+++ b/tests/test_mmr_ci_gate.py
@@ -220,7 +220,7 @@ class TestDefaultDenyDoesNotBecomeATotalBlock:
         The first version of #925 converted the outer gate (`checks.summary`)
         from a blocklist to an allowlist and then wrote the escalation as a
         blocklist: it enumerated the `pr_wait_ci` statuses that STOP and let
-        everything else through. `no_checks_required` was already live (#416)
+        everything else through. `no_checks_required` was already live (mcp-server-sdlc#416)
         and unlisted, so the escalation would have merged on it.
 
         Every assertion in this file passed against that hole. That is the
@@ -264,7 +264,7 @@ class TestDefaultDenyDoesNotBecomeATotalBlock:
 
         `mcp-server-sdlc#491` (PR #495) makes GitHub's `pr_status` report real
         results, which makes the escalation branch *look* like dead code. It is
-        not: #494 records the identical silent-permissive shape on GitLab —
+        not: mcp-server-sdlc#494 records the identical silent-permissive shape on GitLab —
         `no_pipeline_data` returned with `ok: true` — and it is still open.
 
         This is the instance-vs-class distinction the whole file is about, one
@@ -277,7 +277,7 @@ class TestDefaultDenyDoesNotBecomeATotalBlock:
             "the skill must warn against removing the escalation once the "
             "upstream reporter is fixed — it reads as dead code and is not"
         )
-        assert "#494" in mmr_text, (
+        assert "mcp-server-sdlc#494" in mmr_text, (
             "the skill must cite the still-open GitLab variant; without a live "
             "counter-example the warning is an assertion a future editor can "
             "reasonably dismiss"


### PR DESCRIPTION
## Summary

GitHub resolves a bare `#N` against the **current** repo. `skills/mmr/SKILL.md` and its test cited `#416` and `#494` unqualified, so both linked to unrelated cc-workflow issues rather than the `mcp-server-sdlc` ones intended.

## Changes

| Reference | Resolved to (cc-workflow) | Meant (mcp-server-sdlc) |
|---|---|---|
| `#416` | feat(precheck): sandbox-aware auto-approval | feat(pr_wait_ci): short-circuit on empty status-check rollup |
| `#494` | /devspec without sub-command should suggest next action | bug(pr_status/gitlab): indeterminate pipeline state returned as `ok` |

**`#416` was load-bearing** — it is the citation for `no_checks_required` existing at all. A reader following it found an unrelated precheck feature and could reasonably conclude the claim was unfounded. That is *worse* than no citation: it makes a true statement look unsupported.

The test asserted `"#494" in mmr_text`, actively pinning the wrong reference. It now pins the qualified form.

Same family as the two-`#48` collision and `mcp-server-discord` vs `-watcher`: **an identifier that is valid, resolves cleanly, and points at the wrong thing.** No tool errors, nothing looks broken — which is what makes it durable.

## How it was found

@polyjuice demonstrated that a commit body reading verbatim `This does NOT close #48.` **closed #48** — GitHub's closing-keyword parser matched `close #48` and has no concept of negation. The sentence written to prevent closure caused it.

Her corollary was the actionable part: *don't trust that "does not close" language held — go re-check issue states.* Auditing my own merged work under that rule surfaced this. My commits were clean of negated keywords; the cross-repo references were not.

## Linked Issues

Closes #927

Follows #926, which introduced the refs.

## Test Plan

```
gate suite     14 pass
red check      revert skill to unqualified text -> the qualified-ref
               assertion fails, and only that one
validate.sh    179 passed / 0 failed (exit 0)
```

**Full pytest deliberately NOT re-run.** This is five string substitutions with no executable behaviour; 1614 passed on the parent commit `8429c05` minutes ago. Stating it rather than implying the suite ran.
