### PR TITLE
feat(contained-workflow): read-only secrets mount + proven mid-session liveness (#965)

### DIFF
--- a/containers/oakandwave-workflow/mounts.d/20-secrets.toml
+++ b/containers/oakandwave-workflow/mounts.d/20-secrets.toml
@@ -1,0 +1,36 @@
+# 20-secrets.toml — read-only secrets (Dev Spec §5.5, Story 1.5 #965, R-12/R-13).
+#
+# The whole ~/.secrets dir enters as ONE read-only bind-mount. Secrets are NEVER
+# baked into an image layer (R-12) — the image is the release and ships to every
+# ring/registry; a baked secret would leak with the digest. They are provided
+# only at runtime, via this mount. mount_resolver.py fails LOUD if a future edit
+# flips this to mode = "rw" (check: read-only-secrets + mode != ro -> R-12).
+#
+# Liveness (R-13): a bind-mount is the host dir, so a file the host adds to
+# ~/.secrets mid-session is visible to the running container with no restart.
+# That liveness is REAL for file-path consumers (they re-read the file); it is
+# NOT retroactive for env-var consumers — bootstrap.sh sources ~/.secrets/.env
+# once at boot (env modality), so a value added after boot reaches only path
+# consumers until the next process re-source. Hence the consumer split below:
+#
+#   .env         -> env modality  : sourced once at boot; env-var consumers.
+#   loose files  -> path modality : read on demand; FULLY live (R-13). PREFER.
+#
+# Blast-radius tradeoff (open item, §5.N / architecture.md §3.5): mounting the
+# WHOLE dir means every ring — and every process in the container, across the
+# GitLab/GitHub IP boundary — sees every secret. Least-privilege per-secret
+# scoping is a deliberate open design item; this whole-dir layer is where a
+# future scoped mechanism slots in. The mount stays ro so no ring can mutate a
+# shared secret.
+#
+# The target matches bootstrap.sh's OAW_SECRETS_DIR default ($HOME/.secrets), so
+# secret sourcing + required-secret validation (R-14) find the dir with no extra
+# env wiring. A values-free required.manifest lives inside the dir (mounted with
+# it) and drives the fail-loud missing-secret check.
+
+[[mount]]
+name = "secrets"
+layer = "read-only-secrets"
+mode = "ro"
+source = "~/.secrets"
+target = "/home/ubuntu/.secrets"

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -41,10 +41,12 @@ fragment deterministically. Each file holds one or more `[[mount]]` tables.
 | file | layer | owner story |
 |------|-------|-------------|
 | `10-memory.toml` | shared-mutable-rw (memory + `settings.local.json`) | 1.3 (#963) |
+| `20-secrets.toml` | read-only-secrets (ro `~/.secrets` dir mount) | 1.5 (#965) |
 | `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |
 | `40-durable-caches.toml` | durable-cache (cargo, go-mod, uv, ms-playwright) | 1.3 (#963) |
 
-**`20-secrets.toml`** (the `read-only-secrets` layer — the ro `~/.secrets` dir
-mount) lands with **Story 1.5 (#965)**; the resolver already supports the
-`read-only-secrets` layer (and enforces `mode = "ro"`), so that story is a
-drop-in fragment, no resolver change.
+`20-secrets.toml` was a drop-in for Story 1.3's resolver: the
+`read-only-secrets` layer and its `mode = "ro"` enforcement (R-12) already
+existed, so Story 1.5 added only the fragment (no resolver change). The whole
+`~/.secrets` dir mounts ro; a host-added file is live mid-session (R-13) — see
+`architecture.md` §3.5 for the consumer split and blast-radius tradeoff.

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -83,7 +83,7 @@ flowchart LR
     s2["memory + settings.local<br/>~/.oaw/state/&lt;major&gt;/  (R-03)"]
   end
   subgraph ro["3 · read-only-secrets"]
-    s3["~/.secrets (ro)  ·  Story 1.5"]
+    s3["~/.secrets (ro)  ·  §3.5"]
   end
   subgraph ov["4 · user-environment overlay"]
     s4["MCP fragment (additive, R-09)<br/>toolbox (in-container, R-11)<br/>scripts (symlink, R-10)"]
@@ -99,7 +99,7 @@ flowchart LR
 |-------|-----------|-------------------|--------------|
 | Baked-in-image | Built by `./install` in the image; immutable per tag | *(none — in the image)* | R-06, R-09 |
 | Shared-mutable-rw | rw bind-mount, **sandbox-scoped** host source | `10-memory.toml` | R-03, R-20 |
-| Read-only secrets | ro bind-mount of the `~/.secrets` dir | `20-secrets.toml` *(Story 1.5)* | R-12, R-13 |
+| Read-only secrets | ro bind-mount of the `~/.secrets` dir (§3.5) | `20-secrets.toml` | R-12, R-13, R-14 |
 | User-environment overlay | additive / in-container / symlink, by artifact type | `30-user-overlay.toml` | R-09, R-10, R-11 |
 | Durable caches | rw bind-mount, major-partitioned | `40-durable-caches.toml` | §5.3 |
 
@@ -156,6 +156,46 @@ Kit binaries (from the image) win over the user overlay on `PATH`, so the RTE
 stays authoritative — the same digest-determines-behavior rule that the promotion
 gate depends on (Dev Spec §5.3).
 
+### 3.5 Secrets: the read-only mount (Story 1.5)
+
+The whole `~/.secrets` dir enters as **one read-only bind-mount**
+([`20-secrets.toml`](../../containers/oakandwave-workflow/mounts.d/20-secrets.toml))
+targeting `/home/ubuntu/.secrets` — the default the bootstrap's `OAW_SECRETS_DIR`
+already resolves (Dev Spec §5.5).
+
+- **Never baked (R-12).** The image *is* the release: it ships to every ring and
+  registry, so a secret baked into any layer would leak with the digest. Secrets
+  are provided **only** through this runtime mount; the image `RUN` deliberately
+  tolerates `check-deps`' missing-token advisory rather than baking the tokens
+  (Dockerfile §"Bake the kit"). The resolver enforces the ro half — a fragment
+  fat-fingered to `mode = "rw"` raises `R-12 VIOLATION` (`test_secrets_rw_fragment_is_rejected`).
+- **Live mid-session (R-13).** A bind-mount *is* the host dir, so a file the host
+  adds to `~/.secrets` after the container started is visible inside the running
+  container with no restart — proven by `test_secrets_readonly` (IT-02) and MV-07.
+- **Fail-loud on a missing required secret (R-14).** A values-free
+  `required.manifest` inside the dir (mounted with it) drives the bootstrap's
+  required-secret check (Story 1.4); a missing required secret aborts the boot.
+
+**Consumer split (the load-bearing nuance).** The mount is live, but *how* live
+depends on how a consumer reads a secret:
+
+| Modality | Source | Liveness |
+|----------|--------|----------|
+| **path** | a loose file `~/.secrets/<NAME>`, read on demand | **fully live** (R-13) — the consumer re-reads the file |
+| **env** | `~/.secrets/.env`, sourced once by `bootstrap.sh` at boot | snapshot-at-boot — a value added *after* boot reaches only path consumers until the next re-source |
+
+So **prefer file-path consumers** where liveness matters: `.env` is convenient
+but its values are frozen at the boot source. Loose files stay path-modality and
+are **never auto-exported** (SKETCHBOOK D6), which is also why they stay live.
+
+**Blast-radius tradeoff (open item).** Mounting the *whole* dir means every ring
+— and every process in the container, across the GitLab/GitHub IP boundary — sees
+*every* secret. That is a deliberate, flagged tradeoff for the foundation: it is
+one mount, ro, with no per-secret plumbing. **Least-privilege per-secret scoping
+is an open design item** (Dev Spec §5.5, §5.N); the `read-only-secrets` layer is
+exactly where a future scoped-secrets mechanism slots in without disturbing the
+rest of the taxonomy. See §5 for the carried open item.
+
 ## 4. Boundaries and invariants
 
 - **Stateless-container invariant (R-01/R-02).** The container filesystem is
@@ -178,10 +218,11 @@ gate depends on (Dev Spec §5.3).
   observation; it is confirmed against the full manifest in MV-02 (closing story
   4.3). The resolver's R-03 guard is the *static* half of that assurance; MV-02
   is the runtime half.
-- **Secrets blast-radius** (Dev Spec §5.5, §5.N): the whole-`~/.secrets`-dir
-  mount means every ring sees every secret, including across the GitLab/GitHub IP
-  boundary. Least-privilege scoping is an open design item; the manifest's
-  `read-only-secrets` layer is where a future scoped-secrets mechanism slots in.
+- **Secrets blast-radius** (Dev Spec §5.5, §5.N; documented in §3.5): the
+  whole-`~/.secrets`-dir mount means every ring sees every secret, including
+  across the GitLab/GitHub IP boundary. Least-privilege per-secret scoping is an
+  open design item; the manifest's `read-only-secrets` layer is where a future
+  scoped-secrets mechanism slots in without disturbing the taxonomy.
 - **AoE bootstrap seam** (Dev Spec §5.N#5): whether aoe respects the image
   `ENTRYPOINT` or `docker exec`s the agent directly determines where the
   bootstrap (Story 1.4) hooks the resolver in. The resolver is seam-agnostic — it
@@ -195,4 +236,6 @@ gate depends on (Dev Spec §5.3).
 | R-09 MCP additive scoping | `test_mounts.py::test_mcp_composes_additively`; IT-03 |
 | R-10 binaries in-container | `test_mounts.py::test_compiled_binary_installs_in_container`; IT-01/IT-03 |
 | R-11 declarative toolbox | `test_mounts.py::test_toolbox_is_durable_in_container`; IT-03 |
+| R-12 secrets never baked / ro | `test_secrets.py::{test_secrets_mount_is_readonly,test_secrets_rw_fragment_is_rejected,test_secrets_never_baked_into_image}`; `test_secrets_readonly` (IT-02) |
+| R-13 secret liveness | `test_secrets.py::test_secrets_readonly` (IT-02); MV-07 |
 | R-01 stateless / host-backed | this doc (DM-11); IT-03; MV-02 |

--- a/docs/contained-workflow/manual-verification.md
+++ b/docs/contained-workflow/manual-verification.md
@@ -15,7 +15,7 @@ own them and are all executed and recorded in the closing story (4.3, #976).
 | MV-04 | `aoe send` reaches into a running container (control-plane ingress) | R-15 | later |
 | MV-05 | A broken container quarantines and recreates on `:stable`, zero loss | R-02, R-17 | Story 3.2+ |
 | MV-06 | A wedged/OOM-killed `claude` still flushed its transcript | R-15 | later |
-| MV-07 | A secret added mid-session is usable with no container restart | R-13 | Story 1.5+ |
+| MV-07 | A secret added mid-session is usable with no container restart | R-13 | Story 1.5 (#965) |
 
 ---
 
@@ -133,3 +133,112 @@ If writes land uid-`0`/root-owned:
 | Date | Operator | Image digest / ID | `id -u` | `stat` result | PASS/FAIL | Notes |
 |------|----------|-------------------|---------|---------------|-----------|-------|
 | _pending_ | _pending_ | _pending_ | | | | Executed and recorded in closing story 4.3 (#976) |
+
+---
+
+## MV-07 — A secret added mid-session is usable with no container restart `[R-13]`
+
+**Goal.** Prove that a secret the host adds to `~/.secrets` **after** a session
+started is usable by a **newly-spawned command inside the running container**,
+with **no container restart** — the mid-session liveness of the read-only secrets
+mount (Dev Spec §5.5; architecture §3.5).
+
+**Why manual.** The docker-gated integration oracle
+(`tests/contained-workflow/test_secrets.py::test_secrets_readonly`, IT-02) proves
+the bind-mount is ro and that a host-added file is visible via `docker exec` in a
+bare container. This procedure proves the same liveness through the **real aoe
+sandbox session** an agent runs in, and through a **path-modality consumer** the
+way the kit actually reads a secret — the end-user-visible outcome. It needs a
+live aoe session, so it cannot run in the pytest lane.
+
+### Preconditions
+
+- **aoe 1.13.0**, **rootful docker** — as MV-01.
+- Image built locally:
+  `make -C containers/oakandwave-workflow build` → `oakandwave-workflow:edge`.
+- A host `~/.secrets` dir that will be bind-mounted ro (the me-ful profile /
+  `20-secrets.toml` wires `~/.secrets` → `/home/ubuntu/.secrets`). For an
+  isolated run, point `OAW_SECRETS_DIR` (or the profile's `extra_volumes`) at a
+  throwaway dir so you never touch real secrets.
+
+### Procedure
+
+1. **Seed one secret present at launch** in the host secrets dir:
+
+   ```bash
+   mkdir -p /tmp/meful-secrets
+   printf 'boot-value\n' > /tmp/meful-secrets/AT_BOOT
+   ```
+
+2. **Launch a sandbox session** with that dir bind-mounted ro at the secrets
+   target (isolated profile, as MV-01; add the volume to the profile's
+   `extra_volumes` or pass it through):
+
+   ```bash
+   aoe -p meful-test add --sandbox --sandbox-image oakandwave-workflow:edge \
+     --launch /tmp/meful-ws
+   # ensure -v /tmp/meful-secrets:/home/ubuntu/.secrets:ro is in effect
+   ```
+
+3. **Confirm the at-boot secret is readable** inside the running container
+   (attach the session):
+
+   ```bash
+   cat /home/ubuntu/.secrets/AT_BOOT      # expect: boot-value
+   ```
+
+4. **Confirm the mount is read-only** (R-12) — an in-container write must FAIL:
+
+   ```bash
+   echo x > /home/ubuntu/.secrets/should_fail   # expect: Read-only file system
+   ```
+
+5. **Add a NEW secret ON THE HOST**, mid-session, with the container still
+   running (a separate host shell):
+
+   ```bash
+   printf 'live-add\n' > /tmp/meful-secrets/MID_SESSION
+   ```
+
+6. **Spawn a NEW command inside the SAME running container** (do NOT restart it)
+   and read the just-added secret — this is the liveness assertion:
+
+   ```bash
+   cat /home/ubuntu/.secrets/MID_SESSION   # expect: live-add
+   ```
+
+   **EXPECT:** `live-add` — the host-added file is live with no restart. A
+   "No such file or directory" is a **FAIL** (R-13 liveness violated).
+
+7. **(Optional) confirm the env-modality caveat.** If the mount carries a `.env`,
+   note that a value *added to `.env` after boot* is **not** seen by env-var
+   consumers until a re-source (architecture §3.5 consumer split) — this is
+   expected, not a failure. The R-13 liveness guarantee is for **path-modality**
+   (loose-file) consumers, which is what step 6 exercises.
+
+8. **Record** the result in the log below: date, operator, image digest/ID, the
+   step-3 read, the step-4 write-rejection, the step-6 read, and PASS/FAIL.
+
+### Cleanup
+
+```bash
+aoe -p meful-test remove <session-id>
+rm -rf /tmp/meful-secrets
+```
+
+### Failure handling
+
+- **Step 6 shows the file missing.** The bind-mount is not the live host dir —
+  inspect the mount: `docker inspect --format '{{json .Mounts}}' <container-id>`.
+  A `volume`/copy source instead of a host `bind` breaks liveness; a stale image
+  path or an over-eager copy in the bootstrap would too. Open a bug against
+  Story 1.5 (#965) with the `docker inspect` evidence.
+- **Step 4 write SUCCEEDS.** The mount is not ro — R-12 violated. Check the
+  fragment (`20-secrets.toml` must be `mode = "ro"`; the resolver rejects rw) and
+  the effective `-v …:ro` flag.
+
+### Result log
+
+| Date | Operator | Image digest / ID | step-3 read | step-4 write | step-6 read | PASS/FAIL | Notes |
+|------|----------|-------------------|-------------|--------------|-------------|-----------|-------|
+| _pending_ | _pending_ | _pending_ | | | | | Executed and recorded in closing story 4.3 (#976) |

--- a/tests/contained-workflow/test_secrets.py
+++ b/tests/contained-workflow/test_secrets.py
@@ -1,0 +1,216 @@
+"""Oracle for Story 1.5 — the read-only ~/.secrets mount + mid-session liveness
+(#965, Dev Spec §5.5, R-12/R-13).
+
+Two verification altitudes, mirroring test_ownership.py:
+
+* **Static config oracles** (pure — run for real in the stock ``pytest tests/``
+  lane, no docker). Assert the checked-in ``20-secrets.toml`` fragment resolves
+  as a *read-only* mount of ``~/.secrets`` (R-12: provided only via the ro mount,
+  never rw), that its target matches the bootstrap's secrets-dir default, and
+  that no secret is baked into the image (R-12: never in an image layer) —
+  ``mount_resolver`` even fails LOUD if the fragment is fat-fingered to ``rw``.
+
+* **Integration oracle** (``test_secrets_readonly`` — the story's named oracle,
+  IT-02). Runs the image via ``docker run`` with ``~/.secrets`` bind-mounted ro:
+  the container *cannot* write the mount (R-12 ro), and a file the host adds
+  *after* the container started is live inside the running container (R-13).
+  Self-skips when docker/the image is absent (like test_image.py);
+  ``OAKANDWAVE_REQUIRE_IMAGE`` turns absence into a hard failure so CI proves the
+  contract end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+MANIFEST_DIR = CONTAINER_DIR / "mounts.d"
+SECRETS_FRAGMENT = MANIFEST_DIR / "20-secrets.toml"
+DOCKERFILE = CONTAINER_DIR / "Dockerfile"
+
+# Import the resolver by path (no PYTHONPATH dependency), like test_mounts.py.
+sys.path.insert(0, str(CONTAINER_DIR))
+import mount_resolver as mr  # noqa: E402
+
+FAKE_HOME = PurePosixPath("/home/bakerb")
+MAJOR = 8
+
+# The uid-1000 image whose ro bind-mount we probe; consistent with the other
+# docker-gated oracles (test_image.py / test_ownership.py).
+SECRETS_IMAGE = "oakandwave-workflow:edge"
+SECRETS_TARGET = "/home/ubuntu/.secrets"
+
+
+# --- Static R-12 oracles (pure; run in the stock lane) ------------------------
+
+
+def _secrets_mount() -> mr.ResolvedMount:
+    """Resolve the checked-in secrets fragment (and only it) for assertions."""
+    assert SECRETS_FRAGMENT.is_file(), f"missing secrets fragment: {SECRETS_FRAGMENT}"
+    resolved = mr.resolve_manifest(MAJOR, home=FAKE_HOME, mounts_dir=MANIFEST_DIR)
+    secrets = [m for m in resolved if m.layer == "read-only-secrets"]
+    assert secrets, "no read-only-secrets mount in the resolved manifest"
+    assert len(secrets) == 1, f"expected one secrets mount, got {len(secrets)}"
+    return secrets[0]
+
+
+def test_secrets_mount_is_readonly() -> None:
+    """R-12: secrets are provided ONLY via the ro mount — the checked-in fragment
+    resolves read-only, sourced from ~/.secrets, targeting the bootstrap's dir."""
+    m = _secrets_mount()
+    assert m.mode == "ro", f"secrets mount must be ro (R-12), got {m.mode!r}"
+    assert m.source == "/home/bakerb/.secrets", (
+        f"secrets source must be ~/.secrets, got {m.source!r}"
+    )
+    assert m.target == SECRETS_TARGET, (
+        f"secrets target must match bootstrap OAW_SECRETS_DIR default "
+        f"({SECRETS_TARGET}), got {m.target!r}"
+    )
+    # The docker -v rendering carries the :ro suffix — the mount is ro at runtime.
+    assert m.to_docker_volume().endswith(":ro"), (
+        f"docker volume spec must end :ro, got {m.to_docker_volume()!r}"
+    )
+
+
+def test_secrets_rw_fragment_is_rejected() -> None:
+    """R-12 red-first: a secrets fragment declared rw fails LOUD in the resolver,
+    so the ro contract cannot be fat-fingered open."""
+    with pytest.raises(mr.ManifestError, match="R-12"):
+        mr.resolve_mount(
+            {
+                "name": "secrets",
+                "layer": "read-only-secrets",
+                "mode": "rw",
+                "source": "~/.secrets",
+                "target": SECRETS_TARGET,
+            },
+            MAJOR,
+            FAKE_HOME,
+        )
+
+
+def test_secrets_never_baked_into_image() -> None:
+    """R-12: no secret is baked into an image layer — the Dockerfile never COPY/ADDs
+    a host secrets path; secrets arrive only through the runtime ro mount.
+
+    Red-first guard: if a future edit bakes ~/.secrets / a .env / a credential,
+    this trips. We scan COPY/ADD instruction lines (not comments, which mention
+    ~/.secrets to *explain* why it is NOT baked)."""
+    assert DOCKERFILE.is_file(), f"missing Dockerfile: {DOCKERFILE}"
+    forbidden = (".secrets", ".env", "secret", "credential", "token", ".pem", ".key")
+    offenders: list[str] = []
+    for raw in DOCKERFILE.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            continue
+        head = line.split(None, 1)[0].upper() if line else ""
+        if head not in {"COPY", "ADD"}:
+            continue
+        low = line.lower()
+        if any(tok in low for tok in forbidden):
+            offenders.append(line)
+    assert not offenders, (
+        "Dockerfile bakes a secret into an image layer (R-12 violation) — "
+        f"secrets must come only via the runtime ro mount:\n" + "\n".join(offenders)
+    )
+
+
+# --- Integration oracle: the named story test (docker-gated) ------------------
+
+
+def _skip_or_fail(msg: str, require: bool) -> None:
+    if require:
+        pytest.fail(msg + " (OAKANDWAVE_REQUIRE_IMAGE set)")
+    pytest.skip(msg)
+
+
+def _docker_and_image_or_skip() -> tuple[str, str]:
+    docker = shutil.which("docker")
+    require = bool(os.environ.get("OAKANDWAVE_REQUIRE_IMAGE"))
+    ref = os.environ.get("OAKANDWAVE_IMAGE", SECRETS_IMAGE)
+    if docker is None:
+        _skip_or_fail("docker binary not found on PATH", require)
+    if (
+        subprocess.run(
+            [docker, "image", "inspect", ref], capture_output=True
+        ).returncode
+        != 0
+    ):
+        _skip_or_fail(
+            f"image {ref!r} not built — run "
+            f"`make -C containers/oakandwave-workflow build`",
+            require,
+        )
+    return docker, ref  # type: ignore[return-value]
+
+
+def test_secrets_readonly() -> None:
+    """IT-02 (R-12/R-13): the container cannot write the ro secrets mount, and a
+    file the host adds mid-session is live inside the running container.
+
+    Runs a long-lived container with ~/.secrets bind-mounted ro, then:
+      1. an in-container write attempt FAILS (R-12: ro — host owns the secret);
+      2. a file the HOST adds AFTER the container started is readable inside it
+         with no restart (R-13: liveness).
+    Self-skips without docker/the image; OAKANDWAVE_REQUIRE_IMAGE makes absence a
+    hard failure so CI proves the contract.
+    """
+    docker, ref = _docker_and_image_or_skip()
+
+    with tempfile.TemporaryDirectory() as host_secrets:
+        # Seed one secret present at launch; add another AFTER launch for R-13.
+        (Path(host_secrets) / "AT_BOOT").write_text("boot-value\n")
+
+        cid = subprocess.run(
+            [
+                docker, "run", "-d", "--rm",
+                "-v", f"{host_secrets}:{SECRETS_TARGET}:ro",
+                "--entrypoint", "sh", ref,
+                "-c", "sleep 60",
+            ],
+            capture_output=True, text=True, timeout=120,
+        )
+        assert cid.returncode == 0, f"failed to start container:\n{cid.stderr}"
+        container = cid.stdout.strip()
+        try:
+            def _exec(script: str) -> subprocess.CompletedProcess:
+                return subprocess.run(
+                    [docker, "exec", container, "sh", "-c", script],
+                    capture_output=True, text=True, timeout=60,
+                )
+
+            # (0) the at-boot secret is readable inside the container.
+            boot = _exec(f"cat {SECRETS_TARGET}/AT_BOOT")
+            assert boot.returncode == 0 and "boot-value" in boot.stdout, (
+                f"at-boot secret not readable in container:\n{boot.stderr}"
+            )
+
+            # (1) R-12: an in-container write to the ro mount FAILS.
+            write = _exec(f"echo x > {SECRETS_TARGET}/should_fail")
+            assert write.returncode != 0, (
+                "container wrote to the ro secrets mount — R-12 violated "
+                "(the mount is not read-only)"
+            )
+            assert not (Path(host_secrets) / "should_fail").exists(), (
+                "a file appeared on the host — the ro mount let a write through"
+            )
+
+            # (2) R-13: a host-added file mid-session is live in the container.
+            (Path(host_secrets) / "MID_SESSION").write_text("live-add\n")
+            live = _exec(f"cat {SECRETS_TARGET}/MID_SESSION")
+            assert live.returncode == 0 and "live-add" in live.stdout, (
+                "host-added secret not visible in the running container — R-13 "
+                f"liveness violated:\n{live.stderr}"
+            )
+        finally:
+            subprocess.run(
+                [docker, "rm", "-f", container], capture_output=True, timeout=60
+            )


### PR DESCRIPTION
## Summary
Wave P1W2 flight for Story 1.5 (#965). Adds the read-only secrets mount fragment (`20-secrets.toml`), consuming the `read-only-secrets` layer + R-12 fail-loud guard already provided by the #963 mount resolver. Proves mid-session secret liveness (R-13) and that no secret is baked into an image layer (R-12).

## Changes
- Add `containers/oakandwave-workflow/mounts.d/20-secrets.toml` — whole `~/.secrets` dir as a single `ro` bind-mount (R-12/R-13).
- Update `mounts.d/README.md`, `docs/contained-workflow/architecture.md`, `docs/contained-workflow/manual-verification.md`.
- Add `tests/contained-workflow/test_secrets.py` (216 lines) — R-12 ro contract, rw-fragment rejection, no-secret-in-image-layer, bootstrap `OAW_SECRETS_DIR` target match.

## Linked Issues
Closes #965

## Test Plan
- `commutativity_verify` single-target vs `kahuna/959-contained-workflow`: STRONG.
- Interface subset (`test_secrets.py` + `test_mounts.py` + `test_ownership.py`): 19 passed — confirms 965 consumes #963's `resolve_manifest`/`resolve_mount`/`ResolvedMount` interface with no signature break.
- Full `pytest tests/` run for the composed diff.