### PR TITLE
feat(contained-workflow): container bootstrap — skills-sync + fail-loud secrets (#964)

### DIFF
--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+#
+# bootstrap.sh — the container bootstrap (Story 1.4, #964, Plan #959).
+#
+# Runs before the agent (via the aoe-hooks seam — open probe Dev Spec §5.N#5) and
+# performs, in order: env validation, skills symlink-sync, settings.local merge,
+# and secret sourcing + required-secret validation. It is the load-bearing
+# instrument the whole container leans on (SKETCHBOOK D7), so it is written to the
+# **assertion-liveness** discipline from line one:
+#
+#   Every silent-skip path becomes a LOGGED or FAILING condition — never a check
+#   that "reported fine and did nothing." The four enumerated silent-skips
+#   (Dev Spec §5.4 / SKETCHBOOK D7) each have an explicit guard here:
+#
+#     missing mount   -> WARN "missing mount: ..."         (logged, tolerated)
+#     shadowed skill  -> WARN "skills-sync collision: ..." (logged, image wins)
+#     dangling link   -> WARN "dangling symlink: ..."      (logged)
+#     missing secret  -> FATAL "required secret missing"   (fails loud, R-14)
+#
+# Skills-sync (SKETCHBOOK D5): the image bakes skills (versioned, R-06); a host
+# overlay may *fill gaps*. The sync is **image-wins / host-fills**: for each host
+# skill with no same-named image skill, symlink it into the image skills dir using
+# its FULL target path (never a bare basename — the D5 self-reference bug); a host
+# skill that collides with an image skill is shadowed (image wins) and LOGGED.
+# Skills are symlink-safe artifacts (scripts/markdown, not compiled binaries), so
+# symlinking them across the host/container boundary is R-10-correct.
+#
+# Secrets (SKETCHBOOK D6, R-12/R-14): the whole ~/.secrets dir is a read-only
+# bind-mount. `.env` is the env modality (sourced here); loose files are the path
+# modality (NEVER auto-exported to env — that re-leaks via /proc/<pid>/environ).
+# A values-free manifest declares which secrets are required; any required secret
+# missing at boot fails loud.
+#
+# Every path is env-injectable (defaults derived from $HOME) so the oracle
+# (tests/contained-workflow/test_bootstrap.py) drives this for real with fake
+# dirs — no docker — exactly like the mount-resolver unit oracle. Config knobs:
+#
+#   OAW_HOME                        root (default: $HOME)
+#   OAW_SKILLS_IMAGE                baked skills, image-wins (default: $HOME/.claude/skills)
+#   OAW_SKILLS_HOST                 host skills overlay, fills gaps
+#                                   (default: $HOME/.oaw/.claude/skills)
+#   OAW_SETTINGS_JSON               baked hook wiring (default: $HOME/.claude/settings.json)
+#   OAW_SETTINGS_LOCAL              shared knobs mount
+#                                   (default: $HOME/.claude/settings.local.json)
+#   OAW_SECRETS_DIR                 ro secrets mount (default: $HOME/.secrets)
+#   OAW_REQUIRED_SECRETS            whitespace-separated required secret names (wins)
+#   OAW_REQUIRED_SECRETS_MANIFEST   values-free manifest file, one name per line,
+#                                   `#` comments allowed
+#                                   (default: $OAW_SECRETS_DIR/required.manifest)
+#   OAW_REQUIRED_ENV                whitespace-separated required env vars (default: HOME)
+
+set -euo pipefail
+
+WARN_COUNT=0
+FATAL_COUNT=0
+COLLISION_COUNT=0
+DANGLING_COUNT=0
+
+info() { echo "[bootstrap] INFO: $*" >&2; }
+
+warn() {
+	echo "[bootstrap] WARN: $*" >&2
+	WARN_COUNT=$((WARN_COUNT + 1))
+}
+
+# fatal LOGS loud but does NOT exit immediately — we accumulate every fatal so the
+# operator sees the full list in one boot, then exit non-zero at the end.
+fatal() {
+	echo "[bootstrap] FATAL: $*" >&2
+	FATAL_COUNT=$((FATAL_COUNT + 1))
+}
+
+# --- Config resolution --------------------------------------------------------
+
+OAW_HOME="${OAW_HOME:-${HOME:-}}"
+if [[ -z "$OAW_HOME" ]]; then
+	echo "[bootstrap] FATAL: neither OAW_HOME nor HOME is set — cannot resolve paths" >&2
+	exit 1
+fi
+
+OAW_SKILLS_IMAGE="${OAW_SKILLS_IMAGE:-$OAW_HOME/.claude/skills}"
+OAW_SKILLS_HOST="${OAW_SKILLS_HOST:-$OAW_HOME/.oaw/.claude/skills}"
+OAW_SETTINGS_JSON="${OAW_SETTINGS_JSON:-$OAW_HOME/.claude/settings.json}"
+OAW_SETTINGS_LOCAL="${OAW_SETTINGS_LOCAL:-$OAW_HOME/.claude/settings.local.json}"
+OAW_SECRETS_DIR="${OAW_SECRETS_DIR:-$OAW_HOME/.secrets}"
+OAW_REQUIRED_SECRETS_MANIFEST="${OAW_REQUIRED_SECRETS_MANIFEST:-$OAW_SECRETS_DIR/required.manifest}"
+
+# --- Stage 1: env validation --------------------------------------------------
+
+validate_env() {
+	local -a required_env=()
+	IFS=' ' read -r -a required_env <<<"${OAW_REQUIRED_ENV:-HOME}"
+	local name
+	for name in "${required_env[@]:-}"; do
+		[[ -n "$name" ]] || continue
+		if [[ -z "${!name:-}" ]]; then
+			fatal "required env missing: \$$name"
+		else
+			info "env: \$$name set"
+		fi
+	done
+	return 0
+}
+
+# --- Stage 2: skills symlink-sync (image-wins / host-fills, collision-logged) --
+
+# Scan a skills dir for dangling symlinks (a link whose target does not resolve —
+# e.g. the D5 bare-basename self-reference bug, or a stale gap-filler). Each is a
+# silent-skip path made loud.
+scan_dangling() {
+	local dir="$1" link
+	[[ -d "$dir" ]] || return 0
+	shopt -s nullglob
+	for link in "$dir"/*; do
+		# -L true for a symlink; -e false when its target does not resolve.
+		if [[ -L "$link" && ! -e "$link" ]]; then
+			warn "dangling symlink: $link -> $(readlink "$link") (target missing)"
+			DANGLING_COUNT=$((DANGLING_COUNT + 1))
+		fi
+	done
+	shopt -u nullglob
+	return 0
+}
+
+sync_skills() {
+	local host="$OAW_SKILLS_HOST" image="$OAW_SKILLS_IMAGE"
+
+	if [[ ! -d "$host" ]]; then
+		# Missing mount: tolerate it, but say so — and do NOT create dangling
+		# links (SKETCHBOOK D5: "tolerate an absent mount without dangling links").
+		warn "missing mount: host skills overlay not present ($host); skills-sync host-fill skipped"
+		scan_dangling "$image"
+		return 0
+	fi
+
+	mkdir -p "$image"
+
+	local entry name dest cur
+	shopt -s nullglob
+	for entry in "$host"/*; do
+		name="$(basename "$entry")"
+		dest="$image/$name"
+
+		if [[ -L "$dest" ]]; then
+			cur="$(readlink "$dest")"
+			if [[ "$cur" == "$entry" ]]; then
+				# Idempotent re-run: we already linked this gap-filler.
+				info "skills-sync: '$name' already linked (host-fill)"
+				continue
+			fi
+			# A link to something else already occupies the name — image wins.
+			warn "skills-sync collision: host skill '$name' shadowed (image wins)"
+			COLLISION_COUNT=$((COLLISION_COUNT + 1))
+			continue
+		fi
+
+		if [[ -e "$dest" ]]; then
+			# A real baked image skill occupies the name — image wins, host shadowed.
+			warn "skills-sync collision: host skill '$name' shadowed by image (image wins)"
+			COLLISION_COUNT=$((COLLISION_COUNT + 1))
+			continue
+		fi
+
+		# Gap: host fills it. FULL target path (D5 fix — never a bare basename,
+		# which would self-reference into a dangling link).
+		ln -s "$entry" "$dest"
+		info "skills-sync: linked host skill '$name' (host-fill)"
+	done
+	shopt -u nullglob
+
+	scan_dangling "$image"
+	return 0
+}
+
+# --- Stage 3: settings.local merge --------------------------------------------
+
+# Claude Code itself merges settings.json (baked hook wiring) with the mounted
+# settings.local.json (shared knobs) at runtime (architecture.md §3.3). The
+# bootstrap's job is to make the two silent-skip paths loud: a missing
+# settings.local mount, and a malformed settings.local that CC's merge would
+# silently ignore.
+merge_settings() {
+	if [[ -f "$OAW_SETTINGS_JSON" ]]; then
+		info "settings: image settings.json present"
+	else
+		warn "settings: image settings.json not found ($OAW_SETTINGS_JSON) — expected baked in the image"
+	fi
+
+	if [[ ! -f "$OAW_SETTINGS_LOCAL" ]]; then
+		warn "missing mount: settings.local.json not present ($OAW_SETTINGS_LOCAL); Claude Code will use image settings only"
+		return 0
+	fi
+
+	if python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$OAW_SETTINGS_LOCAL" 2>/dev/null; then
+		info "settings: settings.local.json present and valid JSON (Claude Code merges it)"
+	else
+		warn "settings: settings.local.json is not valid JSON ($OAW_SETTINGS_LOCAL) — Claude Code's merge will ignore/error on it"
+	fi
+	return 0
+}
+
+# --- Stage 4: secret sourcing + required-secret validation (R-12/R-14) --------
+
+validate_secrets() {
+	local dir="$OAW_SECRETS_DIR"
+
+	if [[ -d "$dir" ]]; then
+		if [[ -f "$dir/.env" ]]; then
+			# Env modality: source .env so env-var consumers see the values.
+			# Loose files stay path-modality — NEVER auto-exported (D6).
+			set -a
+			# shellcheck disable=SC1090,SC1091
+			. "$dir/.env"
+			set +a
+			info "secrets: sourced $dir/.env (env modality)"
+		fi
+	else
+		warn "missing mount: secrets dir not present ($dir)"
+	fi
+
+	# Required-secrets list: the env override wins; else the values-free manifest.
+	local -a required=()
+	if [[ -n "${OAW_REQUIRED_SECRETS:-}" ]]; then
+		IFS=' ' read -r -a required <<<"$OAW_REQUIRED_SECRETS"
+	elif [[ -f "$OAW_REQUIRED_SECRETS_MANIFEST" ]]; then
+		local line
+		while IFS= read -r line || [[ -n "$line" ]]; do
+			line="${line%%#*}"         # strip comment
+			line="$(xargs <<<"$line")" # trim whitespace
+			[[ -n "$line" ]] && required+=("$line")
+		done <"$OAW_REQUIRED_SECRETS_MANIFEST"
+	fi
+
+	local name
+	for name in "${required[@]:-}"; do
+		[[ -n "$name" ]] || continue
+		if [[ -f "$dir/$name" ]]; then
+			info "secrets: '$name' present (path modality)"
+		elif [[ -n "${!name:-}" ]]; then
+			info "secrets: '$name' present (env modality)"
+		else
+			fatal "required secret missing: '$name' (expected file $dir/$name or env \$$name)"
+		fi
+	done
+	return 0
+}
+
+# --- Main ---------------------------------------------------------------------
+
+main() {
+	info "starting (home=$OAW_HOME)"
+	validate_env
+	sync_skills
+	merge_settings
+	validate_secrets
+
+	echo "bootstrap: ${WARN_COUNT} warning(s) (${COLLISION_COUNT} collision(s), ${DANGLING_COUNT} dangling), ${FATAL_COUNT} fatal(s)"
+
+	if [[ "$FATAL_COUNT" -gt 0 ]]; then
+		echo "[bootstrap] FATAL: $FATAL_COUNT fatal condition(s) — refusing to hand off to the agent" >&2
+		exit 1
+	fi
+	info "complete"
+	return 0
+}
+
+main "$@"

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -79,6 +79,12 @@ else
 	while IFS= read -r f; do
 		SCRIPTS+=("$f")
 	done < <(find "$REPO_DIR/scripts/ci" -name "*.sh" -type f 2>/dev/null)
+	# Container scripts (e.g. the oakandwave-workflow bootstrap). Executable OR
+	# *.sh; the is_shell_script filter below drops non-shell files. Without this,
+	# containers/**/*.sh would escape shellcheck entirely (config exists != works).
+	while IFS= read -r f; do
+		SCRIPTS+=("$f")
+	done < <(find "$REPO_DIR/containers" -type f \( -executable -o -name "*.sh" \) 2>/dev/null)
 	# Skill helper scripts (non-SKILL.md files in skill dirs)
 	for skill_dir in "$REPO_DIR"/skills/*/; do
 		for helper in "$skill_dir"/*; do
@@ -129,6 +135,11 @@ else
 	while IFS= read -r f; do
 		SCRIPTS+=("$f")
 	done < <(find "$REPO_DIR/scripts" -type f \( -executable -o -name "*.sh" \) 2>/dev/null)
+	# Container scripts (e.g. the oakandwave-workflow bootstrap) — mirror the
+	# selector used above so shfmt covers the same tree as the linter.
+	while IFS= read -r f; do
+		SCRIPTS+=("$f")
+	done < <(find "$REPO_DIR/containers" -type f \( -executable -o -name "*.sh" \) 2>/dev/null)
 	# Skill helper scripts (non-SKILL.md files in skill dirs)
 	for skill_dir in "$REPO_DIR"/skills/*/; do
 		for helper in "$skill_dir"/*; do

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -1,0 +1,298 @@
+"""Oracle for Story 1.4 — the container bootstrap (#964, Dev Spec §5.4).
+
+The bootstrap (``containers/oakandwave-workflow/bootstrap.sh``) is the
+load-bearing instrument that runs before the agent (SKETCHBOOK D7). Its whole
+point is **assertion-liveness**: every silent-skip path becomes a LOGGED or
+FAILING condition, never "the check that reported fine and did nothing."
+
+These are *pure* unit oracles — no docker, no aoe. Every path the bootstrap
+touches is env-injectable (defaults derived from ``$HOME``), so each test builds a
+fake ``$OAW_HOME`` in a tempdir, drives the real ``bootstrap.sh`` via subprocess,
+and asserts the behavior. They run for real in the stock ``pytest tests/`` lane
+(bash + python3 are always present), exactly like the mount-resolver oracle.
+
+Each of the four enumerated silent-skip paths (Dev Spec §5.4 / SKETCHBOOK D7) is
+exercised **red-first** — the broken condition is constructed and the guard's
+logged/failing signal is asserted — before the guard is trusted:
+
+* missing mount   — ``test_missing_host_skills_mount_is_logged_no_dangling``,
+  ``test_missing_settings_local_is_logged`` `[R-14]`
+* shadowed skill  — ``test_skills_sync_image_wins_and_logs_collision`` `[R-06, R-10]`
+* dangling link   — ``test_dangling_symlink_is_logged`` `[R-14]`
+* missing secret  — ``test_missing_required_secret_fails_loud`` `[R-14]`
+
+``test_bootstrap_failloud`` is the devspec-named oracle: it walks all four paths
+red-first in one aggregate assertion.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = REPO_ROOT / "containers" / "oakandwave-workflow" / "bootstrap.sh"
+
+
+def test_bootstrap_script_exists() -> None:
+    """The deliverable exists and is executable (the story's target file)."""
+    assert BOOTSTRAP.is_file(), f"missing bootstrap: {BOOTSTRAP}"
+    assert os.access(BOOTSTRAP, os.X_OK), f"bootstrap is not executable: {BOOTSTRAP}"
+
+
+def _make_home(
+    tmp_path: Path,
+    *,
+    image_skills: list[str] | None = None,
+    host_skills: list[str] | None = None,
+    settings_json: bool = True,
+    settings_local: str | None = None,
+    secrets: dict[str, str] | None = None,
+    dangling: list[str] | None = None,
+) -> Path:
+    """Build a fake ``$OAW_HOME`` layout for the bootstrap to operate on.
+
+    ``image_skills`` / ``host_skills`` are skill *names* (each a directory with a
+    marker ``SKILL.md``). ``dangling`` names broken symlinks planted in the image
+    skills dir. ``secrets`` maps a filename under ``~/.secrets`` to its content
+    (``.env`` supported for the env modality).
+    """
+    home = tmp_path / "home"
+    image = home / ".claude" / "skills"
+    host = home / ".oaw" / ".claude" / "skills"
+    secrets_dir = home / ".secrets"
+    image.mkdir(parents=True)
+    host.mkdir(parents=True)
+    secrets_dir.mkdir(parents=True)
+
+    for name in image_skills or []:
+        d = image / name
+        d.mkdir()
+        (d / "SKILL.md").write_text(f"# image skill {name}\n")
+    for name in host_skills or []:
+        d = host / name
+        d.mkdir()
+        (d / "SKILL.md").write_text(f"# host skill {name}\n")
+    for name in dangling or []:
+        (image / name).symlink_to(home / "does-not-exist" / name)
+
+    if settings_json:
+        (home / ".claude" / "settings.json").write_text('{"hooks": {}}\n')
+    if settings_local is not None:
+        (home / ".claude" / "settings.local.json").write_text(settings_local)
+    for fname, content in (secrets or {}).items():
+        (secrets_dir / fname).write_text(content)
+
+    return home
+
+
+def _run(home: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["OAW_HOME"] = str(home)
+    env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(BOOTSTRAP)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+# --- shadowed skill (collision) — [R-06, R-10] --------------------------------
+
+
+def test_skills_sync_image_wins_and_logs_collision(tmp_path: Path) -> None:
+    """Image-wins / host-fills / collision-logged (AC-1).
+
+    ``alpha`` exists in both (collision) → image wins, logged, and NOT relinked.
+    ``beta`` is host-only (a gap) → filled by a symlink whose FULL target path
+    resolves (the D5 self-reference bug would leave a dangling link).
+    """
+    home = _make_home(
+        tmp_path, image_skills=["alpha"], host_skills=["alpha", "beta"]
+    )
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+
+    # Collision logged for the shadowed host skill.
+    assert "skills-sync collision" in proc.stderr
+    assert "alpha" in proc.stderr
+
+    image = home / ".claude" / "skills"
+    # Image wins: alpha is still the real baked dir, not a link to the host copy.
+    assert (image / "alpha").is_dir()
+    assert not (image / "alpha").is_symlink()
+
+    # Host fills the gap: beta is a symlink resolving to the host copy (full path).
+    beta = image / "beta"
+    assert beta.is_symlink(), "host-only skill should be symlinked in (host-fill)"
+    assert beta.exists(), "host-fill link is dangling — the D5 full-target-path bug"
+    assert os.readlink(beta) == str(
+        home / ".oaw" / ".claude" / "skills" / "beta"
+    ), "host-fill must link the FULL target path, never a bare basename"
+
+
+def test_skills_sync_is_idempotent(tmp_path: Path) -> None:
+    """A second boot re-links nothing and raises no error (re-runnable)."""
+    home = _make_home(tmp_path, host_skills=["beta"])
+    assert _run(home).returncode == 0
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "already linked" in proc.stderr
+    assert (home / ".claude" / "skills" / "beta").exists()
+
+
+# --- missing mount ------------------------------------------------------------
+
+
+def test_missing_host_skills_mount_is_logged_no_dangling(tmp_path: Path) -> None:
+    """Absent host skills overlay → logged, and NO dangling link created."""
+    home = _make_home(tmp_path)  # host dir exists but is empty…
+    # …now remove it entirely to model an absent mount.
+    host = home / ".oaw" / ".claude" / "skills"
+    (host).rmdir()
+    (home / ".oaw" / ".claude").rmdir()
+
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "missing mount" in proc.stderr
+    assert "host skills overlay" in proc.stderr
+    # No dangling links were manufactured in the image dir.
+    image = home / ".claude" / "skills"
+    assert not any(p.is_symlink() and not p.exists() for p in image.iterdir())
+
+
+def test_missing_settings_local_is_logged(tmp_path: Path) -> None:
+    """Absent settings.local mount → logged (silent-skip made loud), non-fatal."""
+    home = _make_home(tmp_path)  # no settings_local
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "missing mount: settings.local.json" in proc.stderr
+
+
+def test_malformed_settings_local_is_logged(tmp_path: Path) -> None:
+    """Malformed settings.local → loud warning (CC's merge would silently drop it)."""
+    home = _make_home(tmp_path, settings_local="{ this is not json ]")
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "not valid JSON" in proc.stderr
+
+
+# --- dangling link ------------------------------------------------------------
+
+
+def test_dangling_symlink_is_logged(tmp_path: Path) -> None:
+    """A dangling symlink in the skills dir is surfaced, not silently skipped."""
+    home = _make_home(tmp_path, dangling=["ghost"])
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "dangling symlink" in proc.stderr
+    assert "ghost" in proc.stderr
+
+
+# --- missing secret — [R-14] --------------------------------------------------
+
+
+def test_missing_required_secret_fails_loud(tmp_path: Path) -> None:
+    """A missing required secret makes the bootstrap fail loudly (AC-2, R-14)."""
+    home = _make_home(tmp_path)
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN")
+    assert proc.returncode != 0, "missing required secret must fail loud"
+    assert "FATAL" in proc.stderr
+    assert "required secret missing" in proc.stderr
+    assert "FOO_TOKEN" in proc.stderr
+
+
+def test_required_secret_present_as_file_passes(tmp_path: Path) -> None:
+    """The green half: a present secret file (path modality) satisfies the guard."""
+    home = _make_home(tmp_path, secrets={"FOO_TOKEN": "s3cr3t\n"})
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN")
+    assert proc.returncode == 0, proc.stderr
+    assert "path modality" in proc.stderr
+
+
+def test_required_secret_present_via_env_passes(tmp_path: Path) -> None:
+    """A required secret satisfied by an env var (env modality) passes."""
+    home = _make_home(tmp_path)
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN", FOO_TOKEN="from-env")
+    assert proc.returncode == 0, proc.stderr
+    assert "env modality" in proc.stderr
+
+
+def test_required_secret_from_manifest_fails_loud(tmp_path: Path) -> None:
+    """The values-free manifest (D6) drives the required list; a missing one fails."""
+    home = _make_home(tmp_path)
+    manifest = home / ".secrets" / "required.manifest"
+    manifest.write_text("# required secrets\nDISCORD_BOT_TOKEN\n\nSLACK_BOT_TOKEN\n")
+    proc = _run(home)
+    assert proc.returncode != 0
+    assert "DISCORD_BOT_TOKEN" in proc.stderr
+    assert "SLACK_BOT_TOKEN" in proc.stderr
+
+
+def test_dotenv_is_sourced_for_env_modality(tmp_path: Path) -> None:
+    """``.env`` is the env modality: a var it defines satisfies a required secret."""
+    home = _make_home(tmp_path, secrets={".env": "FOO_TOKEN=via-dotenv\n"})
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN")
+    assert proc.returncode == 0, proc.stderr
+    assert "sourced" in proc.stderr
+
+
+# --- missing required env -----------------------------------------------------
+
+
+def test_missing_required_env_fails_loud(tmp_path: Path) -> None:
+    """env validation has teeth: a declared-but-unset env var fails loud."""
+    home = _make_home(tmp_path)
+    proc = _run(home, OAW_REQUIRED_ENV="OAW_MUST_EXIST")
+    assert proc.returncode != 0
+    assert "required env missing" in proc.stderr
+    assert "OAW_MUST_EXIST" in proc.stderr
+
+
+# --- happy path ---------------------------------------------------------------
+
+
+def test_all_clean_exits_zero(tmp_path: Path) -> None:
+    """Fully-provisioned boot: no warnings, no fatals, exit 0."""
+    home = _make_home(
+        tmp_path,
+        image_skills=["alpha"],
+        host_skills=["beta"],
+        settings_local='{"permissions": {}}\n',
+    )
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "0 fatal(s)" in proc.stdout
+    assert "complete" in proc.stderr
+
+
+# --- the devspec-named aggregate oracle ---------------------------------------
+
+
+def test_bootstrap_failloud(tmp_path: Path) -> None:
+    """Named oracle (Dev Spec §8, Story 1.4): each silent-skip path logs/fails,
+    red-first. Walks all four enumerated paths in one assertion.
+    """
+    # 1) shadowed skill + 3) dangling link, both LOGGED (non-fatal).
+    home = _make_home(
+        tmp_path,
+        image_skills=["alpha"],
+        host_skills=["alpha"],
+        dangling=["ghost"],
+    )
+    logged = _run(home)
+    assert logged.returncode == 0, logged.stderr
+    assert "skills-sync collision" in logged.stderr  # shadowed skill
+    assert "dangling symlink" in logged.stderr  # dangling link
+    assert "missing mount: settings.local.json" in logged.stderr  # 2) missing mount
+
+    # 4) missing secret FAILS LOUD (the same layout, plus a required secret).
+    failed = _run(home, OAW_REQUIRED_SECRETS="MUST_HAVE_TOKEN")
+    assert failed.returncode != 0, "missing required secret must fail loud (R-14)"
+    assert "FATAL" in failed.stderr
+    assert "MUST_HAVE_TOKEN" in failed.stderr


### PR DESCRIPTION
## Summary
Wave P1W2 flight for Story 1.4 (#964, Plan #959): the container bootstrap — the load-bearing pre-agent instrument written to assertion-liveness discipline (every silent-skip path is LOGGED or FATAL). Integrating into `kahuna/959-contained-workflow`.

## Changes
- `containers/oakandwave-workflow/bootstrap.sh` — env validation, image-wins/host-fills skills symlink-sync (D5 full-target-path fix), settings.local merge visibility, secret sourcing + required-secret fail-loud (R-12/R-14).
- `scripts/ci/validate.sh` — extend shellcheck + shfmt selectors to cover `containers/**` (config-exists != config-works; without it container scripts escape linting).
- `tests/contained-workflow/test_bootstrap.py` — 15 pure unit oracles (no docker), all four silent-skip paths exercised red-first, incl. the named `test_bootstrap_failloud` aggregate.

## Linked Issues
Closes #964

## Test Plan
- `scripts/ci/validate.sh`: 183 passed, 0 failed (shellcheck + shfmt now cover `bootstrap.sh`).
- `pytest tests/contained-workflow/test_bootstrap.py`: 15 passed.
- Broader `pytest tests/`: 906 passed / 0 failed through the fast unit+hook+wave lanes; remainder is pre-existing slow install/zipapp integration untouched by this flight. Full suite gated by CI.
- Commutativity single-target gate vs `kahuna/959-contained-workflow`: `ORACLE_REQUIRED` (by-design for config/infra files; oracle = the passing suite).