### PR TITLE
promote(P1W2): mount resolver + bootstrap + secrets → main (Plan #959)

### DIFF
--- a/containers/oakandwave-workflow/README.md
+++ b/containers/oakandwave-workflow/README.md
@@ -85,8 +85,13 @@ throwaway-CI ring arrive in Phase 2 (Stories 2.1, 2.2).
 
 - **Kit MCP servers are not baked.** `./install` runs with `--no-mcps`: the kit's
   MCP servers install from private `Wave-Engineering/*` repos over the network,
-  which is non-hermetic and needs build-time credentials. Baking them (R-06/R-09)
-  is tracked with the mount-manifest / MCP-scoping work (Story 1.3, #963).
+  which is non-hermetic and needs build-time credentials. Story 1.3 (#963)
+  delivers the *scoping* half of R-09 — the mount manifest + resolver and the
+  additive composition of third-party/user MCPs (`mounts.d/`, `mount_resolver.py`).
+  Actually *baking* the kit's own MCP registrations into the image (the other
+  half of R-09) rides with the CI build (Story 2.1, #966), where build-time
+  private-repo credentials are already in play; the resolver already documents
+  the stable baked image paths those registrations target.
 - **Root-scoped runtimes.** The base installs `bun`/`node`/`uv`/`cargo` under
   `/root`, which the uid-1000 user cannot reach. The baked kit (skills, scripts,
   hooks) needs only `python3` + the system toolchain, so this does not affect the

--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+#
+# bootstrap.sh — the container bootstrap (Story 1.4, #964, Plan #959).
+#
+# Runs before the agent (via the aoe-hooks seam — open probe Dev Spec §5.N#5) and
+# performs, in order: env validation, skills symlink-sync, settings.local merge,
+# and secret sourcing + required-secret validation. It is the load-bearing
+# instrument the whole container leans on (SKETCHBOOK D7), so it is written to the
+# **assertion-liveness** discipline from line one:
+#
+#   Every silent-skip path becomes a LOGGED or FAILING condition — never a check
+#   that "reported fine and did nothing." The four enumerated silent-skips
+#   (Dev Spec §5.4 / SKETCHBOOK D7) each have an explicit guard here:
+#
+#     missing mount   -> WARN "missing mount: ..."         (logged, tolerated)
+#     shadowed skill  -> WARN "skills-sync collision: ..." (logged, image wins)
+#     dangling link   -> WARN "dangling symlink: ..."      (logged)
+#     missing secret  -> FATAL "required secret missing"   (fails loud, R-14)
+#
+# Skills-sync (SKETCHBOOK D5): the image bakes skills (versioned, R-06); a host
+# overlay may *fill gaps*. The sync is **image-wins / host-fills**: for each host
+# skill with no same-named image skill, symlink it into the image skills dir using
+# its FULL target path (never a bare basename — the D5 self-reference bug); a host
+# skill that collides with an image skill is shadowed (image wins) and LOGGED.
+# Skills are symlink-safe artifacts (scripts/markdown, not compiled binaries), so
+# symlinking them across the host/container boundary is R-10-correct.
+#
+# Secrets (SKETCHBOOK D6, R-12/R-14): the whole ~/.secrets dir is a read-only
+# bind-mount. `.env` is the env modality (sourced here); loose files are the path
+# modality (NEVER auto-exported to env — that re-leaks via /proc/<pid>/environ).
+# A values-free manifest declares which secrets are required; any required secret
+# missing at boot fails loud.
+#
+# Every path is env-injectable (defaults derived from $HOME) so the oracle
+# (tests/contained-workflow/test_bootstrap.py) drives this for real with fake
+# dirs — no docker — exactly like the mount-resolver unit oracle. Config knobs:
+#
+#   OAW_HOME                        root (default: $HOME)
+#   OAW_SKILLS_IMAGE                baked skills, image-wins (default: $HOME/.claude/skills)
+#   OAW_SKILLS_HOST                 host skills overlay, fills gaps
+#                                   (default: $HOME/.oaw/.claude/skills)
+#   OAW_SETTINGS_JSON               baked hook wiring (default: $HOME/.claude/settings.json)
+#   OAW_SETTINGS_LOCAL              shared knobs mount
+#                                   (default: $HOME/.claude/settings.local.json)
+#   OAW_SECRETS_DIR                 ro secrets mount (default: $HOME/.secrets)
+#   OAW_REQUIRED_SECRETS            whitespace-separated required secret names (wins)
+#   OAW_REQUIRED_SECRETS_MANIFEST   values-free manifest file, one name per line,
+#                                   `#` comments allowed
+#                                   (default: $OAW_SECRETS_DIR/required.manifest)
+#   OAW_REQUIRED_ENV                whitespace-separated required env vars (default: HOME)
+
+set -euo pipefail
+
+WARN_COUNT=0
+FATAL_COUNT=0
+COLLISION_COUNT=0
+DANGLING_COUNT=0
+
+info() { echo "[bootstrap] INFO: $*" >&2; }
+
+warn() {
+	echo "[bootstrap] WARN: $*" >&2
+	WARN_COUNT=$((WARN_COUNT + 1))
+}
+
+# fatal LOGS loud but does NOT exit immediately — we accumulate every fatal so the
+# operator sees the full list in one boot, then exit non-zero at the end.
+fatal() {
+	echo "[bootstrap] FATAL: $*" >&2
+	FATAL_COUNT=$((FATAL_COUNT + 1))
+}
+
+# --- Config resolution --------------------------------------------------------
+
+OAW_HOME="${OAW_HOME:-${HOME:-}}"
+if [[ -z "$OAW_HOME" ]]; then
+	echo "[bootstrap] FATAL: neither OAW_HOME nor HOME is set — cannot resolve paths" >&2
+	exit 1
+fi
+
+OAW_SKILLS_IMAGE="${OAW_SKILLS_IMAGE:-$OAW_HOME/.claude/skills}"
+OAW_SKILLS_HOST="${OAW_SKILLS_HOST:-$OAW_HOME/.oaw/.claude/skills}"
+OAW_SETTINGS_JSON="${OAW_SETTINGS_JSON:-$OAW_HOME/.claude/settings.json}"
+OAW_SETTINGS_LOCAL="${OAW_SETTINGS_LOCAL:-$OAW_HOME/.claude/settings.local.json}"
+OAW_SECRETS_DIR="${OAW_SECRETS_DIR:-$OAW_HOME/.secrets}"
+OAW_REQUIRED_SECRETS_MANIFEST="${OAW_REQUIRED_SECRETS_MANIFEST:-$OAW_SECRETS_DIR/required.manifest}"
+
+# --- Stage 1: env validation --------------------------------------------------
+
+validate_env() {
+	local -a required_env=()
+	IFS=' ' read -r -a required_env <<<"${OAW_REQUIRED_ENV:-HOME}"
+	local name
+	for name in "${required_env[@]:-}"; do
+		[[ -n "$name" ]] || continue
+		if [[ -z "${!name:-}" ]]; then
+			fatal "required env missing: \$$name"
+		else
+			info "env: \$$name set"
+		fi
+	done
+	return 0
+}
+
+# --- Stage 2: skills symlink-sync (image-wins / host-fills, collision-logged) --
+
+# Scan a skills dir for dangling symlinks (a link whose target does not resolve —
+# e.g. the D5 bare-basename self-reference bug, or a stale gap-filler). Each is a
+# silent-skip path made loud.
+scan_dangling() {
+	local dir="$1" link
+	[[ -d "$dir" ]] || return 0
+	shopt -s nullglob
+	for link in "$dir"/*; do
+		# -L true for a symlink; -e false when its target does not resolve.
+		if [[ -L "$link" && ! -e "$link" ]]; then
+			warn "dangling symlink: $link -> $(readlink "$link") (target missing)"
+			DANGLING_COUNT=$((DANGLING_COUNT + 1))
+		fi
+	done
+	shopt -u nullglob
+	return 0
+}
+
+sync_skills() {
+	local host="$OAW_SKILLS_HOST" image="$OAW_SKILLS_IMAGE"
+
+	if [[ ! -d "$host" ]]; then
+		# Missing mount: tolerate it, but say so — and do NOT create dangling
+		# links (SKETCHBOOK D5: "tolerate an absent mount without dangling links").
+		warn "missing mount: host skills overlay not present ($host); skills-sync host-fill skipped"
+		scan_dangling "$image"
+		return 0
+	fi
+
+	mkdir -p "$image"
+
+	local entry name dest cur
+	shopt -s nullglob
+	for entry in "$host"/*; do
+		name="$(basename "$entry")"
+		dest="$image/$name"
+
+		if [[ -L "$dest" ]]; then
+			cur="$(readlink "$dest")"
+			if [[ "$cur" == "$entry" ]]; then
+				# Idempotent re-run: we already linked this gap-filler.
+				info "skills-sync: '$name' already linked (host-fill)"
+				continue
+			fi
+			# A link to something else already occupies the name — image wins.
+			warn "skills-sync collision: host skill '$name' shadowed (image wins)"
+			COLLISION_COUNT=$((COLLISION_COUNT + 1))
+			continue
+		fi
+
+		if [[ -e "$dest" ]]; then
+			# A real baked image skill occupies the name — image wins, host shadowed.
+			warn "skills-sync collision: host skill '$name' shadowed by image (image wins)"
+			COLLISION_COUNT=$((COLLISION_COUNT + 1))
+			continue
+		fi
+
+		# Gap: host fills it. FULL target path (D5 fix — never a bare basename,
+		# which would self-reference into a dangling link).
+		ln -s "$entry" "$dest"
+		info "skills-sync: linked host skill '$name' (host-fill)"
+	done
+	shopt -u nullglob
+
+	scan_dangling "$image"
+	return 0
+}
+
+# --- Stage 3: settings.local merge --------------------------------------------
+
+# Claude Code itself merges settings.json (baked hook wiring) with the mounted
+# settings.local.json (shared knobs) at runtime (architecture.md §3.3). The
+# bootstrap's job is to make the two silent-skip paths loud: a missing
+# settings.local mount, and a malformed settings.local that CC's merge would
+# silently ignore.
+merge_settings() {
+	if [[ -f "$OAW_SETTINGS_JSON" ]]; then
+		info "settings: image settings.json present"
+	else
+		warn "settings: image settings.json not found ($OAW_SETTINGS_JSON) — expected baked in the image"
+	fi
+
+	if [[ ! -f "$OAW_SETTINGS_LOCAL" ]]; then
+		warn "missing mount: settings.local.json not present ($OAW_SETTINGS_LOCAL); Claude Code will use image settings only"
+		return 0
+	fi
+
+	if python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$OAW_SETTINGS_LOCAL" 2>/dev/null; then
+		info "settings: settings.local.json present and valid JSON (Claude Code merges it)"
+	else
+		warn "settings: settings.local.json is not valid JSON ($OAW_SETTINGS_LOCAL) — Claude Code's merge will ignore/error on it"
+	fi
+	return 0
+}
+
+# --- Stage 4: secret sourcing + required-secret validation (R-12/R-14) --------
+
+validate_secrets() {
+	local dir="$OAW_SECRETS_DIR"
+
+	if [[ -d "$dir" ]]; then
+		if [[ -f "$dir/.env" ]]; then
+			# Env modality: source .env so env-var consumers see the values.
+			# Loose files stay path-modality — NEVER auto-exported (D6).
+			set -a
+			# shellcheck disable=SC1090,SC1091
+			. "$dir/.env"
+			set +a
+			info "secrets: sourced $dir/.env (env modality)"
+		fi
+	else
+		warn "missing mount: secrets dir not present ($dir)"
+	fi
+
+	# Required-secrets list: the env override wins; else the values-free manifest.
+	local -a required=()
+	if [[ -n "${OAW_REQUIRED_SECRETS:-}" ]]; then
+		IFS=' ' read -r -a required <<<"$OAW_REQUIRED_SECRETS"
+	elif [[ -f "$OAW_REQUIRED_SECRETS_MANIFEST" ]]; then
+		local line
+		while IFS= read -r line || [[ -n "$line" ]]; do
+			line="${line%%#*}"         # strip comment
+			line="$(xargs <<<"$line")" # trim whitespace
+			[[ -n "$line" ]] && required+=("$line")
+		done <"$OAW_REQUIRED_SECRETS_MANIFEST"
+	fi
+
+	local name
+	for name in "${required[@]:-}"; do
+		[[ -n "$name" ]] || continue
+		if [[ -f "$dir/$name" ]]; then
+			info "secrets: '$name' present (path modality)"
+		elif [[ -n "${!name:-}" ]]; then
+			info "secrets: '$name' present (env modality)"
+		else
+			fatal "required secret missing: '$name' (expected file $dir/$name or env \$$name)"
+		fi
+	done
+	return 0
+}
+
+# --- Main ---------------------------------------------------------------------
+
+main() {
+	info "starting (home=$OAW_HOME)"
+	validate_env
+	sync_skills
+	merge_settings
+	validate_secrets
+
+	echo "bootstrap: ${WARN_COUNT} warning(s) (${COLLISION_COUNT} collision(s), ${DANGLING_COUNT} dangling), ${FATAL_COUNT} fatal(s)"
+
+	if [[ "$FATAL_COUNT" -gt 0 ]]; then
+		echo "[bootstrap] FATAL: $FATAL_COUNT fatal condition(s) — refusing to hand off to the agent" >&2
+		exit 1
+	fi
+	info "complete"
+	return 0
+}
+
+main "$@"

--- a/containers/oakandwave-workflow/mount_resolver.py
+++ b/containers/oakandwave-workflow/mount_resolver.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Mount-manifest resolver — Story 1.3 (#963), Plan #959, Dev Spec §5.3.
+
+The container filesystem is a disposable RTE; every piece of durable state enters
+through a **declarative mount manifest** (``mounts.d/*.toml``) that this module
+resolves into concrete bind-mounts for the bootstrap (Story 1.4) and the aoe
+``[sandbox]`` profile. The manifest is the single source of truth for the
+five-layer state taxonomy (§5.3); this resolver is the guard that keeps each
+layer honest.
+
+Guards (each fails LOUD — assertion-liveness, D7 — never silently degrades):
+
+* **R-03 — sandbox-scoped memory.** The one rw seam into shared durable state
+  (memory) MUST resolve under ``~/.oaw/state/<major>/`` and MUST NOT touch the
+  live-fleet ``~/.claude`` tree. Pointing it at ``~/.claude/projects/*/memory``
+  would hand a broken ``:edge`` candidate write access to the live fleet's
+  memory — the exact shared-mutable-with-live-fleet disease this whole design
+  cures, reintroduced at the single rw seam. Rejected here, red-first.
+
+* **R-10 — libc boundary.** A compiled binary in the user overlay is installed
+  *in* the container (``install = "in-container"``), never symlinked across the
+  host/container libc boundary (a host ELF fails on ``.so``/interpreter mismatch
+  in a differently-built container). Scripts and config may symlink. A
+  compiled-binary artifact declared ``symlink`` is rejected.
+
+* **R-09 / R-11 — additive composition.** Third-party / user MCP servers compose
+  as an *additive fragment* (``compose = "additive"``), never by mounting the
+  whole ``~/.claude.json`` (which carries far more than MCP config). The kit's
+  own MCP registrations are baked at stable image paths, not mounted. The
+  discretionary-tool toolbox (R-11) is a durable, in-container-materialized mount
+  decoupled from the kit release.
+
+The resolver never touches the filesystem to validate a path (sources may not
+exist yet at resolve time); it reasons purely over normalized path text.
+
+CLI::
+
+    python3 mount_resolver.py --major 8                 # docker -v args
+    python3 mount_resolver.py --major 8 --format aoe    # aoe extra_volumes lines
+    python3 mount_resolver.py --major 8 --format json   # structured, for the bootstrap
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+
+# --- Manifest schema constants ------------------------------------------------
+
+MANIFEST_DIR = Path(__file__).resolve().parent / "mounts.d"
+
+# The five-layer state taxonomy (§5.3). "baked-in-image" is not a run mount (it
+# is in the image), so it is not a manifest layer; the four run-layer values are.
+LAYERS = {
+    "shared-mutable-rw",  # memory — the one sandbox-scoped rw seam (R-03)
+    "read-only-secrets",  # ~/.secrets ro mount (wired by Story 1.5)
+    "user-overlay",  # MCP fragment / toolbox / user scripts (R-09/R-10/R-11)
+    "durable-cache",  # CARGO_HOME, GOMODCACHE, uv, ms-playwright (§5.3)
+}
+
+MODES = {"rw", "ro"}
+
+# user-overlay artifact classes and their REQUIRED install mechanism (R-10/R-11).
+#   compiled-binary -> in-container (never symlinked across the libc boundary)
+#   script/config   -> symlink      (portable across the boundary)
+#   mcp-fragment    -> additive     (composed, never a whole-file mount)
+#   toolbox         -> in-container (materialized durable, R-11)
+OVERLAY_INSTALL = {
+    "compiled-binary": "in-container",
+    "script": "symlink",
+    "config": "symlink",
+    "mcp-fragment": "additive",
+    "toolbox": "in-container",
+}
+
+# The sandbox-scoped durable-state root and the live-fleet tree that R-03 fences.
+STATE_ROOT_PARTS = (".oaw", "state")  # ~/.oaw/state/<major>/...
+LIVE_FLEET_ROOT_PART = ".claude"  # ~/.claude/... — never a sandbox mount source
+
+
+class ManifestError(ValueError):
+    """A manifest entry violates the mount contract. Raised LOUD, never swallowed."""
+
+
+@dataclass(frozen=True)
+class ResolvedMount:
+    """A single manifest entry with ``<major>``/``~`` substituted and guards passed."""
+
+    name: str
+    layer: str
+    source: str  # absolute host path
+    target: str  # absolute container path
+    mode: str  # rw | ro
+    artifact: str | None = None
+    install: str | None = None
+    compose: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+
+    def to_docker_volume(self) -> str:
+        """``docker run -v`` spec: ``source:target[:ro]``."""
+        suffix = ":ro" if self.mode == "ro" else ""
+        return f"{self.source}:{self.target}{suffix}"
+
+    def to_aoe_extra_volume(self) -> str:
+        """aoe ``[sandbox].extra_volumes`` entry (same ``-v`` spelling)."""
+        return self.to_docker_volume()
+
+
+# --- Path helpers (text-only; never hit the filesystem) -----------------------
+
+
+def _expand(raw: str, major: int | str, home: PurePosixPath) -> str:
+    """Substitute ``<major>``, ``~`` and ``$HOME`` in a manifest path string.
+
+    Uses the *provided* home (so tests inject a fake one) rather than the process
+    environment. Returns a normalized absolute POSIX path string.
+    """
+    s = raw.replace("<major>", str(major))
+    if s == "~" or s.startswith("~/"):
+        s = str(home) + s[1:]
+    s = s.replace("$HOME", str(home))
+    if not s.startswith("/"):
+        raise ManifestError(
+            f"path must resolve absolute after expansion, got {s!r} (from {raw!r})"
+        )
+    return os.path.normpath(s)
+
+
+def _is_under(child: str, parent: PurePosixPath) -> bool:
+    """True iff normalized ``child`` is ``parent`` or lives beneath it."""
+    c = PurePosixPath(os.path.normpath(child))
+    p = PurePosixPath(os.path.normpath(str(parent)))
+    return c == p or p in c.parents
+
+
+def is_compiled_binary(path: str | os.PathLike) -> bool:
+    """Classify a ``~/.local/bin`` entry for R-10 routing.
+
+    Reads the leading magic bytes: an ELF (``\\x7fELF``) is a compiled binary
+    (install in-container); a ``#!`` shebang is a script (symlink-safe). Anything
+    unreadable/absent is treated conservatively as *not* a plain script, so it is
+    not blindly symlinked across the libc boundary.
+
+    This is the runtime primitive the bootstrap (Story 1.4) uses to route each
+    overlay artifact; the manifest declares the mechanism per *layer*, this
+    classifies an individual *file*.
+    """
+    try:
+        with open(path, "rb") as fh:
+            magic = fh.read(4)
+    except OSError:
+        return True  # conservative: don't symlink something we can't read
+    if magic[:4] == b"\x7fELF":
+        return True
+    if magic[:2] == b"#!":
+        return False
+    # Unknown magic: treat as a binary (safer to install-in-container than to
+    # symlink a possible ELF across the boundary).
+    return True
+
+
+# --- Per-guard validators (individually callable so tests can target them) -----
+
+
+def check_sandbox_scoped_memory(source: str, major: int | str, home: PurePosixPath) -> None:
+    """R-03: a sandbox-scoped rw source is under ``~/.oaw/state/<major>/`` and
+    never inside the live-fleet ``~/.claude`` tree. Raises on violation."""
+    state_root = home.joinpath(*STATE_ROOT_PARTS, str(major))
+    live_root = home.joinpath(LIVE_FLEET_ROOT_PART)
+
+    if _is_under(source, live_root):
+        raise ManifestError(
+            f"R-03 VIOLATION: sandbox memory source {source!r} is inside the "
+            f"live-fleet tree {str(live_root)!r}. The rw memory mount must NEVER "
+            f"point at ~/.claude (e.g. ~/.claude/projects/*/memory) — a broken "
+            f":edge candidate would gain write access to the live fleet's memory. "
+            f"Use a sandbox-scoped path under ~/.oaw/state/<major>/."
+        )
+    if not _is_under(source, state_root):
+        raise ManifestError(
+            f"R-03 VIOLATION: sandbox memory source {source!r} is not under the "
+            f"sandbox-scoped state root {str(state_root)!r}. The one rw seam into "
+            f"durable state must live under ~/.oaw/state/<major>/ so the major "
+            f"partitions the namespace (R-20)."
+        )
+
+
+def check_overlay_install(entry: dict) -> None:
+    """R-10/R-11: a user-overlay entry's install mechanism matches its artifact.
+
+    compiled-binary/toolbox -> in-container; script/config -> symlink;
+    mcp-fragment -> additive. A compiled binary declared ``symlink`` is the R-10
+    libc-boundary bug and is rejected."""
+    artifact = entry.get("artifact")
+    if artifact is None:
+        raise ManifestError(
+            f"user-overlay mount {entry.get('name')!r} must declare an `artifact` "
+            f"(one of {sorted(OVERLAY_INSTALL)})"
+        )
+    if artifact not in OVERLAY_INSTALL:
+        raise ManifestError(
+            f"user-overlay mount {entry.get('name')!r} has unknown artifact "
+            f"{artifact!r}; expected one of {sorted(OVERLAY_INSTALL)}"
+        )
+    required = OVERLAY_INSTALL[artifact]
+    declared = entry.get("install", required)
+    if declared != required:
+        raise ManifestError(
+            f"R-10 VIOLATION: user-overlay mount {entry.get('name')!r} is a "
+            f"{artifact!r} but declares install={declared!r}; it MUST be "
+            f"{required!r}. A compiled binary symlinked across the host/container "
+            f"libc boundary fails on .so/interpreter mismatch — install it "
+            f"in-container instead."
+        )
+
+
+def check_mcp_additive(entry: dict, source: str) -> None:
+    """R-09/R-11: an MCP overlay is an additive *fragment*, never the whole
+    ``~/.claude.json``. Raises on violation."""
+    if entry.get("compose") != "additive":
+        raise ManifestError(
+            f"R-09 VIOLATION: MCP overlay {entry.get('name')!r} must set "
+            f"compose='additive' — third-party/user MCPs compose additively with "
+            f"the baked kit registrations, they never replace them."
+        )
+    if PurePosixPath(source).name == ".claude.json":
+        raise ManifestError(
+            f"R-09 VIOLATION: MCP overlay {entry.get('name')!r} mounts the whole "
+            f"~/.claude.json ({source!r}); mount only an MCP *fragment*. "
+            f"~/.claude.json carries far more than MCP config (see docs/mcp-scoping.md)."
+        )
+
+
+# --- Manifest load + resolve --------------------------------------------------
+
+
+def load_manifest(mounts_dir: Path = MANIFEST_DIR) -> list[dict]:
+    """Load every ``*.toml`` fragment in ``mounts_dir``, filename-sorted.
+
+    Drop-in ordering: ``NN-name.toml`` fragments apply in lexical order so an
+    operator can slot a fragment deterministically. Each file may hold one or
+    more ``[[mount]]`` tables."""
+    if not mounts_dir.is_dir():
+        raise ManifestError(f"mounts.d manifest directory not found: {mounts_dir}")
+    mounts: list[dict] = []
+    for toml_path in sorted(mounts_dir.glob("*.toml")):
+        with toml_path.open("rb") as fh:
+            data = tomllib.load(fh)
+        for entry in data.get("mount", []):
+            entry = dict(entry)
+            entry.setdefault("_fragment", toml_path.name)
+            mounts.append(entry)
+    return mounts
+
+
+def resolve_mount(entry: dict, major: int | str, home: PurePosixPath) -> ResolvedMount:
+    """Validate + resolve one manifest entry into a ``ResolvedMount`` (all guards
+    applied). Raises ``ManifestError`` on any contract violation."""
+    name = entry.get("name")
+    if not name:
+        raise ManifestError(f"mount entry missing `name`: {entry!r}")
+    layer = entry.get("layer")
+    if layer not in LAYERS:
+        raise ManifestError(
+            f"mount {name!r} has invalid layer {layer!r}; expected one of {sorted(LAYERS)}"
+        )
+    mode = entry.get("mode")
+    if mode not in MODES:
+        raise ManifestError(
+            f"mount {name!r} has invalid mode {mode!r}; expected one of {sorted(MODES)}"
+        )
+    raw_source = entry.get("source")
+    raw_target = entry.get("target")
+    if not raw_source or not raw_target:
+        raise ManifestError(f"mount {name!r} must declare both `source` and `target`")
+
+    source = _expand(raw_source, major, home)
+    target = _expand(raw_target, major, home)
+
+    # R-03: the shared-mutable-rw seam (and anything explicitly sandbox_scoped)
+    # must resolve sandbox-scoped and clear of the live-fleet tree.
+    if layer == "shared-mutable-rw" or entry.get("sandbox_scoped"):
+        check_sandbox_scoped_memory(source, major, home)
+
+    # read-only-secrets is inherently ro (fail loud if a fragment says otherwise).
+    if layer == "read-only-secrets" and mode != "ro":
+        raise ManifestError(
+            f"R-12 VIOLATION: secrets mount {name!r} must be mode='ro'; got {mode!r}"
+        )
+
+    artifact = entry.get("artifact")
+    install = entry.get("install")
+    compose = entry.get("compose")
+    if layer == "user-overlay":
+        check_overlay_install(entry)
+        install = entry.get("install", OVERLAY_INSTALL[artifact])
+        if artifact == "mcp-fragment":
+            check_mcp_additive(entry, source)
+
+    env = entry.get("env") or {}
+    if not isinstance(env, dict):
+        raise ManifestError(f"mount {name!r} `env` must be a table, got {type(env).__name__}")
+
+    return ResolvedMount(
+        name=name,
+        layer=layer,
+        source=source,
+        target=target,
+        mode=mode,
+        artifact=artifact,
+        install=install,
+        compose=compose,
+        env={str(k): str(v) for k, v in env.items()},
+    )
+
+
+def resolve_manifest(
+    major: int | str,
+    home: str | os.PathLike | None = None,
+    mounts_dir: Path = MANIFEST_DIR,
+) -> list[ResolvedMount]:
+    """Load and fully resolve the manifest for a given kit ``major`` version.
+
+    ``home`` defaults to the runtime user's ``$HOME``; tests inject a fake root.
+    """
+    home_path = PurePosixPath(str(home) if home is not None else os.path.expanduser("~"))
+    return [resolve_mount(e, major, home_path) for e in load_manifest(mounts_dir)]
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def _major_from(value: str) -> int:
+    """Accept a bare major (``8``) or a full semver (``8.1.0``) → major int."""
+    head = value.split(".", 1)[0]
+    try:
+        return int(head)
+    except ValueError as exc:  # noqa: TRY003
+        raise SystemExit(f"--major must be an int or semver, got {value!r}") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--major",
+        required=True,
+        help="kit major version (int) or full semver (major extracted)",
+    )
+    parser.add_argument("--home", default=None, help="override $HOME (test/dry-run)")
+    parser.add_argument(
+        "--format",
+        choices=("docker", "aoe", "json"),
+        default="docker",
+        help="output shape (default: docker -v args)",
+    )
+    parser.add_argument(
+        "--mounts-dir",
+        default=str(MANIFEST_DIR),
+        help="manifest directory (default: ./mounts.d)",
+    )
+    args = parser.parse_args(argv)
+
+    major = _major_from(args.major)
+    try:
+        resolved = resolve_manifest(major, home=args.home, mounts_dir=Path(args.mounts_dir))
+    except ManifestError as exc:
+        print(f"mount-manifest error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        payload = [
+            {
+                "name": m.name,
+                "layer": m.layer,
+                "source": m.source,
+                "target": m.target,
+                "mode": m.mode,
+                "artifact": m.artifact,
+                "install": m.install,
+                "compose": m.compose,
+                "env": m.env,
+            }
+            for m in resolved
+        ]
+        print(json.dumps(payload, indent=2))
+    elif args.format == "aoe":
+        for m in resolved:
+            print(m.to_aoe_extra_volume())
+    else:  # docker
+        for m in resolved:
+            print(f"-v {m.to_docker_volume()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/containers/oakandwave-workflow/mounts.d/10-memory.toml
+++ b/containers/oakandwave-workflow/mounts.d/10-memory.toml
@@ -1,0 +1,27 @@
+# 10-memory.toml — shared-mutable-rw memory (Dev Spec §5.3, R-03, R-20).
+#
+# The ONE rw seam into shared durable state. Its host source is sandbox-scoped
+# under ~/.oaw/state/<major>/ — NEVER the live-fleet ~/.claude/projects/*/memory
+# tree. mount_resolver.py fails LOUD (check_sandbox_scoped_memory) if a future
+# edit points this at ~/.claude: a broken :edge candidate must never gain write
+# access to the live fleet's memory. The <major> segment partitions the state
+# namespace so mixing majors is isolated, not corrupting (R-20).
+
+[[mount]]
+name = "memory"
+layer = "shared-mutable-rw"
+mode = "rw"
+sandbox_scoped = true
+source = "~/.oaw/state/<major>/memory"
+target = "/home/ubuntu/.claude/projects/_sandbox/memory"
+
+# settings.local.json — the genuinely-shared knobs (permissions / env / identity).
+# settings.json (hook wiring) is BAKED in the image (versioned); Claude Code
+# merges the two. This half is host-backed and sandbox-scoped like memory.
+[[mount]]
+name = "settings-local"
+layer = "shared-mutable-rw"
+mode = "rw"
+sandbox_scoped = true
+source = "~/.oaw/state/<major>/settings.local.json"
+target = "/home/ubuntu/.claude/settings.local.json"

--- a/containers/oakandwave-workflow/mounts.d/20-secrets.toml
+++ b/containers/oakandwave-workflow/mounts.d/20-secrets.toml
@@ -1,0 +1,36 @@
+# 20-secrets.toml — read-only secrets (Dev Spec §5.5, Story 1.5 #965, R-12/R-13).
+#
+# The whole ~/.secrets dir enters as ONE read-only bind-mount. Secrets are NEVER
+# baked into an image layer (R-12) — the image is the release and ships to every
+# ring/registry; a baked secret would leak with the digest. They are provided
+# only at runtime, via this mount. mount_resolver.py fails LOUD if a future edit
+# flips this to mode = "rw" (check: read-only-secrets + mode != ro -> R-12).
+#
+# Liveness (R-13): a bind-mount is the host dir, so a file the host adds to
+# ~/.secrets mid-session is visible to the running container with no restart.
+# That liveness is REAL for file-path consumers (they re-read the file); it is
+# NOT retroactive for env-var consumers — bootstrap.sh sources ~/.secrets/.env
+# once at boot (env modality), so a value added after boot reaches only path
+# consumers until the next process re-source. Hence the consumer split below:
+#
+#   .env         -> env modality  : sourced once at boot; env-var consumers.
+#   loose files  -> path modality : read on demand; FULLY live (R-13). PREFER.
+#
+# Blast-radius tradeoff (open item, §5.N / architecture.md §3.5): mounting the
+# WHOLE dir means every ring — and every process in the container, across the
+# GitLab/GitHub IP boundary — sees every secret. Least-privilege per-secret
+# scoping is a deliberate open design item; this whole-dir layer is where a
+# future scoped mechanism slots in. The mount stays ro so no ring can mutate a
+# shared secret.
+#
+# The target matches bootstrap.sh's OAW_SECRETS_DIR default ($HOME/.secrets), so
+# secret sourcing + required-secret validation (R-14) find the dir with no extra
+# env wiring. A values-free required.manifest lives inside the dir (mounted with
+# it) and drives the fail-loud missing-secret check.
+
+[[mount]]
+name = "secrets"
+layer = "read-only-secrets"
+mode = "ro"
+source = "~/.secrets"
+target = "/home/ubuntu/.secrets"

--- a/containers/oakandwave-workflow/mounts.d/30-user-overlay.toml
+++ b/containers/oakandwave-workflow/mounts.d/30-user-overlay.toml
@@ -1,0 +1,51 @@
+# 30-user-overlay.toml — the user-environment overlay (Dev Spec §5.3, D4a).
+#
+# The fourth state axis: the user's OWN environment — their MCP servers, their
+# non-kit scripts, their discretionary dev tools. The kit ships an *extensible
+# base* (PC-4), so adopters compose here without touching a kit release. Three
+# mechanisms, by artifact type — enforced by mount_resolver.check_overlay_install:
+#
+#   compiled-binary -> in-container   (never symlinked across the libc boundary, R-10)
+#   script / config -> symlink        (portable across the boundary)
+#   mcp-fragment    -> additive       (composed with baked kit MCPs, never whole-file, R-09)
+#   toolbox         -> in-container   (durable, materialized by a declarative manifest, R-11)
+
+# --- Third-party / user MCP servers (R-09) -----------------------------------
+# Composes ADDITIVELY with the kit's own MCP registrations (disc-server,
+# sdlc-server, wtf-server, nerf-server, discord-watcher) which are BAKED at
+# stable image paths — baking kills the dangling-registration bug (a stale path
+# to a moved binary). We mount only an MCP *fragment*, never the whole
+# ~/.claude.json (which carries far more than MCP config). See docs/mcp-scoping.md.
+[[mount]]
+name = "mcp-fragment"
+layer = "user-overlay"
+artifact = "mcp-fragment"
+compose = "additive"
+mode = "ro"
+source = "~/.oaw/overlay/<major>/mcp.json"
+target = "/home/ubuntu/.oaw/overlay/mcp.json"
+
+# --- Discretionary dev-tool toolbox (R-11) -----------------------------------
+# A declarative manifest (mise / apt-list) an in-container installer materializes
+# into this durable dir. Decoupled from kit releases (updating ripgrep is not a
+# kit release), reproducible on a fresh box, user-owned.
+[[mount]]
+name = "toolbox"
+layer = "user-overlay"
+artifact = "toolbox"
+mode = "rw"
+source = "~/.oaw/toolbox/<major>"
+target = "/home/ubuntu/.oaw/toolbox"
+
+# --- User's non-kit shebang scripts (symlink-safe config) --------------------
+# ~/.local/bin is ~154 shebang scripts (symlink-safe) + ~26 ELF (hazard). This
+# mount carries the SCRIPT half; the bootstrap (Story 1.4) routes each entry with
+# mount_resolver.is_compiled_binary — ELF go in-container, shebangs symlink.
+[[mount]]
+name = "user-scripts"
+layer = "user-overlay"
+artifact = "script"
+install = "symlink"
+mode = "rw"
+source = "~/.oaw/overlay/<major>/local-bin"
+target = "/home/ubuntu/.oaw/overlay/local-bin"

--- a/containers/oakandwave-workflow/mounts.d/40-durable-caches.toml
+++ b/containers/oakandwave-workflow/mounts.d/40-durable-caches.toml
@@ -1,0 +1,39 @@
+# 40-durable-caches.toml — durable caches (Dev Spec §5.3).
+#
+# The container filesystem is disposable; these caches survive `docker rm` on a
+# host-backed mount so a candidate recreate does not re-download the world. Each
+# is sandbox-scoped under ~/.oaw/cache/<major>/ (major-partitioned like state)
+# and, where the tool reads an env var, declares it so the bootstrap (Story 1.4)
+# can export it. These are caches, not shared durable STATE, so they are not
+# under the R-03 sandbox-scoped-memory guard — but keeping them off the live tree
+# is still the right hygiene.
+
+[[mount]]
+name = "cargo"
+layer = "durable-cache"
+mode = "rw"
+source = "~/.oaw/cache/<major>/cargo"
+target = "/home/ubuntu/.cargo"
+env = { CARGO_HOME = "/home/ubuntu/.cargo" }
+
+[[mount]]
+name = "go-mod-cache"
+layer = "durable-cache"
+mode = "rw"
+source = "~/.oaw/cache/<major>/go-mod"
+target = "/home/ubuntu/go/pkg/mod"
+env = { GOMODCACHE = "/home/ubuntu/go/pkg/mod" }
+
+[[mount]]
+name = "uv-cache"
+layer = "durable-cache"
+mode = "rw"
+source = "~/.oaw/cache/<major>/uv"
+target = "/home/ubuntu/.cache/uv"
+
+[[mount]]
+name = "ms-playwright"
+layer = "durable-cache"
+mode = "rw"
+source = "~/.oaw/cache/<major>/ms-playwright"
+target = "/home/ubuntu/.cache/ms-playwright"

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -1,0 +1,50 @@
+# `mounts.d/` — the mount manifest
+
+Declarative, drop-in manifest for the container's **run-layer** mounts (Dev Spec
+§5.3, Story 1.3 #963). The container filesystem is a disposable RTE; every piece
+of durable state enters through a mount declared here. `../mount_resolver.py`
+loads these fragments, substitutes `<major>` and `~`, enforces the mount
+contract, and emits `docker -v` / aoe `extra_volumes` specs for the bootstrap
+(Story 1.4).
+
+## Ordering
+
+Fragments apply in **lexical filename order** — the `NN-name.toml` prefix slots a
+fragment deterministically. Each file holds one or more `[[mount]]` tables.
+
+## Entry schema
+
+| key | required | values | meaning |
+|-----|----------|--------|---------|
+| `name` | yes | string | mount identifier |
+| `layer` | yes | `shared-mutable-rw` \| `read-only-secrets` \| `user-overlay` \| `durable-cache` | which of the four run-layers (§5.3) |
+| `mode` | yes | `rw` \| `ro` | bind-mount mode |
+| `source` | yes | path | host source; `<major>` and `~` are substituted |
+| `target` | yes | path | container mount point |
+| `sandbox_scoped` | no | bool | opt a mount into the R-03 sandbox-scoped guard (implicit for `shared-mutable-rw`) |
+| `artifact` | user-overlay only | `compiled-binary` \| `script` \| `config` \| `mcp-fragment` \| `toolbox` | classifies the overlay artifact (drives the install mechanism, R-10/R-11) |
+| `install` | no | `in-container` \| `symlink` \| `additive` | install mechanism; defaults from `artifact`, and a mismatch is rejected |
+| `compose` | mcp-fragment | `additive` | MCP fragments compose additively, never whole-file (R-09) |
+| `env` | no | table | env vars this mount implies (e.g. `CARGO_HOME`) |
+
+## Guards (each fails loud — see `../mount_resolver.py`)
+
+- **R-03** — a `shared-mutable-rw` (or `sandbox_scoped`) source must resolve under
+  `~/.oaw/state/<major>/` and **never** inside the live-fleet `~/.claude` tree.
+- **R-10** — a `compiled-binary` overlay artifact installs `in-container`, never
+  `symlink` (host ELF fails on the libc boundary); scripts/config symlink.
+- **R-09 / R-11** — an `mcp-fragment` composes `additive` and is never the whole
+  `~/.claude.json`; the `toolbox` is a durable in-container-materialized mount.
+
+## Fragments here
+
+| file | layer | owner story |
+|------|-------|-------------|
+| `10-memory.toml` | shared-mutable-rw (memory + `settings.local.json`) | 1.3 (#963) |
+| `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |
+| `40-durable-caches.toml` | durable-cache (cargo, go-mod, uv, ms-playwright) | 1.3 (#963) |
+
+**`20-secrets.toml`** (the `read-only-secrets` layer — the ro `~/.secrets` dir
+mount) lands with **Story 1.5 (#965)**; the resolver already supports the
+`read-only-secrets` layer (and enforces `mode = "ro"`), so that story is a
+drop-in fragment, no resolver change.

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -41,10 +41,12 @@ fragment deterministically. Each file holds one or more `[[mount]]` tables.
 | file | layer | owner story |
 |------|-------|-------------|
 | `10-memory.toml` | shared-mutable-rw (memory + `settings.local.json`) | 1.3 (#963) |
+| `20-secrets.toml` | read-only-secrets (ro `~/.secrets` dir mount) | 1.5 (#965) |
 | `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |
 | `40-durable-caches.toml` | durable-cache (cargo, go-mod, uv, ms-playwright) | 1.3 (#963) |
 
-**`20-secrets.toml`** (the `read-only-secrets` layer — the ro `~/.secrets` dir
-mount) lands with **Story 1.5 (#965)**; the resolver already supports the
-`read-only-secrets` layer (and enforces `mode = "ro"`), so that story is a
-drop-in fragment, no resolver change.
+`20-secrets.toml` was a drop-in for Story 1.3's resolver: the
+`read-only-secrets` layer and its `mode = "ro"` enforcement (R-12) already
+existed, so Story 1.5 added only the fragment (no resolver change). The whole
+`~/.secrets` dir mounts ro; a host-added file is live mid-session (R-13) — see
+`architecture.md` §3.5 for the consumer split and blast-radius tradeoff.

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -83,7 +83,7 @@ flowchart LR
     s2["memory + settings.local<br/>~/.oaw/state/&lt;major&gt;/  (R-03)"]
   end
   subgraph ro["3 · read-only-secrets"]
-    s3["~/.secrets (ro)  ·  Story 1.5"]
+    s3["~/.secrets (ro)  ·  §3.5"]
   end
   subgraph ov["4 · user-environment overlay"]
     s4["MCP fragment (additive, R-09)<br/>toolbox (in-container, R-11)<br/>scripts (symlink, R-10)"]
@@ -99,7 +99,7 @@ flowchart LR
 |-------|-----------|-------------------|--------------|
 | Baked-in-image | Built by `./install` in the image; immutable per tag | *(none — in the image)* | R-06, R-09 |
 | Shared-mutable-rw | rw bind-mount, **sandbox-scoped** host source | `10-memory.toml` | R-03, R-20 |
-| Read-only secrets | ro bind-mount of the `~/.secrets` dir | `20-secrets.toml` *(Story 1.5)* | R-12, R-13 |
+| Read-only secrets | ro bind-mount of the `~/.secrets` dir (§3.5) | `20-secrets.toml` | R-12, R-13, R-14 |
 | User-environment overlay | additive / in-container / symlink, by artifact type | `30-user-overlay.toml` | R-09, R-10, R-11 |
 | Durable caches | rw bind-mount, major-partitioned | `40-durable-caches.toml` | §5.3 |
 
@@ -156,6 +156,46 @@ Kit binaries (from the image) win over the user overlay on `PATH`, so the RTE
 stays authoritative — the same digest-determines-behavior rule that the promotion
 gate depends on (Dev Spec §5.3).
 
+### 3.5 Secrets: the read-only mount (Story 1.5)
+
+The whole `~/.secrets` dir enters as **one read-only bind-mount**
+([`20-secrets.toml`](../../containers/oakandwave-workflow/mounts.d/20-secrets.toml))
+targeting `/home/ubuntu/.secrets` — the default the bootstrap's `OAW_SECRETS_DIR`
+already resolves (Dev Spec §5.5).
+
+- **Never baked (R-12).** The image *is* the release: it ships to every ring and
+  registry, so a secret baked into any layer would leak with the digest. Secrets
+  are provided **only** through this runtime mount; the image `RUN` deliberately
+  tolerates `check-deps`' missing-token advisory rather than baking the tokens
+  (Dockerfile §"Bake the kit"). The resolver enforces the ro half — a fragment
+  fat-fingered to `mode = "rw"` raises `R-12 VIOLATION` (`test_secrets_rw_fragment_is_rejected`).
+- **Live mid-session (R-13).** A bind-mount *is* the host dir, so a file the host
+  adds to `~/.secrets` after the container started is visible inside the running
+  container with no restart — proven by `test_secrets_readonly` (IT-02) and MV-07.
+- **Fail-loud on a missing required secret (R-14).** A values-free
+  `required.manifest` inside the dir (mounted with it) drives the bootstrap's
+  required-secret check (Story 1.4); a missing required secret aborts the boot.
+
+**Consumer split (the load-bearing nuance).** The mount is live, but *how* live
+depends on how a consumer reads a secret:
+
+| Modality | Source | Liveness |
+|----------|--------|----------|
+| **path** | a loose file `~/.secrets/<NAME>`, read on demand | **fully live** (R-13) — the consumer re-reads the file |
+| **env** | `~/.secrets/.env`, sourced once by `bootstrap.sh` at boot | snapshot-at-boot — a value added *after* boot reaches only path consumers until the next re-source |
+
+So **prefer file-path consumers** where liveness matters: `.env` is convenient
+but its values are frozen at the boot source. Loose files stay path-modality and
+are **never auto-exported** (SKETCHBOOK D6), which is also why they stay live.
+
+**Blast-radius tradeoff (open item).** Mounting the *whole* dir means every ring
+— and every process in the container, across the GitLab/GitHub IP boundary — sees
+*every* secret. That is a deliberate, flagged tradeoff for the foundation: it is
+one mount, ro, with no per-secret plumbing. **Least-privilege per-secret scoping
+is an open design item** (Dev Spec §5.5, §5.N); the `read-only-secrets` layer is
+exactly where a future scoped-secrets mechanism slots in without disturbing the
+rest of the taxonomy. See §5 for the carried open item.
+
 ## 4. Boundaries and invariants
 
 - **Stateless-container invariant (R-01/R-02).** The container filesystem is
@@ -178,10 +218,11 @@ gate depends on (Dev Spec §5.3).
   observation; it is confirmed against the full manifest in MV-02 (closing story
   4.3). The resolver's R-03 guard is the *static* half of that assurance; MV-02
   is the runtime half.
-- **Secrets blast-radius** (Dev Spec §5.5, §5.N): the whole-`~/.secrets`-dir
-  mount means every ring sees every secret, including across the GitLab/GitHub IP
-  boundary. Least-privilege scoping is an open design item; the manifest's
-  `read-only-secrets` layer is where a future scoped-secrets mechanism slots in.
+- **Secrets blast-radius** (Dev Spec §5.5, §5.N; documented in §3.5): the
+  whole-`~/.secrets`-dir mount means every ring sees every secret, including
+  across the GitLab/GitHub IP boundary. Least-privilege per-secret scoping is an
+  open design item; the manifest's `read-only-secrets` layer is where a future
+  scoped-secrets mechanism slots in without disturbing the taxonomy.
 - **AoE bootstrap seam** (Dev Spec §5.N#5): whether aoe respects the image
   `ENTRYPOINT` or `docker exec`s the agent directly determines where the
   bootstrap (Story 1.4) hooks the resolver in. The resolver is seam-agnostic — it
@@ -195,4 +236,6 @@ gate depends on (Dev Spec §5.3).
 | R-09 MCP additive scoping | `test_mounts.py::test_mcp_composes_additively`; IT-03 |
 | R-10 binaries in-container | `test_mounts.py::test_compiled_binary_installs_in_container`; IT-01/IT-03 |
 | R-11 declarative toolbox | `test_mounts.py::test_toolbox_is_durable_in_container`; IT-03 |
+| R-12 secrets never baked / ro | `test_secrets.py::{test_secrets_mount_is_readonly,test_secrets_rw_fragment_is_rejected,test_secrets_never_baked_into_image}`; `test_secrets_readonly` (IT-02) |
+| R-13 secret liveness | `test_secrets.py::test_secrets_readonly` (IT-02); MV-07 |
 | R-01 stateless / host-backed | this doc (DM-11); IT-03; MV-02 |

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -1,0 +1,198 @@
+# Architecture — contained workflow
+
+Deliverable **DM-11** (Plan #959, Dev Spec §5.A). Trigger: the system has more
+than two interacting components. This document is the component-level map; the
+authoritative requirement/design source is
+[`docs/contained-workflow-devspec.md`](../contained-workflow-devspec.md) and its
+design rationale is `docs/contained-workflow-SKETCHBOOK.md` (merged #958). Where
+this doc and the Dev Spec differ, the Dev Spec governs.
+
+## 1. What this system is
+
+The OaW Claude Code kit, packaged as a **versioned container image**
+(`oakandwave-workflow:<semver>`) on the AoE sandbox base, so the **image digest
+*is* the release** (R-05). The container is a **stateless, disposable RTE**: all
+durable state lives on host-backed mounts (R-01), so a broken candidate is
+`docker rm`, not an incident. The OaW dev team runs these containers (the
+*dogfood ring*) to prove a candidate before the wider fleet adopts the promoted
+`:stable` digest.
+
+The design exists to install a boundary that was missing: previously every agent
+read one shared `~/.claude`, so one break blocked the whole fleet and a kit could
+not be tested without mutating live state (Dev Spec §1.2).
+
+## 2. Component map
+
+```mermaid
+flowchart TB
+  subgraph host["host workstation (rootful docker, no userns remap)"]
+    aoe["aoe 1.13.0<br/>per-session sandbox"]
+    surgeon["flight surgeon<br/>(:stable, host-side)"]
+    subgraph edge["oakandwave-workflow:edge container (uid-1000)"]
+      boot["bootstrap.sh<br/>(Story 1.4)"]
+      resolver["mount_resolver.py<br/>(Story 1.3)"]
+      kit["baked kit: skills / hooks /<br/>scripts / kit MCPs / toolchain"]
+    end
+    subgraph hoststate["host-backed durable state"]
+      mem["~/.oaw/state/&lt;major&gt;/<br/>memory + settings.local"]
+      sec["~/.secrets (ro)"]
+      overlay["~/.oaw/overlay, ~/.oaw/toolbox<br/>user MCPs / tools"]
+      caches["~/.oaw/cache/&lt;major&gt;/<br/>cargo / go / uv / playwright"]
+    end
+  end
+  ghcr["ghcr.io<br/>images by digest"]
+  flightdeck["FlightDeck (#854)<br/>telemetry + gate signal"]
+
+  aoe -->|launch| edge
+  resolver -->|reads mounts.d/| mem & sec & overlay & caches
+  boot -->|resolves via| resolver
+  surgeon -->|reads host-backed transcript| edge
+  ghcr -->|pull :edge / :stable| aoe
+  edge -->|transcript / soak| flightdeck
+```
+
+**Interacting components** (the >2 that trigger this doc):
+
+| Component | Role | Owner story |
+|-----------|------|-------------|
+| The image (`Dockerfile` + `Makefile`) | Bakes the kit + toolchain; the digest is the release | 1.1 (#961) |
+| me-ful sandbox profile (`sandbox-profile.toml`) | Launches the image as uid-1000 so bind-mount writes are host-owned | 1.2 (#962) |
+| **Mount manifest + resolver (`mounts.d/`, `mount_resolver.py`)** | **Declares + resolves the run-layer mounts; enforces the state-taxonomy guards** | **1.3 (#963)** |
+| Bootstrap (`bootstrap.sh`) | Runs before the agent: skills-sync, settings merge, secret sourcing, env validation | 1.4 (#964) |
+| Secrets mount | ro `~/.secrets` dir mount with mid-session liveness | 1.5 (#965) |
+| CI build/push + throwaway-CI ring | Builds, signs, SBOMs, pushes by digest; smokes install-from-zero | 2.1/2.2 |
+| Promotion gate | Mechanical conjunction over FlightDeck + CI; retags the tested digest | 2.3 |
+| Flight surgeon | Host-side probe reading the host-backed transcript; quarantine + rollback | 3.1/3.2 |
+
+## 3. The mount manifest (Story 1.3, this story)
+
+Every piece of `~/.claude` state files onto one of the **five layers** of the
+state taxonomy (Dev Spec §5.3), and the layer decides how it enters the
+container. Layer 1 is *baked in the image* (not a run mount); the other four are
+run-layer bind-mounts declared in
+[`containers/oakandwave-workflow/mounts.d/`](../../containers/oakandwave-workflow/mounts.d/)
+and materialized by
+[`mount_resolver.py`](../../containers/oakandwave-workflow/mount_resolver.py).
+
+```mermaid
+flowchart LR
+  subgraph img["1 · baked-in-image (versioned)"]
+    s1["skills / hook scripts<br/>kit MCP registrations"]
+  end
+  subgraph rw["2 · shared-mutable-rw"]
+    s2["memory + settings.local<br/>~/.oaw/state/&lt;major&gt;/  (R-03)"]
+  end
+  subgraph ro["3 · read-only-secrets"]
+    s3["~/.secrets (ro)  ·  Story 1.5"]
+  end
+  subgraph ov["4 · user-environment overlay"]
+    s4["MCP fragment (additive, R-09)<br/>toolbox (in-container, R-11)<br/>scripts (symlink, R-10)"]
+  end
+  subgraph ca["5 · durable caches"]
+    s5["cargo / go / uv / playwright<br/>~/.oaw/cache/&lt;major&gt;/"]
+  end
+```
+
+### 3.1 Layers and their mechanisms
+
+| Layer | Mechanism | Manifest fragment | Requirements |
+|-------|-----------|-------------------|--------------|
+| Baked-in-image | Built by `./install` in the image; immutable per tag | *(none — in the image)* | R-06, R-09 |
+| Shared-mutable-rw | rw bind-mount, **sandbox-scoped** host source | `10-memory.toml` | R-03, R-20 |
+| Read-only secrets | ro bind-mount of the `~/.secrets` dir | `20-secrets.toml` *(Story 1.5)* | R-12, R-13 |
+| User-environment overlay | additive / in-container / symlink, by artifact type | `30-user-overlay.toml` | R-09, R-10, R-11 |
+| Durable caches | rw bind-mount, major-partitioned | `40-durable-caches.toml` | §5.3 |
+
+### 3.2 The resolver and its guards
+
+`mount_resolver.py` loads the `mounts.d/*.toml` fragments (lexical order),
+substitutes `<major>` and `~`, applies the guards, and emits `docker -v` /
+aoe `extra_volumes` / JSON for the bootstrap:
+
+```bash
+python3 containers/oakandwave-workflow/mount_resolver.py --major 8 --format aoe
+```
+
+Each guard **fails loud** — a manifest violation raises `ManifestError`, never
+degrades silently (the D7 assertion-liveness discipline):
+
+- **R-03 — sandbox-scoped memory.** The one rw seam into shared durable state
+  (memory) must resolve under `~/.oaw/state/<major>/` and must **never** touch
+  the live-fleet `~/.claude` tree. Pointing it at `~/.claude/projects/*/memory`
+  would hand a broken `:edge` candidate write access to the live fleet's memory —
+  the exact shared-mutable-with-live-fleet disease this design cures, at the one
+  rw seam. The `<major>` segment partitions the namespace so mixing majors is
+  isolated, not corrupting (R-20). This is the story's canonical oracle
+  (`test_memory_source_scoped`).
+- **R-10 — the libc boundary.** A compiled binary in the user overlay is
+  installed *in* the container (`install = "in-container"`), never symlinked
+  across the host/container libc boundary — a host ELF fails on `.so`/interpreter
+  mismatch in a differently-built container. Scripts and config may symlink. The
+  resolver rejects a `compiled-binary` declared `symlink`; the `is_compiled_binary`
+  file classifier (ELF magic vs `#!` shebang) is the runtime primitive the
+  bootstrap uses to route each `~/.local/bin` entry (measured: ~154 shebang
+  scripts symlink-safe, ~26 ELF must install in-container).
+- **R-09 / R-11 — additive composition.** Third-party / user MCP servers compose
+  as an *additive fragment* (`compose = "additive"`) via the scoping already
+  governed by [`docs/mcp-scoping.md`](../mcp-scoping.md) — never by mounting the
+  whole `~/.claude.json` (which carries far more than MCP config). The kit's own
+  MCP registrations (`disc-server`, `sdlc-server`, `wtf-server`, `nerf-server`,
+  `discord-watcher` — see `mcps.json`) are **baked at stable image paths**;
+  baking kills the dangling-registration bug (a stale path to a moved binary).
+  The discretionary-tool toolbox (R-11) is a durable, in-container-materialized
+  mount decoupled from the kit release.
+
+### 3.3 settings.json split
+
+`settings.json` straddles versioned and shared, so it is **split** (Dev Spec
+§5.3): the image ships `settings.json` (hook wiring — versioned, because hook
+registrations point at script paths that live in the image), and the
+`10-memory.toml` fragment bind-mounts `settings.local.json` (permissions / env /
+identity — the genuinely shared knobs). Claude Code merges the two.
+
+### 3.4 PATH precedence
+
+Kit binaries (from the image) win over the user overlay on `PATH`, so the RTE
+stays authoritative — the same digest-determines-behavior rule that the promotion
+gate depends on (Dev Spec §5.3).
+
+## 4. Boundaries and invariants
+
+- **Stateless-container invariant (R-01/R-02).** The container filesystem is
+  disposable; everything durable is a host-backed mount, so recreate loses no
+  state. The resolver's job is to make every durable mount explicit and guarded.
+- **me-ful ownership (R-04).** The container runs as uid-1000 `ubuntu`, so
+  bind-mount writes land host-user-owned (`bakerb`). Delivered by the image
+  `USER` (Story 1.1) + the isolated aoe profile (Story 1.2).
+- **Portability (PC-3).** No OaW-org specifics (cephfs paths, secret contents)
+  are baked into the image; org infrastructure is a run-layer overlay only. The
+  manifest's host sources are the run-layer seam.
+- **Major-partitioned namespace (R-20).** `~/.oaw/state/<major>/` and
+  `~/.oaw/cache/<major>/` are keyed by kit major, so mixing majors is isolated,
+  not corrupting — the SemVer compatibility contract (Dev Spec §5.8).
+
+## 5. Open items carried by this component
+
+- **Isolation under the full custom mount set** (Dev Spec §5.N#3, MV-02): the
+  "live `~/.claude` is not exposed" result was one default-`--sandbox`
+  observation; it is confirmed against the full manifest in MV-02 (closing story
+  4.3). The resolver's R-03 guard is the *static* half of that assurance; MV-02
+  is the runtime half.
+- **Secrets blast-radius** (Dev Spec §5.5, §5.N): the whole-`~/.secrets`-dir
+  mount means every ring sees every secret, including across the GitLab/GitHub IP
+  boundary. Least-privilege scoping is an open design item; the manifest's
+  `read-only-secrets` layer is where a future scoped-secrets mechanism slots in.
+- **AoE bootstrap seam** (Dev Spec §5.N#5): whether aoe respects the image
+  `ENTRYPOINT` or `docker exec`s the agent directly determines where the
+  bootstrap (Story 1.4) hooks the resolver in. The resolver is seam-agnostic — it
+  is a pure function from `(manifest, major, home)` to a mount set.
+
+## 6. Verification
+
+| Requirement | Verified by |
+|-------------|-------------|
+| R-03 sandbox-scoped memory | `tests/contained-workflow/test_mounts.py::test_memory_source_scoped`; IT-03; MV-02 |
+| R-09 MCP additive scoping | `test_mounts.py::test_mcp_composes_additively`; IT-03 |
+| R-10 binaries in-container | `test_mounts.py::test_compiled_binary_installs_in_container`; IT-01/IT-03 |
+| R-11 declarative toolbox | `test_mounts.py::test_toolbox_is_durable_in_container`; IT-03 |
+| R-01 stateless / host-backed | this doc (DM-11); IT-03; MV-02 |

--- a/docs/contained-workflow/manual-verification.md
+++ b/docs/contained-workflow/manual-verification.md
@@ -15,7 +15,7 @@ own them and are all executed and recorded in the closing story (4.3, #976).
 | MV-04 | `aoe send` reaches into a running container (control-plane ingress) | R-15 | later |
 | MV-05 | A broken container quarantines and recreates on `:stable`, zero loss | R-02, R-17 | Story 3.2+ |
 | MV-06 | A wedged/OOM-killed `claude` still flushed its transcript | R-15 | later |
-| MV-07 | A secret added mid-session is usable with no container restart | R-13 | Story 1.5+ |
+| MV-07 | A secret added mid-session is usable with no container restart | R-13 | Story 1.5 (#965) |
 
 ---
 
@@ -133,3 +133,112 @@ If writes land uid-`0`/root-owned:
 | Date | Operator | Image digest / ID | `id -u` | `stat` result | PASS/FAIL | Notes |
 |------|----------|-------------------|---------|---------------|-----------|-------|
 | _pending_ | _pending_ | _pending_ | | | | Executed and recorded in closing story 4.3 (#976) |
+
+---
+
+## MV-07 — A secret added mid-session is usable with no container restart `[R-13]`
+
+**Goal.** Prove that a secret the host adds to `~/.secrets` **after** a session
+started is usable by a **newly-spawned command inside the running container**,
+with **no container restart** — the mid-session liveness of the read-only secrets
+mount (Dev Spec §5.5; architecture §3.5).
+
+**Why manual.** The docker-gated integration oracle
+(`tests/contained-workflow/test_secrets.py::test_secrets_readonly`, IT-02) proves
+the bind-mount is ro and that a host-added file is visible via `docker exec` in a
+bare container. This procedure proves the same liveness through the **real aoe
+sandbox session** an agent runs in, and through a **path-modality consumer** the
+way the kit actually reads a secret — the end-user-visible outcome. It needs a
+live aoe session, so it cannot run in the pytest lane.
+
+### Preconditions
+
+- **aoe 1.13.0**, **rootful docker** — as MV-01.
+- Image built locally:
+  `make -C containers/oakandwave-workflow build` → `oakandwave-workflow:edge`.
+- A host `~/.secrets` dir that will be bind-mounted ro (the me-ful profile /
+  `20-secrets.toml` wires `~/.secrets` → `/home/ubuntu/.secrets`). For an
+  isolated run, point `OAW_SECRETS_DIR` (or the profile's `extra_volumes`) at a
+  throwaway dir so you never touch real secrets.
+
+### Procedure
+
+1. **Seed one secret present at launch** in the host secrets dir:
+
+   ```bash
+   mkdir -p /tmp/meful-secrets
+   printf 'boot-value\n' > /tmp/meful-secrets/AT_BOOT
+   ```
+
+2. **Launch a sandbox session** with that dir bind-mounted ro at the secrets
+   target (isolated profile, as MV-01; add the volume to the profile's
+   `extra_volumes` or pass it through):
+
+   ```bash
+   aoe -p meful-test add --sandbox --sandbox-image oakandwave-workflow:edge \
+     --launch /tmp/meful-ws
+   # ensure -v /tmp/meful-secrets:/home/ubuntu/.secrets:ro is in effect
+   ```
+
+3. **Confirm the at-boot secret is readable** inside the running container
+   (attach the session):
+
+   ```bash
+   cat /home/ubuntu/.secrets/AT_BOOT      # expect: boot-value
+   ```
+
+4. **Confirm the mount is read-only** (R-12) — an in-container write must FAIL:
+
+   ```bash
+   echo x > /home/ubuntu/.secrets/should_fail   # expect: Read-only file system
+   ```
+
+5. **Add a NEW secret ON THE HOST**, mid-session, with the container still
+   running (a separate host shell):
+
+   ```bash
+   printf 'live-add\n' > /tmp/meful-secrets/MID_SESSION
+   ```
+
+6. **Spawn a NEW command inside the SAME running container** (do NOT restart it)
+   and read the just-added secret — this is the liveness assertion:
+
+   ```bash
+   cat /home/ubuntu/.secrets/MID_SESSION   # expect: live-add
+   ```
+
+   **EXPECT:** `live-add` — the host-added file is live with no restart. A
+   "No such file or directory" is a **FAIL** (R-13 liveness violated).
+
+7. **(Optional) confirm the env-modality caveat.** If the mount carries a `.env`,
+   note that a value *added to `.env` after boot* is **not** seen by env-var
+   consumers until a re-source (architecture §3.5 consumer split) — this is
+   expected, not a failure. The R-13 liveness guarantee is for **path-modality**
+   (loose-file) consumers, which is what step 6 exercises.
+
+8. **Record** the result in the log below: date, operator, image digest/ID, the
+   step-3 read, the step-4 write-rejection, the step-6 read, and PASS/FAIL.
+
+### Cleanup
+
+```bash
+aoe -p meful-test remove <session-id>
+rm -rf /tmp/meful-secrets
+```
+
+### Failure handling
+
+- **Step 6 shows the file missing.** The bind-mount is not the live host dir —
+  inspect the mount: `docker inspect --format '{{json .Mounts}}' <container-id>`.
+  A `volume`/copy source instead of a host `bind` breaks liveness; a stale image
+  path or an over-eager copy in the bootstrap would too. Open a bug against
+  Story 1.5 (#965) with the `docker inspect` evidence.
+- **Step 4 write SUCCEEDS.** The mount is not ro — R-12 violated. Check the
+  fragment (`20-secrets.toml` must be `mode = "ro"`; the resolver rejects rw) and
+  the effective `-v …:ro` flag.
+
+### Result log
+
+| Date | Operator | Image digest / ID | step-3 read | step-4 write | step-6 read | PASS/FAIL | Notes |
+|------|----------|-------------------|-------------|--------------|-------------|-----------|-------|
+| _pending_ | _pending_ | _pending_ | | | | | Executed and recorded in closing story 4.3 (#976) |

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -79,6 +79,12 @@ else
 	while IFS= read -r f; do
 		SCRIPTS+=("$f")
 	done < <(find "$REPO_DIR/scripts/ci" -name "*.sh" -type f 2>/dev/null)
+	# Container scripts (e.g. the oakandwave-workflow bootstrap). Executable OR
+	# *.sh; the is_shell_script filter below drops non-shell files. Without this,
+	# containers/**/*.sh would escape shellcheck entirely (config exists != works).
+	while IFS= read -r f; do
+		SCRIPTS+=("$f")
+	done < <(find "$REPO_DIR/containers" -type f \( -executable -o -name "*.sh" \) 2>/dev/null)
 	# Skill helper scripts (non-SKILL.md files in skill dirs)
 	for skill_dir in "$REPO_DIR"/skills/*/; do
 		for helper in "$skill_dir"/*; do
@@ -129,6 +135,11 @@ else
 	while IFS= read -r f; do
 		SCRIPTS+=("$f")
 	done < <(find "$REPO_DIR/scripts" -type f \( -executable -o -name "*.sh" \) 2>/dev/null)
+	# Container scripts (e.g. the oakandwave-workflow bootstrap) — mirror the
+	# selector used above so shfmt covers the same tree as the linter.
+	while IFS= read -r f; do
+		SCRIPTS+=("$f")
+	done < <(find "$REPO_DIR/containers" -type f \( -executable -o -name "*.sh" \) 2>/dev/null)
 	# Skill helper scripts (non-SKILL.md files in skill dirs)
 	for skill_dir in "$REPO_DIR"/skills/*/; do
 		for helper in "$skill_dir"/*; do

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -1,0 +1,298 @@
+"""Oracle for Story 1.4 — the container bootstrap (#964, Dev Spec §5.4).
+
+The bootstrap (``containers/oakandwave-workflow/bootstrap.sh``) is the
+load-bearing instrument that runs before the agent (SKETCHBOOK D7). Its whole
+point is **assertion-liveness**: every silent-skip path becomes a LOGGED or
+FAILING condition, never "the check that reported fine and did nothing."
+
+These are *pure* unit oracles — no docker, no aoe. Every path the bootstrap
+touches is env-injectable (defaults derived from ``$HOME``), so each test builds a
+fake ``$OAW_HOME`` in a tempdir, drives the real ``bootstrap.sh`` via subprocess,
+and asserts the behavior. They run for real in the stock ``pytest tests/`` lane
+(bash + python3 are always present), exactly like the mount-resolver oracle.
+
+Each of the four enumerated silent-skip paths (Dev Spec §5.4 / SKETCHBOOK D7) is
+exercised **red-first** — the broken condition is constructed and the guard's
+logged/failing signal is asserted — before the guard is trusted:
+
+* missing mount   — ``test_missing_host_skills_mount_is_logged_no_dangling``,
+  ``test_missing_settings_local_is_logged`` `[R-14]`
+* shadowed skill  — ``test_skills_sync_image_wins_and_logs_collision`` `[R-06, R-10]`
+* dangling link   — ``test_dangling_symlink_is_logged`` `[R-14]`
+* missing secret  — ``test_missing_required_secret_fails_loud`` `[R-14]`
+
+``test_bootstrap_failloud`` is the devspec-named oracle: it walks all four paths
+red-first in one aggregate assertion.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = REPO_ROOT / "containers" / "oakandwave-workflow" / "bootstrap.sh"
+
+
+def test_bootstrap_script_exists() -> None:
+    """The deliverable exists and is executable (the story's target file)."""
+    assert BOOTSTRAP.is_file(), f"missing bootstrap: {BOOTSTRAP}"
+    assert os.access(BOOTSTRAP, os.X_OK), f"bootstrap is not executable: {BOOTSTRAP}"
+
+
+def _make_home(
+    tmp_path: Path,
+    *,
+    image_skills: list[str] | None = None,
+    host_skills: list[str] | None = None,
+    settings_json: bool = True,
+    settings_local: str | None = None,
+    secrets: dict[str, str] | None = None,
+    dangling: list[str] | None = None,
+) -> Path:
+    """Build a fake ``$OAW_HOME`` layout for the bootstrap to operate on.
+
+    ``image_skills`` / ``host_skills`` are skill *names* (each a directory with a
+    marker ``SKILL.md``). ``dangling`` names broken symlinks planted in the image
+    skills dir. ``secrets`` maps a filename under ``~/.secrets`` to its content
+    (``.env`` supported for the env modality).
+    """
+    home = tmp_path / "home"
+    image = home / ".claude" / "skills"
+    host = home / ".oaw" / ".claude" / "skills"
+    secrets_dir = home / ".secrets"
+    image.mkdir(parents=True)
+    host.mkdir(parents=True)
+    secrets_dir.mkdir(parents=True)
+
+    for name in image_skills or []:
+        d = image / name
+        d.mkdir()
+        (d / "SKILL.md").write_text(f"# image skill {name}\n")
+    for name in host_skills or []:
+        d = host / name
+        d.mkdir()
+        (d / "SKILL.md").write_text(f"# host skill {name}\n")
+    for name in dangling or []:
+        (image / name).symlink_to(home / "does-not-exist" / name)
+
+    if settings_json:
+        (home / ".claude" / "settings.json").write_text('{"hooks": {}}\n')
+    if settings_local is not None:
+        (home / ".claude" / "settings.local.json").write_text(settings_local)
+    for fname, content in (secrets or {}).items():
+        (secrets_dir / fname).write_text(content)
+
+    return home
+
+
+def _run(home: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["OAW_HOME"] = str(home)
+    env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(BOOTSTRAP)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+# --- shadowed skill (collision) — [R-06, R-10] --------------------------------
+
+
+def test_skills_sync_image_wins_and_logs_collision(tmp_path: Path) -> None:
+    """Image-wins / host-fills / collision-logged (AC-1).
+
+    ``alpha`` exists in both (collision) → image wins, logged, and NOT relinked.
+    ``beta`` is host-only (a gap) → filled by a symlink whose FULL target path
+    resolves (the D5 self-reference bug would leave a dangling link).
+    """
+    home = _make_home(
+        tmp_path, image_skills=["alpha"], host_skills=["alpha", "beta"]
+    )
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+
+    # Collision logged for the shadowed host skill.
+    assert "skills-sync collision" in proc.stderr
+    assert "alpha" in proc.stderr
+
+    image = home / ".claude" / "skills"
+    # Image wins: alpha is still the real baked dir, not a link to the host copy.
+    assert (image / "alpha").is_dir()
+    assert not (image / "alpha").is_symlink()
+
+    # Host fills the gap: beta is a symlink resolving to the host copy (full path).
+    beta = image / "beta"
+    assert beta.is_symlink(), "host-only skill should be symlinked in (host-fill)"
+    assert beta.exists(), "host-fill link is dangling — the D5 full-target-path bug"
+    assert os.readlink(beta) == str(
+        home / ".oaw" / ".claude" / "skills" / "beta"
+    ), "host-fill must link the FULL target path, never a bare basename"
+
+
+def test_skills_sync_is_idempotent(tmp_path: Path) -> None:
+    """A second boot re-links nothing and raises no error (re-runnable)."""
+    home = _make_home(tmp_path, host_skills=["beta"])
+    assert _run(home).returncode == 0
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "already linked" in proc.stderr
+    assert (home / ".claude" / "skills" / "beta").exists()
+
+
+# --- missing mount ------------------------------------------------------------
+
+
+def test_missing_host_skills_mount_is_logged_no_dangling(tmp_path: Path) -> None:
+    """Absent host skills overlay → logged, and NO dangling link created."""
+    home = _make_home(tmp_path)  # host dir exists but is empty…
+    # …now remove it entirely to model an absent mount.
+    host = home / ".oaw" / ".claude" / "skills"
+    (host).rmdir()
+    (home / ".oaw" / ".claude").rmdir()
+
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "missing mount" in proc.stderr
+    assert "host skills overlay" in proc.stderr
+    # No dangling links were manufactured in the image dir.
+    image = home / ".claude" / "skills"
+    assert not any(p.is_symlink() and not p.exists() for p in image.iterdir())
+
+
+def test_missing_settings_local_is_logged(tmp_path: Path) -> None:
+    """Absent settings.local mount → logged (silent-skip made loud), non-fatal."""
+    home = _make_home(tmp_path)  # no settings_local
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "missing mount: settings.local.json" in proc.stderr
+
+
+def test_malformed_settings_local_is_logged(tmp_path: Path) -> None:
+    """Malformed settings.local → loud warning (CC's merge would silently drop it)."""
+    home = _make_home(tmp_path, settings_local="{ this is not json ]")
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "not valid JSON" in proc.stderr
+
+
+# --- dangling link ------------------------------------------------------------
+
+
+def test_dangling_symlink_is_logged(tmp_path: Path) -> None:
+    """A dangling symlink in the skills dir is surfaced, not silently skipped."""
+    home = _make_home(tmp_path, dangling=["ghost"])
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "dangling symlink" in proc.stderr
+    assert "ghost" in proc.stderr
+
+
+# --- missing secret — [R-14] --------------------------------------------------
+
+
+def test_missing_required_secret_fails_loud(tmp_path: Path) -> None:
+    """A missing required secret makes the bootstrap fail loudly (AC-2, R-14)."""
+    home = _make_home(tmp_path)
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN")
+    assert proc.returncode != 0, "missing required secret must fail loud"
+    assert "FATAL" in proc.stderr
+    assert "required secret missing" in proc.stderr
+    assert "FOO_TOKEN" in proc.stderr
+
+
+def test_required_secret_present_as_file_passes(tmp_path: Path) -> None:
+    """The green half: a present secret file (path modality) satisfies the guard."""
+    home = _make_home(tmp_path, secrets={"FOO_TOKEN": "s3cr3t\n"})
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN")
+    assert proc.returncode == 0, proc.stderr
+    assert "path modality" in proc.stderr
+
+
+def test_required_secret_present_via_env_passes(tmp_path: Path) -> None:
+    """A required secret satisfied by an env var (env modality) passes."""
+    home = _make_home(tmp_path)
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN", FOO_TOKEN="from-env")
+    assert proc.returncode == 0, proc.stderr
+    assert "env modality" in proc.stderr
+
+
+def test_required_secret_from_manifest_fails_loud(tmp_path: Path) -> None:
+    """The values-free manifest (D6) drives the required list; a missing one fails."""
+    home = _make_home(tmp_path)
+    manifest = home / ".secrets" / "required.manifest"
+    manifest.write_text("# required secrets\nDISCORD_BOT_TOKEN\n\nSLACK_BOT_TOKEN\n")
+    proc = _run(home)
+    assert proc.returncode != 0
+    assert "DISCORD_BOT_TOKEN" in proc.stderr
+    assert "SLACK_BOT_TOKEN" in proc.stderr
+
+
+def test_dotenv_is_sourced_for_env_modality(tmp_path: Path) -> None:
+    """``.env`` is the env modality: a var it defines satisfies a required secret."""
+    home = _make_home(tmp_path, secrets={".env": "FOO_TOKEN=via-dotenv\n"})
+    proc = _run(home, OAW_REQUIRED_SECRETS="FOO_TOKEN")
+    assert proc.returncode == 0, proc.stderr
+    assert "sourced" in proc.stderr
+
+
+# --- missing required env -----------------------------------------------------
+
+
+def test_missing_required_env_fails_loud(tmp_path: Path) -> None:
+    """env validation has teeth: a declared-but-unset env var fails loud."""
+    home = _make_home(tmp_path)
+    proc = _run(home, OAW_REQUIRED_ENV="OAW_MUST_EXIST")
+    assert proc.returncode != 0
+    assert "required env missing" in proc.stderr
+    assert "OAW_MUST_EXIST" in proc.stderr
+
+
+# --- happy path ---------------------------------------------------------------
+
+
+def test_all_clean_exits_zero(tmp_path: Path) -> None:
+    """Fully-provisioned boot: no warnings, no fatals, exit 0."""
+    home = _make_home(
+        tmp_path,
+        image_skills=["alpha"],
+        host_skills=["beta"],
+        settings_local='{"permissions": {}}\n',
+    )
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "0 fatal(s)" in proc.stdout
+    assert "complete" in proc.stderr
+
+
+# --- the devspec-named aggregate oracle ---------------------------------------
+
+
+def test_bootstrap_failloud(tmp_path: Path) -> None:
+    """Named oracle (Dev Spec §8, Story 1.4): each silent-skip path logs/fails,
+    red-first. Walks all four enumerated paths in one assertion.
+    """
+    # 1) shadowed skill + 3) dangling link, both LOGGED (non-fatal).
+    home = _make_home(
+        tmp_path,
+        image_skills=["alpha"],
+        host_skills=["alpha"],
+        dangling=["ghost"],
+    )
+    logged = _run(home)
+    assert logged.returncode == 0, logged.stderr
+    assert "skills-sync collision" in logged.stderr  # shadowed skill
+    assert "dangling symlink" in logged.stderr  # dangling link
+    assert "missing mount: settings.local.json" in logged.stderr  # 2) missing mount
+
+    # 4) missing secret FAILS LOUD (the same layout, plus a required secret).
+    failed = _run(home, OAW_REQUIRED_SECRETS="MUST_HAVE_TOKEN")
+    assert failed.returncode != 0, "missing required secret must fail loud (R-14)"
+    assert "FATAL" in failed.stderr
+    assert "MUST_HAVE_TOKEN" in failed.stderr

--- a/tests/contained-workflow/test_mounts.py
+++ b/tests/contained-workflow/test_mounts.py
@@ -1,0 +1,279 @@
+"""Oracle for Story 1.3 — the mount-manifest resolver (#963, Dev Spec §5.3).
+
+The resolver (``containers/oakandwave-workflow/mount_resolver.py``) is the guard
+that keeps the five-layer state taxonomy honest. These are *pure* unit oracles —
+no docker, no aoe, no filesystem sources — so they run for real in the stock
+``pytest tests/`` lane. Each guard is exercised red-first (the violation raises)
+and green (the correct shape resolves).
+
+Coverage:
+
+* ``test_memory_source_scoped`` — the named story oracle: a live-fleet memory
+  source is rejected; a sandbox-scoped one is accepted `[R-03]`.
+* ``test_compiled_binary_installs_in_container`` — a compiled-binary overlay
+  symlink is rejected; classification routes ELF→in-container, shebang→symlink
+  `[R-10]`.
+* ``test_mcp_composes_additively`` — a non-additive or whole-``.claude.json`` MCP
+  overlay is rejected; the fragment shape resolves `[R-09, R-11]`.
+* ``test_manifest_resolves`` — the checked-in ``mounts.d/`` manifest resolves
+  clean end-to-end `[R-03, R-09, R-10, R-11]`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+MANIFEST_DIR = CONTAINER_DIR / "mounts.d"
+
+# The resolver is a self-contained module colocated with the manifest; import it
+# by path (no PYTHONPATH dependency), mirroring test_ownership.py's REPO_ROOT style.
+sys.path.insert(0, str(CONTAINER_DIR))
+import mount_resolver as mr  # noqa: E402
+
+FAKE_HOME = PurePosixPath("/home/bakerb")
+MAJOR = 8
+
+
+def _resolve_one(entry: dict, major: int = MAJOR, home: PurePosixPath = FAKE_HOME):
+    return mr.resolve_mount(entry, major, home)
+
+
+# --- R-03: sandbox-scoped memory (the named story oracle) ---------------------
+
+
+def test_memory_source_scoped() -> None:
+    """R-03: a live-fleet memory source is rejected; a sandbox-scoped one accepted.
+
+    This is the story's canonical oracle. The rw memory mount is the single seam
+    into shared durable state — pointing it at the live ``~/.claude`` tree would
+    hand a broken ``:edge`` candidate write access to the fleet's memory.
+    """
+    base = {
+        "name": "memory",
+        "layer": "shared-mutable-rw",
+        "mode": "rw",
+        "target": "/home/ubuntu/.claude/projects/_sandbox/memory",
+    }
+
+    # ACCEPT — sandbox-scoped under ~/.oaw/state/<major>/.
+    ok = _resolve_one({**base, "source": "~/.oaw/state/<major>/memory"})
+    assert ok.source == "/home/bakerb/.oaw/state/8/memory"
+    assert ok.mode == "rw"
+
+    # REJECT — the live-fleet memory tree (the exact disease R-03 fences).
+    with pytest.raises(mr.ManifestError, match="R-03"):
+        _resolve_one({**base, "source": "~/.claude/projects/foo/memory"})
+
+    # REJECT — anywhere under ~/.claude, even if not literally .../memory.
+    with pytest.raises(mr.ManifestError, match="R-03"):
+        _resolve_one({**base, "source": "~/.claude/projects"})
+
+    # REJECT — off the sandbox-scoped state root entirely (e.g. an arbitrary dir).
+    with pytest.raises(mr.ManifestError, match="R-03"):
+        _resolve_one({**base, "source": "~/somewhere-else/memory"})
+
+    # REJECT — the WRONG major's state root (namespace partition, R-20): major 9
+    # state is not sandbox-scoped for a major-8 resolve.
+    with pytest.raises(mr.ManifestError, match="R-03"):
+        _resolve_one({**base, "source": "~/.oaw/state/9/memory"})
+
+
+def test_sandbox_scoped_flag_applies_guard_to_any_layer() -> None:
+    """The R-03 guard fires on any mount flagged ``sandbox_scoped``, not only the
+    memory layer — a durable-cache mislabeled into the live tree is still caught."""
+    entry = {
+        "name": "settings-local",
+        "layer": "shared-mutable-rw",
+        "mode": "rw",
+        "sandbox_scoped": True,
+        "source": "~/.claude/settings.local.json",
+        "target": "/home/ubuntu/.claude/settings.local.json",
+    }
+    with pytest.raises(mr.ManifestError, match="R-03"):
+        _resolve_one(entry)
+
+
+# --- R-10: compiled binaries install in-container -----------------------------
+
+
+def test_compiled_binary_installs_in_container() -> None:
+    """R-10: a compiled-binary overlay must install in-container, never symlink."""
+    good = {
+        "name": "user-bin",
+        "layer": "user-overlay",
+        "artifact": "compiled-binary",
+        "mode": "rw",
+        "source": "~/.oaw/overlay/<major>/bin",
+        "target": "/home/ubuntu/.oaw/overlay/bin",
+    }
+    resolved = _resolve_one(good)
+    assert resolved.install == "in-container"
+
+    # REJECT — a compiled binary declared symlink is the libc-boundary bug.
+    with pytest.raises(mr.ManifestError, match="R-10"):
+        _resolve_one({**good, "install": "symlink"})
+
+    # Scripts/config default to symlink and resolve clean.
+    script = {
+        "name": "user-scripts",
+        "layer": "user-overlay",
+        "artifact": "script",
+        "mode": "rw",
+        "source": "~/.oaw/overlay/<major>/local-bin",
+        "target": "/home/ubuntu/.oaw/overlay/local-bin",
+    }
+    assert _resolve_one(script).install == "symlink"
+
+
+def test_is_compiled_binary_classifier(tmp_path: Path) -> None:
+    """The runtime file classifier the bootstrap uses to route each ~/.local/bin
+    entry: ELF magic -> in-container; shebang -> symlink; unreadable -> conservative."""
+    elf = tmp_path / "an-elf"
+    elf.write_bytes(b"\x7fELF\x02\x01\x01\x00rest")
+    assert mr.is_compiled_binary(elf) is True
+
+    script = tmp_path / "a-script"
+    script.write_text("#!/usr/bin/env bash\necho hi\n")
+    assert mr.is_compiled_binary(script) is False
+
+    # Absent path: conservatively NOT a plain script (don't symlink a possible ELF).
+    assert mr.is_compiled_binary(tmp_path / "does-not-exist") is True
+
+
+# --- R-09 / R-11: additive MCP composition ------------------------------------
+
+
+def test_mcp_composes_additively() -> None:
+    """R-09/R-11: an MCP overlay composes additively as a fragment, never as the
+    whole ~/.claude.json."""
+    good = {
+        "name": "mcp-fragment",
+        "layer": "user-overlay",
+        "artifact": "mcp-fragment",
+        "compose": "additive",
+        "mode": "ro",
+        "source": "~/.oaw/overlay/<major>/mcp.json",
+        "target": "/home/ubuntu/.oaw/overlay/mcp.json",
+    }
+    resolved = _resolve_one(good)
+    assert resolved.compose == "additive"
+
+    # REJECT — a non-additive (replacing) MCP overlay.
+    with pytest.raises(mr.ManifestError, match="R-09"):
+        _resolve_one({**good, "compose": "replace"})
+
+    # REJECT — mounting the whole ~/.claude.json (carries far more than MCP config).
+    with pytest.raises(mr.ManifestError, match="R-09"):
+        _resolve_one(
+            {
+                **good,
+                "source": "~/.claude.json",
+                "target": "/home/ubuntu/.claude.json",
+            }
+        )
+
+
+def test_toolbox_is_durable_in_container() -> None:
+    """R-11: the discretionary-tool toolbox is a durable, in-container mount."""
+    resolved = _resolve_one(
+        {
+            "name": "toolbox",
+            "layer": "user-overlay",
+            "artifact": "toolbox",
+            "mode": "rw",
+            "source": "~/.oaw/toolbox/<major>",
+            "target": "/home/ubuntu/.oaw/toolbox",
+        }
+    )
+    assert resolved.install == "in-container"
+    assert resolved.mode == "rw"
+
+
+# --- Schema / structural guards -----------------------------------------------
+
+
+def test_secrets_layer_must_be_readonly() -> None:
+    """R-12: the read-only-secrets layer rejects a rw mode (guards Story 1.5's
+    drop-in fragment against a fat-finger)."""
+    entry = {
+        "name": "secrets",
+        "layer": "read-only-secrets",
+        "mode": "rw",
+        "source": "~/.secrets",
+        "target": "/home/ubuntu/.secrets",
+    }
+    with pytest.raises(mr.ManifestError, match="R-12"):
+        _resolve_one(entry)
+
+
+def test_invalid_layer_and_mode_rejected() -> None:
+    """Unknown layer / mode fail loud rather than silently pass."""
+    with pytest.raises(mr.ManifestError, match="invalid layer"):
+        _resolve_one(
+            {"name": "x", "layer": "bogus", "mode": "rw", "source": "/a", "target": "/b"}
+        )
+    with pytest.raises(mr.ManifestError, match="invalid mode"):
+        _resolve_one(
+            {
+                "name": "x",
+                "layer": "durable-cache",
+                "mode": "append",
+                "source": "/a",
+                "target": "/b",
+            }
+        )
+
+
+# --- End-to-end: the checked-in manifest resolves clean -----------------------
+
+
+def test_manifest_resolves() -> None:
+    """The real ``mounts.d/`` manifest loads and fully resolves with every guard
+    applied `[R-03, R-09, R-10, R-11]`."""
+    resolved = mr.resolve_manifest(MAJOR, home=FAKE_HOME, mounts_dir=MANIFEST_DIR)
+    by_name = {m.name: m for m in resolved}
+
+    # The three layers Story 1.3 owns are all present.
+    assert "memory" in by_name
+    assert "mcp-fragment" in by_name
+    assert "toolbox" in by_name
+    assert any(m.layer == "durable-cache" for m in resolved)
+
+    # The memory mount resolved sandbox-scoped under this major.
+    assert by_name["memory"].source == "/home/bakerb/.oaw/state/8/memory"
+
+    # No manifest mount points into the live-fleet ~/.claude tree as its source.
+    for m in resolved:
+        assert not m.source.startswith("/home/bakerb/.claude"), (
+            f"mount {m.name!r} sources from the live-fleet tree: {m.source}"
+        )
+
+    # The MCP overlay is an additive fragment, not a whole-file mount.
+    mcp = by_name["mcp-fragment"]
+    assert mcp.compose == "additive"
+    assert not mcp.source.endswith(".claude.json")
+
+    # Durable caches carry their env wiring for the bootstrap to export.
+    cargo = by_name["cargo"]
+    assert cargo.env.get("CARGO_HOME") == "/home/ubuntu/.cargo"
+
+    # docker -v rendering round-trips (ro suffix only on ro mounts).
+    assert mcp.to_docker_volume().endswith(":ro")
+    assert not by_name["memory"].to_docker_volume().endswith(":ro")
+
+
+def test_manifest_dir_exists() -> None:
+    """DM sanity: the manifest directory and the fragments Story 1.3 owns are
+    checked in. A superset check (not exact equality) so a sibling wave story —
+    Story 1.5's ``20-secrets.toml`` — can drop a fragment in without tripping
+    this oracle."""
+    assert MANIFEST_DIR.is_dir(), f"missing manifest dir: {MANIFEST_DIR}"
+    fragments = {p.name for p in MANIFEST_DIR.glob("*.toml")}
+    owned = {"10-memory.toml", "30-user-overlay.toml", "40-durable-caches.toml"}
+    missing = owned - fragments
+    assert not missing, f"missing Story 1.3 manifest fragments: {sorted(missing)}"

--- a/tests/contained-workflow/test_secrets.py
+++ b/tests/contained-workflow/test_secrets.py
@@ -1,0 +1,216 @@
+"""Oracle for Story 1.5 — the read-only ~/.secrets mount + mid-session liveness
+(#965, Dev Spec §5.5, R-12/R-13).
+
+Two verification altitudes, mirroring test_ownership.py:
+
+* **Static config oracles** (pure — run for real in the stock ``pytest tests/``
+  lane, no docker). Assert the checked-in ``20-secrets.toml`` fragment resolves
+  as a *read-only* mount of ``~/.secrets`` (R-12: provided only via the ro mount,
+  never rw), that its target matches the bootstrap's secrets-dir default, and
+  that no secret is baked into the image (R-12: never in an image layer) —
+  ``mount_resolver`` even fails LOUD if the fragment is fat-fingered to ``rw``.
+
+* **Integration oracle** (``test_secrets_readonly`` — the story's named oracle,
+  IT-02). Runs the image via ``docker run`` with ``~/.secrets`` bind-mounted ro:
+  the container *cannot* write the mount (R-12 ro), and a file the host adds
+  *after* the container started is live inside the running container (R-13).
+  Self-skips when docker/the image is absent (like test_image.py);
+  ``OAKANDWAVE_REQUIRE_IMAGE`` turns absence into a hard failure so CI proves the
+  contract end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+MANIFEST_DIR = CONTAINER_DIR / "mounts.d"
+SECRETS_FRAGMENT = MANIFEST_DIR / "20-secrets.toml"
+DOCKERFILE = CONTAINER_DIR / "Dockerfile"
+
+# Import the resolver by path (no PYTHONPATH dependency), like test_mounts.py.
+sys.path.insert(0, str(CONTAINER_DIR))
+import mount_resolver as mr  # noqa: E402
+
+FAKE_HOME = PurePosixPath("/home/bakerb")
+MAJOR = 8
+
+# The uid-1000 image whose ro bind-mount we probe; consistent with the other
+# docker-gated oracles (test_image.py / test_ownership.py).
+SECRETS_IMAGE = "oakandwave-workflow:edge"
+SECRETS_TARGET = "/home/ubuntu/.secrets"
+
+
+# --- Static R-12 oracles (pure; run in the stock lane) ------------------------
+
+
+def _secrets_mount() -> mr.ResolvedMount:
+    """Resolve the checked-in secrets fragment (and only it) for assertions."""
+    assert SECRETS_FRAGMENT.is_file(), f"missing secrets fragment: {SECRETS_FRAGMENT}"
+    resolved = mr.resolve_manifest(MAJOR, home=FAKE_HOME, mounts_dir=MANIFEST_DIR)
+    secrets = [m for m in resolved if m.layer == "read-only-secrets"]
+    assert secrets, "no read-only-secrets mount in the resolved manifest"
+    assert len(secrets) == 1, f"expected one secrets mount, got {len(secrets)}"
+    return secrets[0]
+
+
+def test_secrets_mount_is_readonly() -> None:
+    """R-12: secrets are provided ONLY via the ro mount — the checked-in fragment
+    resolves read-only, sourced from ~/.secrets, targeting the bootstrap's dir."""
+    m = _secrets_mount()
+    assert m.mode == "ro", f"secrets mount must be ro (R-12), got {m.mode!r}"
+    assert m.source == "/home/bakerb/.secrets", (
+        f"secrets source must be ~/.secrets, got {m.source!r}"
+    )
+    assert m.target == SECRETS_TARGET, (
+        f"secrets target must match bootstrap OAW_SECRETS_DIR default "
+        f"({SECRETS_TARGET}), got {m.target!r}"
+    )
+    # The docker -v rendering carries the :ro suffix — the mount is ro at runtime.
+    assert m.to_docker_volume().endswith(":ro"), (
+        f"docker volume spec must end :ro, got {m.to_docker_volume()!r}"
+    )
+
+
+def test_secrets_rw_fragment_is_rejected() -> None:
+    """R-12 red-first: a secrets fragment declared rw fails LOUD in the resolver,
+    so the ro contract cannot be fat-fingered open."""
+    with pytest.raises(mr.ManifestError, match="R-12"):
+        mr.resolve_mount(
+            {
+                "name": "secrets",
+                "layer": "read-only-secrets",
+                "mode": "rw",
+                "source": "~/.secrets",
+                "target": SECRETS_TARGET,
+            },
+            MAJOR,
+            FAKE_HOME,
+        )
+
+
+def test_secrets_never_baked_into_image() -> None:
+    """R-12: no secret is baked into an image layer — the Dockerfile never COPY/ADDs
+    a host secrets path; secrets arrive only through the runtime ro mount.
+
+    Red-first guard: if a future edit bakes ~/.secrets / a .env / a credential,
+    this trips. We scan COPY/ADD instruction lines (not comments, which mention
+    ~/.secrets to *explain* why it is NOT baked)."""
+    assert DOCKERFILE.is_file(), f"missing Dockerfile: {DOCKERFILE}"
+    forbidden = (".secrets", ".env", "secret", "credential", "token", ".pem", ".key")
+    offenders: list[str] = []
+    for raw in DOCKERFILE.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            continue
+        head = line.split(None, 1)[0].upper() if line else ""
+        if head not in {"COPY", "ADD"}:
+            continue
+        low = line.lower()
+        if any(tok in low for tok in forbidden):
+            offenders.append(line)
+    assert not offenders, (
+        "Dockerfile bakes a secret into an image layer (R-12 violation) — "
+        f"secrets must come only via the runtime ro mount:\n" + "\n".join(offenders)
+    )
+
+
+# --- Integration oracle: the named story test (docker-gated) ------------------
+
+
+def _skip_or_fail(msg: str, require: bool) -> None:
+    if require:
+        pytest.fail(msg + " (OAKANDWAVE_REQUIRE_IMAGE set)")
+    pytest.skip(msg)
+
+
+def _docker_and_image_or_skip() -> tuple[str, str]:
+    docker = shutil.which("docker")
+    require = bool(os.environ.get("OAKANDWAVE_REQUIRE_IMAGE"))
+    ref = os.environ.get("OAKANDWAVE_IMAGE", SECRETS_IMAGE)
+    if docker is None:
+        _skip_or_fail("docker binary not found on PATH", require)
+    if (
+        subprocess.run(
+            [docker, "image", "inspect", ref], capture_output=True
+        ).returncode
+        != 0
+    ):
+        _skip_or_fail(
+            f"image {ref!r} not built — run "
+            f"`make -C containers/oakandwave-workflow build`",
+            require,
+        )
+    return docker, ref  # type: ignore[return-value]
+
+
+def test_secrets_readonly() -> None:
+    """IT-02 (R-12/R-13): the container cannot write the ro secrets mount, and a
+    file the host adds mid-session is live inside the running container.
+
+    Runs a long-lived container with ~/.secrets bind-mounted ro, then:
+      1. an in-container write attempt FAILS (R-12: ro — host owns the secret);
+      2. a file the HOST adds AFTER the container started is readable inside it
+         with no restart (R-13: liveness).
+    Self-skips without docker/the image; OAKANDWAVE_REQUIRE_IMAGE makes absence a
+    hard failure so CI proves the contract.
+    """
+    docker, ref = _docker_and_image_or_skip()
+
+    with tempfile.TemporaryDirectory() as host_secrets:
+        # Seed one secret present at launch; add another AFTER launch for R-13.
+        (Path(host_secrets) / "AT_BOOT").write_text("boot-value\n")
+
+        cid = subprocess.run(
+            [
+                docker, "run", "-d", "--rm",
+                "-v", f"{host_secrets}:{SECRETS_TARGET}:ro",
+                "--entrypoint", "sh", ref,
+                "-c", "sleep 60",
+            ],
+            capture_output=True, text=True, timeout=120,
+        )
+        assert cid.returncode == 0, f"failed to start container:\n{cid.stderr}"
+        container = cid.stdout.strip()
+        try:
+            def _exec(script: str) -> subprocess.CompletedProcess:
+                return subprocess.run(
+                    [docker, "exec", container, "sh", "-c", script],
+                    capture_output=True, text=True, timeout=60,
+                )
+
+            # (0) the at-boot secret is readable inside the container.
+            boot = _exec(f"cat {SECRETS_TARGET}/AT_BOOT")
+            assert boot.returncode == 0 and "boot-value" in boot.stdout, (
+                f"at-boot secret not readable in container:\n{boot.stderr}"
+            )
+
+            # (1) R-12: an in-container write to the ro mount FAILS.
+            write = _exec(f"echo x > {SECRETS_TARGET}/should_fail")
+            assert write.returncode != 0, (
+                "container wrote to the ro secrets mount — R-12 violated "
+                "(the mount is not read-only)"
+            )
+            assert not (Path(host_secrets) / "should_fail").exists(), (
+                "a file appeared on the host — the ro mount let a write through"
+            )
+
+            # (2) R-13: a host-added file mid-session is live in the container.
+            (Path(host_secrets) / "MID_SESSION").write_text("live-add\n")
+            live = _exec(f"cat {SECRETS_TARGET}/MID_SESSION")
+            assert live.returncode == 0 and "live-add" in live.stdout, (
+                "host-added secret not visible in the running container — R-13 "
+                f"liveness violated:\n{live.stderr}"
+            )
+        finally:
+            subprocess.run(
+                [docker, "rm", "-f", container], capture_output=True, timeout=60
+            )


### PR DESCRIPTION
## Summary

Promote wave **P1W2** of Plan #959 (Contained Workflow) to `main`, via a disposable per-wave
branch rebased onto current `main`. (The per-plan persistent kahuna diverged under squash +
linear-history `main`; the campaign switched to the per-wave disposable model. Supersedes #984.)

## Changes

- #963 — mount-manifest resolver + five-layer state taxonomy
- #964 — container bootstrap (skills-sync + fail-loud secrets)
- #965 — read-only secrets mount + proven mid-session liveness

Additive: `mount_resolver.py`, `bootstrap.sh`, `mounts.d/*` fragments, tests, docs (2035
insertions). Plus a **safe additive extension** to `scripts/ci/validate.sh` — broadens the
shellcheck/shfmt selector to `containers/**` so the new `bootstrap.sh` is linted; no change to
any existing selector. `validate.sh` 183/0.

## Trust gate

Adjudicated. `commutativity → ORACLE_REQUIRED` — a *modify* of an existing CI_INFRA file
(`scripts/ci/validate.sh`), correctly flagged by `commutativity-probe#2`'s retained guard. The
modify is a purely-additive coverage extension (cannot break existing checks), adjudicated safe.
CI on this PR (single-runner, merge-result) is the authoritative full-suite gate — it also
settles the spurious `test_install.py` races seen under concurrent sibling load.

## Linked issues

#963 #964 #965 (already closed by the wave-engine flight merges into the integration branch).
