### PR TITLE
fix(hooks): secrets gate flagged Object.keys and was INERT on git add -A

### DIFF
--- a/scripts/hooks/workflow/pre-stage-secrets-gate.sh
+++ b/scripts/hooks/workflow/pre-stage-secrets-gate.sh
@@ -7,6 +7,19 @@
 # Does NOT hard-block — emits a warning that requires confirmation.
 #
 # Disable: SECRETS_GATE_DISABLED=1
+#
+# Three defects fixed in #929, all of which made this gate WORSE than absent:
+#
+#   1. Patterns were unanchored, so `\.key` matched the JS builtin `Object.keys`
+#      and `\.env` matched `foo.environment.ts`. A gate that cries wolf on a
+#      language builtin is one somebody disables — which is how a real secret
+#      ships.
+#   2. File extraction took everything after `git add`, so a compound command
+#      (`git add x.ts && grep "Object.keys" x.ts`) dragged arguments of the
+#      NEXT command into the file list. That is how a builtin became a "file".
+#   3. Flag-stripping reduced `git add -A` to an EMPTY list, so the broadest
+#      staging command — the one most likely to sweep in a secret nobody
+#      noticed — was never scanned at all. Silent, and reported success.
 set -uo pipefail
 
 if [[ "${SECRETS_GATE_DISABLED:-0}" == "1" ]]; then
@@ -25,19 +38,50 @@ if ! printf '%s' "$COMMAND" | grep -qE '^\s*git\s+(add|stage)'; then
 	exit 0
 fi
 
-# Extract filenames from the command (everything after git add/stage and flags)
-FILES=$(printf '%s' "$COMMAND" | sed -E 's/^\s*git\s+(add|stage)\s+//' | sed -E 's/\s*-[^ ]+\s*//g')
+# Secret-pattern filenames.
+#
+# Extension patterns are anchored to END of basename: a secret is a file NAMED
+# `server.key`, not any name containing the letters ".key". Dotfile-style env
+# files are matched deliberately at the START (`.env`, `.env.local`,
+# `.env.production`) since that family carries the suffix after the marker.
+SECRET_PATTERNS='(^\.env$|^\.env\.|\.secret$|\.key$|\.pem$|\.p12$|\.pfx$|^credentials\.json$|^service-account.*\.json$|-credentials\.|\.tfvars$)'
 
-# Secret-pattern filenames
-SECRET_PATTERNS='(\.env|\.env\.|\.secret|\.key|\.pem|\.p12|\.pfx|credentials\.json|service-account.*\.json|.*-credentials\.|.*\.tfvars)'
+# Extract the file arguments.
+#
+# Truncate at the first shell operator so arguments belonging to a LATER
+# command in the same line are never treated as files being staged.
+ARGS=$(printf '%s' "$COMMAND" | sed -E 's/^[[:space:]]*git[[:space:]]+(add|stage)[[:space:]]*//')
+ARGS=${ARGS%%&&*}
+ARGS=${ARGS%%||*}
+ARGS=${ARGS%%;*}
+ARGS=${ARGS%%|*}
+
+# Does this invocation stage broadly? `-A`, `--all`, `-u`, `--update`, or a
+# bare `.` all stage files not named on the command line, so the argument list
+# cannot tell us what is being staged — ask git instead.
+BROAD=0
+if printf '%s' "$ARGS" | grep -qE '(^|[[:space:]])(-A|--all|-u|--update|-[A-Za-z]*A[A-Za-z]*|\.)([[:space:]]|$)'; then
+	BROAD=1
+fi
+
+# Drop flags, then strip surrounding quotes from each remaining token.
+NAMED=$(printf '%s' "$ARGS" | tr ' ' '\n' | grep -vE '^-' | tr -d '"'"'"'' | grep -vE '^\s*$' || true)
+
+CANDIDATES=""
+if [[ "$BROAD" == "1" ]]; then
+	# What WOULD be staged. Without this the broadest command scanned nothing.
+	CANDIDATES=$(git status --porcelain 2>/dev/null | sed -E 's/^.{3}//' | sed -E 's/^.* -> //' || true)
+fi
+CANDIDATES=$(printf '%s\n%s\n' "$CANDIDATES" "$NAMED" | grep -vE '^\s*$' || true)
 
 MATCHES=""
-for file in $FILES; do
-	base=$(basename "$file" 2>/dev/null || echo "$file")
+while IFS= read -r file; do
+	[[ -z "$file" ]] && continue
+	base=$(basename "$file" 2>/dev/null || printf '%s' "$file")
 	if printf '%s' "$base" | grep -qEi "$SECRET_PATTERNS"; then
 		MATCHES="${MATCHES}${file} "
 	fi
