### PR TITLE
fix(skills/disc): add forward and directmsg intents — capability shipped, entry point did not

### DIFF
--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -412,11 +412,14 @@ These handle interaction with external systems: Discord, Slack, voice, and file 
 
 Unified Discord integration for the Oak and Wave server. Handles sending messages, reading channels, creating channels/threads, listing channels, and check-in -- all routed by natural language intent.
 
+**Two surfaces, not one.** Most intents are `disc-server` MCP tool calls. **`forward` and `directmsg` are `discord-watcher` CLI subcommands** — there is no `disc_forward` MCP tool and never has been. An intent having no `disc_*` tool is the expected shape for watcher-owned features.
+
 **When to use it:**
 - To check in on `#roll-call` at session start
 - To send status updates or announcements to Discord channels
 - To read what other agents or team members have posted
 - To create new channels or threads for coordination
+- To route your doorbells to another agent while you are away, or to reach one whose doorbells are forwarded
 
 **Examples:**
 
@@ -428,7 +431,16 @@ Unified Discord integration for the Oak and Wave server. Handles sending message
 /disc create #wave-3-status   # Create a new channel
 /disc list channels           # List all text channels
 /disc thread "session-42" in #agent-ops  # Create a thread
+
+/disc forward babelfish                  # Route MY doorbells to agent babelfish
+/disc forward babelfish --exclude dev,ci # ...except doorbells from #dev or #ci
+/disc forward off                        # Clear the rule
+/disc dm treebeard "PR #12 is red"       # Direct message, bypasses forwarding
 ```
+
+**`<agent>` is an agent, never a channel** — a Dev-Name or Dev-Team token. Passing a channel silently "succeeds" and then fails at every delivery. `--exclude` names channels/authors whose doorbells **stay local**, not recipients to omit.
+
+To reach a forwarded agent from Discord itself, a user sends `//dm @<dev-name|dev-team> <message>` — both the target and a non-empty body are required.
 
 All messages are signed with the agent's Dev-Name, Dev-Avatar, and Dev-Team. Channel names are resolved via `mcp__disc-server__disc_resolve`. Configuration is read from `~/.claude/discord.json` (see [Discord Configuration](discord-config.md)).
 

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: disc
-description: Discord integration via disc-server MCP — routes /disc intents to disc_* tool calls.
+description: Discord integration — /disc routes to disc-server MCP tools, plus discord-watcher CLI subcommands for forward/directmsg.
 usage: |
   /disc send #ch "msg"  /disc read #ch  /disc list  /disc create #ch  /disc thread "name" in #ch
+  /disc forward <agent> [--exclude a,b]  /disc forward off  /disc dm <agent> "msg"
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -11,9 +12,9 @@ usage: |
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 
-# Disc — disc-server MCP Router
+# Disc — Discord Router (disc-server MCP + discord-watcher CLI)
 
-Route all /disc intents to `disc-server` MCP tool calls.
+Route each /disc intent to **its owning surface**. Most are `disc-server` MCP tool calls — but `forward` and `directmsg` are **not**. They are `discord-watcher` CLI subcommands, and there is **no `disc_forward` MCP tool**. Check the routing table below rather than assuming a `disc_*` tool exists for an intent.
 
 **Resolve identity** — read `<project_root>/.claude/agent-identity.json` for `dev_name`, `dev_avatar`, `dev_team` (defaults: Claude, 🤖, unknown). Fall back to `/tmp/claude-agent-<md5(project_root)>.json` if the durable file is absent (transition window).
 
@@ -25,11 +26,38 @@ Route all /disc intents to `disc-server` MCP tool calls.
 
 Last-resort fallbacks only if `discord.json` is missing the key: default `1487288523638837268`, roll-call `1487382005036617851`.
 
-**Route intent:**
+**Route intent — disc-server MCP tools:**
 - send / check-in / no args → `disc_send(channel_id, "**<name>** <avatar> (<team>): <msg>")` — check-in sends to #roll-call
 - read → `disc_read(channel_id, limit=20)` — summarize digest, highlight agent-addressed messages
 - list → `disc_list(guild_id, type="text")` — format as clean list
 - create channel → `disc_create_channel(guild_id, name)` — confirm with created id
 - create thread → `disc_create_thread(channel_id, name)` — confirm with created id
