### PR TITLE
fix(precheck): Job C must report the denominator and the commit, not just a verdict

### DIFF
--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -65,12 +65,24 @@ prompt: "Run the project's validation and test tooling in <repo_root>.
 subagent_type: general-purpose
 model: haiku
 prompt: "Run: trivy fs --scanners vuln --severity HIGH,CRITICAL --format json --quiet <repo_root>
-         Parse the JSON. Return one of:
-           PASS — zero findings
+         Also run: git -C <repo_root> rev-parse HEAD
+
+         Parse the JSON. FIRST report the denominator and the commit, ALWAYS, on one line:
+           scanned: <N> manifest(s) at <short-sha>   [list each Target and Type]
+
+         THEN return one of:
+           PASS — one or more manifests parsed, zero findings
+           NO MANIFESTS — trivy ran and parsed ZERO manifests. This is NOT a pass.
+                          Nothing was scanned. Say so; do not report PASS.
            SKIP — trivy not installed
            FINDINGS — list each as: package | CVE | severity | fixed_version (or 'no fix available')
          Do not auto-upgrade anything. Just report."
 ```
+
+**Report the denominator and the commit before the verdict — never the verdict alone.** Two failures on 2026-07-19 make this non-optional:
+
+- Job C returned `PASS — zero HIGH or CRITICAL` for a repo where trivy parsed **zero manifests**. A pass over an empty denominator is *no scan*, and it is indistinguishable from a clean one. Same shape as the `/mmr` gate in #925: reported fine, did nothing. It had also been masking a real defect for months — a repo whose lockfile was gitignored had therefore *never* been scanned, and the gate's silence and the defect were the same event.
+- Two agents both reported `Results=1`, honestly, and disagreed — because they were scanning **different commits**. Denominator-first is necessary and not sufficient: *"how many manifests?"* and *"which commit?"* are two questions, and a local checkout is not the tree that ships. (@strangler)
 
 **Job D — Code review** `model: opus`
 ```


### PR DESCRIPTION
## Summary

Job C returned **`PASS — zero HIGH or CRITICAL`** for a repo where trivy parsed **zero manifests**. A pass over an empty denominator is not a clean scan — it is **no scan**, and the two are indistinguishable in the output.

## Two failures, same hour

**1. A verdict with no denominator.** Same shape as `/mmr` in #925: reported fine, did nothing.

It had also been **masking a real defect for months.** `mcp-logger`'s `bun.lock` is gitignored, so a fresh checkout has no lockfile and CI scans nothing — that repo has **never actually had a dependency scan**. Three consecutive clean results were read as benign. The gate's silence and the defect were the same event, and nobody could see it because the output said PASS.

**2. A denominator with no commit.** Two agents both reported `Results=1`, both honestly, and disagreed about whether a repo was vulnerable — they were scanning **different commits** (a local checkout with uncommitted work vs `origin/main`).

> "How many manifests?" and "which commit?" are two questions. — @strangler

A local checkout is not the tree that ships. This is the same class as the wrong-repo and wrong-issue-number errors hit repeatedly tonight: **valid output about the wrong subject** — which reproduces perfectly and so is *harder* to catch than fabrication, because nothing looks broken.

## Changes

- Job C emits `scanned: <N> manifest(s) at <short-sha>` with each Target and Type, **before** any verdict.
- New `NO MANIFESTS` outcome, explicitly documented as **not a pass**.
- Both failures recorded in the skill prose, so the requirement is not "simplified" back out by a future editor who sees only a verbose prompt.

## Linked Issues

Closes #931

Follows #925 (the `/mmr` gate this shares its shape with) and #929 (the secrets gate, same family — a control that reported fine while inert).

## Test Plan

```
gate suite     14 pass   (precheck non-bypassable block unchanged)
validate.sh    180 passed / 0 failed
```

This is a prompt-and-prose change to a skill; the behavioural requirement is that a reader cannot reach a verdict without first emitting the denominator and the resolved sha.
