### PR TITLE
feat(contained-workflow): build the oakandwave-workflow image (#961)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Build-context trimming for containers/oakandwave-workflow/Dockerfile
+# (the repo root is the build context; `./install` needs skills/, scripts/,
+# src/, config/, assets/, install, deps.json, mcps.json — do NOT exclude those).
+
+.git
+.github
+.gitlab-ci.yml
+.claude
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+dist
+reports
+node_modules
+*.png
+tests
+sdlc-dashboard
+CHANGELOG.md

--- a/containers/oakandwave-workflow/Dockerfile
+++ b/containers/oakandwave-workflow/Dockerfile
@@ -1,0 +1,129 @@
+# syntax=docker/dockerfile:1
+#
+# oakandwave-workflow — the versioned kit image (Story 1.1, Plan #959).
+#
+# Composition (Dev Spec §5.2):
+#   FROM aoe-dev-sandbox  →  kit-dep toolchain layer  →  ./install the kit
+#
+# The base ships Rust / Python+uv / Node and a uid-1000 `ubuntu` user, but is
+# MISSING Go, trivy, shellcheck, shfmt, glab, bao (OpenBao) and aws (TC-3). This
+# image bakes those in system-wide (/usr/local/bin — on PATH for every user) and
+# installs the kit for the uid-1000 runtime user so the image *digest is the
+# release* (R-05) and everything versioned-with-the-release is baked, not
+# bind-mounted (R-06).
+#
+# Reproducibility: every tool version is a pinned ARG (override with --build-arg).
+# See the Makefile for the canonical `make build`.
+
+ARG BASE_IMAGE=ghcr.io/agent-of-empires/aoe-dev-sandbox:1.13.0
+FROM ${BASE_IMAGE}
+
+# Re-declare after FROM so ${BASE_IMAGE} is in scope for the LABEL below.
+ARG BASE_IMAGE
+
+# --- Pinned kit-dep tool versions (override via --build-arg) ------------------
+ARG GO_VERSION=1.24.5
+ARG SHELLCHECK_VERSION=0.10.0
+ARG SHFMT_VERSION=3.10.0
+ARG GLAB_VERSION=1.53.0
+ARG TRIVY_VERSION=0.72.0
+ARG BAO_VERSION=2.6.0
+ARG AWSCLI_VERSION=2.24.0
+# The base is linux/amd64; the fetch URLs below are arch-specific. Rebuild with
+# matching ARGs if a multi-arch base is ever introduced.
+ARG GOARCH=amd64
+
+# All tool installs run as root and land in system paths; the kit install (last
+# stage) drops to the uid-1000 user.
+USER root
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Build-time fetch/extract deps (curl is present in the base, but pin the rest).
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates curl tar xz-utils unzip \
+	&& rm -rf /var/lib/apt/lists/*
+
+# --- Go -----------------------------------------------------------------------
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" -o /tmp/go.tar.gz \
+	&& tar -C /usr/local -xzf /tmp/go.tar.gz \
+	&& ln -sf /usr/local/go/bin/go /usr/local/bin/go \
+	&& ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt \
+	&& rm -f /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# --- shellcheck ---------------------------------------------------------------
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" -o /tmp/shellcheck.tar.xz \
+	&& tar -C /tmp -xJf /tmp/shellcheck.tar.xz \
+	&& install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck \
+	&& rm -rf /tmp/shellcheck.tar.xz "/tmp/shellcheck-v${SHELLCHECK_VERSION}"
+
+# --- shfmt --------------------------------------------------------------------
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${GOARCH}" -o /usr/local/bin/shfmt \
+	&& chmod 0755 /usr/local/bin/shfmt
+
+# --- glab (GitLab CLI) --------------------------------------------------------
+RUN curl -fsSL "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${GOARCH}.tar.gz" -o /tmp/glab.tar.gz \
+	&& tar -C /tmp -xzf /tmp/glab.tar.gz \
+	&& install -m 0755 /tmp/bin/glab /usr/local/bin/glab \
+	&& rm -rf /tmp/glab.tar.gz /tmp/bin
+
+# --- trivy (pinned release tarball; hermetic — no piped installer) ------------
+RUN curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o /tmp/trivy.tar.gz \
+	&& tar -C /tmp -xzf /tmp/trivy.tar.gz trivy \
+	&& install -m 0755 /tmp/trivy /usr/local/bin/trivy \
+	&& rm -f /tmp/trivy.tar.gz /tmp/trivy
+
+# --- bao (OpenBao CLI) --------------------------------------------------------
+RUN curl -fsSL "https://github.com/openbao/openbao/releases/download/v${BAO_VERSION}/openbao_${BAO_VERSION}_linux_${GOARCH}.tar.gz" -o /tmp/bao.tar.gz \
+	&& tar -C /tmp -xzf /tmp/bao.tar.gz bao \
+	&& install -m 0755 /tmp/bao /usr/local/bin/bao \
+	&& rm -f /tmp/bao.tar.gz /tmp/bao
+
+# --- aws CLI v2 ---------------------------------------------------------------
+RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o /tmp/awscli.zip \
+	&& unzip -q /tmp/awscli.zip -d /tmp \
+	&& /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli \
+	&& rm -rf /tmp/awscli.zip /tmp/aws
+
+# --- Bake the kit for the uid-1000 (ubuntu) runtime user ----------------------
+# Reuse the base's uid-1000 `ubuntu` user (TC-2). The kit installs $HOME-rooted,
+# so it must run AS that user for the runtime user to resolve it. MCP servers are
+# NOT baked here (they pull private repos over the network — non-hermetic; see
+# README "Deferred"); --no-mcps keeps the foundation image self-contained.
+ENV KIT_SRC=/opt/oakandwave-workflow
+COPY --chown=ubuntu:ubuntu . ${KIT_SRC}
+
+USER ubuntu
+ENV HOME=/home/ubuntu
+# Kit scripts install to ~/.local/bin; put it (and go) ahead on PATH.
+ENV PATH="/home/ubuntu/.local/bin:/usr/local/go/bin:${PATH}"
+WORKDIR ${KIT_SRC}
+# install's final step is a runtime-readiness advisory (check-deps.sh) whose exit
+# code is the count of missing deps. In a build it necessarily flags `bun` (only
+# needed for the deferred MCP builds) and the secret tokens (never baked — R-12;
+# provided at runtime via the ro ~/.secrets mount). Tolerate ONLY that specific
+# advisory — the sentinel line is emitted solely by check-deps as the last step,
+# after all install work — and fail the build on any other error. Then positively
+# assert the kit actually landed.
+RUN set +e; \
+	out="$(./install --no-mcps --without-logrotate --yes 2>&1)"; rc=$?; \
+	set -e; \
+	printf '%s\n' "$out"; \
+	if [ "$rc" -ne 0 ]; then \
+		printf '%s\n' "$out" | grep -q "required dependency/dependencies missing" \
+			|| { echo "install failed (not the dependency advisory) — rc=$rc"; exit "$rc"; }; \
+	fi; \
+	test -d "$HOME/.claude/skills"; \
+	test -n "$(find "$HOME/.claude/skills" -name SKILL.md -print -quit)"; \
+	test -f "$HOME/.claude/settings.json"
+
+WORKDIR /home/ubuntu
+
+# --- OCI provenance (CI stamps the authoritative semver/revision in Story 2.1) -
+LABEL org.opencontainers.image.title="oakandwave-workflow" \
+	org.opencontainers.image.description="Versioned OaW Claude Code kit image on the AoE sandbox base" \
+	org.opencontainers.image.source="https://github.com/Wave-Engineering/claudecode-workflow" \
+	org.opencontainers.image.base.name="${BASE_IMAGE}"
+
+# ENTRYPOINT/CMD inherited from the base (CMD ["sleep","infinity"]); aoe manages
+# the container lifecycle and sets the runtime uid via [sandbox] (Story 1.2).

--- a/containers/oakandwave-workflow/Makefile
+++ b/containers/oakandwave-workflow/Makefile
@@ -1,0 +1,79 @@
+# oakandwave-workflow — unified build system (DM-02, Story 1.1).
+#
+# `make build` / `make test` behave identically in CI and terminal (R-06):
+# every path is derived from this Makefile's own location, so the result does
+# not depend on the caller's working directory, and `test` shells out to the
+# same pytest oracle in both environments.
+#
+#   make build   Build the image (default tag oakandwave-workflow:edge).
+#   make test    Run the image-toolchain oracle (skips if the image is absent).
+#   make ci      build + test — the image exists, so the oracle runs for real.
+#   make verify  Ad-hoc smoke: report the kit-dep toolchain versions (Dev Spec §5.B).
+#   make clean   Remove the locally built image.
+#
+# Override tool versions or the base image with, e.g.:
+#   make build GO_VERSION=1.24.5 BASE_IMAGE=ghcr.io/agent-of-empires/aoe-dev-sandbox:1.13.0
+
+IMAGE      ?= oakandwave-workflow
+TAG        ?= edge
+REF        := $(IMAGE):$(TAG)
+BASE_IMAGE ?= ghcr.io/agent-of-empires/aoe-dev-sandbox:1.13.0
+
+# Directory of this Makefile → repo root is two levels up (containers/<name>/).
+THIS_DIR  := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+REPO_ROOT := $(abspath $(THIS_DIR)/../..)
+
+DOCKERFILE := $(THIS_DIR)/Dockerfile
+ORACLE     := $(REPO_ROOT)/tests/contained-workflow/test_image.py
+
+# Optional per-tool version overrides forwarded to the build as --build-arg.
+BUILD_ARGS := --build-arg BASE_IMAGE=$(BASE_IMAGE)
+ifdef GO_VERSION
+BUILD_ARGS += --build-arg GO_VERSION=$(GO_VERSION)
+endif
+ifdef SHELLCHECK_VERSION
+BUILD_ARGS += --build-arg SHELLCHECK_VERSION=$(SHELLCHECK_VERSION)
+endif
+ifdef SHFMT_VERSION
+BUILD_ARGS += --build-arg SHFMT_VERSION=$(SHFMT_VERSION)
+endif
+ifdef GLAB_VERSION
+BUILD_ARGS += --build-arg GLAB_VERSION=$(GLAB_VERSION)
+endif
+ifdef TRIVY_VERSION
+BUILD_ARGS += --build-arg TRIVY_VERSION=$(TRIVY_VERSION)
+endif
+ifdef BAO_VERSION
+BUILD_ARGS += --build-arg BAO_VERSION=$(BAO_VERSION)
+endif
+ifdef AWSCLI_VERSION
+BUILD_ARGS += --build-arg AWSCLI_VERSION=$(AWSCLI_VERSION)
+endif
+
+.PHONY: build test ci verify clean
+
+build:
+	docker build $(BUILD_ARGS) -f $(DOCKERFILE) -t $(REF) $(REPO_ROOT)
+
+# The oracle self-skips when docker or the image is unavailable, so `make test`
+# is safe to run without a build; `make ci` builds first so it runs for real.
+# OAKANDWAVE_IMAGE lets the oracle target this Makefile's tag.
+test:
+	OAKANDWAVE_IMAGE=$(REF) python3 -m pytest $(ORACLE) -q
+
+ci: build
+	OAKANDWAVE_IMAGE=$(REF) OAKANDWAVE_REQUIRE_IMAGE=1 python3 -m pytest $(ORACLE) -q
+
+verify:
+	docker run --rm --entrypoint sh $(REF) -c '\
+		set -e; \
+		go version; \
+		trivy --version; \
+		shellcheck --version; \
+		shfmt --version; \
+		glab --version; \
+		bao version; \
+		aws --version'
+
+clean:
+	- docker image rm $(REF)

--- a/containers/oakandwave-workflow/README.md
+++ b/containers/oakandwave-workflow/README.md
@@ -1,0 +1,94 @@
+# oakandwave-workflow image
+
+The OaW Claude Code kit, packaged as a **versioned container image** on the AoE
+sandbox base. The image *digest is the release* (R-05): everything
+versioned-with-the-release — skills, hooks, scripts, and the kit-dep toolchain —
+is baked in, and nothing versioned is bind-mounted (R-06). Run the OaW dev team
+in these containers (the **dogfood ring**) to prove a candidate before the wider
+fleet adopts it.
+
+Design authority: `docs/contained-workflow-devspec.md` (Plan #959). This story
+(1.1) delivers the image, its build system, and the toolchain oracle; isolation,
+mounts, secrets, promotion, and the flight surgeon land in later waves.
+
+## What's in the image
+
+| Layer | Contents |
+|-------|----------|
+| Base | `ghcr.io/agent-of-empires/aoe-dev-sandbox:1.13.0` — Ubuntu 26.04, Rust / Python+uv / Node, uid-1000 `ubuntu` user |
+| Kit-dep toolchain (added) | Go, trivy, shellcheck, shfmt, glab, bao (OpenBao), aws — installed system-wide in `/usr/local/bin`, pinned by `--build-arg` |
+| Kit | `./install`-ed skills, scripts, hooks, and config for the uid-1000 user (`/home/ubuntu/.claude`, `/home/ubuntu/.local/bin`) |
+
+The runtime user is **uid-1000 / non-root** (R-04); the me-ful ownership contract
+(files land host-user-owned) is wired by the aoe `[sandbox]` config in Story 1.2.
+
+## Build
+
+```bash
+make -C containers/oakandwave-workflow build      # -> oakandwave-workflow:edge
+```
+
+`make build` derives every path from the Makefile's own location, so it behaves
+identically from any working directory — CI or terminal (R-06). Override the base
+or any tool version:
+
+```bash
+make -C containers/oakandwave-workflow build \
+  BASE_IMAGE=ghcr.io/agent-of-empires/aoe-dev-sandbox:1.13.0 \
+  GO_VERSION=1.24.5 TRIVY_VERSION=0.72.0
+```
+
+## Verify the toolchain
+
+The named oracle (`tests/contained-workflow/test_image.py::test_image_toolchain`)
+runs `docker run` against the built image and asserts every kit-dep tool resolves
+and reports a version:
+
+```bash
+make -C containers/oakandwave-workflow test   # skips cleanly if the image isn't built
+make -C containers/oakandwave-workflow ci     # build, then run the oracle for real
+```
+
+`make ci` sets `OAKANDWAVE_REQUIRE_IMAGE=1`, so a missing image is a hard failure
+there while remaining a graceful skip in the stock `pytest tests/` lane (the
+10 GB image is not present in that environment).
+
+Ad-hoc smoke (Dev Spec §5.B):
+
+```bash
+make -C containers/oakandwave-workflow verify
+# or directly:
+docker run --rm --entrypoint sh oakandwave-workflow:edge \
+  -c 'trivy --version && shellcheck --version && glab --version'
+```
+
+## Run an agent on the candidate
+
+```bash
+aoe add --sandbox --sandbox-image oakandwave-workflow:edge <workspace-path>
+```
+
+Host prerequisites (docker, aoe, `~/.secrets`, cephfs, uid mapping, ghcr auth)
+are in `docs/contained-workflow/environment-prerequisites.md`.
+
+## Rings & tags (context)
+
+- `:edge` — the candidate under test. The **dogfood ring** (OaW dev-agents) and
+  the **throwaway-CI ring** (install-from-zero smoke) prove it.
+- `:stable` — the promoted digest the fleet pulls at container-recreate.
+
+Promotion is a digest retag (`:edge → :stable`), never a rebuild — the digest
+tested is the digest promoted (R-07/R-23). The build/push/sign pipeline and the
+throwaway-CI ring arrive in Phase 2 (Stories 2.1, 2.2).
+
+## Deferred in this story
+
+- **Kit MCP servers are not baked.** `./install` runs with `--no-mcps`: the kit's
+  MCP servers install from private `Wave-Engineering/*` repos over the network,
+  which is non-hermetic and needs build-time credentials. Baking them (R-06/R-09)
+  is tracked with the mount-manifest / MCP-scoping work (Story 1.3, #963).
+- **Root-scoped runtimes.** The base installs `bun`/`node`/`uv`/`cargo` under
+  `/root`, which the uid-1000 user cannot reach. The baked kit (skills, scripts,
+  hooks) needs only `python3` + the system toolchain, so this does not affect the
+  1.1 oracle; exposing those runtimes to the runtime user rides with the
+  runtime-user/mount work (Stories 1.2–1.3).

--- a/docs/contained-workflow/environment-prerequisites.md
+++ b/docs/contained-workflow/environment-prerequisites.md
@@ -1,0 +1,49 @@
+# Environment prerequisites — contained workflow
+
+Host/platform requirements to **build** the `oakandwave-workflow` image and
+**run** an agent in it. Deliverable DM-13 (Plan #959, Dev Spec §5.A).
+
+This is the host contract. The image itself is portable and carries no OaW-org
+specifics (PC-3) — org infrastructure (cephfs, secrets) is a run-layer overlay,
+never baked into a layer.
+
+## Host tooling
+
+| Requirement | Why | Notes |
+|-------------|-----|-------|
+| **Docker** (rootful, no userns remap) | Build and run the image | In-container root == host root (TC-2). "me-ful" therefore needs the uid-1000 user *and* the aoe `[sandbox] uid` config, not just one. |
+| **aoe 1.13.0** | Per-session sandbox launch (`aoe add --sandbox`) | The image base tag tracks this exact aoe version. The sandbox model is one-container-per-session (TC-1). |
+| **make**, **python3** | `make build` / `make test`; the toolchain oracle | python3 also drives the kit's zipapp package builds during `./install`. |
+| **ghcr.io auth** | Pull the base image | The base `ghcr.io/agent-of-empires/aoe-dev-sandbox:1.13.0` (~9.9 GB) requires a token (TC-5). `docker login ghcr.io` before the first build. |
+| Network egress on the default bridge | Fetch pinned toolchain release archives at build time; runtime egress to scream-hole / discord / `api.github.com` | Proven reachable on the default bridge (TC-5). |
+
+## Host-backed state (run layer)
+
+The container filesystem is a **disposable RTE** — all durable state lives on
+host-backed mounts, so a broken candidate is `docker rm`, not an incident (R-01).
+These are provided at run time (later waves wire the full mount manifest); the
+image does not require them to build.
+
+| Host path | Mount | Purpose |
+|-----------|-------|---------|
+| `~/.oaw/state/<major>/` | rw | Sandbox-scoped memory — **never** the live-fleet `~/.claude/projects/*/memory/` (R-03). The major partitions the namespace so mixing majors is isolated (R-20). |
+| `~/.secrets` | **read-only** | Secrets are never baked into image layers (R-12); provided only via this mount, and live-addable mid-session (R-13). Fail loud at boot on a missing required secret (R-14). |
+| `/mnt/cephfs` | bind (host's already-mounted path) | Org infrastructure. Containers bind-mount the host's mount; they never mount ceph directly (the admin key stays on the host) (TC-6). |
+| `CARGO_HOME`, `GOMODCACHE`, `~/.cache/uv`, `~/.cache/ms-playwright` | rw | Durable caches (Dev Spec §5.3). |
+
+## Identity / uid mapping
+
+- The image ships and defaults to the base's **uid-1000 `ubuntu`** user; the kit
+  is installed under `/home/ubuntu` (R-04, TC-2).
+- Because docker here is rootful with no userns remap, bind-mount writes are
+  owned by whatever uid the container runs as. The operator sets `[sandbox] uid`
+  (and `user` / `home_dir`) in an **isolated** aoe profile so writes land
+  host-user-owned (`bakerb`) — verified in Story 1.2 (MV-01). Never edit the
+  fleet's global aoe config to test this.
+
+## Not required to build
+
+- CephFS, `~/.secrets`, and `~/.oaw/state` are **run-time** concerns; the image
+  builds without them.
+- The kit's MCP servers are **not** baked in this story (`./install --no-mcps`) —
+  see the image README "Deferred". No MCP credentials are needed to build.

--- a/tests/contained-workflow/test_image.py
+++ b/tests/contained-workflow/test_image.py
@@ -1,0 +1,140 @@
+"""Oracle for Story 1.1 — the built oakandwave-workflow image carries the kit-dep
+toolchain (R-05, R-06).
+
+This is a *real-image* oracle, not a proxy: it runs ``docker run`` against the
+built image and asserts every kit-dep tool the base is missing (Go, trivy,
+shellcheck, shfmt, glab — plus bao and aws from the tool manifest, §5.2) resolves
+on PATH and reports a version.
+
+Environment gating (mirrors the repo's CC_FULL_ENV_TESTS philosophy — the 10 GB
+image is not present in the stock validate/pytest lane, so its absence must
+*skip*, never fail):
+
+* ``OAKANDWAVE_IMAGE`` — image ref to probe (default ``oakandwave-workflow:edge``).
+  The Makefile sets this so ``make test`` / ``make ci`` target the right tag.
+* ``OAKANDWAVE_REQUIRE_IMAGE`` — when set (``make ci`` sets it after ``make
+  build``), a missing docker binary or a missing image is a hard failure rather
+  than a skip. This is how CI proves the image was actually built and smoked.
+
+So ``make build`` and ``make test`` behave identically in CI and terminal
+(R-06): identical skip semantics when the image is absent, identical assertions
+when it is present.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+DEFAULT_IMAGE = "oakandwave-workflow:edge"
+
+# The kit-dep tools the base image (aoe-dev-sandbox) is MISSING and this image
+# bakes in (Dev Spec TC-3 / §5.2). Each entry: (binary, version-probe-args).
+# `test_image_toolchain` (the story's named oracle) covers the first five; bao
+# and aws round out the §5.2 manifest and the Makefile `verify` smoke.
+KIT_DEP_TOOLS: list[tuple[str, list[str]]] = [
+    ("go", ["version"]),
+    ("trivy", ["--version"]),
+    ("shellcheck", ["--version"]),
+    ("shfmt", ["--version"]),
+    ("glab", ["--version"]),
+    ("bao", ["version"]),
+    ("aws", ["--version"]),
+]
+
+
+def _image_ref() -> str:
+    return os.environ.get("OAKANDWAVE_IMAGE", DEFAULT_IMAGE)
+
+
+def _require_image() -> bool:
+    return bool(os.environ.get("OAKANDWAVE_REQUIRE_IMAGE"))
+
+
+def _docker() -> str | None:
+    return shutil.which("docker")
+
+
+def _image_present(docker: str, ref: str) -> bool:
+    result = subprocess.run(
+        [docker, "image", "inspect", ref],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _resolve_image_or_skip() -> tuple[str, str]:
+    """Return (docker_path, image_ref) or skip/fail per the gating env vars."""
+    docker = _docker()
+    if docker is None:
+        msg = "docker binary not found on PATH"
+        if _require_image():
+            pytest.fail(msg + " (OAKANDWAVE_REQUIRE_IMAGE set)")
+        pytest.skip(msg)
+
+    ref = _image_ref()
+    if not _image_present(docker, ref):
+        msg = (
+            f"image {ref!r} not built locally — run "
+            f"`make -C containers/oakandwave-workflow build`"
+        )
+        if _require_image():
+            pytest.fail(msg + " (OAKANDWAVE_REQUIRE_IMAGE set)")
+        pytest.skip(msg)
+
+    return docker, ref
+
+
+def _run_in_image(docker: str, ref: str, script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [docker, "run", "--rm", "--entrypoint", "sh", ref, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_image_toolchain() -> None:
+    """docker run reports every baked kit-dep tool present on PATH (R-05, R-06).
+
+    Runs a single container that must resolve *every* tool via `command -v` and
+    emit a version line for each — a red on any one fails the digest.
+    """
+    docker, ref = _resolve_image_or_skip()
+
+    # One container, one script: `command -v` proves it's on PATH; the version
+    # probe proves it actually executes. `set -e` makes the first miss fatal.
+    lines = ["set -e"]
+    for binary, args in KIT_DEP_TOOLS:
+        lines.append(f"command -v {binary}")
+        lines.append(f"{binary} {' '.join(args)}")
+    script = "\n".join(lines)
+
+    proc = _run_in_image(docker, ref, script)
+    assert proc.returncode == 0, (
+        f"toolchain probe failed in {ref}:\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+
+    # Every tool's resolved path must appear in stdout (command -v output).
+    for binary, _ in KIT_DEP_TOOLS:
+        assert f"/{binary}" in proc.stdout or binary in proc.stdout, (
+            f"{binary} not resolved on PATH in {ref}:\n{proc.stdout}"
+        )
+
+
+def test_image_runs_as_non_root_uid_1000() -> None:
+    """The image's default user is the uid-1000 (non-root) runtime user (R-04).
+
+    Story 1.2 wires the aoe [sandbox] uid config; this asserts the image half of
+    the me-ful contract (TC-2) — a uid-1000 user exists and is the default.
+    """
+    docker, ref = _resolve_image_or_skip()
+    proc = _run_in_image(docker, ref, "id -u; id -un")
+    assert proc.returncode == 0, proc.stderr
+    uid = proc.stdout.strip().splitlines()[0]
+    assert uid == "1000", f"expected default uid 1000, got {uid!r}\n{proc.stdout}"


### PR DESCRIPTION
## Summary
Wave P1W1 flight for Plan #959. Packages the kit as a versioned container image (`oakandwave-workflow`) on the AoE dev-sandbox base with the missing kit-dep toolchain baked in. Integrates into the `kahuna/959-contained-workflow` per-wave sandbox.

## Changes
- `containers/oakandwave-workflow/Dockerfile`: FROM aoe-dev-sandbox:1.13.0; adds Go, trivy, shellcheck, shfmt, glab, bao (OpenBao), aws system-wide (pinned ARGs); `./install` the kit for the uid-1000 runtime user. MCP servers deferred to Story 1.3.
- `containers/oakandwave-workflow/Makefile` (DM-02): build/test/ci/verify/clean; paths derived from Makefile location (R-06).
- `containers/oakandwave-workflow/README.md` (DM-01) + `docs/contained-workflow/environment-prerequisites.md` (DM-13).
- `tests/contained-workflow/test_image.py`: real-image oracle, env-gated (skips when image absent, hard-fails under `OAKANDWAVE_REQUIRE_IMAGE`).
- `.dockerignore`: trims the repo-root build context.

## Linked Issues
Closes #961

## Test Plan
Reconcile-node oracle (composed kahuna+flight state), run this round:
- `scripts/ci/validate.sh`: 181 passed, 0 failed
- `python3 -m pytest tests/`: 1693 passed, 4 skipped, 64 xfailed, 2 xpassed, 26 subtests passed
- `commutativity_verify` (single-target, base=kahuna/959-contained-workflow): ORACLE_REQUIRED → oracle satisfied by the green suite above. Purely additive changeset (6 new files, zero overlap with existing paths).