+
+**Route intent — `discord-watcher` CLI (Bash, NOT an MCP tool):**
+- forward → `discord-watcher forward <agent> [--exclude a,b,c]` — routes this agent's doorbells to another **agent**. Confirms with `disc forward: forwarding doorbells to <label>`.
+- forward off / stop → `discord-watcher forward --off` — confirms `rule cleared`, or `no rule to clear` if none was set.
+- directmsg / dm → `discord-watcher directmsg <agent> <content...>` (`dm` is an accepted alias) — bypasses the forward rule and rides the deliver-router.
+
+Exact usage, read from the installed binary:
+```
+usage: discord-watcher forward <target> [--exclude a,b,c] | forward --off
+usage: discord-watcher directmsg <target> <content...>
+```
+
+⚠️ **`<target>` is an AGENT, never a channel.** It becomes the aoe session name (`rule.target = {label, session}`), so it must be a **Dev-Name or Dev-Team token** (`babelfish`, `oaw`) — leading `@`/`#` are stripped. **This fails silently if you get it wrong:** any non-`--` token is accepted, so `forward #agent-ops` exits 0 and prints `forwarding doorbells to #agent-ops`. The rule is written and looks healthy; every doorbell then fails at delivery. Do not pattern-match off `#ch` used elsewhere in this skill.
+
+⚠️ **`--exclude` is about what stays LOCAL, not who is excluded as a recipient.** Comma-separated **channel names, channel ids, or author usernames** — doorbells matching any of them are kept by this agent instead of being forwarded (`isExcludedFromForward`: matches `channel.name`, `channel.id`, or `msg.author.username`, normalized lowercase with `@`/`#` stripped).
+
+**Message-side sigil (no invocation needed).** The watcher parses `//directmsg` / `//dm` at the **start** of a Discord message (`/^\/\/(?:directmsg|dm)\b\s*/i`). Correct form — **both parts are required**:
+
+```
+//dm @<dev-name|dev-team> <message>
+```
+
+`parseDirectMsg` matches `/^(\S+)\s+([\s\S]+)$/`, so a target token **and** a non-empty body are mandatory. `//dm help` returns null; `//dm need you now` silently parses `need` as the target, matches no agent, and the message is **forwarded away** — the exact failure the direct lane exists to prevent. The `@<target>` mention is also what routes the doorbell to that watcher at all.
+
+The override is **scoped**, not global: it fires only when the target matches the *receiving* agent's own dev-name or dev-team (`isDirectMsgForLocal`), overriding **that agent's** forward rule. Relay this form to users verbatim when they ask how to reach an agent whose doorbells are forwarded; it is not something `/disc` invokes.
+
+**Why the split matters:** these are different binaries. `disc-server` is the MCP server this skill mostly drives; `discord-watcher` is the notification daemon. A `disc_forward` tool does not exist and never has — attempting one fails. If a future intent has no `disc_*` tool, that is the expected shape for watcher-owned features, not a bug to route around.
 
 **Turn-taking on shared channels** — before answering a team-addressed question when many agents are listening, follow the mic convention (claim the talking-stick or defer). Full convention: https://github.com/Wave-Engineering/claudecode-workflow/blob/main/docs/discord-mic-convention.md (in the cc-workflow repo at `docs/discord-mic-convention.md`; not deployed to the Cellar, so the bare relative path won't resolve from a non-repo session).


### PR DESCRIPTION
## Summary

`disc forward` and `directmsg` are implemented and deployed in the `discord-watcher` binary, but `/disc` had no route for either — they were reachable only by someone who already knew the raw CLI syntax. The root cause was one framing sentence: *"Route all /disc intents to disc-server MCP tool calls."* Both are `discord-watcher` **CLI subcommands**, not MCP tools (there is no `disc_forward` tool), so a skill built around tool-routing had no shape for them and the omission was invisible.

## Changes

- Route `forward` / `forward off` / `directmsg` to the `discord-watcher` CLI, with usage strings copied **verbatim** out of the installed binary.
- Correct the framing so an intent lacking a `disc_*` tool reads as the expected shape for watcher-owned features rather than a gap to route around.
- Document `<target>` as an **agent** (Dev-Name / Dev-Team, the aoe session), never a channel. This one is load-bearing: passing a channel exits 0 and prints `forwarding doorbells to #x`, writes a rule that passes the addressable check, then fails at every delivery — a silent no-op behind a success message.
- Document the `//dm` sigil with its **mandatory target argument**. The parser requires both a target and a non-empty body; `//dm need you now` silently takes `need` as the target and the message is forwarded away — the exact failure the direct lane exists to prevent. Also corrected the override's scope: it applies to the addressed agent's rule, not to any active rule.
- Document `--exclude` as channels/authors whose doorbells stay **local**, not recipients to omit.
- Fix the H1, which still read `disc-server MCP Router` two lines above text contradicting it.
- Update `docs/skill-reference.md`, which carried the identical MCP-only framing and would have left a reader in exactly the state #939 describes.

## Linked Issues

Closes #939

## Test Plan

What was actually run:

- `./scripts/ci/validate.sh` — **180 passed, 0 failed**, re-run *after* the code-review fixes (includes SKILL.md frontmatter + skill-registration gates, which read every skill file).
- `python3 -m pytest tests/` — **1614 passed, 4 skipped, 64 xfailed, 2 xpassed**, on a run that includes the final state.
- Targeted: the 3 test files referencing disc / skill-reference — **160 passed**.
- **Every behavioral claim verified against the running binary** at `~/.local/bin/discord-watcher` via `strings -a` with a positive control — not against repo source. The two usage strings in the skill are asserted byte-identical to the binary's own.
- Liveness check on the premise: `git show HEAD:skills/disc/SKILL.md` contained **0** occurrences of forward/directmsg, confirming the gap was real before the fix.

Code review returned 2 critical + 2 important findings — all fixed, each reproduced in the binary before being written up.

Dependency scan is **`NO MANIFESTS`** (trivy parsed 0 of 2 tracked manifests) — deliberately not recorded as a pass; tracked separately in #941. This change has no dependency surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Qpm8a9VbV6VcXiASkV4Pk