### PR TITLE
fix(ci): shellcheck coverage must not depend on the exec bit

### DIFF
--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -11,11 +11,13 @@
 #   Shell scripts are identified by .sh extension or #!/…sh shebang.
 #   Python files are identified by .py extension or #!/…python shebang.
 #
-#   Note: the shellcheck pass scans executable files in scripts/ (excluding
-#   ci/) plus *.sh files in ci/, while shfmt scans all executable-or-*.sh
-#   files in scripts/ (including ci/). Both scan skill helpers and config/.
-#   The slight asymmetry means a non-.sh executable in ci/ is checked by
-#   shfmt but not by the shellcheck pass.
+#   Note: the shellcheck pass scans executable-or-*.sh files in scripts/
+#   (excluding ci/) plus *.sh files in ci/, while shfmt scans all
+#   executable-or-*.sh files in scripts/ (including ci/). Both scan skill
+#   helpers and config/. The two selectors match for scripts/ — coverage does
+#   NOT depend on the exec bit (#948). The one remaining asymmetry: a non-.sh
+#   executable in ci/ is checked by shfmt but not by the shellcheck pass, since
+#   the shellcheck ci/ pass is *.sh-only.
 
 set -euo pipefail
 
@@ -64,10 +66,15 @@ else
 	while IFS= read -r f; do
 		SCRIPTS+=("$f")
 	done < <(find "$REPO_DIR" -maxdepth 1 -name "*.sh" -type f 2>/dev/null)
-	# Scripts directory (excluding ci/)
+	# Scripts directory (excluding ci/). Executable OR *.sh — coverage must
+	# NOT depend on the exec bit: godspeed-lookback.sh is mode 644 (it is
+	# sourced, not executed), so an executable-only selector silently skipped
+	# the shared library both Stop hooks source while reporting all-green.
+	# The shfmt selector below already used this predicate; shellcheck's was
+	# never updated to match. (#948)
 	while IFS= read -r f; do
 		SCRIPTS+=("$f")
-	done < <(find "$REPO_DIR/scripts" -type f -executable ! -path "*/ci/*" 2>/dev/null)
+	done < <(find "$REPO_DIR/scripts" -type f \( -executable -o -name "*.sh" \) ! -path "*/ci/*" 2>/dev/null)
 	# CI scripts
 	while IFS= read -r f; do
 		SCRIPTS+=("$f")

--- a/scripts/godspeed-lookback.sh
+++ b/scripts/godspeed-lookback.sh
@@ -58,6 +58,7 @@
 # An unrecognised shape raises rather than defaulting. A detector that cannot
 # read its input must not be able to report "nothing found". (#920)
 # ---------------------------------------------------------------------------
