### PR TITLE
fix(hooks): read string content and require an arming form

### DIFF
--- a/scripts/godspeed-lookback.sh
+++ b/scripts/godspeed-lookback.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
 # godspeed-lookback.sh — Godspeed mandate lookback utility.
 #
-# Scans a Claude Code JSONL transcript for the most-recent `godspeed` and
-# `HALT!` in user-role turns and emits the arm status. Sourced by both Stop
-# hooks; also runnable standalone with --demo or --eval.
+# Scans a Claude Code JSONL transcript for the most-recent ARMING `godspeed`
+# turn (sentence-initial, or slash-prefixed after a space; not a question, a
+# quoted mention, a file path, or a machine-generated turn — see `arms` in the
+# jq prelude) and the most-recent `HALT!` in user-role turns, and emits the arm
+# status. Sourced by both Stop hooks; also runnable standalone with --demo or
+# --eval.
 #
 # Output of godspeed_status():
 #   ARMED <d>     godspeed found d user turns ago; HALT! not newer
 #   HALTED        HALT! is newer than godspeed (or godspeed never appeared)
 #   UNARMED       no godspeed within the last N user turns
+#   UNKNOWN       the scan could not be trusted. Either it could not run at all
+#                 (unreadable content shape, or every line in the window
+#                 unparseable), or it ran DEGRADED — recovered by dropping torn
+#                 lines — and would otherwise have returned ARMED while the
+#                 dropped bytes contained a `HALT!`.
+#                 NOT the same as UNARMED: callers stand down on both, but
+#                 UNKNOWN is reported on stderr instead of passing as all-clear.
+#                 A single torn line does NOT blind the window: it is dropped,
+#                 the drop is announced, and the scan continues.
 #
 # Usage (sourced):
 #   source godspeed-lookback.sh
@@ -27,10 +39,284 @@
 # Issue: cc-workflow#818
 
 # ---------------------------------------------------------------------------
