### PR TITLE
fix(hooks): godspeed_gated_actions must fail closed on malformed input

### DIFF
--- a/scripts/godspeed-lookback.sh
+++ b/scripts/godspeed-lookback.sh
@@ -610,8 +610,15 @@ _GODSPEED_GATED_PATH_RE='(sites/[^/]*prod[^/]*/|/production/|\.prod\.(ya?ml|json
 # ---------------------------------------------------------------------------
 # godspeed_gated_actions <tools_json>
 #
-# Echoes one line per gated action found (empty output = nothing gated).
+# Echoes one line per gated action found. Empty output means nothing gated —
+# and ONLY that: a payload it cannot read (malformed JSON, a non-array, an
+# array of non-objects, or the EXTRACTION_FAILED sentinel) emits a fail-closed
+# reason line instead of empty, so "I could not look" never renders as
+# "nothing found". (#950)
+#
 # <tools_json> is a JSON array of {name, input} from the last assistant turn.
+# Callers gate on non-empty output → STOP, so a fail-closed reason string is a
+# STOP by construction.
 # ---------------------------------------------------------------------------
 godspeed_gated_actions() {
 	local tools_json="${1:-}"
@@ -635,6 +642,47 @@ godspeed_gated_actions() {
 		printf 'godspeed: jq unavailable — action gate INERT this turn\n' >&2
 		return 0
 	}
+
+	# The payload must be a JSON array of objects whose `input` is itself an
+	# object (or absent). That is the exact shape the extraction below can read;
+	# anything else is treated as GATED. (#950)
+	#
+	# The defect: the extraction runs `jq ... 2>/dev/null || true`, so any input
+	# it cannot parse collapsed to empty `cmds`, and godspeed_decision reads empty
+	# as "nothing gated" — a fail-OPEN on the gate that fires every turn. Measured
+	# directly: `{not valid json` -> empty -> NOOP.
+	#
+	# The `.input` clause is NOT redundant with "array of objects". `.input` is
+	# indexed as `.input.command` / `.input.file_path`, which ERRORS on a string,
+	# number, boolean, or array `.input` — `//` catches null/false, not an
+	# indexing error. So `[{"name":"Bash","input":"git push --force"}]` is an
+	# array of objects, passes a top-level-only check, then crashes the
+	# extraction to empty. Worse, jq aborts the whole single pass, so a genuine
+	# force-push sharing the array with one bad sibling is missed too. Both were
+	# reproduced. (The reviewer's `(.input // {})` form would let `input:false`
+	# through — `//` replaces false — and it still crashes on `false.command`;
+	# `.input==null or (.input|type)=="object"` is exact.)
+	#
+	# This is the last layer of the #920 family. In production tools_json comes
+	# from godspeed_turn_tools, whose output is always well-formed — but this
+	# function is public, directly callable, and must not depend on an upstream
+	# guard it does not own. The check runs ONCE, at the contract boundary.
+	#
+	# Fail CLOSED, matching the EXTRACTION_FAILED convention above: an extraction
+	# that cannot read its input is not evidence of no gated action. `[]` is NOT
+	# caught — an empty array is a well-formed "nothing this turn" and stays a
+	# legitimate NOOP; `all(empty)` is vacuously true. Runs BEFORE the PCRE check
+	# on purpose: garbage input is a stronger, jq-only signal than a missing regex
+	# engine, and should fail closed even where PCRE is absent.
+	if ! printf '%s' "$tools_json" |
+		jq -e 'type == "array"
+		       and all(.[]; type == "object"
+		                    and (.input == null or (.input | type) == "object"))' \
+			>/dev/null 2>&1; then
+		printf 'malformed tool payload: not a JSON array of {input:object} — treated as gated (fail-closed)\n'
+		return 0
+	fi
+
 	_godspeed_require_pcre || {
 		printf 'godspeed: PCRE unavailable — action gate INERT this turn\n' >&2
 		return 0

--- a/tests/test_godspeed_gated_actions.py
+++ b/tests/test_godspeed_gated_actions.py
@@ -1,0 +1,183 @@
+"""
+tests/test_godspeed_gated_actions.py — godspeed_gated_actions must fail CLOSED.
+
+Covers cc-workflow#950. `godspeed_gated_actions` extracted commands with
+`jq ... 2>/dev/null || true`, so MALFORMED tools_json produced an empty result,
+which godspeed_decision reads as "no gated action found" — a fail-OPEN on the
+action gate that fires every agent turn.
+
+WHY THESE TESTS CALL THE FUNCTION DIRECTLY (load-bearing — the AC)
+-----------------------------------------------------------------
+In production, tools_json comes from godspeed_turn_tools, which after #920
+guarantees well-formed JSON, the literal EXTRACTION_FAILED, or "[]". Routing a
+malformed-input test through godspeed_turn_tools would exercise that UPSTREAM
+guard, not this function's own contract — the guard is exactly what hides the
+defect. So every test here invokes godspeed_gated_actions (and godspeed_decision)
+directly with the payload, the way a future third caller might.
+
+The direction is fail-CLOSED, matching the EXTRACTION_FAILED convention #920
+established: an extraction that cannot read its input is not evidence of no
+gated action. `[]` remains a legitimate all-clear — the fix must not over-correct
+every quiet path into a STOP.
+"""
+
+import os
+import subprocess
+import unittest
+
+SCRIPT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'scripts', 'godspeed-lookback.sh'))
+
+FORCE_PUSH = '[{"name":"Bash","input":{"command":"git push --force origin main"}}]'
+
+
+def gated_actions(tools_json):
+    """Call godspeed_gated_actions directly; return stdout stripped."""
+    r = subprocess.run(
+        ['bash', '-c', 'source "$1"; godspeed_gated_actions "$2"', '_', SCRIPT, tools_json],
+        capture_output=True, text=True, timeout=15)
+    return r.stdout.strip()
+
+
+def decision(tools_json, arm_status='UNARMED'):
+    """Call godspeed_decision directly with the given tools_json; return stdout."""
+    r = subprocess.run(
+        ['bash', '-c', 'source "$1"; godspeed_decision "$2" "" "sess" "$3"',
+         '_', SCRIPT, arm_status, tools_json],
+        capture_output=True, text=True, timeout=15)
+    return r.stdout.strip()
+
+
+class TestMalformedInputFailsClosed(unittest.TestCase):
+    """Anything that is not a JSON array of objects must be treated as gated."""
+
+    def test_parse_error_fails_closed(self):
+        """RED: the reported defect — unparseable JSON read as all-clear.
+
+        `godspeed_gated_actions "{not valid json"` returned empty before the fix;
+        empty is how godspeed_decision spells 'nothing gated'.
+        """
+        self.assertNotEqual(
+            gated_actions('{not valid json'), "",
+            "malformed JSON produced an empty (all-clear) gated-action list")
+
+    def test_non_array_object_fails_closed(self):
+        """RED: valid JSON that is an object, not the expected array."""
+        self.assertNotEqual(gated_actions('{"a":1}'), "")
+
+    def test_json_string_fails_closed(self):
+        """RED: valid JSON that is a bare string."""
+        self.assertNotEqual(gated_actions('"just a string"'), "")
+
+    def test_array_of_non_objects_fails_closed(self):
+        """RED: a JSON array whose elements are not objects.
+
+        The extraction does `.[] | select(.name == ...)`; on a number element
+        `.name` errors, jq aborts, `2>/dev/null || true` swallows it to empty.
+        """
+        self.assertNotEqual(gated_actions('[1,2,3]'), "")
+
+    def test_empty_object_fails_closed(self):
+        """The `type == "array"` conjunct is load-bearing — pin it.
+
+        For `{}`, `all(.[]; ...)` is vacuously true, so WITHOUT the array
+        conjunct the guard would pass `{}` and fail open. Only the conjunct
+        closes it, and nothing else in the suite exercises that element. Raised
+        by review as minor #2.
+        """
+        self.assertNotEqual(gated_actions('{}'), "")
+
+    def test_non_object_input_fails_closed(self):
+        """RED (residual, caught in review): `.input` is a string, not an object.
+
+        `[{"name":"Bash","input":"..."}]` IS an array of objects, so a
+        top-level-only guard passes it — then `.input.command` indexes a string,
+        jq errors, and it collapses to empty. The `.input` must be object-or-null.
+        """
+        self.assertNotEqual(
+            gated_actions('[{"name":"Bash","input":"git push --force origin main"}]'), "",
+            "a non-object .input slipped the guard and failed open")
+
+    def test_boolean_input_fails_closed(self):
+        """RED: `input:false` — the case `(.input // {})` would mishandle.
+
+        `//` replaces false, so a `// {}`-style guard would pass this, then
+        `false.command` crashes the extraction. `.input==null or object` is exact.
+        """
+        self.assertNotEqual(gated_actions('[{"name":"Bash","input":false}]'), "")
+
+    def test_gated_action_not_missed_beside_a_malformed_sibling(self):
+        """RED: a real force-push must not be lost because a sibling is malformed.
+
+        With the bad element FIRST, jq aborts the single pass before reaching the
+        force-push, so the genuine gated action is missed entirely. Fail-closed on
+        the whole payload is the safe resolution — the turn still STOPs.
+        """
+        payload = ('[{"name":"Bash","input":"x"},'
+                   '{"name":"Bash","input":{"command":"git push --force origin main"}}]')
+        self.assertNotEqual(gated_actions(payload), "",
+                            "force-push missed because a sibling element was malformed")
+
+    def test_failclosed_reason_is_named_not_blank(self):
+        """The fail-closed output must be a human-readable reason, not noise.
+
+        godspeed_decision only checks non-empty, but the string lands in the
+        block reason a human reads, so it must say WHY.
+        """
+        out = gated_actions('{not valid json')
+        self.assertIn("fail-closed", out)
+
+
+class TestCleanInputsStayClean(unittest.TestCase):
+    """The fix must not over-correct: genuinely-empty paths stay NOOP."""
+
+    def test_empty_array_is_clean(self):
+        """GREEN GUARD: [] is a legitimate all-clear, not a fail-closed."""
+        self.assertEqual(gated_actions('[]'), "")
+
+    def test_object_without_name_is_clean(self):
+        """GREEN GUARD: a valid array of objects with no gated action → empty."""
+        self.assertEqual(gated_actions('[{"foo":"bar"}]'), "")
+
+    def test_benign_command_is_clean(self):
+        """GREEN GUARD: a non-gated command must not STOP (no over-flagging)."""
+        self.assertEqual(
+            gated_actions('[{"name":"Bash","input":{"command":"ls -la"}}]'), "")
+
+
+class TestGatedActionsStillDetected(unittest.TestCase):
+    """The fix must not blind the gate to real gated actions."""
+
+    def test_force_push_still_detected(self):
+        self.assertIn("git push --force", gated_actions(FORCE_PUSH))
+
+    def test_extraction_failed_still_fails_closed(self):
+        """GREEN GUARD: the #920 sentinel still produces a fail-closed reason."""
+        out = gated_actions('EXTRACTION_FAILED')
+        self.assertNotEqual(out, "")
+        self.assertIn("fail-closed", out)
+
+
+class TestDecisionStopsOnMalformedTools(unittest.TestCase):
+    """The end-to-end consequence: a malformed payload must STOP, not NOOP."""
+
+    def test_decision_stops_on_parse_error(self):
+        """RED: godspeed_decision returned NOOP on unparseable tools_json."""
+        self.assertEqual(decision('{not valid json'), "STOP",
+                         "malformed tools_json granted a clean pass")
+
+    def test_decision_stops_on_array_of_non_objects(self):
+        """RED: same via the array-of-numbers path."""
+        self.assertEqual(decision('[1,2,3]'), "STOP")
+
+    def test_decision_noop_on_empty_array(self):
+        """GREEN GUARD: [] is a legitimate stand-down."""
+        self.assertEqual(decision('[]'), "NOOP")
+
+    def test_decision_stops_on_real_gated_action(self):
+        """GREEN GUARD: the valid gated path is unchanged."""
+        self.assertEqual(decision(FORCE_PUSH), "STOP")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`godspeed_gated_actions` extracted commands with `jq ... 2>/dev/null || true`, so a **malformed `tools_json` collapsed to empty output — which `godspeed_decision` reads as "nothing gated"**. A fail-OPEN on the action gate that fires every agent turn. Reproduced directly on `main`:

```
godspeed_gated_actions "{not valid json"   ->  (empty)   ->  godspeed_decision NOOP
```

The fix validates the payload once at the contract boundary and fails **closed** on anything that is not a JSON array of objects, matching the `EXTRACTION_FAILED` convention #920 established: an extraction that cannot read its input is not evidence of no gated action.

## Why this was latent, not live — and why it still matters

In production `tools_json` comes from `godspeed_turn_tools`, which after #920 already returns well-formed JSON, `EXTRACTION_FAILED`, or `[]`. So the malformed case does not arise on the normal path today. But **the safety of `godspeed_gated_actions` was an emergent property of a guard in a *different* function** — nothing in it stated or enforced its own input contract, nothing tested it, and a third caller (or a change to `godspeed_turn_tools`) silently re-opens it. This is the last layer of the #920 family: the same `2>/dev/null || <default>` shape, one function deeper.

## Changes

`scripts/godspeed-lookback.sh` — one guard, after the `jq` availability check and before the extraction:

```jq
type == "array" and all(.[]; type == "object" and (.input == null or (.input | type) == "object"))
```

- **Fails closed** on a parse error, a non-array (`{...}`, a bare string), an array of non-objects (`[1,2,3]`), AND — caught in review — an array element whose `.input` is not an object. That last case is not redundant: `.input` is indexed as `.input.command`, which *errors* on a string/number/boolean `.input` (`//` catches null/false, not an indexing error), so `[{"name":"Bash","input":"git push --force"}]` passes a top-level-only check then crashes the extraction to empty. Worse, a genuine force-push sharing the array with one bad sibling is missed when jq aborts the single pass. Both reproduced. Emits a named reason line — callers gate on non-empty → STOP.
- **`[]` is deliberately NOT caught** — an empty array is a well-formed "nothing this turn" and stays a legitimate `NOOP`. `all(empty)` is vacuously true.
- **Runs before the PCRE check** on purpose: garbage input is a stronger, jq-only signal than a missing regex engine, and should fail closed even where PCRE is absent. (The no-jq / no-PCRE inert paths remain fail-open by design and tracked separately — unchanged here.)
- Function header updated: "empty output = nothing gated" now reads "and ONLY that."

