### PR TITLE
fix(vox): detach playback so a caller timeout bounds synth, not audio

### DIFF
--- a/scripts/vox
+++ b/scripts/vox
@@ -201,7 +201,8 @@ usage() {
 
 		Options:
 		  --voice NAME       Voice name (exported as VOX_VOICE to the provider)
-		  --bg               Background playback (don't wait for audio to finish)
+		  --bg               Detached playback (the default; kept for compatibility)
+		  --fg               Block until playback finishes (VOX_FOREGROUND=1)
 		  --output, -o FILE  Write audio to FILE instead of playing
 		  --setup [FLAGS]    Interactive first-run setup; picks a provider
 		  -h, --help         Show this help
@@ -282,7 +283,13 @@ do_setup() {
 # --- Parse args ---------------------------------------------------------------
 
 VOICE="${VOX_VOICE:-}"
-BACKGROUND=false
+# Playback defaults to DETACHED so a caller's `timeout` around vox bounds
+# SYNTHESIS, not playback. Foreground (blocking) playback is opt-in via --fg or
+# VOX_FOREGROUND=1. --bg is retained as an explicit request for the (now-default)
+# detached mode, so existing callers keep working and it still overrides the env.
+# (#952)
+FOREGROUND=false
+[[ "${VOX_FOREGROUND:-0}" == "1" ]] && FOREGROUND=true
 OUTPUT_FILE=""
 args=()
 
@@ -297,7 +304,11 @@ while [[ $# -gt 0 ]]; do
 		shift 2
 		;;
 	--bg)
-		BACKGROUND=true
+		FOREGROUND=false
+		shift
+		;;
+	--fg)
+		FOREGROUND=true
 		shift
 		;;
 	--output | -o)
@@ -436,16 +447,45 @@ if [[ -z "$PLAYER" ]]; then
 	exit 1
 fi
 
-if $BACKGROUND; then
+# Bounded-playback prefix for the detached path. `timeout` is GNU coreutils /
+# BusyBox and is ABSENT on stock macOS — exactly like `flock`, which the block
+# below already guards. It must be guarded the same way: an unguarded
+# `timeout -k 5 60 afplay …` on macOS is `command not found`, swallowed by
+# `|| true`, so the now-DEFAULT detached path would play NO audio there. Also
+# feature-probe `-k`, since older BusyBox `timeout` lacks it. With no usable
+# timeout, play unbounded — the pre-fix foreground default was unbounded too, and
+# a detached player cannot wedge the caller regardless. (#952)
+TIMEOUT_PREFIX=""
+if command -v timeout >/dev/null 2>&1; then
+	if timeout -k 1 1 true >/dev/null 2>&1; then
+		TIMEOUT_PREFIX="timeout -k 5 60"
+	else
+		TIMEOUT_PREFIX="timeout 60"
+	fi
+fi
+
+# Playback. DETACHED by default (#952): a long body must not have its audio —
+# and thus its trailing sign-off, which is synthesized as part of the wav at the
+# `. This is <speaker>.` append above — cut mid-word when a caller wraps vox in a
+# `timeout`. Synthesis runs at ~1x realtime, so a long body eats the caller's
+# budget during synth and a foreground player then gets SIGTERM'd partway through
+# playback; the tail is the first thing lost. Detaching playback means the
+# caller's timeout bounds synth only. The detached player keeps its OWN bounded
+# timeout (when one is available — see TIMEOUT_PREFIX), so a stuck player is
+# still bounded, just not by the caller's budget. flock serialization is
+# preserved: vox_play wraps the real player invocation inside the detached
+# subshell, so concurrent agents still take the lock in turn (#895). --output
+# already exited above, so this path only runs when actually speaking.
+if $FOREGROUND; then
+	# shellcheck disable=SC2086
+	vox_play $PLAYER "$audio_out"
+else
 	bgfile="$(mktemp --suffix=.wav)"
 	cp "$audio_out" "$bgfile"
 	(
 		trap 'rm -f "$bgfile"' EXIT
 		# shellcheck disable=SC2086
-		vox_play timeout -k 5 60 $PLAYER "$bgfile" || true
+		vox_play $TIMEOUT_PREFIX $PLAYER "$bgfile" || true
 	) &>/dev/null &
 	disown
-else
-	# shellcheck disable=SC2086
-	vox_play $PLAYER "$audio_out"
 fi

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -176,6 +176,8 @@ Ready for `/scp` / `/scpmr` / `/scpmmr` or rework.
 
 **`vox`:** same info, conversational, 1-2 sentences, ending with "Ready for your call."
 
+**FRONT-LOAD the speaker identity — open with `"<Dev-Name> here."`** (#952). Synthesis runs at ~1x realtime, so a long body can exhaust a caller's `timeout` budget *during synthesis*, and whatever is still playing gets cut — the tail first. `vox` appends its own `. This is <name>.` sign-off, but the sign-off is the tail, so it is exactly what a truncation drops. Leading with the name means the identity is spoken first and survives a cut. Example: `vox "<Dev-Name> here. Precheck gate ready on #<N>. <one sentence>. Ready for your call."` — do NOT open with "Precheck gate ready on #<N>…" and rely on the appended sign-off to identify you; that identity is the first thing lost. `vox` playback is non-blocking by default (it detaches, so a caller timeout bounds synthesis, not playback), so no flag is needed — just invoke `vox` normally.
+
 ## Sandbox Auto-Approval (KAHUNA Flight Agents)
 
 Flight Agents working inside a KAHUNA sandbox push to a per-wave integration branch (`kahuna/<N>-<slug>`), not to `main`. In that context the human gate is a redundant pause — the wave Orchestrator has already decided the wave runs autonomously and reviews aggregated results at the wave gate, not per-flight. The full checklist (validation, code-reviewer, trivy) and Discord/`vox` notifications still run; only the STOP-and-wait step is bypassed.

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -56,6 +56,23 @@ def _run(argv: list[str], env: dict[str, str], stdin: str | None = None) -> subp
     )
 
 
+def _poll(pred, timeout: float = 5.0, interval: float = 0.05):
+    """Return the first truthy value of pred() within `timeout`, else its last.
+
+    Playback is detached by default since #952, so vox returns before the player
+    runs; assertions that observe the player's side effects must poll rather than
+    read immediately.
+    """
+    import time
+
+    deadline = time.monotonic() + timeout
+    val = pred()
+    while not val and time.monotonic() < deadline:
+        time.sleep(interval)
+        val = pred()
+    return val
+
+
 @pytest.fixture()
 def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     """A minimal env that isolates ~/.config/vox to tmp and suppresses any real player.
@@ -229,7 +246,14 @@ def test_empty_message_errors(env, magic_provider, tmp_path):
 
 
 def test_tmpfile_is_cleaned_up_after_playback(env, magic_provider, tmp_path):
-    """When --output is NOT set, vox creates a tmp wav, plays it, then deletes it."""
+    """When --output is NOT set, vox synthesizes a tmp wav, plays it, then deletes
+    it — no leak.
+
+    Playback is DETACHED by default since #952, so vox returns before the player
+    finishes. This poll-based version verifies the same property (played, then
+    cleaned up) without assuming synchronous completion; the previous form read
+    the sentinel the instant vox returned, which now races the detached player.
+    """
     # Fixture player that records the audio path it received to a sentinel file.
     sentinel = tmp_path / "played-path"
     player = _write_executable(
@@ -244,10 +268,31 @@ printf '%s' "$1" > "{sentinel}"
     r = _run([str(VOX), "hello"], env=env)
     assert r.returncode == 0, r.stderr
 
-    played_path = sentinel.read_text()
+    # Wait for the detached player to record the path it was handed...
+    played_path = _poll(lambda: sentinel.read_text() if sentinel.exists() else "")
     assert played_path, "player sentinel empty — player did not run"
-    # After vox exits, the tmpfile trap should have removed the audio file.
-    assert not Path(played_path).exists(), f"tmpfile {played_path} was not cleaned up"
+    # ...then for the tmpfile to be removed (main + detached-subshell EXIT traps).
+    assert _poll(lambda: not Path(played_path).exists()), \
+        f"tmpfile {played_path} was not cleaned up"
+
+
+def test_fg_plays_synchronously(env, magic_provider, tmp_path):
+    """--fg blocks until playback finishes, so the player's side effects are
+    observable the instant vox returns (the pre-#952 default, now opt-in)."""
+    sentinel = tmp_path / "fg-played-path"
+    player = _write_executable(
+        tmp_path / "fg-recording-player.sh",
+        f"""#!/usr/bin/env bash
+printf '%s' "$1" > "{sentinel}"
+""",
+    )
+    env["VOX_PLAYER"] = str(player)
+    env["VOX_PROVIDER"] = str(magic_provider)
+
+    r = _run([str(VOX), "--fg", "hello"], env=env)
+    assert r.returncode == 0, r.stderr
+    # No poll: --fg is synchronous, so the sentinel is written before vox returns.
+    assert sentinel.read_text(), "player sentinel empty — --fg did not play synchronously"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vox_playback_budget.py
+++ b/tests/test_vox_playback_budget.py
@@ -1,0 +1,233 @@
+"""
+tests/test_vox_playback_budget.py — a caller timeout must bound synth, not playback.
+
+Covers cc-workflow#952. `vox` synthesized the whole wav (body + the appended
+". This is <name>." sign-off) and then played it, under ONE caller timeout. Synth
+runs ~1x realtime, so a long body ate the timeout budget during synthesis and a
+FOREGROUND player was then SIGTERM'd partway through playback — and the sign-off,
+being the tail, was the first thing cut. The fix makes playback DETACHED by
+default, so the caller's timeout bounds synthesis only.
+
+HOW THIS IS TESTED WITHOUT REAL AUDIO (the assertion-liveness AC)
+----------------------------------------------------------------
+vox resolves its provider and player from $VOX_PROVIDER / $VOX_PLAYER. We inject:
+
+  - a fake PROVIDER that sleeps `SYNTH_SECS` (simulating ~1x-realtime synthesis)
+    then writes a tiny valid WAV, and
+  - a fake PLAYER that sleeps `PLAY_SECS` (simulating playback) and, only on
+    reaching the end, writes a "DONE" marker file.
+
+Wrap vox in `timeout WRAP`. The marker is the observable that stands in for "the
+sign-off was heard": it is written ONLY if the player ran to completion.
+
+  foreground, WRAP < SYNTH+PLAY  -> player SIGTERM'd mid-playback -> NO marker
+  detached,   WRAP < SYNTH+PLAY  -> vox returns after synth+fork  -> marker
+                                    (player finishes in the background)
+
+A fix not shown to survive the failing case is not known to work, so the
+foreground case must genuinely lose the marker.
+"""
+
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+VOX = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'scripts', 'vox'))
+
+
+def _make_exec(path, body):
+    with open(path, 'w') as f:
+        f.write(body)
+    os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class VoxBudgetHarness(unittest.TestCase):
+    """Builds an injectable fake provider + player around a temp dir."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix='vox952-')
+        self.marker = os.path.join(self.dir, 'played-to-end')
+        self.provider = os.path.join(self.dir, 'provider.sh')
+        self.player = os.path.join(self.dir, 'player.sh')
+
+        # Provider: sleep SYNTH_SECS, then write a minimal valid WAV to
+        # $VOX_OUTPUT_FILE (44-byte RIFF header, zero samples — enough for the
+        # wake-noise python step to open it).
+        _make_exec(self.provider, textwrap.dedent(r'''
+            #!/usr/bin/env bash
+            sleep "${SYNTH_SECS:-0}"
+            python3 - "$VOX_OUTPUT_FILE" <<'PY'
+            import sys, wave
+            with wave.open(sys.argv[1], 'wb') as w:
+                w.setnchannels(1); w.setsampwidth(2); w.setframerate(16000)
+                w.writeframes(b'')
+            PY
+        ''').lstrip())
+
+        # Player: last arg is the wav path (ignored). Sleep PLAY_SECS, then —
+        # only on reaching the end — touch the marker. A SIGTERM mid-sleep skips
+        # the touch, which is exactly "the tail was cut".
+        _make_exec(self.player, textwrap.dedent(r'''
+            #!/usr/bin/env bash
+            sleep "${PLAY_SECS:-0}"
+            touch "%s"
+        ''' % self.marker).lstrip())
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def run_vox(self, *args, synth, play, wrap):
+        env = dict(os.environ)
+        env.update({
+            'VOX_PROVIDER': self.provider,
+            'VOX_PLAYER': self.player,
+            'SYNTH_SECS': str(synth),
+            'PLAY_SECS': str(play),
+            'VOX_NO_SIGNOFF': '0',
+            # keep the fake fast + hermetic
+            'VOX_NO_LOG': '1',
+            # Neutralize the two ambient vars that would invert what we test:
+            # VOX_FOREGROUND=1 would make the no-flag "default detached" case run
+            # foreground and fail spuriously; VOX_DISABLED=1 would no-op vox
+            # before it ever synthesizes or plays. Both are plausible per-session
+            # settings, so pin them regardless of the inherited environment.
+            'VOX_FOREGROUND': '0',
+            'VOX_DISABLED': '0',
+        })
+        # A dedicated flock path per test avoids cross-test serialization stalls.
+        env['VOX_LOCK'] = os.path.join(self.dir, 'lock')
+        r = subprocess.run(
+            ['timeout', str(wrap), 'bash', VOX, *args, 'a moderately long body of words'],
+            capture_output=True, text=True, env=env, timeout=wrap + 20)
+        return r
+
+    def wait_for_marker(self, timeout):
+        """Poll for the detached player to finish (bounded)."""
+        import time
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if os.path.exists(self.marker):
+                return True
+            time.sleep(0.1)
+        return os.path.exists(self.marker)
+
+
+class TestForegroundTruncatesUnderTightTimeout(VoxBudgetHarness):
+    def test_foreground_loses_the_tail(self):
+        """Characterization of the NEW --fg opt-in: it genuinely blocks, so a
+        tight wrap still truncates it. This proves --fg was not accidentally made
+        detached — it is NOT the red-first proof of the fix (that is
+        test_default_detached_completes_playback below). Against pre-fix vox this
+        test also fails, but for an unrelated reason (--fg did not exist → unknown
+        option), so it is not evidence about truncation on its own.
+
+        WRAP=2, synth=1, play=3 → foreground reaches the player ~1s in, then the
+        wrap kills vox (and the player with it) at 2s, 2s into a 3s playback. The
+        marker is never written — the tail was cut.
+        """
+        r = self.run_vox('--fg', synth=1, play=3, wrap=2)
+        self.assertEqual(r.returncode, 124,
+                         "expected the wrapping timeout to SIGTERM foreground vox")
+        # Give any stray process a moment; the marker must NOT appear.
+        self.assertFalse(self.wait_for_marker(1.0),
+                         "foreground playback was not truncated by the caller timeout")
+
+
+class TestDetachedSurvivesTightTimeout(VoxBudgetHarness):
+    def test_default_detached_completes_playback(self):
+        """The fix: default playback is detached, so the same tight wrap that cut
+        foreground lets synth finish, vox return, and the player run to the end.
+
+        Same timings (synth=1, play=3, wrap=2). vox returns ~1s after synth+fork,
+        under the 2s wrap; the detached player finishes ~3s later and writes the
+        marker.
+        """
+        r = self.run_vox(synth=1, play=3, wrap=2)
+        self.assertEqual(r.returncode, 0,
+                         "detached vox should return cleanly within the wrap "
+                         "(caller timeout bounds synth, not playback)")
+        self.assertTrue(self.wait_for_marker(6.0),
+                        "detached playback did not run to completion")
+
+    def test_explicit_bg_flag_also_detaches(self):
+        """--bg is retained and behaves as the default detached mode."""
+        r = self.run_vox('--bg', synth=1, play=3, wrap=2)
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(self.wait_for_marker(6.0))
+
+    def test_synth_exceeding_the_wrap_still_fails(self):
+        """Honesty guard: detaching bounds the caller timeout to SYNTH.
+
+        If SYNTH alone exceeds the wrap, vox is still killed — the fix does not
+        (and should not) claim to bound synthesis. synth=3, wrap=2 → rc 124.
+        """
+        r = self.run_vox(synth=3, play=1, wrap=2)
+        self.assertEqual(r.returncode, 124,
+                         "a synth longer than the wrap must still time out")
+
+
+class TestDetachedPlaysWithoutTimeoutBinary(VoxBudgetHarness):
+    """macOS regression guard — Linux CI cannot see this without simulating it.
+
+    `timeout(1)` is GNU coreutils / BusyBox and is absent on stock macOS. The
+    detached path prefixes the player with `timeout -k 5 60`; unguarded, that is
+    `command not found` on macOS, swallowed by `|| true`, so the now-DEFAULT
+    detached path would play NO audio. Raised by review as critical #1.
+
+    Simulate a no-`timeout` host by symlinking the real PATH into a temp bin dir
+    with `timeout`/`gtimeout` removed, then assert default vox still plays.
+    """
+
+    def _no_timeout_path(self):
+        binroot = os.path.join(self.dir, 'nobin')
+        os.makedirs(binroot, exist_ok=True)
+        for d in ('/usr/bin', '/bin', '/usr/local/bin'):
+            if not os.path.isdir(d):
+                continue
+            for name in os.listdir(d):
+                link = os.path.join(binroot, name)
+                if not os.path.exists(link):
+                    try:
+                        os.symlink(os.path.join(d, name), link)
+                    except OSError:
+                        pass
+        for t in ('timeout', 'gtimeout'):
+            p = os.path.join(binroot, t)
+            if os.path.lexists(p):
+                os.unlink(p)
+        return binroot
+
+    def test_default_plays_when_timeout_is_absent(self):
+        binroot = self._no_timeout_path()
+        # The simulation is only meaningful if `timeout` is genuinely gone.
+        probe = subprocess.run(['bash', '-c', 'command -v timeout'],
+                               env={'PATH': binroot}, capture_output=True, text=True)
+        if probe.returncode == 0:
+            self.skipTest("could not hide `timeout` from PATH on this host")
+
+        # Inherit the ambient env (HOME, TMPDIR, …) and override ONLY PATH so the
+        # no-`timeout` condition is the single variable — a bare env breaks vox's
+        # own HOME-dependent lookups and would fail for the wrong reason.
+        env = dict(os.environ)
+        env.update({
+            'PATH': binroot,
+            'VOX_PROVIDER': self.provider, 'VOX_PLAYER': self.player,
+            'SYNTH_SECS': '0', 'PLAY_SECS': '0',
+            'VOX_NO_LOG': '1', 'VOX_NO_SIGNOFF': '0',
+            'VOX_FOREGROUND': '0', 'VOX_DISABLED': '0',
+            'VOX_LOCK': os.path.join(self.dir, 'lock-nt'),
+        })
+        subprocess.run(['bash', VOX, 'a body'], env=env,
+                       capture_output=True, text=True, timeout=30)
+        self.assertTrue(self.wait_for_marker(6.0),
+                        "detached vox played nothing when `timeout` was absent "
+                        "(the macOS silence regression)")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`vox` synthesized the whole wav (message body + the appended `. This is <name>.` sign-off) and **then** played it, under one caller `timeout`. Synthesis runs at ~1× realtime, so a long body ate the caller's budget *during synthesis*, and a foreground player was then SIGTERM'd partway through playback — the sign-off, being the tail, was the first thing cut. This makes playback **detached by default**, so a caller `timeout` bounds synthesis, not playback.

**Live reproduction during this work:** BJ heard one of my longer voxes cut off before it finished — from the *installed* (unfixed) vox — while `"<name> here."` at the front reached him. That is the defect and the fix in one observation: the tail is lost, a front-loaded identity survives.

## Root cause (settled — not re-investigated)

The sign-off is a pure bash concat *before* synthesis (`scripts/vox` — `TEXT="${TEXT}. This is ${SPEAKER}."`, then the provider synthesizes `TEXT`). So the signature is baked into the wav; it is never "dropped during append." It is lost at **playback**: a foreground `$PLAYER "$audio_out"` inside a caller's `timeout WRAP` is killed when `WRAP < synth + playback`, and playback is the tail. The vox log confirmed the speaker resolved correctly and the audio was synthesized — it was just never fully heard.

## Changes

**`scripts/vox` — playback detached by default.**
- Replaced `BACKGROUND` (set by `--bg`) with `FOREGROUND` (default `false`; opt in via `--fg` or `VOX_FOREGROUND=1`). The speak path now forks the player into a detached subshell by default, so the main script returns right after synthesis + fork.
- `--bg` is retained as an accepted alias for the now-default detached mode, and it overrides `VOX_FOREGROUND` — existing callers keep working.
- The detached player keeps its own `timeout -k 5 60`, so a stuck player is still bounded — just not by the caller's budget. **`timeout` is guarded like `flock`** (both are GNU/BusyBox and absent on stock macOS): the prefix is probed once (`command -v timeout`, plus a `-k` feature-probe for older BusyBox) and omitted if unavailable, so a no-`timeout` host plays unbounded rather than silent. This was caught in review — without the guard, detached-by-default would have silenced vox on macOS entirely, since `timeout -k 5 60 afplay` is `command not found` there and `|| true` swallows it.
- **Preserved:** `--output` still exits before playback; flock serialization (#895) still holds — `vox_play` wraps the player inside the detached subshell, so concurrent agents still take the lock in turn; the `cp "$audio_out" "$bgfile"` is synchronous *before* the fork, so the main script's EXIT trap can't delete the wav out from under the player.

**`skills/precheck/SKILL.md` — front-load identity.** The vox template now opens with `"<Dev-Name> here."` so a truncated tail still carries the name. Do NOT open with "Precheck gate ready on #N…" and rely on the appended sign-off to identify you — that identity is the first thing a truncation drops.

## Linked Issues

Closes #952

## Test Plan

**New:** `tests/test_vox_playback_budget.py`. Injects a fake provider (controls synth time) and fake player (writes a completion marker only on reaching the end) via `$VOX_PROVIDER` / `$VOX_PLAYER`, wraps vox in `timeout WRAP`, and uses the marker as the observable that stands in for "the sign-off was heard."

**RED-FIRST — the behavioral test goes red against pre-fix vox.** `test_default_detached_completes_playback` (synth=1, play=3, wrap=2): against pre-fix vox (foreground default) the player is SIGTERM'd 2s into a 3s playback → no marker → RED. After the fix, vox returns ~1s after synth+fork, under the 2s wrap, and the detached player finishes → marker → GREEN. Same timings, opposite outcome.

Honest scoping of the other three:
- `test_foreground_loses_the_tail` — a **characterization** of the new `--fg` opt-in (it genuinely blocks, so a tight wrap truncates it). NOT a red-first: `--fg` did not exist pre-fix, so its pre-fix failure is an unknown-option artifact, not truncation evidence. Labeled as such in the file.
- `test_explicit_bg_flag_also_detaches` — green guard (`--bg` was detached before and after).
- `test_synth_exceeding_the_wrap_still_fails` — **honesty guard**: detaching bounds the caller timeout to *synthesis*; a synth longer than the wrap must still time out (synth=3, wrap=2 → rc 124). The fix does not, and should not, claim to bound synthesis.

**macOS-silence regression guard** (`test_default_plays_when_timeout_is_absent`): simulates a no-`timeout` host by symlinking the real PATH minus `timeout`/`gtimeout`, and asserts default vox still plays. Verified discriminating — RED against an unguarded-`timeout` build, GREEN with the guard; and directly: fixed vox plays on the simulated host while pre-fix `--bg` goes silent. Linux CI cannot see this regression without the simulation.

**GREEN after fix:** 5 passed.

**One existing test needed updating for the new default** — `test_vox.py::test_tmpfile_is_cleaned_up_after_playback` read the player's sentinel the instant vox returned, which the old *foreground* default guaranteed. Detached-by-default makes vox return before the player runs, so that read raced. Rewrote it to poll for both the play and the cleanup (same no-leak property, async-aware) and added `test_fg_plays_synchronously` to keep the synchronous contract covered under `--fg`.

**Direct timing proof (fast fake provider, provider flakiness removed):**
```
default (detached):  main returns in 0.10s while the player runs 3s to completion (marker written)
--fg (blocking):     main blocks 3.11s for the full playback
```

- **Lint (vox is shellchecked by validate.sh as of #948):** `shellcheck scripts/vox` clean, shfmt clean — no unused `BACKGROUND` var left behind.
- **Full suite:** `1691 passed, 4 skipped, 64 xfailed, 2 xpassed, 26 subtests passed` in 528s. **validate.sh:** `181 passed, 0 failed`. **vox** shellcheck + shfmt clean.

## Notes for the reviewer

- **Default-detached is a behavior change**, chosen deliberately (the issue's preferred fix over patching only precheck). vox's callers are fire-and-forget announcements (precheck, status); a caller that must block until speech ends now uses `--fg` / `VOX_FOREGROUND=1`. I could not find a caller that depends on blocking.
- **Code review (opus) found a macOS silence regression in the first version** — the detached path's `timeout` prefix was unguarded, so plain `vox` would have played nothing on stock macOS (a supported platform the file special-cases for `afplay`/`flock`). Now probed-and-guarded, with a hermetic regression test. Review also flagged that the test harness didn't neutralize ambient `VOX_FOREGROUND`/`VOX_DISABLED`; both now pinned. Direct fixes to review findings, each with a proving test.
- **This does not deploy.** The installed vox changes only when babelfish runs `./install` after merge — BJ will keep hearing truncation from the live vox until then.
- Synthesis is still in-band before the fork, so a slow/broken provider still times out during synth — correctly, since #952 is about playback truncation, not synth latency. The provider TTS outage seen all session is a separate matter.
- Job C **NO MANIFESTS** — the #941 coverage gap. No dependencies touched.