+# shellcheck disable=SC2016  # jq program — `$`-refs are jq vars, must NOT expand in bash
 _GODSPEED_JQ_PRELUDE='
   def txt:
     (.message.content // [])
@@ -180,7 +181,7 @@ _GODSPEED_JQ_PRELUDE='
     # SINGLE-QUOTED shell string: one literal apostrophe — even inside a comment
     # — closes it, and the jq body then reaches bash as commands. It fails
     # loudly, but it fails at source time in a file both Stop hooks source.
-    and ((txt | test("[`\"\u0027‘’“”]/?godspeed")) | not)
+    and ((txt | test("[`\"\u0027\u2018\u2019\u201c\u201d]/?godspeed")) | not)
     and ((txt | test("[^.!?\\n]*\\bgodspeed\\b[^.!?\\n]*\\?")) | not)
     and (txt | test("(^|[.!?]\\s+)godspeed\\b|(^|\\s)/godspeed\\b"));
 
@@ -333,6 +334,7 @@ godspeed_status() {
 	local scan_lines=$((N * 20 + 500))
 
 	local out rc
+	# shellcheck disable=SC2016  # jq program — `$N`/`$rev` are jq vars, must not expand in bash
 	out=$(_godspeed_jq_scan "$scan_lines" "$transcript_path" '
       # Collect user turns that carry actual human text — exclude tool-result
       # wrapper entries (type=="user" but content is tool_result blocks with no
@@ -443,6 +445,7 @@ godspeed_turn_tools() {
 	}
 
 	local out rc
+	# shellcheck disable=SC2016  # jq program — `$all`/`$boundary` are jq vars, must not expand in bash
 	out=$(_godspeed_jq_scan 600 "$transcript_path" '
         . as $all
         | ([ $all | to_entries[]
@@ -652,7 +655,7 @@ godspeed_gated_actions() {
 			if printf '%s' "$stripped" | grep -Pq "$_GODSPEED_GATED_CMD_RE" 2>/dev/null; then
 				printf 'command: %s\n' "$(printf '%s' "$stripped" | cut -c1-90)"
 			fi
-		done < <(printf '%s' "$cmds" | tr ';|&' '\n\n\n')
+		done < <(printf '%s' "$cmds" | tr ';|&' '\n')
 	fi
 
 	# --- Write/Edit: prod-shaped desired-state paths ---
@@ -764,11 +767,15 @@ godspeed_decision() {
 # ---------------------------------------------------------------------------
 # _godspeed_notify <kind> [d] [N]
 #
-# Notifies BJ via vox + Discord on STOP or ASK. Best-effort; never fails.
-# kind: "STOP" | "ASK"
+# Notifies BJ via vox + Discord. Best-effort; never fails.
+#
+# $1 (kind) is accepted for call-site signature stability but no longer read:
+# only ASK reaches here now, since the gated-action path deliberately does NOT
+# notify (#917). Binding it to a local would be a dead assignment — see the
+# NOTE in the body — so the positional is documented and left unread rather than
+# stored. (#948)
 # ---------------------------------------------------------------------------
 _godspeed_notify() {
-	local kind="$1"
 	local d="${2:-?}"
 	local N="${GODSPEED_WINDOW:-200}"
 


### PR DESCRIPTION
## Summary

`validate.sh`'s shellcheck pass selected scripts with `find scripts -type f -executable`, so **`godspeed-lookback.sh` — mode 644 because it is sourced, not executed — was never shellchecked**, while `validate.sh` reported all-green. It is the shared library both Stop hooks source, and the one script of the three not linted. This makes lint coverage independent of the exec bit, then clears the findings the newly-covered file exposes.

## The severity: this defect was masking violations in already-merged work, live on main

`godspeed-lookback.sh` has **never been shellcheck-clean on main** — measured across two revisions:

```
7146b3a (pre-#951, 435 lines)   SC2020 x1, SC2034 x1                       shellcheck exit 1
5e00160 (post-#951, 891 lines)  SC1112 x2, SC2016 x3, SC2020 x1, SC2034 x1 shellcheck exit 1
```

**#951 added 456 lines to this file and 5 new findings with them** — and every one merged green, because #948's defect meant the file was never shellchecked. `validate.sh` reported `181 passed, 0 failed` while the shared safety library accumulated violations invisibly. My own merged work carries the unlinted ones.

Which finding came from where was **measured, not inferred** (`git log -S` on the smart-quote byte resolves to `5e00160`):

- **SC1112 ×2 (smart quotes) — introduced by #951.** They are in the `arms` quoted-mention exclusion I added for #921 (`[`\"'‘’“”]`). Absent at 7146b3a.
- **SC2016 ×3 (jq single-quoted programs) — introduced by #951.** The shared `_GODSPEED_JQ_PRELUDE` and the two `_godspeed_jq_scan` call sites. Absent at 7146b3a.
- **SC2020 ×1 (tr) and SC2034 ×1 (dead var) — predate #951.** Present at 7146b3a already.

Nothing here is a bug — these are style/info findings. The point is not their severity; it is that **`validate.sh`'s green was not evidence about this file, and nothing said so.**

## Changes

**The class fix, not `chmod +x`.** The shellcheck selector now matches the **shfmt** selector already present in the same file:

```diff
- find "$REPO_DIR/scripts" -type f -executable ! -path "*/ci/*"
+ find "$REPO_DIR/scripts" -type f \( -executable -o -name "*.sh" \) ! -path "*/ci/*"
```

That `shfmt` already used `\( -executable -o -name "*.sh" \)` while `shellcheck` did not is the proof this was an oversight, not a design choice — the correct predicate was sitting 50 lines below the broken one. Coverage no longer depends on a mode bit. (`chmod +x` would fix the instance; this fixes the class.)

**Findings cleared in the same commit** — order is load-bearing: flipping the selector on an unclean file turns `validate.sh` red, so the selector change and the fixes must land together.

- **SC1112** → the smart quotes in the `arms` char class are rewritten as jq `\u` escapes (`‘’“”`), consistent with the `'` already used there for the apostrophe. Verified the escaped class still matches all quote forms (backtick, straight, smart) and rejects the plain char — the #921 quoted-mention exclusion is unchanged.
- **SC2016 ×3** → `# shellcheck disable=SC2016` on each jq-program line. These are legitimate: jq requires literal `$` (`$N`, `$all`, `$boundary` are jq variables and must not expand in bash). Per-line, not file-wide, so a real future SC2016 elsewhere still surfaces.
- **SC2020** → `tr ';|&' '\n\n\n'` → `tr ';|&' '\n'`. `tr` pads the second set with its last char, so a single `\n` maps all three delimiters. Verified the gated-command split is unchanged (a `git push --force` after `;` is still detected).
- **SC2034** → removed the dead `local kind="$1"` in `_godspeed_notify`. Only ASK reaches that function since #917 removed the STOP-notify path; the variable was never read. The positional is documented and left unread rather than stored.

## Linked Issues

Closes #948

## Test Plan

**The AC that matters is the positive control — a lint gate never shown to fail is not known to work.** Injected a shfmt-clean, shellcheck-dirty violation (`echo $UNSET_VAR`, SC2086) into `godspeed-lookback.sh`:

```
shfmt:       clean
shellcheck:  exit 1
validate.sh: exit 1 — FAILED in [SHELLCHECK]: [!] scripts/godspeed-lookback.sh
             Results: 180 passed, 1 failed
```

Removed it → `181 passed, 0 failed`, exit 0. The failure is unambiguously in the **shellcheck** section (a shfmt-only violation would have proved nothing about the gate this PR fixes), and the file is now both covered and shown to be capable of failing the gate.

- **Coverage confirmed:** `godspeed-lookback.sh` now appears in `validate.sh`'s **shellcheck** section (was shfmt-only). Verified by extracting that section.
- **`shellcheck -x scripts/godspeed-lookback.sh`** → exit 0.
- **`bash scripts/ci/validate.sh`** → `181 passed, 0 failed` (one more than before — a file that was previously skipped).
- **Behavior preserved:** godspeed suites 79 passed / 26 subtests; the corpus `arms` predicate still arms exactly 4 of 40 real turns; `_godspeed_notify "ASK"` still runs after the `kind` removal.
- **Full suite:** `1667 passed, 4 skipped, 64 xfailed, 2 xpassed, 26 subtests passed` in 555s.

## Notes for the reviewer

- **This edits `godspeed-lookback.sh`, the hook library** — but only its lint-visible surface (a regex rewritten to an equivalent escaped form, a `tr` simplified, a dead variable removed, three disable comments). No control-flow change; the godspeed suites pin the behavior.
- Job C returned **NO MANIFESTS** — the same genuine coverage gap tracked in **#941** (unpinned `requirements.txt`, lockfile-less `package.json`). This PR touches no dependencies.
- **Code review (opus, 2 rounds' worth in one pass):** one *minor* finding — the `validate.sh` header comment still described the old executable-only selector, contradicting the fix. Corrected in the same PR (a doc-only line; no re-review). Priorities 1-5 confirmed correct: selector union, SC2016 scoping, `tr` behavior, `kind` removal safety, and the SC1112 regex equivalence.
- **#950 is sequenced after this** per the issue, and lands off the new main so its own edits to `godspeed-lookback.sh` are actually linted.