-done
+done <<<"$CANDIDATES"
 
 if [[ -n "$MATCHES" ]]; then
 	SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || true)

--- a/tests/regression/test_pre_stage_secrets_gate.sh
+++ b/tests/regression/test_pre_stage_secrets_gate.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# test_pre_stage_secrets_gate.sh — regression tests for #929
+#
+# The gate had three defects that composed into something worse than absent:
+#
+#   1. Unanchored patterns flagged the JS builtin `Object.keys` (via `\.key`)
+#      and `foo.environment.ts` (via `\.env`). @treebeard was blocked from
+#      committing mcp-logger#3 by exactly this. She escalated instead of using
+#      --no-verify, which is why it was found rather than routed around.
+#   2. File extraction took everything after `git add`, so a compound command
+#      dragged the NEXT command's arguments in as "files".
+#   3. Flag-stripping reduced `git add -A` to an empty list, so the broadest
+#      staging command was never scanned. Silent, and reported success.
+#
+# (1) makes people disable the gate; (3) means it was already off where it
+# mattered most. Every case below was verified RED against the pre-fix script.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")/../.." && pwd)/scripts/hooks/workflow/pre-stage-secrets-gate.sh"
+PASS=0
+FAIL=0
+
+# Run the hook with a synthesized PreToolUse payload; echo "BLOCK" or "ALLOW".
+run_gate() {
+	local cmd="$1" dir="${2:-}"
+	local payload out
+	payload=$(printf '{"session_id":"test","tool_input":{"command":%s}}' "$(printf '%s' "$cmd" | jq -Rs .)")
+	if [[ -n "$dir" ]]; then
+		out=$(cd "$dir" && printf '%s' "$payload" | bash "$HOOK" 2>/dev/null || true)
+	else
+		out=$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null || true)
+	fi
+	if printf '%s' "$out" | grep -q '"decision":"block"'; then printf 'BLOCK'; else printf 'ALLOW'; fi
+}
+
+check() {
+	local label="$1" want="$2" got="$3"
+	if [[ "$want" == "$got" ]]; then
+		printf '  [+] %s\n' "$label"
+		PASS=$((PASS + 1))
+	else
+		printf '  [x] %s — wanted %s, got %s\n' "$label" "$want" "$got"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+printf '\n== defect 1: ordinary code must not flag ==\n'
+# The exact string that blocked mcp-logger#3.
+check "Object.keys as a grep argument" ALLOW \
+	"$(run_gate 'git add index.ts && grep -c "Object.keys" index.ts')"
+check "foo.environment.ts (contains .env)" ALLOW "$(run_gate 'git add foo.environment.ts')"
+check "monkey.test.ts" ALLOW "$(run_gate 'git add monkey.test.ts')"
+check "hotkeys.tsx" ALLOW "$(run_gate 'git add src/hotkeys.tsx')"
+check "keys.ts" ALLOW "$(run_gate 'git add lib/keys.ts')"
+
+printf '\n== genuine secrets must still block ==\n'
+check "server.key" BLOCK "$(run_gate 'git add server.key')"
+check ".env" BLOCK "$(run_gate 'git add .env')"
+check ".env.local" BLOCK "$(run_gate 'git add .env.local')"
+check "cert.pem" BLOCK "$(run_gate 'git add certs/cert.pem')"
+check "credentials.json" BLOCK "$(run_gate 'git add credentials.json')"
+check "terraform.tfvars" BLOCK "$(run_gate 'git add infra/terraform.tfvars')"
+check "svc-credentials.yaml" BLOCK "$(run_gate 'git add svc-credentials.yaml')"
+
+printf '\n== defect 2: compound commands must not leak later arguments ==\n'
+check "&& with a secret-shaped arg to the NEXT command" ALLOW \
+	"$(run_gate 'git add README.md && cat server.key')"
+check "; separated" ALLOW "$(run_gate 'git add README.md ; ls .env')"
+check "piped" ALLOW "$(run_gate 'git add README.md | tee .env.local')"
+# ...but a secret named on the git add itself still blocks, even in a compound.
+check "secret on the git add side of a compound" BLOCK \
+	"$(run_gate 'git add .env && echo done')"
+
+printf '\n== defect 3: broad staging must be SCANNED, not skipped ==\n'
+TMP=$(mktemp -d)
+git -C "$TMP" init -q 2>/dev/null
+printf 'x\n' >"$TMP/.env"
+printf 'x\n' >"$TMP/README.md"
+check "git add -A with a secret present" BLOCK "$(run_gate 'git add -A' "$TMP")"
+check "git add . with a secret present" BLOCK "$(run_gate 'git add .' "$TMP")"
+check "git add -u with a secret present" BLOCK "$(run_gate 'git add -u' "$TMP")"
+
+TMP2=$(mktemp -d)
+git -C "$TMP2" init -q 2>/dev/null
+printf 'x\n' >"$TMP2/README.md"
+printf 'x\n' >"$TMP2/index.ts"
+check "git add -A with NO secret present" ALLOW "$(run_gate 'git add -A' "$TMP2")"
+rm -rf "$TMP" "$TMP2"
+
+printf '\n== escape hatch still works ==\n'
+check "SECRETS_GATE_DISABLED=1" ALLOW \
+	"$(SECRETS_GATE_DISABLED=1 run_gate 'git add .env')"
+
+printf '\n== non-git-add commands are ignored ==\n'
+check "git commit" ALLOW "$(run_gate 'git commit -m "add .env support"')"
+check "unrelated command naming a secret" ALLOW "$(run_gate 'cat .env')"
+
+printf '\n──────────────────────────────────────────\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Four defects in `pre-stage-secrets-gate.sh`. Together they made the gate **worse than absent**: noisy where it should be silent, and silent where it must not be.

## How it was found

@treebeard was blocked from committing `mcp-logger#3` by:

```
Potential secrets detected in staged files: Object.keys, Object.keys
```

`Object.keys` is a JavaScript builtin, and guarding that call is load-bearing in the very change being blocked (it is what stops a hostile Proxy crashing the host).

**She did not use `--no-verify` and did not rename the calls to dodge the pattern.** She escalated — which is the only reason this was found rather than silently routed around. Her framing is the reason this is `priority::high`:

> A check that cries wolf on a language builtin is one somebody disables — which is how a real secret ships.

## The four defects

**1. Unanchored patterns.** `\.key` matched `Object.keys`; `\.env` matched `foo.environment.ts`. Now anchored to end-of-basename — a secret is a file *named* `server.key`, not any name containing those letters. Dotfile env forms stay anchored at the start, since that family carries its suffix after the marker (`.env.local`).

**2. Extraction spanned compound commands.** Everything after `git add` was treated as filenames:
```
cmd:    git add index.ts && grep -c "Object.keys" index.ts
FILES-> index.ts && grep"Object.keys" index.ts
```
That is literally how a builtin became a "staged file" — it was an argument to a *different* command. Extraction now truncates at `&&`, `||`, `;`, `|`.

**3. `git add -A` was never scanned — the serious one.** Flag-stripping reduced it to an empty list, the loop never ran, `exit 0`:
```
cmd:    git add -A
FILES-> (empty)
```
**The broadest staging command — the one most likely to sweep in a secret nobody noticed — was silently unscanned while reporting success.** Broad forms (`-A`, `--all`, `-u`, `--update`, bare `.`) now resolve against `git status --porcelain`.

**4. The flag stripper corrupted filenames** — found by the new tests, not in the original issue. `sed -E 's/\s*-[^ ]+\s*//g'` ate `-credentials.yaml` out of `svc-credentials.yaml`, so a genuine secret pattern never matched. **The gate was mangling the names it existed to inspect.**

Same family as #925: a gate that reported fine and did nothing. The difference is this one *also* cried wolf — which is the part that gets a control disabled, and it was already off where it mattered most.

## Linked Issues

Closes #929

## Test Plan

New suite `tests/regression/test_pre_stage_secrets_gate.sh` — **23 assertions, 9 verified RED against the pre-fix script:**

```
[x] Object.keys as a grep argument      wanted ALLOW, got BLOCK
[x] foo.environment.ts                  wanted ALLOW, got BLOCK
[x] svc-credentials.yaml                wanted BLOCK, got ALLOW   <- defect 4
[x] && / ; / | compound leakage         wanted ALLOW, got BLOCK
[x] git add -A / . / -u with a secret   wanted BLOCK, got ALLOW   <- defect 3
Results: 14 passed, 9 failed  (pre-fix)
Results: 23 passed, 0 failed  (post-fix)
```

Genuine secrets still block (`server.key`, `.env`, `.env.local`, `cert.pem`, `credentials.json`, `terraform.tfvars`, `svc-credentials.yaml`). Escape hatch `SECRETS_GATE_DISABLED=1` preserved. Non-`git add` commands ignored.

`validate.sh` 180 passed / 0 failed (was 179 — this suite is the new one). `shellcheck` clean.
