### PR TITLE
chore(contained-workflow): me-ful sandbox config + ownership verification (#962)

### DIFF
--- a/containers/oakandwave-workflow/sandbox-profile.toml
+++ b/containers/oakandwave-workflow/sandbox-profile.toml
@@ -1,0 +1,56 @@
+# oakandwave-workflow — me-ful sandbox profile (Story 1.2, Plan #959).
+#
+# The ISOLATED aoe profile config that launches an agent on the
+# oakandwave-workflow image as uid-1000 (non-root) so files written to
+# bind-mounts land host-user-owned (bakerb) — the "me-ful" contract
+# (Dev Spec §5.1, R-04).
+#
+# ⚠️  ISOLATED PROFILE ONLY. Install this into a *dedicated* aoe profile, never
+#     the fleet's global config:
+#         aoe profile create meful-test
+#         install -m 600 containers/oakandwave-workflow/sandbox-profile.toml \
+#             ~/.config/agent-of-empires/profiles/meful-test/config.toml
+#     The me-ful ownership outcome is proven in an isolated profile (MV-01),
+#     NEVER against the live fleet's ~/.config/agent-of-empires/config.toml
+#     (Dev Spec §5.N#1). Pasting this into the global config would sandbox every
+#     fleet session — do not.
+#
+# ── me-ful mechanism (verified against aoe 1.13.0) ───────────────────────────
+#   Docker here is rootful with no userns remap, so a bind-mount write is owned
+#   by whatever uid the container runs as (TC-2). The uid-1000 identity is
+#   carried by the IMAGE, not by an aoe uid switch: Story 1.1's Dockerfile ends
+#   with `USER ubuntu` (uid 1000), and aoe launches that image without a
+#   `--user` override, so the session runs as uid-1000 `ubuntu` and writes land
+#   bakerb-owned on the host.
+#
+#   NOTE — aoe 1.13.0 has NO native [sandbox] uid/user/home_dir key. Its
+#   SandboxConfig schema is: auto_cleanup, container_runtime, default_image,
+#   default_terminal_mode, enabled_by_default, environment, extra_volumes,
+#   mount_ssh, selinux_relabel, volume_ignores (confirmed from the 1.13.0 binary
+#   and the resolved global config). The uid/user/home_dir keys below therefore
+#   DECLARE the identity contract the image must satisfy (and are forward-
+#   compatible for a future aoe that exposes a native uid override); aoe 1.13.0
+#   does not consume them. MV-01 is the authoritative runtime proof that writes
+#   land uid-1000 — the unit oracle proves only that this config is correct and
+#   aoe-loadable.
+
+[sandbox]
+# Launch every session in this profile in a container sandbox.
+enabled_by_default = true
+
+# The me-ful image. Its default USER is uid-1000 `ubuntu` (Story 1.1) — this is
+# the operative lever that runs the container as uid 1000 under aoe 1.13.0.
+default_image = "oakandwave-workflow:edge"
+
+# Rootful docker, no userns remap (TC-2): in-container uid == host uid.
+container_runtime = "docker"
+
+# ── Declared me-ful identity contract (R-04) ─────────────────────────────────
+# Reuse the base image's uid-1000 `ubuntu` user (TC-2); ownership works by uid
+# regardless of name. These are the values MV-01 confirms produce bakerb-owned
+# (uid 1000) writes on the host. See the header note on aoe 1.13.0 consumption:
+# under 1.13.0 these are declarative (the image USER delivers the uid); they are
+# kept here as the identity contract and for forward-compatibility.
+uid = 1000
+user = "ubuntu"
+home_dir = "/home/ubuntu"

--- a/docs/contained-workflow/manual-verification.md
+++ b/docs/contained-workflow/manual-verification.md
@@ -1,0 +1,135 @@
+# Manual verification procedures — contained workflow
+
+Deliverable **DM-10** (Plan #959, Dev Spec §5.A / §6.4). Procedures that need a
+real container + host and cannot run in the automated lane. Each must be
+**executed AND recorded** — a silent skip is not a pass (Dev Spec §7 DoD).
+
+The full set is MV-01..MV-07 (Dev Spec §6.4); they land with the stories that
+own them and are all executed and recorded in the closing story (4.3, #976).
+
+| ID | Procedure | Requirement | Added in |
+|----|-----------|-------------|----------|
+| MV-01 | Files land `bakerb`-owned under the me-ful config (isolated profile) | R-04 | Story 1.2 (#962) |
+| MV-02 | Live `~/.claude` not exposed under the full custom mount set | R-01, R-03 | Story 1.3+ |
+| MV-03 | Network egress reaches scream-hole / discord / github from inside | R-05 | later |
+| MV-04 | `aoe send` reaches into a running container (control-plane ingress) | R-15 | later |
+| MV-05 | A broken container quarantines and recreates on `:stable`, zero loss | R-02, R-17 | Story 3.2+ |
+| MV-06 | A wedged/OOM-killed `claude` still flushed its transcript | R-15 | later |
+| MV-07 | A secret added mid-session is usable with no container restart | R-13 | Story 1.5+ |
+
+---
+
+## MV-01 — Files land `bakerb`-owned under the me-ful config `[R-04]`
+
+**Goal.** Prove that a file written to a bind-mount **from inside** the container
+is owned by the host user (`bakerb`, uid 1000), not root — the me-ful ownership
+outcome (Dev Spec §5.1, §5.N#1).
+
+**Why manual.** The static config oracle
+(`tests/contained-workflow/test_ownership.py::test_uid_config`) proves the
+profile is correct and aoe-loadable; the docker-gated integration oracle
+(`::test_bind_mount_write_is_host_owned`, IT-04) proves the **image** runs
+non-root. This procedure proves the remaining **aoe** guarantee: that
+`aoe --sandbox` launches the image *without a `--user` override*, so the running
+session is uid-1000 and its bind-mount writes are host-owned. That needs a live
+aoe session and cannot run in the pytest lane.
+
+### Preconditions
+
+- **aoe 1.13.0**, **rootful docker** (no userns remap) — `docker info` shows no
+  `userns` remap; `id -u` on the host is `1000` (`bakerb`).
+- Image built locally:
+  `make -C containers/oakandwave-workflow build` → `oakandwave-workflow:edge`.
+- The me-ful profile config:
+  `containers/oakandwave-workflow/sandbox-profile.toml`.
+
+### Procedure
+
+1. **Create an ISOLATED aoe profile** — never edit the fleet's global config
+   (`~/.config/agent-of-empires/config.toml`):
+
+   ```bash
+   aoe profile create meful-test
+   ```
+
+2. **Install the me-ful config** into that profile only:
+
+   ```bash
+   install -m 600 containers/oakandwave-workflow/sandbox-profile.toml \
+     ~/.config/agent-of-empires/profiles/meful-test/config.toml
+   ```
+
+3. **Prepare a host workspace** to write into (the workspace is host-backed —
+   the bind-mount under test):
+
+   ```bash
+   mkdir -p /tmp/meful-ws && cd /tmp/meful-ws && git init -q
+   ```
+
+4. **Launch a sandbox session on the image** in the isolated profile:
+
+   ```bash
+   aoe -p meful-test add --sandbox --sandbox-image oakandwave-workflow:edge \
+     --launch /tmp/meful-ws
+   ```
+
+   **Confirm** the launch does **not** error with an aoe config-parse /
+   `unknown field` message. This checks the profile loads cleanly. (Under aoe
+   1.13.0 the `uid`/`user`/`home_dir` keys are declarative; if a future aoe
+   rejects them, the fix is to drop those three keys from `[sandbox]` — they are
+   inert on 1.13.0 and the uid is delivered by the image `USER` regardless.)
+
+5. **Confirm the runtime identity** inside the container (attach the session):
+
+   ```bash
+   id -u    # expect: 1000
+   id -un   # expect: ubuntu
+   ```
+
+6. **Write a file to the host-backed bind-mount** from inside:
+
+   ```bash
+   echo meful > /tmp/meful-ws/meful-probe.txt
+   ```
+
+7. **Check ownership on the HOST** (a separate host shell, not the container):
+
+   ```bash
+   stat -c '%U %u %G %g  %n' /tmp/meful-ws/meful-probe.txt
+   ```
+
+   **EXPECT:** `bakerb 1000 …` — uid `1000`, host user. A `root`/`0` result is a
+   **FAIL**.
+
+8. **Record** the result in the log below: date, operator, image digest
+   (`docker inspect --format '{{index .RepoDigests 0}}' oakandwave-workflow:edge`
+   once pushed, else the local image ID), the `id -u` value, the `stat` output,
+   and PASS/FAIL.
+
+### Cleanup
+
+```bash
+aoe -p meful-test remove <session-id>   # or delete via the TUI
+aoe profile delete meful-test
+rm -rf /tmp/meful-ws
+```
+
+### Failure handling
+
+If writes land uid-`0`/root-owned:
+
+- Capture the container's effective user and the aoe launch args:
+  ```bash
+  docker inspect --format '{{.Config.User}}' <container-id>
+  docker inspect --format '{{json .Args}}' <container-id>
+  ```
+- A root result means aoe is launching with a `--user 0` override (or the base
+  entrypoint re-escalates). The me-ful lever in aoe 1.13.0 is the **image
+  `USER`**; a root outcome despite `USER ubuntu` in the image is a bug — open a
+  bug against Story 1.2 (#962) with the `docker inspect` evidence.
+
+### Result log
+
+| Date | Operator | Image digest / ID | `id -u` | `stat` result | PASS/FAIL | Notes |
+|------|----------|-------------------|---------|---------------|-----------|-------|
+| _pending_ | _pending_ | _pending_ | | | | Executed and recorded in closing story 4.3 (#976) |

--- a/tests/contained-workflow/test_ownership.py
+++ b/tests/contained-workflow/test_ownership.py
@@ -1,0 +1,219 @@
+"""Oracle for Story 1.2 — the me-ful sandbox config runs the container as
+uid-1000 so files written to bind-mounts land host-user-owned (R-04).
+
+Two verification altitudes:
+
+* **Static config oracle** (``test_uid_config`` and friends). Parses the
+  checked-in me-ful sandbox profile (``containers/oakandwave-workflow/
+  sandbox-profile.toml``) and asserts it declares the uid-1000 identity, targets
+  the uid-1000 image, and carries only ``[sandbox]`` keys aoe 1.13.0 tolerates
+  (so the profile always launches). It needs no docker/aoe, so it runs *for
+  real* in the stock ``pytest tests/`` lane.
+
+* **Integration oracle** (``test_bind_mount_write_is_host_owned`` — IT-04).
+  Runs the image directly via ``docker run -v`` and asserts a file the container
+  writes to a bind-mount is uid-1000-owned on the host. Self-skips when docker
+  or the image is absent (mirrors ``test_image.py``); ``OAKANDWAVE_REQUIRE_IMAGE``
+  turns absence into a hard failure so CI proves the ownership contract.
+
+aoe 1.13.0 finding (load-bearing): the ``[sandbox]`` schema has no native
+uid/user/home_dir key — the uid-1000 identity is delivered by the image's
+``USER ubuntu`` default (Story 1.1). The declared keys are the identity
+contract; ``test_sandbox_keys_are_aoe_loadable`` guards the launch-safety of the
+``[sandbox]`` table. The aoe-level guarantee (aoe does not override ``--user``)
+is proven manually in MV-01 (``docs/contained-workflow/manual-verification.md``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SANDBOX_PROFILE = (
+    REPO_ROOT / "containers" / "oakandwave-workflow" / "sandbox-profile.toml"
+)
+
+# The uid-1000 image whose `USER ubuntu` default is the operative me-ful lever.
+MEFUL_IMAGE = "oakandwave-workflow:edge"
+
+# aoe 1.13.0 SandboxConfig fields (from the 1.13.0 binary + the resolved global
+# config schema) UNION the declared me-ful identity keys the Dev Spec directs.
+# A `[sandbox]` key outside this union risks an aoe config-parse rejection at
+# session-create — this allowlist is the launch-safety guard.
+AOE_113_SANDBOX_KEYS = {
+    "auto_cleanup",
+    "container_runtime",
+    "cpu_limit",
+    "custom_instruction",
+    "default_image",
+    "default_terminal_mode",
+    "enabled_by_default",
+    "environment",
+    "extra_volumes",
+    "mount_ssh",
+    "port_mappings",
+    "selinux_relabel",
+    "volume_ignores",
+    "volume_ignores_strategy",
+}
+DECLARED_IDENTITY_KEYS = {"uid", "user", "home_dir"}
+
+
+def _load() -> dict:
+    """Parse the profile; a successful parse is a proxy for aoe-loadable TOML."""
+    assert SANDBOX_PROFILE.is_file(), (
+        f"missing me-ful sandbox profile: {SANDBOX_PROFILE}"
+    )
+    with SANDBOX_PROFILE.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _sandbox() -> dict:
+    cfg = _load()
+    sandbox = cfg.get("sandbox")
+    assert isinstance(sandbox, dict), "config has no [sandbox] table"
+    return sandbox
+
+
+def test_uid_config() -> None:
+    """The named story oracle: the sandbox config sets uid 1000 (R-04).
+
+    'Sets uid 1000' has two faces, both asserted: the config DECLARES the
+    uid-1000 identity contract, and it targets the image whose default USER
+    (uid-1000 `ubuntu`) is what actually runs the container as 1000 under aoe.
+    """
+    sandbox = _sandbox()
+
+    # Declared identity: uid 1000.
+    assert sandbox.get("uid") == 1000, (
+        f"[sandbox].uid must be 1000, got {sandbox.get('uid')!r}"
+    )
+
+    # The operative lever: launch the uid-1000 image.
+    assert sandbox.get("default_image") == MEFUL_IMAGE, (
+        f"[sandbox].default_image must be {MEFUL_IMAGE!r} (its USER is uid-1000), "
+        f"got {sandbox.get('default_image')!r}"
+    )
+
+
+def test_meful_identity_reuses_base_ubuntu() -> None:
+    """The declared identity reuses the base image's uid-1000 `ubuntu` (TC-2)."""
+    sandbox = _sandbox()
+    assert sandbox.get("user") == "ubuntu", (
+        f"[sandbox].user must reuse the base 'ubuntu' user, got {sandbox.get('user')!r}"
+    )
+    assert sandbox.get("home_dir") == "/home/ubuntu", (
+        f"[sandbox].home_dir must be /home/ubuntu, got {sandbox.get('home_dir')!r}"
+    )
+
+
+def test_sandbox_launches_in_a_container() -> None:
+    """The profile actually turns the sandbox on (else me-ful never engages)."""
+    sandbox = _sandbox()
+    assert sandbox.get("enabled_by_default") is True, (
+        "[sandbox].enabled_by_default must be true — otherwise sessions run on "
+        "the host and the me-ful uid contract never applies"
+    )
+    assert sandbox.get("container_runtime", "docker") == "docker", (
+        "me-ful assumes rootful docker (TC-2); container_runtime must be 'docker'"
+    )
+
+
+def test_sandbox_keys_are_aoe_loadable() -> None:
+    """Launch-safety: every [sandbox] key is one aoe 1.13.0 tolerates.
+
+    aoe 1.13.0 has no native uid/user/home_dir sandbox key; those are declarative
+    (delivered by the image USER). This guards a future edit from adding a key
+    outside the tolerated union and silently breaking the profile launch.
+    """
+    sandbox = _sandbox()
+    allowed = AOE_113_SANDBOX_KEYS | DECLARED_IDENTITY_KEYS
+    unexpected = set(sandbox) - allowed
+    assert not unexpected, (
+        f"[sandbox] has keys aoe 1.13.0 may reject at session-create: "
+        f"{sorted(unexpected)}"
+    )
+
+
+# --- IT-04 integration oracle (docker-gated; self-skips without the image) ----
+
+
+def _skip_or_fail(msg: str, require: bool) -> None:
+    if require:
+        pytest.fail(msg + " (OAKANDWAVE_REQUIRE_IMAGE set)")
+    pytest.skip(msg)
+
+
+def test_bind_mount_write_is_host_owned() -> None:
+    """IT-04 (R-04): a file the container writes to a bind-mount is uid-1000-owned
+    on the host, not root.
+
+    Runs the image directly (``docker run -v``), sidestepping the aoe stack: it
+    proves the IMAGE half of me-ful — its uid-1000 ``USER`` default makes
+    bind-mount writes host-user-owned. The aoe half (aoe does not override
+    ``--user``) is MV-01. Self-skips when docker/the image is absent, like the
+    image oracle; ``OAKANDWAVE_REQUIRE_IMAGE`` makes absence a hard failure (CI).
+    """
+    docker = shutil.which("docker")
+    require = bool(os.environ.get("OAKANDWAVE_REQUIRE_IMAGE"))
+    ref = os.environ.get("OAKANDWAVE_IMAGE", MEFUL_IMAGE)
+
+    if docker is None:
+        _skip_or_fail("docker binary not found on PATH", require)
+    if (
+        subprocess.run(
+            [docker, "image", "inspect", ref], capture_output=True
+        ).returncode
+        != 0
+    ):
+        _skip_or_fail(
+            f"image {ref!r} not built — run "
+            f"`make -C containers/oakandwave-workflow build`",
+            require,
+        )
+
+    with tempfile.TemporaryDirectory() as host_dir:
+        # World-writable so the container's uid can write regardless of the test
+        # runner's uid; the FILE's owner (what R-04 is about) still reflects the
+        # writing container's uid.
+        os.chmod(host_dir, 0o777)
+        proc = subprocess.run(
+            [
+                docker,
+                "run",
+                "--rm",
+                "-v",
+                f"{host_dir}:/mnt/bind",
+                ref,
+                "sh",
+                "-c",
+                "id -u > /mnt/bind/uid && touch /mnt/bind/probe",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, (
+            f"container write to the bind-mount failed:\n{proc.stderr}"
+        )
+
+        probe = Path(host_dir) / "probe"
+        assert probe.exists(), "container did not create the bind-mount file"
+
+        in_container_uid = (Path(host_dir) / "uid").read_text().strip()
+        assert in_container_uid == "1000", (
+            f"container ran as uid {in_container_uid!r}, expected 1000 (non-root)"
+        )
+
+        st_uid = probe.stat().st_uid
+        assert st_uid == 1000, (
+            f"bind-mount file is uid {st_uid} on the host, expected 1000 "
+            "(me-ful). uid 0 means the container ran as root — R-04 violated."
+        )


### PR DESCRIPTION
## Summary
Wave P1W1 flight for Story 1.2 (Plan #959). Adds the me-ful aoe sandbox profile that launches the oakandwave-workflow image as uid-1000 so bind-mount writes land host-user-owned (R-04), plus its ownership oracle and manual-verification runbook.

## Changes
- `containers/oakandwave-workflow/sandbox-profile.toml` — isolated me-ful aoe profile; targets the uid-1000 `oakandwave-workflow:edge` image; declares the uid/user/home_dir identity contract (aoe 1.13.0 has no native uid key — the image's `USER ubuntu` is the operative lever).
- `tests/contained-workflow/test_ownership.py` — static config oracle (runs for real in stock `pytest tests/`) + docker-gated IT-04 bind-mount ownership integration test (self-skips without docker/image; `OAKANDWAVE_REQUIRE_IMAGE` hard-fails in CI).
- `docs/contained-workflow/manual-verification.md` — MV-01 runbook proving aoe does not override `--user`.

## Cross-flight integration note (PRIME reconcile, P1W1)
Purely additive — 3 new files, zero overlap with #961. Verified #961's Dockerfile ends with `USER ubuntu` (uid 1000), the exact identity contract #962 declares. commutativity_verify (single-target, base kahuna/959) = STRONG.

## Linked Issues
Closes #962

## Test Plan
- `scripts/ci/validate.sh` → 181 passed, 0 failed
- `pytest tests/contained-workflow/` → 7 passed (docker-gated integration self-skips)
- full `scripts/ci/test.sh` suite run as composed-state gate