+# Shared jq prelude — ONE implementation of content extraction and arming form.
+#
+# Injected into every jq program in this file and in the two Stop hooks that
+# source it. Deliberately a single string rather than copies: #919 established
+# that two module instances of one detector is how a fix reaches half its call
+# sites, and these three scripts had ten independent copies of the same
+# extraction between them. (#920)
+#
+# `txt` is the fix for #920. `.message.content` is a plain STRING on a large
+# share of user messages — measured 20,174 string / 119,269 array across 3821
+# transcripts (1.8 GB, one workstation). jq aborts on the FIRST string it meets,
+# so the old array-only `map(...)` did not degrade gracefully; it killed the
+# whole scan. 3651 of 3821 transcripts (95.6%) carry at least one, and 261 of
+# 303 main-session transcripts (86.1%) do — the failure was total per file, not
+# proportional.
+#
+# An unrecognised shape raises rather than defaulting. A detector that cannot
+# read its input must not be able to report "nothing found". (#920)
+# ---------------------------------------------------------------------------
+_GODSPEED_JQ_PRELUDE='
+  def txt:
+    (.message.content // [])
+    | if type == "string" then .
+      elif type == "array" then (map(select(.type == "text") | .text) | join(" "))
+      else error("godspeed: unhandled .message.content type: \(type)")
+      end;
+
+  # Claude Code writes a number of MACHINE-generated turns with role=="user".
+  # The Stop hooks own block text is one of them — that is the #921 inversion,
+  # the brake pressing the accelerator — but a corpus sweep showed it is a whole
+  # family, not one case.
+  #
+  # Deliberately NOT in this list: `<system-reminder>`. That one is APPENDED to
+  # genuine human turns rather than constituting the turn, so excluding on it
+  # would silently drop real instructions — including an arming turn that happens
+  # to be the first message of a session. Every marker below is the WHOLE turn;
+  # that is the property that makes exclusion safe.
+  #
+  # NONE of these are ^-anchored, deliberately. jq compiles Oniguruma with
+  # ONIG_OPTION_SINGLELINE, so `^` is a STRING anchor (\A), not a line anchor —
+  # verified with jq -n on the two-line string a\nb: test("^b") is false, and the
+  # "m" flag does not change it. An anchored marker would therefore match only at
+  # offset 0 of the JOINED text, and `txt` joins an array turns text blocks with
+  # a space, so any preceding block would hide the marker. Bare substrings are
+  # distinctive enough and cannot be defeated by a leading block. (#921)
+  def _injected_envelope_re:
+    "\\[godspeed-(GATE|checkpoint|STOP)\\]"
+    + "|<task-notification>"
+    + "|<local-command-(stdout|stderr)>"
+    + "|Base directory for this skill:"
+    + "|Caveat: The messages below were generated"
+    + "|This session is being continued from a previous conversation"
+    + "|Stop hook feedback:";
+
+  # ARMING/HALTING exclusion. Includes slash-command envelopes: a turn that is
+  # the expansion of `/precheck` must not arm.
+  def is_machine_turn:
+    txt | test(_injected_envelope_re + "|<command-(message|name|args)>");
+
+  # DECAY COUNTING is a DIFFERENT question, and for one marker the answer
+  # differs. `<command-name>/precheck</command-name>` is machine-FORMATTED but
+  # BJ typed it — it is a real interaction, and the mandate is supposed to decay
+  # across real interactions. Excluding it from the count would make `d` rise
+  # slower than the model intends, which lowers `bar_pct`, which returns GO where
+  # the model meant ASK. In this fleet /precheck, /scp and /scpmmr are frequent,
+  # so that is a measurable widening of autonomy — the wrong direction to get
+  # wrong by accident.
+  #
+  # So: a command turn does NOT arm, but it DOES count. One predicate cannot
+  # answer both questions, which is why there are two. (#921)
+  def counts_as_human_turn:
+    (txt | test(_injected_envelope_re)) | not;
+
+  # Arming requires a FORM, not a substring. The form was DERIVED FROM THE REAL
+  # CORPUS, not from a description of it — an earlier draft of this fix used
+  # "the turn IS the token or leads with it", taken from the issue text, and it
+  # rejected 3 of the 4 genuine arming turns on this workstation:
+  #
+  #   godspeed                                                        <- bare
+  #   agreed. continuous, phas-boundary reporting.  godspeed, my friend
+  #   thank you. please be as autonomous as you can safely be.  /godspeed
+  #   roll them in. im working with lots of agents, so /godspeed
+  #
+  # The real idiom is a TRAILING token, usually slash-prefixed, appended to a
+  # sentence of instruction. The true negatives are interrogative or quoted:
+  #
+  #   are you in godspeed mode?
+  #   how do we turn off `/godspeed`?
+  #   agentc can merge w/o user approval in wavemachine, lazyriver, and godspeed
+  #
+  # So the discriminator is NOT position-in-message. It is: the token is either
+  # SLASH-PREFIXED (the explicit command form) or SENTENCE-INITIAL, and is not
+  # inside a question or a quotation.
+  #
+  # THE SLASH MUST FOLLOW WHITESPACE OR OPEN THE STRING. This is the single
+  # highest-value clause in the definition and it was missing from the first
+  # draft, which matched `/godspeed` anywhere. Sweeping 3772 real transcripts for
+  # every user turn mentioning the token found 40, of which the draft armed 17
+  # and only 4 were genuine — a 76% false-positive rate on a control that GRANTS
+  # AUTONOMY. The dominant cause is almost too neat — the file path in this very
+  # repo,
+  #
+  #     scripts/godspeed-lookback.sh
+  #
+  # contains the literal substring `/godspeed`. So merely NAMING the detector
+  # armed it. A code-review prompt, a subagent task-notification, a `git status`
+  # paste and a compaction summary all armed the mandate in the sweep. Requiring
+  # whitespace before the slash removes that entire family, because a path has a
+  # word character there and a typed command has a space.
+  #
+  # `\n\s*` was also dropped as an arming form. It made ANY line beginning with
+  # the token arm, so pasting a quoted example — routine in this repo — armed the
+  # mandate. Nothing was lost: all four corpus true-positives arm via the slash
+  # form or via `[.!?]\s+`, and the bare-token turn arms via `^`. A clause that
+  # no genuine case needs, and that fires on quotation, is not a discriminator.
+  #
+  # `^` here is a STRING anchor, not a line anchor — jq compiles Oniguruma with
+  # ONIG_OPTION_SINGLELINE. Verified rather than assumed:
+  #
+  #     on the two-line string  a\nb :
+  #         test("^b")  ->  false      (a line anchor would give true)
+  #         test("^a")  ->  true
+  #
+  # An earlier revision of this comment asserted the opposite. It mattered: if
+  # `^` were a line anchor it would already do everything `\n\s*` did, and
+  # dropping that clause would have bought nothing. It is string-anchored, so
+  # the removal is what actually closed the pasted-example hole.
+  #
+  # Belt and braces with is_machine_turn — this failure mode inverts a safety
+  # control, so it gets two independent guards. (#921)
+  def arms:
+    (is_machine_turn | not)
+    # Quoted mentions are TALKING ABOUT the command, not issuing it. The corpus
+    # carries the token in backticks, in straight double quotes and in smart
+    # quotes, always in a sentence about the feature rather than an instruction.
+    #
+    # The straight single quote is written as the escape \u0027, and the prose
+    # prelude avoids apostrophes entirely, because the whole block is a
+    # SINGLE-QUOTED shell string: one literal apostrophe — even inside a comment
+    # — closes it, and the jq body then reaches bash as commands. It fails
+    # loudly, but it fails at source time in a file both Stop hooks source.
+    and ((txt | test("[`\"\u0027‘’“”]/?godspeed")) | not)
+    and ((txt | test("[^.!?\\n]*\\bgodspeed\\b[^.!?\\n]*\\?")) | not)
+    and (txt | test("(^|[.!?]\\s+)godspeed\\b|(^|\\s)/godspeed\\b"));
+
+  # HALT! stays a liberal substring match — over-halting is the safe direction —
+  # but a hook echo still must not disarm a live mandate. (#921)
+  #
+  # KNOWN LIMIT: a user turn that QUOTES a sentinel while also saying HALT! is
+  # filtered out of the turn list before this runs, so that HALT is not seen.
+  # Accepted rather than fixed: it requires BJ to type the literal sentinel, and
+  # halting without quoting one works normally. Fixing it needs the arming and
+  # halting scans to run over different lists, which breaks the shared index
+  # arithmetic that gs_d/halt_d compare on.
+  def halts:
+    (is_machine_turn | not) and (txt | test("HALT!"));
+'
+
+# ---------------------------------------------------------------------------
+# _godspeed_jq_scan <scan_lines> <transcript_path> <jq_program> [jq_flags...]
+#
+# The ONE place a jq program is run over a transcript. All three public
+# extractors go through it, so the crash taxonomy is defined once.
+#
+# Two failure classes reach jq, and they need opposite treatments:
+#
+#   TYPE failure  — `.message.content` in a shape `txt` cannot read. The prelude
+#                   raises deliberately (#920); nothing is recoverable, so this
+#                   propagates and the caller reports its own loud default.
+#   PARSE failure — a torn write: two JSON objects concatenated by a racing
+#                   append (`...LlwqhUPdY6Dphw{"parentUuid":...`), seen on 5 of
+#                   3821 transcripts. `jq -s` slurps, so ONE torn line anywhere
+#                   in the window aborts the whole scan.
+#
+# A torn line is durable — it stays in the file — so treating a parse failure as
+# fatal would leave that session's mandate permanently unarmable and its #917
+# gate STOPping every turn until the bad line aged out of the window. Safe, but
+# permanently degraded. So: retry line-wise, DROP the unparseable lines, and say
+# so on stderr. Dropping a torn record costs one turn of context; blinding the
+# window costs the whole scan.
+#
+# The retry is also how the two classes are told apart without parsing jq's
+# message: if the lenient pass succeeds it was a parse failure (now recovered);
+# if it fails the same way it was a type failure (unrecoverable). Healthy
+# transcripts never reach the retry and pay nothing for it.
+#
+# CONTRACT — the caller distinguishes three outcomes by EXIT CODE, and the
+# helper writes its own diagnostics to stderr:
+#
+#   0  clean       — the strict pass succeeded, nothing dropped.
+#   2  DEGRADED    — recovered by dropping N unparseable lines. Output is
+#                    well-formed but INCOMPLETE. Callers whose answer is a
+#                    safety decision must treat this as failure.
+#   1  unreadable  — nothing usable; caller reports its own loud default.
+#
+# The exit code carries this, NOT a global. An earlier draft used
+# `_GODSPEED_SCAN_ERR` and it was silently dead: every caller invokes this via
+# `out=$(_godspeed_jq_scan ...)`, which is a COMMAND SUBSTITUTION and therefore
+# a subshell, so assignments never reached the parent and every "loud" failure
+# printed an empty reason. That is the #920 defect reproduced inside the fix for
+# #920 — a crash that reports nothing actionable. Exit codes cross a subshell;
+# variables do not.
+#
+# Why DEGRADED is distinct from clean, and why it is not merely cosmetic: a torn
+# write is a RACING APPEND, so the torn line sits at the write head — precisely
+# where the current turn's records live. Dropping it and returning 0 would let
+# `godspeed_turn_tools` emit a well-formed but incomplete tool list, and "I
+# dropped the evidence" would render as "no gated action found". Same signature
+# as the #917 fail-open. `godspeed_status` can accept the drop (its `d` shifts
+# by one, in the safe direction); the action gate cannot.
+# ---------------------------------------------------------------------------
+_godspeed_jq_scan() {
+	local scan_lines="$1" transcript_path="$2" program="$3"
+	shift 3
+
+	local out rc
+	out=$(
+		tail -n "$scan_lines" "$transcript_path" 2>/dev/null |
+			jq "$@" "$_GODSPEED_JQ_PRELUDE$program" 2>&1
+	)
+	rc=$?
+	if [[ $rc -eq 0 ]]; then
+		printf '%s' "$out"
+		return 0
+	fi
+
+	local strict_err="$out"
+
+	# `fromjson?` yields nothing on an unparseable line — no `// empty`, which
+	# would also swallow a legitimately falsy record.
+	local recovered total kept dropped out2 rc2
+	recovered=$(
+		tail -n "$scan_lines" "$transcript_path" 2>/dev/null |
+			jq -Rc 'fromjson?' 2>/dev/null
+	)
+	total=$(tail -n "$scan_lines" "$transcript_path" 2>/dev/null | grep -c '[^[:space:]]' || true)
+	kept=$(printf '%s\n' "$recovered" | grep -c '[^[:space:]]' || true)
+	dropped=$((total - kept))
+
+	# Nothing survived. This is a total loss, not a recovery — and it must not be
+	# allowed to look like one: an empty stream slurps to `[]`, the program runs
+	# cleanly over it, and `godspeed_status` would return a confident UNARMED
+	# with rc=0 for a window it could not read at all.
+	if [[ $kept -eq 0 ]]; then
+		printf 'godspeed: scan window unreadable — %s of %s line(s) unparseable: %s\n' \
+			"$dropped" "$total" "${strict_err//$'\n'/ }" >&2
+		return 1
+	fi
+
+	out2=$(printf '%s\n' "$recovered" | jq "$@" "$_GODSPEED_JQ_PRELUDE$program" 2>&1)
+	rc2=$?
+	if [[ $rc2 -eq 0 ]]; then
+		printf 'godspeed: DEGRADED — dropped %s unparseable line(s) of %s (torn write); result is incomplete\n' \
+			"$dropped" "$total" >&2
+		printf '%s' "$out2"
+		return 2
+	fi
+
+	# Report the RETRY's diagnostic, not the strict pass's. When a transcript
+	# carries both a torn line and an unreadable content shape, the strict error
+	# names the torn write while the durable, actionable problem is the shape.
+	printf 'godspeed: transcript scan failed: %s\n' \
+		"${out2:-$strict_err}" | tr '\n' ' ' >&2
+	printf '\n' >&2
+	return 1
+}
+
+# ---------------------------------------------------------------------------
 # godspeed_status <transcript_path>
 #
 # Scans the last GODSPEED_WINDOW user turns. Only user-role turns count —
 # assistant echoes of "godspeed" do not arm the mandate.
+#
+# Returns UNKNOWN when the scan could not run. UNKNOWN is NOT UNARMED: the old
+# `2>/dev/null || echo "UNARMED"` made a crashed detector byte-identical to a
+# healthy one reporting all-clear, which is why this stayed broken through three
+# releases. Callers treat UNKNOWN as "no mandate" (the safe direction) but the
+# failure is now visible on stderr instead of silent. (#920)
 # ---------------------------------------------------------------------------
 godspeed_status() {
 	local transcript_path="$1"
@@ -46,38 +332,34 @@ godspeed_status() {
 	# 20× N + 500 is a conservative ceiling that stays fast.
 	local scan_lines=$((N * 20 + 500))
 
-	tail -n "$scan_lines" "$transcript_path" 2>/dev/null |
-		jq -rs --argjson N "$N" '
+	local out rc
+	out=$(_godspeed_jq_scan "$scan_lines" "$transcript_path" '
       # Collect user turns that carry actual human text — exclude tool-result
       # wrapper entries (type=="user" but content is tool_result blocks with no
       # text).  Without this filter every tool result inflates d by 1, causing
       # the mandate to age out far faster than intended.
+      #
+      # Injected envelopes are excluded here too: a machine-generated turn is not
+      # a human interaction, and counting it would decay the mandate for reasons
+      # BJ had no part in.
+      #
+      # `counts_as_human_turn`, NOT `is_machine_turn` — the two differ on slash
+      # commands, which BJ types and which therefore must still decay the
+      # mandate even though they must not arm it. (#921)
       [.[] | select(
         .type == "user" and
-        ((.message.content // []) | map(select(.type == "text") | .text) | join("") | length > 0)
+        ((txt | length) > 0) and
+        counts_as_human_turn
       )] as $user_turns |
 
       # Reverse so index 0 = most-recent user turn.
       ($user_turns | reverse | to_entries) as $rev |
 
-      # Find the most-recent user turn containing \bgodspeed\b (case-sensitive,
-      # word-bounded). Assistant echoes are excluded because we already filtered
-      # to type=="user". Returns the first (most-recent) matching entry index,
-      # or -1 if none.
-      ($rev | map(select(
-        (.value.message.content // []) |
-        map(select(.type == "text") | .text) |
-        join(" ") |
-        test("\\bgodspeed\\b")
-      )) | first | .key // -1) as $gs_d |
+      # Most-recent user turn that ARMS (see `arms`), or -1 if none.
+      ($rev | map(select(.value | arms)) | first | .key // -1) as $gs_d |
 
-      # Find the most-recent user turn containing "HALT!" (exact, case-sensitive).
-      ($rev | map(select(
-        (.value.message.content // []) |
-        map(select(.type == "text") | .text) |
-        join(" ") |
-        test("HALT!")
-      )) | first | .key // -1) as $halt_d |
+      # Most-recent user turn carrying HALT!, or -1.
+      ($rev | map(select(.value | halts)) | first | .key // -1) as $halt_d |
 
       # Decision:
       # - godspeed not found or aged out → UNARMED
@@ -90,7 +372,154 @@ godspeed_status() {
       else
         "ARMED \($gs_d)"
       end
-    ' 2>/dev/null || echo "UNARMED"
+    ' -rs --argjson N "$N")
+	rc=$?
+
+	if [[ $rc -eq 1 ]]; then
+		echo "UNKNOWN"
+		return 0
+	fi
+
+	# rc 2 (DEGRADED) is accepted CONDITIONALLY, and only the ARMED verdict is
+	# conditional.
+	#
+	# An earlier revision accepted DEGRADED outright, reasoning that a dropped
+	# line only shifts `d` by one, in the safe direction. That reasoning is
+	# incomplete by this file's own argument: a torn write is a racing APPEND, so
+	# the dropped line sits at the write head — exactly where a just-typed `HALT!`
+	# lives. Dropping it returns ARMED where HALTED is correct, and ARMED also
+	# makes precheck-asking-detector.sh stand down. A fail-open on the one input
+	# whose entire purpose is to revoke autonomy.
+	#
+	# But withholding ARMED on EVERY degraded scan overshoots in the other
+	# direction: it re-blinds the window that the recovery exists to save, which
+	# is the explicit thing #920 says must not happen.
+	#
+	# So ask the precise question instead of assuming the bad case: could the
+	# dropped bytes have carried a HALT! at all? The unparseable lines are
+	# recoverable in one jq pass, and `HALT!` is a literal. If it is not in them,
+	# the drop provably cannot have hidden a halt and ARMED stands. If it is, the
+	# verdict is withheld. UNARMED and HALTED both stand callers down, so neither
+	# can be made wrong in the dangerous direction by a drop and both pass
+	# through untouched — only the verdict that GRANTS latitude has to be
+	# re-earned. (#920)
+	if [[ $rc -eq 2 && "$out" == "ARMED "* ]]; then
+		local dropped_text
+		dropped_text=$(
+			tail -n "$scan_lines" "$transcript_path" 2>/dev/null |
+				jq -Rr 'select((try (fromjson|true) catch false) | not)' 2>/dev/null
+		)
+		if [[ "$dropped_text" == *'HALT!'* ]]; then
+			printf 'godspeed: degraded scan withheld an ARMED verdict — a dropped line carried HALT!\n' >&2
+			echo "UNKNOWN"
+			return 0
+		fi
+	fi
+
+	printf '%s\n' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# godspeed_turn_tools <transcript_path>
+#
+# Emits the CURRENT TURN's tool_use union as compact JSON — the action gate's
+# substrate (#917). Previously this jq lived in two places (here via --decide,
+# and in stop-action-bias-detector.sh) with a comment instructing future readers
+# to keep them "exactly" in sync. #919 established what that costs: one detector
+# with two instances is how a fix reaches half its call sites. One
+# implementation, two callers.
+#
+# Emits the literal EXTRACTION_FAILED on error — NEVER "[]". An extraction that
+# could not run is not evidence of no gated action, and `2>/dev/null || echo
+# "[]"` is precisely how the #917 gate shipped inert. Callers fail CLOSED on it.
+# (#920)
+# ---------------------------------------------------------------------------
+godspeed_turn_tools() {
+	local transcript_path="$1"
+
+	[[ -f "$transcript_path" ]] || {
+		echo "[]"
+		return 0
+	}
+
+	local out rc
+	out=$(_godspeed_jq_scan 600 "$transcript_path" '
+        . as $all
+        | ([ $all | to_entries[]
+             | select(.value.type == "user" and ((.value | txt | length) > 0))
+             | .key ] | last // -1) as $boundary
+        | [ $all[($boundary + 1):][]
+            | select(.type == "assistant" and (.message.role // "") == "assistant")
+            | (.message.content // [])
+            | if type == "array" then .[] else empty end
+            | select(.type == "tool_use")
+            | {name, input} ]
+      ' -cs)
+	rc=$?
+
+	# ANY non-clean result fails CLOSED — including rc 2 (DEGRADED). A torn write
+	# is a racing append, so the dropped line sits at the write head, which is
+	# exactly where THIS turn's assistant records are. A well-formed but
+	# incomplete tool list would render "I dropped the evidence" as "no gated
+	# action found" — the #917 fail-open, rebuilt inside its own fix. An
+	# extraction that lost data is not evidence of no gated action. (#920)
+	#
+	# THE COST, stated rather than left implicit: a torn line is durable and this
+	# window is 600 lines (~20-40 turns), so this returns EXTRACTION_FAILED —
+	# and the gate therefore STOPs — on every turn until it ages out. That is the
+	# same "permanently degraded" shape godspeed_status refuses to pay, and the
+	# difference is deliberate: there, the degraded state withholds a gate; here,
+	# it applies one. Paying it in the direction of MORE gating is acceptable.
+	#
+	# It could be made cheaper by failing closed only when a line was dropped
+	# AFTER $boundary — the write-head argument only justifies distrusting drops
+	# inside the current turn. Not done here: it needs the helper to report WHERE
+	# it dropped, which is a wider contract change than this fix warrants.
+	if [[ $rc -ne 0 ]]; then
+		echo "EXTRACTION_FAILED"
+		return 0
+	fi
+
+	[[ -z "$out" || "$out" == "null" ]] && out="[]"
+	printf '%s\n' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# godspeed_last_assistant_text <transcript_path>
+#
+# Emits the last assistant turn's text. One implementation, three callers
+# (--decide and both Stop hooks) — they previously carried three copies, each
+# ending in `2>/dev/null`, which routed the prelude's own error() into the void.
+# That defeated the point of raising on an unhandled shape: a torn write or an
+# unknown content type produced an empty string, and precheck-asking-detector.sh
+# exits 0 on empty — inert, with nothing on stderr, BEFORE it ever reaches
+# godspeed_status and its UNKNOWN diagnostic.
+#
+# Emits empty on failure (this text is advisory, not a gate — unlike
+# godspeed_turn_tools, which must fail closed) but WARNS on stderr, so a
+# degraded hook is observable rather than silent. (#920)
+# ---------------------------------------------------------------------------
+godspeed_last_assistant_text() {
+	local transcript_path="$1"
+
+	[[ -f "$transcript_path" ]] || return 0
+
+	local out rc
+	out=$(_godspeed_jq_scan 200 "$transcript_path" '
+        [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
+        | last
+        | txt
+      ' -rs)
+	rc=$?
+
+	# rc 2 (DEGRADED) is accepted: this text is advisory input to the mandate
+	# model, never a gate, and the helper has already warned. Only a total loss
+	# yields empty. (#920)
+	if [[ $rc -eq 1 ]]; then
+		return 0
+	fi
+
+	printf '%s\n' "$out"
 }
 
 # ---------------------------------------------------------------------------
@@ -183,9 +612,30 @@ _GODSPEED_GATED_PATH_RE='(sites/[^/]*prod[^/]*/|/production/|\.prod\.(ya?ml|json
 # ---------------------------------------------------------------------------
 godspeed_gated_actions() {
 	local tools_json="${1:-}"
+
+	# The caller could not read the turn. Name it rather than returning empty —
+	# "no gated actions found" and "I could not look" must not render the same in
+	# the block reason. godspeed_decision has already forced STOP. (#920)
+	if [[ "$tools_json" == "EXTRACTION_FAILED" ]]; then
+		printf 'extraction failed: turn could not be read — treated as gated (fail-closed)\n'
+		return 0
+	fi
+
 	[[ -z "$tools_json" || "$tools_json" == "null" || "$tools_json" == "[]" ]] && return 0
-	command -v jq &>/dev/null || return 0
-	_godspeed_require_pcre || return 0
+
+	# These two remain fail-OPEN by design: making a missing jq/PCRE stop every
+	# turn fleet-wide is a behaviour change with a blast radius that needs its
+	# own decision, not a drive-by. But they must not be SILENT — an inert gate
+	# that says nothing is the exact shape of the three defects above. Tracked
+	# separately. (#920)
+	command -v jq &>/dev/null || {
+		printf 'godspeed: jq unavailable — action gate INERT this turn\n' >&2
+		return 0
+	}
+	_godspeed_require_pcre || {
+		printf 'godspeed: PCRE unavailable — action gate INERT this turn\n' >&2
+		return 0
+	}
 
 	# --- Bash: gated verb at command position ---
 	local cmds seg stripped
@@ -246,6 +696,15 @@ godspeed_decision() {
 	local verified_pct="${GODSPEED_VERIFIED_CONFIDENCE:-80}"
 	local unverified_pct="${GODSPEED_UNVERIFIED_CONFIDENCE:-40}"
 
+	# The turn could not be read. FAIL CLOSED — an extraction that crashed is not
+	# evidence of no gated action. This is the fail-open that shipped in v7.1.0:
+	# the jq aborted on string content, `|| echo "[]"` swallowed it, and the gate
+	# reported "nothing found" fleet-wide. (#920)
+	if [[ "$tools_json" == "EXTRACTION_FAILED" ]]; then
+		echo "STOP"
+		return 0
+	fi
+
 	# Gate on ACTIONS taken this turn, never on turn text. Fires regardless of
 	# mandate — a godspeed mandate speeds up autonomous work, it does not make
 	# a prod-shaped action invisible. But STOP no longer commands a halt; the
@@ -258,8 +717,24 @@ godspeed_decision() {
 	fi
 
 	# No mandate → hook stands down.
+	#
+	# WHITELIST, not blacklist. Only a well-formed "ARMED <d>" proceeds to the
+	# mandate path; everything else — UNARMED, HALTED, UNKNOWN, and any string
+	# this function does not recognise — stands down. Enumerating the non-armed
+	# states instead would mean an unrecognised status GRANTS autonomy, which is
+	# the wrong default for a function whose contract is "an unreadable
+	# transcript must never grant autonomy". That is not hypothetical: if jq ever
+	# exits 0 while writing to stderr, godspeed_status's 2>&1 capture puts the
+	# stderr text in the status, and a blacklist would fall straight through it
+	# into the ARMED branch with a garbage d.
+	#
+	# Note the direction differs from the gated-action check above — there, an
+	# extraction that cannot run is not evidence of no gated action and must fail
+	# CLOSED. Same crash, opposite safe direction, because one grants latitude
+	# and the other withholds it. (#920)
 	case "$arm_status" in
-	UNARMED | HALTED)
+	"ARMED "[0-9]*) ;; # fall through to the mandate path below
+	*)
 		echo "NOOP"
 		return 0
 		;;
@@ -401,28 +876,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		INPUT=$(cat 2>/dev/null || true)
 		TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)
 		SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
-		LAST_TEXT=$(
-			[[ -f "$TRANSCRIPT_PATH" ]] && tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
-				jq -rs '[.[] | select(.type == "assistant")] | last |
-					(.message.content // []) | map(select(.type == "text") | .text) | join(" ")
-				' 2>/dev/null || echo ""
-		)
-		# Turn-scoped union — must match the hook's extraction exactly. (#917)
-		TOOLS_JSON=$(
-			[[ -f "$TRANSCRIPT_PATH" ]] && tail -n 600 "$TRANSCRIPT_PATH" 2>/dev/null |
-				jq -cs '
-					. as $all
-					| ([ $all | to_entries[]
-						 | select(.value.type == "user"
-							 and (((.value.message.content // []) | map(select(.type == "text") | .text) | join("")) | length > 0))
-						 | .key ] | last // -1) as $boundary
-					| [ $all[($boundary + 1):][]
-						| select(.type == "assistant")
-						| (.message.content // [])[]
-						| select(.type == "tool_use")
-						| {name, input} ]
-				' 2>/dev/null || echo "[]"
-		)
+		LAST_TEXT=$(godspeed_last_assistant_text "$TRANSCRIPT_PATH")
+		# Turn-scoped union — ONE implementation, shared with the Stop hook. (#917, #920)
+		TOOLS_JSON=$(godspeed_turn_tools "$TRANSCRIPT_PATH")
 		ARM=$(godspeed_status "$TRANSCRIPT_PATH")
 		godspeed_decision "$ARM" "$LAST_TEXT" "$SESSION_ID" "$TOOLS_JSON"
 		;;

--- a/scripts/precheck-asking-detector.sh
+++ b/scripts/precheck-asking-detector.sh
@@ -40,16 +40,10 @@ if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
 	exit 0
 fi
 
-LAST_ASSISTANT_TEXT=$(
-	tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
-		jq -rs '
-      [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
-      | last
-      | (.message.content // [])
-      | map(select(.type == "text") | .text)
-      | join(" ")
-    ' 2>/dev/null
-)
+# ONE implementation, shared with the other two entrypoints. It warns on stderr
+# instead of swallowing — this hook exits 0 on empty text, so a swallowed
+# extraction failure made it inert with nothing reported anywhere. (#920)
+LAST_ASSISTANT_TEXT=$(godspeed_last_assistant_text "$TRANSCRIPT_PATH")
 
 if [[ -z "$LAST_ASSISTANT_TEXT" || "$LAST_ASSISTANT_TEXT" == "null" ]]; then
 	exit 0
@@ -59,16 +53,23 @@ ARM_STATUS=$(godspeed_status "$TRANSCRIPT_PATH")
 
 case "$ARM_STATUS" in
 
-ARMED*)
+"ARMED "[0-9]*)
 	# Mandate active: stop-action-bias-detector.sh owns the full mandate
 	# decision model and all notifications. Stand down here to avoid duplicate
 	# blocks and double Discord/vox pings. When the mandate is in effect the
 	# action-bias hook already covers "don't ask permission" broadly.
+	#
+	# WHITELIST, matching godspeed_decision exactly — deliberately not `ARMED*`.
+	# Standing down is the permissive branch here, so an unrecognised status must
+	# not reach it. The bare prefix glob also accepted `ARMEDGARBAGE` and, more
+	# realistically, any diagnostic text that happens to begin with ARMED. There
+	# must be ONE definition of a well-formed armed status across both hooks;
+	# two spellings of it is how the fix reaches half the call sites. (#920)
 	exit 0
 	;;
 
 *)
-	# UNARMED / HALTED: original narrow-regex behavior.
+	# UNARMED / HALTED / UNKNOWN / anything unrecognised: narrow-regex behavior.
 	# Three patterns for "asking whether to run /precheck":
 	#   1. Interrogative  — trigger word within ~40 chars of "precheck", ending "?"
 	#   2. Deferral       — "let me know" idiom near "precheck"

--- a/scripts/stop-action-bias-detector.sh
+++ b/scripts/stop-action-bias-detector.sh
@@ -16,7 +16,14 @@
 #      supplied >= bar → GO (continue autonomously, no block)
 #      supplied <  bar → ASK (block + checkpoint prompt; model names gap for BJ)
 #
-# Arm:  type `godspeed` in any user turn → mandate active
+# Arm:  in a user turn, either `godspeed` starting a sentence, or `/godspeed`
+#       preceded by a space (or opening the message) → mandate active.
+#       Do NOT arm: questions ("are you in godspeed mode?"), quoted mentions
+#       (`/godspeed`, "/godspeed"), machine-generated turns (the hook's own
+#       block text, task notifications, skill bodies, compaction summaries),
+#       and — importantly — file paths. `scripts/godspeed-lookback.sh` contains
+#       the substring `/godspeed`, so the space before the slash is what stops
+#       merely naming the detector from arming it. (#921)
 # Halt: type `HALT!` (exact) → mandate cancelled until next godspeed
 #
 # Contract (Claude Code Stop hook):
@@ -49,16 +56,9 @@ if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
 fi
 
 # Extract the last assistant turn text (skip thinking and tool_use blocks).
-LAST_ASSISTANT_TEXT=$(
-	tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null |
-		jq -rs '
-      [.[] | select(.type == "assistant" and (.message.role // "") == "assistant")]
-      | last
-      | (.message.content // [])
-      | map(select(.type == "text") | .text)
-      | join(" ")
-    ' 2>/dev/null
-)
+# ONE implementation, shared with --decide and precheck-asking-detector.sh; it
+# warns on stderr rather than swallowing an extraction failure. (#920)
+LAST_ASSISTANT_TEXT=$(godspeed_last_assistant_text "$TRANSCRIPT_PATH")
 
 # Extract every tool_use block in the CURRENT TURN — what the turn actually
 # DID. This is the gate's substrate; text is used only by the mandate model.
@@ -75,23 +75,11 @@ LAST_ASSISTANT_TEXT=$(
 # user entry carrying real human text (the same predicate godspeed_status uses
 # to avoid counting tool_result wrappers as user turns); everything after it is
 # this turn. Union, never `last`. (#917)
-LAST_TOOL_USES=$(
-	tail -n 600 "$TRANSCRIPT_PATH" 2>/dev/null |
-		jq -cs '
-      . as $all
-      | ([ $all
-           | to_entries[]
-           | select(.value.type == "user"
-               and (((.value.message.content // []) | map(select(.type == "text") | .text) | join("")) | length > 0))
-           | .key ] | last // -1) as $boundary
-      | [ $all[($boundary + 1):][]
-          | select(.type == "assistant" and (.message.role // "") == "assistant")
-          | (.message.content // [])[]
-          | select(.type == "tool_use")
-          | {name, input} ]
-    ' 2>/dev/null || echo "[]"
-)
-[[ -z "$LAST_TOOL_USES" || "$LAST_TOOL_USES" == "null" ]] && LAST_TOOL_USES="[]"
+#
+# ONE implementation, shared with --decide via godspeed_turn_tools. It returns
+# EXTRACTION_FAILED (never "[]") when the scan cannot run, and godspeed_decision
+# fails CLOSED on that. (#920)
+LAST_TOOL_USES=$(godspeed_turn_tools "$TRANSCRIPT_PATH")
 
 # Bail only when the turn has NEITHER text NOR actions. The old text-only guard
 # was a leftover of the text substrate: a tool_use-only final message (no text

--- a/tests/test_godspeed_content_shape.py
+++ b/tests/test_godspeed_content_shape.py
@@ -1,0 +1,820 @@
+"""
+tests/test_godspeed_content_shape.py — content-shape and arming-form tests.
+
+Covers cc-workflow#920 (`.message.content` is often a plain string; jq aborts and
+the crash is swallowed into a default) and cc-workflow#921 (hook-generated text
+arms the mandate it gates).
+
+WHY THIS FILE EXISTS SEPARATELY FROM test_godspeed.py
+-----------------------------------------------------
+`test_godspeed.py`'s `_user()` builds `content` as an ARRAY, unconditionally, and
+so does every other builder in it. That suite was green through three shipped
+fail-opens because the shape it exercises is not the shape production carries.
+Measured across the full local corpus (one workstation), and RE-DERIVED rather
+than inherited when this suite was written:
+
+    original sweep   transcripts with >=1 user-role string content  3651/3821 = 95.6%
+    re-derived       transcripts with >=1 user-role string content  3606/3776 = 95.5%
+    re-derived       transcripts unreadable by a strict jq slurp        5      (torn writes)
+    original sweep   user messages: 20,174 string / 119,269 array            = 14.5%
+
+The re-derivation reproduces both headline claims. A FIRST attempt at it returned
+92.8%, because the measuring script used `head -c` and `jq -s` — truncating
+mid-line and aborting on torn lines, so unreadable files silently became
+non-hits. The instrument carried the very defect it was measuring, and
+undercounted it. Re-run with the lenient line-wise parse this branch introduces,
+it reproduces.
+
+jq aborts on the FIRST string it meets, so the per-file failure is total, not
+proportional. The per-message ratio is supporting evidence; 95.5% is the defect.
+
+A NOTE ON VACUOUS GREEN (load-bearing — do not "simplify" this away)
+--------------------------------------------------------------------
+The #921 arming-form tests are written in ARRAY form on purpose.
+
+In STRING form they would pass today for the wrong reason: #920 makes the jq
+crash, the crash is swallowed to `UNARMED`, and a test asserting "not armed"
+would go green against a detector that is simply dead. That is a test that was
+never red, which proves nothing.
+
+So: #921 assertions run in array form (genuinely red today), and the
+string-form variants are marked as #920-dependent — they can only become
+meaningful once arming actually runs.
+"""
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+
+from tests.test_godspeed import (
+    _asst, _asst_tools, _make, _user, run_decide, run_eval)
+
+SCRIPT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'scripts', 'godspeed-lookback.sh'))
+
+
+# ---------------------------------------------------------------------------
+# Transcript builders reproducing REAL shapes.
+#
+# Sampled from ~/.claude/projects/**/*.jsonl rather than invented. The envelope
+# keys below are the ones a real user record actually carries; the load-bearing
+# difference from _user() is `content` being a bare string.
+# ---------------------------------------------------------------------------
+
+def _user_str(text):
+    """User turn with `content` as a plain STRING — the shape in 95.5% of files."""
+    return json.dumps({
+        "type": "user",
+        "message": {"role": "user", "content": text},
+    })
+
+
+def _user_str_real_envelope(text):
+    """String content carrying the full envelope observed on real records.
+
+    Positive control: proves the crash is driven by the content shape and not by
+    some missing sibling key.
+    """
+    return json.dumps({
+        "type": "user",
+        "userType": "external",
+        "isSidechain": False,
+        "cwd": "/home/user/repo",
+        "sessionId": "ffffffff-0000-4000-8000-000000000001",
+        "version": "2.0.0",
+        "gitBranch": "main",
+        "uuid": "ffffffff-0000-4000-8000-000000000002",
+        "parentUuid": None,
+        "timestamp": "2026-07-20T00:00:00.000Z",
+        "message": {"role": "user", "content": text},
+    })
+
+
+def _user_content(value):
+    """User turn with an arbitrary `content` value — crash simulator.
+
+    Used only to prove a crash is reported rather than swallowed. Shapes other
+    than string/array were NOT observed in the corpus; this is deliberately
+    synthetic and is not a claim about real data.
+    """
+    return json.dumps({"type": "user", "message": {"role": "user", "content": value}})
+
+
+def _write_tmp(content, case):
+    """Persist transcript text to a temp .jsonl and return its path.
+
+    Used by tests that drive a shell function directly rather than via
+    `run_eval`, which manages its own temp file. `case` is the TestCase, used to
+    register cleanup — an earlier revision took no cleanup and leaked a file per
+    call into /tmp on every run.
+    """
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+        f.write(content)
+        path = f.name
+    case.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+    return path
+
+
+def _torn_write(line_a, line_b):
+    """Two JSON objects concatenated with no newline — a real torn write.
+
+    Observed on 5 / 3776 transcripts (re-derived) as
+    `jq: parse error: Invalid numeric literal`, e.g.
+    `...LlwqhUPdY6Dphw{"parentUuid":...` — a racing append, not NaN.
+    `godspeed_status` uses `jq -rs` (slurp), so ONE torn line anywhere in the
+    scan window kills the entire window.
+    """
+    return line_a + line_b
+
+
+HOOK = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'scripts',
+                 'stop-action-bias-detector.sh'))
+
+
+def emitted_sentinels():
+    """Sentinels the hook actually EMITS, read from the emitting script.
+
+    An earlier revision hardcoded these under a comment claiming they were read
+    from the source — a comment describing an intention rather than the code,
+    which would have stopped the next reader from adding the protection it
+    promised. Reading them for real turned up two things a literal never would:
+
+      1. The sentinels are emitted by `stop-action-bias-detector.sh`, not by
+         `godspeed-lookback.sh`, which is where the first attempt looked.
+      2. `[godspeed-STOP]` is emitted NOWHERE in the current tree.
+
+    (2) is not dead weight in the exclusion list, though — see
+    LEGACY_STOP_SENTINEL below.
+    """
+    with open(HOOK, encoding='utf-8') as fh:
+        return sorted(set(re.findall(r'\[godspeed-[A-Za-z0-9_-]+\]', fh.read())))
+
+
+GATE_SENTINEL = "[godspeed-GATE]"
+CHECKPOINT_SENTINEL = "[godspeed-checkpoint]"
+
+# Emitted by an OLDER revision of the hook and still present in real transcripts
+# on this workstation — the corpus sweep found it verbatim:
+#
+#   Stop hook feedback:
+#   [godspeed-STOP] Gated axis detected (prod/deploy/irreversible keyword)...
+#
+# The scan window reaches back over transcripts written by previous versions, so
+# an exclusion list that covers only what the CURRENT build emits is wrong. This
+# is why the test below asserts emitted ⊆ excluded rather than equality.
+LEGACY_STOP_SENTINEL = "[godspeed-STOP]"
+
+
+# ---------------------------------------------------------------------------
+# #920 — content shape
+# ---------------------------------------------------------------------------
+
+class TestStringContentArms(unittest.TestCase):
+    """A string-content turn must be read, not crashed over."""
+
+    def test_string_content_godspeed_arms(self):
+        """RED: string content carrying `godspeed` → ARMED 0 (today: UNARMED via crash)."""
+        t = _make(_user_str("godspeed"))
+        self.assertEqual(run_eval(t), "ARMED 0")
+
+    def test_string_content_real_envelope_arms(self):
+        """RED: same, with the real record envelope."""
+        t = _make(_user_str_real_envelope("godspeed"))
+        self.assertEqual(run_eval(t), "ARMED 0")
+
+    def test_mixed_string_and_array_arms(self):
+        """RED: the real-world shape — both forms interleaved in one transcript.
+
+        This is the case both prior suites lacked entirely.
+        """
+        t = _make(
+            _user("please start"),
+            _asst("ok"),
+            _user_str("godspeed"),
+        )
+        self.assertEqual(run_eval(t), "ARMED 0")
+
+    def test_one_string_turn_does_not_blind_the_whole_scan(self):
+        """RED: a single string turn must not kill an otherwise-array transcript.
+
+        Mirrors the measured red-first case: 1 string among 27 user turns killed
+        the entire scan.
+
+        The assertion is EXACT, not `!= "UNARMED"`. The weak form is satisfied by
+        `UNKNOWN`, by `HALTED`, and by any garbage status — it would pass against
+        an implementation that still lost the window, which is the very pattern
+        this file condemns 30 lines below. Caught in review; it had survived
+        because writing the rule down is not the same as applying it.
+
+        7 user turns (`godspeed`, the string-prose turn, 5 fillers), so reversed
+        the arming turn sits at index 6.
+        """
+        lines = [_user_str("some prose with no keyword")]
+        for _ in range(5):
+            lines.append(_user("filler"))
+            lines.append(_asst("ack"))
+        lines.insert(0, _user("godspeed"))
+        t = _make(*lines)
+        self.assertEqual(run_eval(t), "ARMED 6",
+                         "one string-content turn blinded the whole window")
+
+    def test_halt_in_string_content_disarms(self):
+        """RED: HALT! must be honoured in string form too.
+
+        Fails OPEN today in the dangerous direction: the crash returns UNARMED,
+        which happens to look safe here, but the same blindness means a HALT!
+        that should override an ARMED state is never seen.
+        """
+        t = _make(_user("godspeed"), _asst("working"), _user_str("HALT!"))
+        self.assertEqual(run_eval(t), "HALTED")
+
+
+class TestCrashIsNotSilent(unittest.TestCase):
+    """A detector that crashed must be observably different from one reporting all-clear."""
+
+    def test_torn_write_does_not_blind_the_window(self):
+        """RED: a torn line must be DROPPED and the window recovered — not just reported.
+
+        `jq -rs` slurps, so this one bad line blinds the entire window. Today the
+        parse error is swallowed by `2>/dev/null || echo "UNARMED"`.
+
+        Asserts the STRONGER of the two AC clauses. An earlier version of this
+        test asserted only `!= "UNARMED"`, which `UNKNOWN` satisfies — that would
+        have passed against an implementation that still lost the whole window,
+        i.e. a test weaker than the criterion it was written for. A torn line is
+        durable, so a fatal parse failure would leave that session's mandate
+        permanently unarmable.
+
+        `ARMED 0`, not `ARMED 1`: the torn line is the one carrying the later
+        "more" turn, so dropping it makes `godspeed` the most-recent user turn.
+        Recovery is not free — a dropped record shifts `d`, which is why the drop
+        is announced on stderr (next test) rather than performed quietly. It is
+        still strictly better than losing the window: `d` off by one ages the
+        mandate slightly fast, in the safe direction.
+
+        Discriminating in both directions: a blinded window yields `UNARMED`, so
+        this cannot pass by accident against the unfixed script.
+        """
+        t = _torn_write(_user("godspeed") + "\n" + "LlwqhUPdY6Dphw", _user("more") + "\n")
+        self.assertEqual(
+            run_eval(t), "ARMED 0",
+            "torn line blinded the scan instead of being dropped")
+
+    def test_torn_write_recovery_is_announced_on_stderr(self):
+        """RED: recovery must not be silent — a dropped record is still data loss."""
+        t = _torn_write(_user("godspeed") + "\n" + "LlwqhUPdY6Dphw", _user("more") + "\n")
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+            f.write(t)
+            path = f.name
+        try:
+            r = subprocess.run(['bash', SCRIPT, '--eval', path],
+                               capture_output=True, text=True, timeout=15)
+            self.assertIn("unparseable", r.stderr,
+                          "dropped a transcript record with nothing on stderr")
+        finally:
+            os.unlink(path)
+
+    def test_unknown_content_type_reports_unknown(self):
+        """RED: a content shape the extractor cannot handle must report UNKNOWN.
+
+        EXACT, not `!= "UNARMED"`. The weak form is passed by `ARMED 0` — i.e. by
+        an implementation that grants an unrequested autonomy mandate off input
+        it could not read, which is strictly worse than the bug being fixed.
+        A test that green-lights the worst outcome is not a test.
+        """
+        t = _make(_user_content(42))
+        self.assertEqual(
+            run_eval(t), "UNKNOWN",
+            "unhandled content type swallowed into a clean-looking default")
+
+    def test_missing_transcript_still_unarmed(self):
+        """GREEN GUARD: a genuinely absent file is a legitimate UNARMED, not UNKNOWN.
+
+        Keeps the fix from over-correcting every quiet path into a loud one.
+        """
+        r = subprocess.run(['bash', SCRIPT, '--eval', '/nonexistent/transcript.jsonl'],
+                           capture_output=True, text=True, timeout=15)
+        self.assertEqual(r.stdout.strip(), "UNARMED")
+
+
+class TestDegradedScanFailsClosedForTheActionGate(unittest.TestCase):
+    """A recovered-but-incomplete scan must not read as 'nothing gated'.
+
+    The split this class pins: `godspeed_status` ACCEPTS a dropped line (its `d`
+    shifts one turn, in the safe direction) while `godspeed_turn_tools` REFUSES
+    it. Same crash, opposite safe direction, because one answer grants latitude
+    and the other withholds it.
+
+    Found in review, and it is the #920 signature rebuilt inside the #920 fix: a
+    torn write is a racing APPEND, so the dropped line sits at the write head —
+    exactly where the current turn's assistant records live. Returning a
+    well-formed but incomplete tool list renders "I dropped the evidence" as "no
+    gated action found".
+    """
+
+    def _torn_at_write_head(self):
+        """Transcript whose LAST line — this turn's tool_use — is torn."""
+        return (_user("do it") + "\n"
+                + _asst("ok") + "\n"
+                + "TORN" + _asst_tools(
+                    "pushing", [{"name": "Bash",
+                                 "input": {"command": "git push --force origin main"}}])
+                + "\n")
+
+    def test_turn_tools_reports_extraction_failed_on_dropped_line(self):
+        r = subprocess.run(
+            ['bash', '-c', 'source "$1"; godspeed_turn_tools "$2"', '_', SCRIPT,
+             _write_tmp(self._torn_at_write_head(), self)],
+            capture_output=True, text=True, timeout=15)
+        self.assertEqual(r.stdout.strip(), "EXTRACTION_FAILED",
+                         "a scan that dropped a line reported a clean tool list")
+
+    def test_status_still_recovers_on_the_same_transcript(self):
+        """The other half of the split — status must NOT refuse the same input."""
+        r = subprocess.run(
+            ['bash', '-c', 'source "$1"; godspeed_status "$2"', '_', SCRIPT,
+             _write_tmp(_user("godspeed") + "\n" + "TORN" + _user("x") + "\n", self)],
+            capture_output=True, text=True, timeout=15)
+        self.assertEqual(r.stdout.strip(), "ARMED 0",
+                         "status refused a recoverable window and became unarmable")
+
+    def test_degraded_withholds_armed_when_a_dropped_line_carried_halt(self):
+        """RED: the drop must not be able to hide a HALT!.
+
+        A torn write is a racing append, so the dropped line sits at the write
+        head — exactly where a just-typed `HALT!` lives. Dropping it and
+        reporting ARMED is a fail-open on the one input whose purpose is to
+        revoke autonomy, and ARMED additionally makes precheck-asking-detector.sh
+        stand down.
+
+        Paired with `test_torn_write_does_not_blind_the_window`, which has the
+        same shape MINUS the HALT: that one must still return ARMED. Together
+        they pin the distinction — the verdict is withheld because the dropped
+        bytes could have carried a halt, not merely because a drop occurred.
+        Without the pair, "withhold on any drop" would pass one and fail the
+        other, and #920's own criterion (a torn line must not blind the window)
+        would be quietly given up.
+        """
+        t = (_user("godspeed") + "\n"
+             + "TORN" + json.dumps({
+                 "type": "user",
+                 "message": {"role": "user", "content": "HALT!"}}) + "\n")
+        self.assertEqual(run_eval(t), "UNKNOWN",
+                         "a dropped line carrying HALT! still produced a mandate")
+
+    def test_wholly_unreadable_window_is_unknown_not_unarmed(self):
+        """Every line unparseable → an empty stream slurps to `[]` and runs CLEAN.
+
+        Without an explicit guard this returns a confident UNARMED, rc=0, for a
+        window that could not be read at all — the loudest possible fail-open
+        wearing a clean result's clothes.
+        """
+        t = "GARBAGE ONE\nGARBAGE TWO\nGARBAGE THREE\n"
+        self.assertEqual(run_eval(t), "UNKNOWN")
+
+
+class TestActionGateWithStringContent(unittest.TestCase):
+    """#917's gate fails OPEN under #920 — the dangerous direction."""
+
+    def test_gated_action_detected_despite_string_content_turn(self):
+        """RED: a gated action must STOP even when the turn holds string content.
+
+        Today the extraction crashes, LAST_TOOL_USES=[], and the gate reports
+        'nothing found' — a fail-open on a safety control.
+
+        Measured transition on this exact fixture: pre-fix `NOOP` (the gate saw
+        nothing because the extraction had crashed), post-fix `STOP`.
+        """
+        t = _make(_user("godspeed"), _asst("ok"), _user_str("carry on"))
+        out = run_decide(
+            t, "pushing now",
+            tools=[{"name": "Bash", "input": {"command": "git push --force origin main"}}])
+        self.assertEqual(out, "STOP",
+                         "gated action was not detected in a string-content turn")
+
+
+# ---------------------------------------------------------------------------
+# #921 — arming form and hook-echo exclusion
+#
+# Array form throughout: see the module docstring. In string form these pass
+# today for the wrong reason.
+# ---------------------------------------------------------------------------
+
+class TestArmingForm(unittest.TestCase):
+    """Every string below is REAL, taken from ~/.claude/projects/**/*.jsonl.
+
+    An earlier draft of this fix implemented the issue's prose — "the message IS
+    the token, or leads with it" — and rejected 3 of the 4 genuine arming turns
+    in the corpus. The issue's description of the form was itself an unmeasured
+    claim; it read as settled because it sat next to measured claims. These
+    fixtures exist so that cannot recur silently.
+    """
+
+    def test_bare_token_arms(self):
+        """REAL: the bare form."""
+        self.assertEqual(run_eval(_make(_user("godspeed"))), "ARMED 0")
+
+    def test_leading_token_arms(self):
+        """Sentence-initial with a trailing clause."""
+        self.assertEqual(run_eval(_make(_user("godspeed, go"))), "ARMED 0")
+
+    def test_real_trailing_vocative_arms(self):
+        """REAL corpus turn — trailing token with a vocative. Rejected by the first draft."""
+        t = _make(_user(
+            "agreed.  continuous, phas-boundary reporting.  godspeed, my friend"))
+        self.assertEqual(run_eval(t), "ARMED 0")
+
+    def test_real_trailing_slash_command_arms(self):
+        """REAL corpus turn — slash-prefixed trailing token. Rejected by the first draft."""
+        t = _make(_user(
+            "thank you.  please be as autonomous as you can safely be.  /godspeed"))
+        self.assertEqual(run_eval(t), "ARMED 0")
+
+    def test_real_mid_sentence_slash_command_arms(self):
+        """REAL corpus turn — slash form mid-sentence. Rejected by the first draft.
+
+        The token does not lead its sentence here ("so /godspeed"), which is why
+        a position-only rule cannot express this idiom.
+        """
+        t = _make(_user(
+            "roll them in.  im working with lots of agents, so /godspeed"))
+        self.assertEqual(run_eval(t), "ARMED 0")
+
+    def test_real_interrogative_does_not_arm(self):
+        """REAL corpus turn — asking ABOUT the mandate must not arm it."""
+        t = _make(_user("are you in godspeed mode?"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_real_code_quoted_question_does_not_arm(self):
+        """REAL corpus turn — slash-prefixed but code-quoted inside a question."""
+        t = _make(_user("how do we turn off `/godspeed`?"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_real_enumeration_does_not_arm(self):
+        """REAL corpus turn — the token ENDS the message but is a list item.
+
+        This is the case that killed a "trailing token within N characters"
+        candidate: it passed 12 of 13 measured cases, and the one it failed
+        showed the threshold was fitted to the examples rather than derived
+        from the idiom.
+        """
+        t = _make(_user(
+            "agentc can merge w/o user approval in wavemachine, lazyriver, and godspeed"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_mid_sentence_mention_does_not_arm(self):
+        """A mention inside a sentence is not an instruction."""
+        t = _make(_user("I was reading the godspeed docs earlier today"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+
+class TestHookEchoDoesNotArm(unittest.TestCase):
+    """The inversion: the brake must not press the accelerator.
+
+    EVERY fixture here embeds ` /godspeed` — a slash form preceded by a space,
+    which the arming form accepts on its own. That is load-bearing and must not
+    be "tidied" out.
+
+    An earlier revision used block text like `[godspeed-GATE] ... git push
+    --force`, which contains no armable form at all: no ` /godspeed`, and no
+    `godspeed` after a sentence boundary. Those fixtures were rejected by the
+    ARMING FORM, never by the sentinel exclusion — so deleting the sentinel
+    clause from `is_machine_turn` left the whole class green. A test asserting a
+    property it does not exercise, in the file whose own docstring condemns
+    exactly that. Verified before and after:
+
+        fixture with ` /godspeed`   with sentinel clause -> arms=false
+                                    without it           -> arms=true
+    """
+
+    def test_gate_sentinel_does_not_arm(self):
+        """RED: the Stop hook's own block text lands as a user turn — it must not arm."""
+        t = _make(_user(
+            f"{GATE_SENTINEL} Gated action detected this turn: /godspeed"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_checkpoint_sentinel_does_not_arm(self):
+        """RED: the checkpoint echo must not arm."""
+        t = _make(_user(
+            f"{CHECKPOINT_SENTINEL} Mandate at d=3/N=200 — re-issue with /godspeed"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_stop_sentinel_does_not_arm(self):
+        """RED: the legacy sentinel must not arm either."""
+        t = _make(_user(
+            f"{LEGACY_STOP_SENTINEL} stopping for approval; resume with /godspeed"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_halt_inside_hook_echo_does_not_disarm(self):
+        """A hook echo must not DISARM — the opposite direction from the tests above.
+
+        An exclusion that only ever suppressed arming would leave this hole open:
+        the hook's own block text quotes the gated action, and block text about a
+        halt must not revoke a live mandate.
+
+        An earlier revision labelled this "cannot be made red" and claimed the
+        arithmetic cancels. That was analysis, not measurement, and it was wrong
+        — it assumed the echo also ARMS (true under HEAD's bare `\\bgodspeed\\b`,
+        false under the corrected arming form). Measured by stripping the
+        sentinel marker out of the shared envelope regex:
+
+            with the exclusion     -> ARMED 0
+            without the exclusion  -> HALTED
+
+        So it discriminates. Note WHERE the protection comes from, because it is
+        not where it looks: the sentinel turn is dropped by the TURN-COUNTING
+        filter (`counts_as_human_turn`) before `halts` ever runs. Stripping only
+        the guard inside `halts` changes nothing — verified. The guard in `halts`
+        is therefore redundant today, and deliberately kept: it is the one that
+        still holds if the counting filter is ever narrowed.
+        """
+        t = _make(_user("godspeed"), _asst("working"),
+                  _user(f"{GATE_SENTINEL} operator said HALT! in an earlier session"))
+        self.assertEqual(run_eval(t), "ARMED 0")
+
+    def test_roundtrip_gate_block_leaves_state_unchanged(self):
+        """RED: the full inversion path — gated action → STOP → block text → still UNARMED.
+
+        This is the acceptance criterion in prose: a gated STOP followed by the
+        agent's reply must leave the mandate state unchanged.
+        """
+        t = _make(
+            _user("do the thing"),
+            _asst("ok"),
+            _user(f"{GATE_SENTINEL} Gated action detected this turn: terraform apply; /godspeed"),
+            _asst("understood, stopping"),
+        )
+        self.assertEqual(run_eval(t), "UNARMED")
+
+
+class TestArmingFormStringShape(unittest.TestCase):
+    """#920-dependent: only meaningful once arming actually runs on string content.
+
+    Kept explicit rather than omitted — after #920 these are the tests that stop
+    the suite from re-acquiring the array-only blind spot.
+    """
+
+    def test_prose_mention_string_content_does_not_arm(self):
+        t = _make(_user_str("are you in godspeed mode?"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_gate_sentinel_string_content_does_not_arm(self):
+        t = _make(_user_str(f"{GATE_SENTINEL} Gated action detected this turn: /godspeed"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+
+def run_decision(arm_status, tools_json, last_text="", session="gs-dec-test"):
+    """Drive godspeed_decision directly, bypassing transcript extraction.
+
+    The fail-closed and whitelist behaviours are the reason this branch exists
+    and they were asserted only by comment. Driving the function directly is the
+    only way to exercise an arm status the extractor would never produce — which
+    is precisely the input the whitelist exists to survive.
+    """
+    r = subprocess.run(
+        ['bash', '-c',
+         'source "$1"; godspeed_decision "$2" "$3" "$4" "$5"',
+         '_', SCRIPT, arm_status, last_text, session, tools_json],
+        capture_output=True, text=True, timeout=15)
+    return r.stdout.strip()
+
+
+class TestFailClosedOnUnreadableTurn(unittest.TestCase):
+    """EXTRACTION_FAILED must never render as 'no gated action found'."""
+
+    def test_decision_stops_on_extraction_failed(self):
+        """RED: an extraction that crashed is not evidence of no gated action."""
+        self.assertEqual(run_decision("UNARMED", "EXTRACTION_FAILED"), "STOP")
+
+    def test_decision_stops_on_extraction_failed_even_when_armed(self):
+        """A mandate speeds up autonomous work; it does not make a crash invisible."""
+        self.assertEqual(run_decision("ARMED 0", "EXTRACTION_FAILED"), "STOP")
+
+    def test_gated_reason_names_the_failure(self):
+        """'I could not look' and 'I looked and found nothing' must not render alike."""
+        r = subprocess.run(
+            ['bash', '-c',
+             'source "$1"; godspeed_gated_actions "EXTRACTION_FAILED"',
+             '_', SCRIPT],
+            capture_output=True, text=True, timeout=15)
+        self.assertIn("extraction failed", r.stdout,
+                      "unreadable turn produced an empty gated-action list")
+
+
+class TestArmStatusWhitelist(unittest.TestCase):
+    """Only a well-formed `ARMED <d>` may reach the mandate path.
+
+    A blacklist (`UNARMED|HALTED` → stand down, everything else → mandate) would
+    make an UNRECOGNISED status grant autonomy. That is not hypothetical: jq
+    stderr is captured into the status on some paths, so a contaminated string
+    must fall to NOOP, not through to the ARMED branch with a garbage `d`.
+    """
+
+    def test_unknown_stands_down(self):
+        self.assertEqual(run_decision("UNKNOWN", "[]"), "NOOP")
+
+    def test_unarmed_stands_down(self):
+        self.assertEqual(run_decision("UNARMED", "[]"), "NOOP")
+
+    def test_halted_stands_down(self):
+        self.assertEqual(run_decision("HALTED", "[]"), "NOOP")
+
+    def test_contaminated_status_stands_down(self):
+        """RED against a blacklist: jq diagnostic text that merely contains ARMED."""
+        self.assertEqual(
+            run_decision("jq: error (at <stdin>:70) ARMED 3", "[]"), "NOOP",
+            "an unrecognised status reached the mandate path")
+
+    def test_armed_prefix_without_digits_stands_down(self):
+        self.assertEqual(run_decision("ARMEDGARBAGE", "[]"), "NOOP")
+
+
+class TestEveryEmittedSentinelIsExcluded(unittest.TestCase):
+    """The #921 contract, stated as an invariant instead of three literals.
+
+    Every sentinel the hook EMITS must be unable to arm the mandate. Asserting
+    that against the emitter — rather than against strings retyped here — is what
+    makes the suite self-maintaining: adding a fourth sentinel to the hook
+    without adding it to the prelude exclusion turns this red, which is exactly
+    the mistake that produced #921 in the first place.
+    """
+
+    def test_the_emitter_still_has_sentinels(self):
+        """Guard the guard: if the extraction silently found nothing, everything
+        below would vacuously pass."""
+        self.assertTrue(
+            emitted_sentinels(),
+            "no [godspeed-*] sentinels found in %s — extraction is broken, and "
+            "every exclusion test below would pass vacuously" % HOOK)
+
+    def test_no_emitted_sentinel_can_arm(self):
+        for sentinel in emitted_sentinels():
+            with self.subTest(sentinel=sentinel):
+                t = _make(_user("%s block text that itself names /godspeed"
+                                % sentinel))
+                self.assertEqual(
+                    run_eval(t), "UNARMED",
+                    "%s arms the mandate it gates" % sentinel)
+
+    def test_legacy_sentinel_still_excluded(self):
+        """Not currently emitted, but present in real transcripts the scan reads."""
+        t = _make(_user("%s stopping for approval; resume with /godspeed"
+                        % LEGACY_STOP_SENTINEL))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+
+class TestCorpusFalsePositives(unittest.TestCase):
+    """Regressions for the 13 false arms found by sweeping 3772 real transcripts.
+
+    The first draft of the #921 fix armed 17 of the 40 real user turns that
+    mention the token; only 4 were genuine. Every string below is REAL, and each
+    one armed the mandate before the arming form was corrected.
+
+    These exist because fixture-driven testing could not have found this: the
+    fixtures encoded the same assumption the implementation did.
+    """
+
+    def test_repo_file_path_does_not_arm(self):
+        """REAL: `scripts/godspeed-lookback.sh` contains the substring `/godspeed`.
+
+        Merely NAMING the detector armed it. This one turn shape covers a code
+        review prompt, a `git status` paste, and a subagent task notification.
+        """
+        t = _make(_user(" M scripts/godspeed-lookback.sh"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_code_review_prompt_does_not_arm(self):
+        """REAL corpus turn — a review prompt naming the changed files."""
+        t = _make(_user(
+            "Review all files changed on the current branch vs main. "
+            "Changed: scripts/godspeed-lookback.sh, scripts/precheck-asking-detector.sh"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_double_quoted_mention_does_not_arm(self):
+        """REAL corpus turn — BJ discussing the feature, not invoking it."""
+        t = _make(_user(
+            'i think it destroys the usefulness of "/godspeed"'))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_task_notification_does_not_arm(self):
+        """REAL: a subagent completion notification quoting a file path."""
+        t = _make(_user(
+            "<task-notification>\n<task-id>a4e6a30cbe89b1318</task-id>\n"
+            "reviewed the hook, then /godspeed\n</task-notification>"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_compaction_summary_quoting_an_arming_turn_does_not_arm(self):
+        """REAL and the nastiest: a summary QUOTING a past arming turn.
+
+        Machine-generated, and it reproduces the exact idiom verbatim. Without
+        the machine-turn exclusion, every compaction would re-arm whatever the
+        summary happened to quote.
+        """
+        t = _make(_user(
+            "This session is being continued from a previous conversation that "
+            "ran out of context. The summary below covers it.\n"
+            '  - BJ said "please be as autonomous as you can safely be. /godspeed"'))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_skill_body_injection_does_not_arm(self):
+        """REAL: a skill body injected as a user turn."""
+        t = _make(_user(
+            "Base directory for this skill: /home/bakerb/.claude/skills/disc\n"
+            "ARGUMENTS: send babelfish a bug report w.r.t. godspeed issues"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+    def test_pasted_multiline_example_does_not_arm(self):
+        """The `\\n\\s*` clause armed on any line beginning with the token.
+
+        Pasting a quoted example is routine in this repo. Dropping that clause
+        cost nothing: all four genuine corpus turns arm via the slash form or a
+        sentence boundary.
+        """
+        t = _make(_user(
+            "here is the doc section:\n\ngodspeed, my friend\n\nwhat do you think?"))
+        self.assertEqual(run_eval(t), "UNARMED")
+
+
+class TestCorpusTruePositives(unittest.TestCase):
+    """The 4 genuine arming turns found in 3772 transcripts. All must survive.
+
+    Guards the opposite direction from TestCorpusFalsePositives: a narrowing that
+    also rejected real arming turns would be a silent removal of a feature BJ
+    uses, and would look identical to a clean pass.
+    """
+
+    # Verbatim corpus turns. The sweep armed exactly these four after the fix,
+    # and the count is quoted as evidence in three separate comments — so the
+    # list length is part of the claim and must not drift from it.
+    REAL_ARMING_TURNS = [
+        "agreed.  continuous, phas-boundary reporting.  godspeed, my friend",
+        "thank you.  please be as autonomous as you can safely be.  /godspeed",
+        "roll them in.  im working with lots of agents, so /godspeed",
+        "ok, i am gonna put you back in godspeed mod, but i left you a list of "
+        "places you can find good test targets in. feel like you have excercised "
+        "the kit well.  /godspeed",
+    ]
+
+    def test_the_list_still_matches_the_measured_count(self):
+        """The 4-of-40 figure is load-bearing evidence; pin it to the fixtures."""
+        self.assertEqual(
+            len(self.REAL_ARMING_TURNS), 4,
+            "the measured count (4) and this fixture list have drifted apart")
+
+    def test_all_real_arming_turns_still_arm(self):
+        for turn in self.REAL_ARMING_TURNS:
+            with self.subTest(turn=turn[:48]):
+                self.assertEqual(
+                    run_eval(_make(_user(turn))), "ARMED 0",
+                    "a genuine arming turn stopped arming")
+
+    def test_bare_token_arms(self):
+        """SYNTHETIC, and labelled so — a bare `godspeed` turn is NOT in the corpus.
+
+        An earlier revision listed this alongside the four real turns under a
+        docstring calling them all real, and described it as "REAL: the bare
+        form". Checked: no turn in the 40 reduces to the bare token. Supporting
+        it is still correct — it is the documented idiom and the cheapest thing
+        BJ could type — but it is a design choice, not a corpus observation, and
+        the two must not be quoted as if they were the same kind of evidence.
+        """
+        self.assertEqual(run_eval(_make(_user("godspeed"))), "ARMED 0")
+
+
+class TestSlashCommandTurnsCountButDoNotArm(unittest.TestCase):
+    """A slash command is machine-FORMATTED but human-ISSUED, and that splits.
+
+    `<command-name>/precheck</command-name>` is written by Claude Code, so it
+    must not arm — but BJ typed it, so it is a real interaction and the mandate
+    must still decay across it. Folding both into one predicate silently widened
+    autonomy: `d` rose slower than the decay model intends, lowering `bar_pct`
+    and returning GO where the model meant ASK. In this fleet /precheck, /scp
+    and /scpmmr are frequent, so the effect is not marginal.
+    """
+
+    def _command_turn(self, name):
+        return _user("<command-message>%s is running…</command-message>\n"
+                     "<command-name>%s</command-name>" % (name.lstrip('/'), name))
+
+    def test_command_turn_counts_toward_decay(self):
+        """RED against a single predicate: the command turn must consume a turn.
+
+        Excluded from counting -> ARMED 0. Counted -> ARMED 1.
+        """
+        t = _make(_user("godspeed"), _asst("ok"), self._command_turn("/precheck"))
+        self.assertEqual(run_eval(t), "ARMED 1",
+                         "a slash-command turn did not decay the mandate")
+
+    def test_command_turn_does_not_arm(self):
+        """The other half: the envelope must not arm even when it names the token."""
+        t = _make(self._command_turn("/godspeed"))
+        self.assertEqual(run_eval(t), "UNARMED",
+                         "a command envelope armed the mandate")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Two Stop-hook defects that must ship together. **#920:** every jq program over transcript content assumed `.message.content` is an array; it is frequently a plain string, jq aborted on the first one, and a trailing `2>/dev/null || echo "<default>"` swallowed the crash — **the detector is dead on 3606 of 3776 transcripts (95.5%)**. **#921:** arming matched a bare `\bgodspeed\b`, and the hook's own block text lands in the transcript as a **user** turn — so the gate armed the very mandate it gates.

They cannot be separated: #920's fix is what makes arming run at all, so **shipping #920 alone activates #921's inversion fleet-wide.**

## The four things a reviewer should carry away

1. **At HEAD, an unreadable transcript GRANTS autonomy.** `godspeed_decision` used a blacklist, so `UNKNOWN` — and any jq-contaminated status — fell through to `GO`. Red-first shows it three times as `AssertionError: 'GO' != 'NOOP'`. That is the severity of this PR: not "the mandate fails to arm", but "the mandate arms itself off a transcript nobody could read."

2. **Merely NAMING the detector armed it.** `scripts/godspeed-lookback.sh` contains the literal substring `/godspeed`. Sweeping 3772 real transcripts found 40 user turns mentioning the token; the pre-fix arming form armed **17, of which 4 were genuine**. Code-review prompts, task notifications, `git status` pastes and compaction summaries all armed the mandate. Now **4 of 4, zero false**.

3. **The first fix for #920 contained #920.** The scan helper reported failures through a shell variable set inside `out=$(...)` — a command substitution, therefore a subshell — so it never reached any caller and every "loud" diagnostic printed an empty reason. Found in review. It now signals by **exit code**, because exit codes cross a subshell and variables do not.

4. **The first measurement of the headline number was wrong, in the defect's own direction.** A first re-derivation returned 92.8%; the measuring script used `head -c` and `jq -s`, so it truncated mid-line and aborted on torn lines, silently turning unreadable files into non-hits. **The instrument carried the defect it was measuring and undercounted it.** Re-run with the lenient parse this PR introduces, it reproduces at 95.5%.

## The headline number, re-derived this session

The issue reports 3651 / 3821 = **95.6%**. Re-measured today rather than quoted:

```
transcripts                        : 3776
with >=1 user-role STRING content  : 3606   = 95.5%
unreadable by a strict jq slurp    :    5   (the torn-write class)
```

Independently reproduces both claims — 95.5% against 95.6%, and the torn-write count of 5 exactly. The corpus has shifted slightly since the original sweep.

**Worth recording how the first attempt at this got it wrong.** A first pass returned **92.8%**, because the measuring script used `head -c` (truncating mid-line) and `jq -s` (which aborts on a torn line) — so every unreadable file silently became a non-hit. **The instrument had the exact defect being fixed, and undercounted the defect.** Re-running it with the same lenient line-wise parse this PR introduces produced the reproducing figure. A number that does not reproduce costs trust in everything around it; an instrument that shares the blind spot cannot be the thing that establishes the number.

## Changes

**One implementation, not ten copies.** The three scripts carried ten independent copies of the same content extraction, one with a comment asking future readers to keep two of them "exactly" in sync. #919 established what that costs. Extraction, machine-turn detection, arming form and the transcript scan now live in a single shared jq prelude plus one `_godspeed_jq_scan` helper; `--decide`, `stop-action-bias-detector.sh` and `precheck-asking-detector.sh` are all callers.

### #920 — read the shape, and never swallow the crash

- `def txt:` handles string and array content; an unrecognised shape **raises** rather than defaulting.
- `godspeed_status` returns a new `UNKNOWN` instead of `UNARMED` when the scan could not run.
- `godspeed_turn_tools` returns `EXTRACTION_FAILED`, **never `[]`**, and `godspeed_decision` fails **closed** on it.
- `godspeed_decision`'s arm-status handling is a **whitelist** — only a well-formed `ARMED <d>` reaches the mandate path. `precheck-asking-detector.sh` now uses the same pattern rather than an `ARMED*` prefix glob, so there is one definition of a well-formed armed status.
- **Torn writes.** Two JSON objects concatenated by a racing append, on 5 of 3821 transcripts. `jq -s` slurps, so one torn line blinds the window. `_godspeed_jq_scan` retries line-wise, drops the unparseable lines and announces it.

**The scan helper signals by exit code — `0` clean, `2` DEGRADED, `1` unreadable — and callers take opposite directions on `2`.** `godspeed_status` accepts a dropped line (its `d` shifts one turn, the safe direction; refusing would leave a session with a durable torn line permanently unarmable). `godspeed_turn_tools` **refuses** it: a torn write is a racing *append*, so the dropped line sits at the write head — exactly where this turn's `tool_use` records live — and a well-formed but incomplete tool list would render "I dropped the evidence" as "no gated action found".

### #921 — arming requires a form, and the brake must not press the accelerator

- `is_machine_turn` excludes Claude Code's injected user-role turns — the hook's own sentinels, `<task-notification>`, `<command-*>`, skill-body injections, compaction summaries — from arming, disarming, and the turn count.
- `arms` requires the token to be slash-prefixed **after whitespace or start-of-string**, or sentence-initial, and not inside a question or a quotation.

### Found by the second review round, after the first rework

- **Slash-command turns must not arm, but must still COUNT.** `is_machine_turn` originally excluded `<command-*>` from arming *and* from the decay count. But BJ types `/precheck`; the envelope is machine-*formatted*, not machine-*generated*. Excluding it made `d` rise slower than the decay model intends, lowering `bar_pct` and returning `GO` where the model meant `ASK` — a silent widening of autonomy, in a fleet where `/precheck`, `/scp` and `/scpmmr` are frequent. Split into two predicates: `is_machine_turn` (arming/halting) and `counts_as_human_turn` (decay).
- **`^` in jq is a STRING anchor, not a line anchor** — `jq -n '"a\nb" | test("^b")'` is `false`, and `"m"` does not change it. A comment in the first rework asserted the opposite. It mattered twice: it is *why* dropping the `\n\s*` clause actually bought something, and it meant the `^`-anchored envelope markers would only have matched at offset 0 of the joined text. The anchors are gone; the markers are bare substrings.
- **A degraded scan may not report ARMED if the dropped bytes could have carried a `HALT!`.** Accepting DEGRADED outright was a fail-open on the one input whose purpose is to revoke autonomy. Rejecting it outright would have re-blinded the window the recovery exists to save. So the question is asked precisely: the unparseable lines are recovered in one jq pass and checked for the literal `HALT!`. Absent → `ARMED` stands. Present → withheld.
- **Several sentinel-exclusion tests were vacuous.** Their fixtures (`[godspeed-GATE] ... git push --force`) contained no armable form at all, so they were rejected by the *arming form* and passed with the sentinel clause deleted — a test asserting a property it did not exercise, in the file whose own docstring condemns exactly that. Every such fixture now embeds ` /godspeed`; verified `arms=false` with the clause and `arms=true` without it.

## How the arming form was actually derived

**Not from the issue text.** An earlier draft implemented the issue's prose — *"the turn IS the token or leads with it"* — and rejected **3 of the 4 genuine arming turns**. A second candidate ("token within 15 trailing characters") passed 12 of 13 cases and was a magic number fitted to the examples.

**Then the corrected draft was swept against the live corpus, and it was still wrong.** Extracting every real user turn mentioning the token from 3772 transcripts found 40, of which that draft armed **17 — and only 4 were genuine. A 76% false-positive rate on a control that grants autonomy.**

The dominant cause is almost too neat:

```
scripts/godspeed-lookback.sh
```

**contains the literal substring `/godspeed`.** Merely *naming* the detector armed it. A code-review prompt, a subagent task-notification, a `git status` paste and a compaction summary all armed the mandate — including the dispatch message that started this work.

```
                          real user turns mentioning godspeed : 40
draft (slash anywhere, \n\s* allowed)              ARM count : 17   (4 genuine, 13 false)
shipped (slash after whitespace, \n\s* removed)    ARM count :  4   (4 genuine, 0 false)
```

Requiring whitespace before the slash removes the whole path family — a path has a word character there, a typed command has a space. `\n\s*` was dropped outright: it armed on any line beginning with the token, so pasting a quoted example armed the mandate, and no genuine case needs it.

**Fixture-driven testing could not have found this.** The fixtures encoded the same assumption the implementation did.

## Linked Issues

Closes #920
Closes #921

## Test Plan

**New:** `tests/test_godspeed_content_shape.py` (53 tests, 6 subtests). Fixtures reproduce shapes sampled from real `~/.claude/projects/**/*.jsonl`; the arming strings are verbatim corpus turns. Two fixtures are SYNTHETIC and are labelled so rather than folded in with the measured ones: an `int` content value (a crash simulator — that shape was not observed in the corpus), and the bare `godspeed` turn. The bare form is the documented idiom and supporting it is correct, but no turn in the corpus reduces to it, so it is a design choice rather than an observation.

**RED FIRST — 38 failed / 17 passed against HEAD** (`7146b3a`), in an isolated HEAD-only tree:

```
AssertionError: 'ARMED 0' != 'UNARMED'   x19   hook echoes, repo paths, quoted mentions, machine turns
AssertionError: 'UNARMED' != 'ARMED 0'   x5    string content never read
AssertionError: 'UNARMED' != 'UNKNOWN'   x3    crash swallowed into a clean-looking default
AssertionError: 'GO' != 'NOOP'           x3    unrecognised arm status GRANTED autonomy
AssertionError: 'NOOP' != 'STOP'         x2    gated action invisible in a string-content turn
AssertionError: 'GO' != 'STOP'                 EXTRACTION_FAILED granted autonomy
AssertionError: '' != 'EXTRACTION_FAILED'      dropped-evidence turn read as clean
AssertionError: 'extraction failed' not found in ''
AssertionError: 'unparseable' not found in ''
AssertionError: 'UNARMED' != 'ARMED 6'
AssertionError: 'UNARMED' != 'HALTED'
```

`'GO' != 'NOOP'` is the sharpest: at HEAD an `UNKNOWN` or jq-contaminated status falls through to **GO**, granting autonomy off a transcript that could not be read.

**A caveat on the "17 passed" figure, because it flatters the result.** One of those nodes is `test_no_emitted_sentinel_can_arm`, which pytest reports as `PASSED` under `-v` while its subtests fail — subtest failures are reported separately (`SUBFAILED`) and counted in the 38. That test is genuinely red at HEAD; verified directly, and verified that `pytest` exits non-zero on a subtest-only failure, so it is not a vacuous green. The honest reading is 16 genuinely-passing nodes plus one whose subtests are red.

**The remaining 16 are individually accounted for:**
- **6** are positive `arms` cases (5 corpus + the bare token). At HEAD a bare `\bgodspeed\b` matches everything, so every *positive* arming test passes and only the negatives fail.
- **2** are `TestArmStatusWhitelist` cases where HEAD's blacklist happens to agree (`UNARMED`, `HALTED`).
- **2** are declared green guards (`test_missing_transcript_still_unarmed`; `test_halt_inside_hook_echo_does_not_disarm`, documented as un-reddable because excluding the echo shifts `d` by one in both directions and the arithmetic cancels).
- **2** are `TestArmingFormStringShape`, passing at HEAD **for the wrong reason** — the jq crashes and the crash is swallowed to `UNARMED`, so "not armed" goes green against a dead detector. Marked #920-dependent in the file.
- **2** are over-narrowing guards (`test_all_real_arming_turns_still_arm`, `test_the_list_still_matches_the_measured_count`). HEAD arms on everything, so they pass; they go red only if a fix *removes* real arming — the silent-feature-removal direction.
- **1** is `test_command_turn_counts_toward_decay`, which passes at HEAD because HEAD counts every turn. It exists because the first version of this fix stopped counting slash-command turns and thereby widened autonomy — it guards a regression this PR nearly shipped.
- **1** is `test_the_emitter_still_has_sentinels`, a guard on the extraction itself.

**GREEN after fix:** 53 passed, 6 subtests passed.

**Full suite:** `1667 passed, 4 skipped, 64 xfailed, 2 xpassed, 26 subtests passed` in 548s.
**`bash scripts/ci/validate.sh`:** `180 passed, 0 failed` (exit 0). **shfmt:** clean on all three scripts.
**End-to-end:** both Stop hooks execute against a string-content transcript (exit 0), and `--eval` on that transcript returns `ARMED 0` — the shape that previously killed the scan, working through the real entry point.
**Corpus regression:** the shipped `arms` predicate arms exactly **4 of the 40** real godspeed-mentioning turns in 3772 transcripts.

## Notes for the reviewer

- **I am editing the hook that fires on my own turns.** Not self-merging.
- **A prior review round found a critical fail-open in this very fix**, and it is worth knowing about: `_godspeed_jq_scan` originally reported failures through a `_GODSPEED_SCAN_ERR` global, set inside a **command substitution** — a subshell — so it never reached any caller and every "loud" diagnostic printed an empty reason. That is #920 rebuilt inside the fix for #920. It is why the helper now signals by exit code: codes cross a subshell, variables do not.
- Two coverage gaps found while verifying this PR's own gates, filed rather than fixed here: **#948** (`validate.sh` never shellchecks `godspeed-lookback.sh` — the executable bit gates lint coverage, so the shared library both hooks source is the one file never linted) and **#941** (trivy parses zero manifests on this repo — unpinned `requirements.txt`, lockfile-less `package.json`). I filed that one independently as #949 while verifying this PR's own gates; it was closed as a duplicate of #941, found hours earlier from a different branch. Two agents reaching the same defect from opposite directions is the useful part of the record.
- Two fail-open paths are **deliberately left open** and merely made loud: a missing `jq` or PCRE makes the action gate inert. Turning those into a fleet-wide stop is a behaviour change with its own blast radius.
- **Settled, not assumed — describing arming does not arm.** The corpus contains turns where BJ *describes* the mandate rather than issuing it, e.g. `i put you on godspeed my friend, because i want you to use your judgement`. These do **not** arm under the shipped form. This was raised at the precheck gate as a behavioural choice rather than a mechanical fix, and **BJ decided it**: describing a thing is not doing it — and the alternative is precisely the bug this PR fixes, discussion of godspeed arming godspeed.
- Known limit, documented at `halts`: a user turn that *quotes* a sentinel while also saying `HALT!` is filtered before the halt scan sees it. Fixing it needs the arming and halting scans over different lists, which breaks the shared index arithmetic `gs_d`/`halt_d` compare on.