## Linked Issues

Closes #950

## Test Plan

**New:** `tests/test_godspeed_gated_actions.py` (18 tests). Every test calls `godspeed_gated_actions` / `godspeed_decision` **directly** with the payload — routing through `godspeed_turn_tools` would exercise the upstream guard, which is exactly what hides the defect (the AC).

**RED FIRST — 11 failed / 7 passed against HEAD** (`2ed2bcd`), isolated HEAD-only tree:

```
7 FAILED — the fail-open cases:
  parse error, non-array object, JSON string, array-of-non-objects → empty (all-clear)
  godspeed_decision → NOOP on parse error and on array-of-non-objects
  the fail-closed reason string is blank

7 PASSED — the guards, proving the fix neither over-corrects nor blinds the gate:
  [] stays clean; object-without-gated-field stays clean; benign command stays clean
  force-push still detected; EXTRACTION_FAILED still fails closed
  decision NOOP on []; decision STOP on a real gated action
```

**GREEN after fix:** 18 passed.

- **No regression:** `tests/test_godspeed*` — 93 passed / 26 subtests.
- **Lint (now enforced — #948 landed first, so validate.sh shellchecks this file):** `shellcheck -x scripts/godspeed-lookback.sh` exit 0; shfmt clean.
- **End-to-end:** the Stop hook still blocks on a force-push turn and the reason names it.
- **Full suite:** `1685 passed, 4 skipped, 64 xfailed, 2 xpassed, 26 subtests passed` in 548s. **validate.sh:** `181 passed, 0 failed`.

## Notes for the reviewer

- **Sequenced after #948 on purpose.** This edits `godspeed-lookback.sh`; because #948 landed first, `validate.sh` now shellchecks the file, so this change's lint surface is actually covered — a lint regression here would fail the gate #948 fixed. Branched off the post-#948 main (`2ed2bcd`).
- **Code review (opus) found a residual fail-open in the first version of this fix** — a top-level-only `all(.[]; type == "object")` guard let a non-object `.input` through to crash the extraction. The predicate now also requires `.input == null or (.input | type) == "object"`. I corrected the reviewer's suggested `(.input // {})` form: `//` also replaces `false`, so `input:false` would have slipped it and still crashed on `false.command`. Four tests added (non-object input, boolean input, the missed-sibling case, and the empty-object guard-conjunct). Mechanical fix-forward, no re-review.
- This edits the action gate that fires on every agent turn — same class as #920/#921. Human approves.
- Job C **NO MANIFESTS** — the coverage gap tracked in #941 (unpinned `requirements.txt`, lockfile-less `package.json`). No dependencies touched.
