### PR TITLE
feat(contained-workflow): CI image build + push + cosign/syft (Story 2.1, #966)

### DIFF
--- a/.github/workflows/oakandwave-workflow-image.yml
+++ b/.github/workflows/oakandwave-workflow-image.yml
@@ -1,0 +1,68 @@
+# oakandwave-workflow image — the Build stage of the contained-workflow pipeline
+# (DM-03, Story 2.1 / #966, Dev Spec §5.B).
+#
+#   build -> push to ghcr -> cosign sign -> syft SBOM -> stamp OCI labels
+#
+# The image *digest is the release* (R-05): everything versioned-with-the-release
+# is baked in, and CI stamps the provenance (semver / source / revision /
+# timestamp) plus a keyless cosign signature and a syft SBOM bound to the digest
+# (R-24). The throwaway-CI ring (Story 2.2, E2E-01) pulls that digest and verifies
+# labels/permissions/signature/SBOM before smoke — the digest tested is the digest
+# promoted (R-23).
+#
+# All build/sign logic lives in scripts/ci/*.sh (project rule: No Procedural Logic
+# in CI/CD YAML); the steps below only wire installer actions to those scripts.
+#
+# Trigger: merge to main and version tags rebuild the candidate; workflow_dispatch
+# allows a manual rebuild. It does NOT run on the kahuna integration branches, so
+# a wave never triggers a heavy push to ghcr.
+name: oakandwave-workflow image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write # keyless cosign (Fulcio/Rekor) via OIDC
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/oakandwave-workflow
+      TAG: edge
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # AOE_PULL_TOKEN (if provisioned) authenticates the cross-org base-image
+      # pull from ghcr.io/agent-of-empires; GITHUB_TOKEN pushes to this org.
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.AOE_PULL_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Build, label, and push the image
+        id: build
+        env:
+          OAKANDWAVE_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        run: ./scripts/ci/build-oakandwave-image.sh
+
+      - name: Sign (cosign) + SBOM (syft) the digest
+        env:
+          DIGEST_REF: ${{ steps.build.outputs.digest_ref }}
+        run: ./scripts/ci/sign-oakandwave-image.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,7 +26,22 @@ jobs:
           python-version: '3.12'
 
       - name: Install test dependencies
-        run: pip install pytest
+        run: pip install pytest pytest-cov
 
       - name: Run test suite (cc-workflow#795 — gate the pytest suite)
+        env:
+          # DM-05/DM-06 (Story 2.1, #966): emit JUnit + coverage into reports/.
+          CC_TEST_REPORTS_DIR: reports
         run: ./scripts/ci/test.sh
+
+      # Coverage is a COMPLETENESS SIGNAL, uploaded regardless of the test gate
+      # (if: always()) — a red suite still publishes its reports (R-06, DM-06).
+      - name: Upload JUnit + coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            reports/junit.xml
+            reports/coverage.xml
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ bun.lock
 # Build output
 dist/
 
+# CI test reports (DM-05 JUnit / DM-06 coverage) — generated, uploaded as artifacts
+reports/
+.coverage
+
 # Pre-created worktrees for parallel agent execution
 .worktrees/
 

--- a/docs/contained-workflow/deployment-verification.md
+++ b/docs/contained-workflow/deployment-verification.md
@@ -1,0 +1,165 @@
+# Deployment Verification — `oakandwave-workflow` image (DM-12)
+
+**Trigger for this document (Dev Spec §5.A):** the contained-workflow pipeline
+*deploys infrastructure* — it pushes a container image to `ghcr.io` that the OaW
+fleet pulls and runs. This runbook is the operator's post-build check that a
+pushed candidate is provenance-correct and fleet-pullable **before** it is
+allowed anywhere near promotion. It is the manual companion to the automated
+throwaway-CI ring (E2E-01, Story 2.2), which performs the same checks in CI and
+blocks the digest on any failure.
+
+**Requirements verified here:** R-05 (image = release), R-23 (the digest tested is
+the digest promoted), R-24 (OCI labels + registry permissions + cosign signature
++ syft SBOM). **Config existence ≠ config works** (project rule): a workflow that
+*ran green* is necessary but not sufficient — verify the artifact itself.
+
+Pipeline under verification: `.github/workflows/oakandwave-workflow-image.yml`
+→ `scripts/ci/build-oakandwave-image.sh` (build + label + push, emits the digest)
+→ `scripts/ci/sign-oakandwave-image.sh` (cosign sign + syft SBOM attest).
+
+---
+
+## 0. Prerequisites
+
+- `docker`, `cosign`, and `syft` on PATH (all three are baked into the image
+  itself; on a bare host, install cosign + syft from Sigstore/Anchore releases).
+- `ghcr.io` login able to **pull** the target package:
+  `echo "$GHCR_TOKEN" | docker login ghcr.io -u <user> --password-stdin`.
+- The image reference. Prefer the **digest** the build job emitted
+  (`ghcr.io/wave-engineering/oakandwave-workflow@sha256:…`), read from the
+  workflow run's `build` step output `digest_ref`. Verifying by digest — never by
+  the moving `:edge` tag — is the whole point of R-23.
+
+```bash
+# The immutable pin every step below verifies against:
+DIGEST_REF="ghcr.io/wave-engineering/oakandwave-workflow@sha256:<digest>"
+```
+
+---
+
+## 1. OCI provenance labels (R-24)
+
+The image must carry all four provenance facts — semver, source repo, git
+revision, build timestamp — under the canonical OCI keys. These are stamped by
+`scripts/ci/oakandwave-oci-labels.sh` (the single source of truth the unit oracle
+`tests/contained-workflow/test_provenance.py::test_oci_labels` also checks).
+
+```bash
+docker buildx imagetools inspect --format '{{json .Provenance}}{{println}}' "$DIGEST_REF"
+docker pull "$DIGEST_REF"
+docker image inspect --format '{{json .Config.Labels}}' "$DIGEST_REF" | python3 -m json.tool
+```
+
+**Pass criteria** — every key present and non-empty:
+
+| Label key | Fact | Example |
+|-----------|------|---------|
+| `org.opencontainers.image.version` | semver (bare, no leading `v`) | `2.4.1` |
+| `org.opencontainers.image.source` | source repo URL | `https://github.com/Wave-Engineering/claudecode-workflow` |
+| `org.opencontainers.image.revision` | git revision (full SHA) | `0123…4567` |
+| `org.opencontainers.image.created` | build timestamp (RFC3339, UTC) | `2026-07-22T12:00:00Z` |
+
+The `revision` MUST match the commit the workflow ran on, and `source` MUST point
+at this repo — those two are what make the digest auditable back to its source.
+
+---
+
+## 2. Cosign signature (R-24)
+
+Signing is **keyless** (Fulcio-issued cert + Rekor transparency log), driven by
+the workflow's OIDC token. Verify the signature exists and was produced by *this
+workflow's* identity, not an arbitrary signer:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "https://github.com/Wave-Engineering/claudecode-workflow/.github/workflows/oakandwave-workflow-image.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$DIGEST_REF"
+```
+
+**Pass criteria:** cosign prints a verified signature entry whose certificate
+identity is the image workflow and whose issuer is GitHub Actions OIDC. A bare
+`cosign verify` that ignores the identity is **not** sufficient — anyone can sign
+a public digest; the identity binding is the security property.
+
+---
+
+## 3. Syft SBOM (R-24)
+
+An SPDX SBOM must be attested to the digest so the fleet can audit the image's
+contents. Verify the attestation is present and is the SPDX predicate:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp "https://github.com/Wave-Engineering/claudecode-workflow/.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$DIGEST_REF" | jq -r '.payload' | base64 -d | jq '.predicateType'
+```
+
+**Pass criteria:** the attestation verifies and its `predicateType` is the SPDX
+type. Spot-check the SBOM lists the baked kit-dep toolchain (go, trivy,
+shellcheck, shfmt, glab, bao, aws) — an empty or base-only SBOM means syft ran
+against the wrong target.
+
+---
+
+## 4. Registry permissions & visibility (R-24)
+
+R-24 requires the candidate be **fleet-pullable at the intended visibility**. Two
+layers, one automated and one operator-owned:
+
+- **Automated (workflow):** `permissions: packages: write` lets the build job push;
+  the `org.opencontainers.image.source` label links the package to this repo so it
+  inherits the repo's access on ghcr.
+- **Operator-owned (one-time, per package):** ghcr package **visibility** and
+  **access** are *not* set from workflow YAML. After the first publish, set them in
+  the org package settings:
+  - Visibility: **internal** (Wave-Engineering members can pull) — the intended
+    default for a fleet image. Public only if external kit adopters (§1.4) need it.
+  - Ensure the fleet's pull identity (the org, or a fleet PAT) has **read**.
+
+**Verify fleet-pullability from a clean identity** (the check that actually
+matters — a package that pushed fine can still be unpullable by the fleet):
+
+```bash
+docker logout ghcr.io
+echo "$FLEET_GHCR_TOKEN" | docker login ghcr.io -u <fleet-user> --password-stdin
+docker pull "$DIGEST_REF"   # MUST succeed as the fleet identity, not just the pusher
+```
+
+**Cross-org base pull:** the build itself pulls
+`ghcr.io/agent-of-empires/aoe-dev-sandbox` (TC-3/TC-5). If that package is private
+to another org, `GITHUB_TOKEN` cannot pull it — provision an `AOE_PULL_TOKEN`
+repo secret (a PAT with `read:packages` on agent-of-empires); the login step
+prefers it when present.
+
+---
+
+## 5. Digest continuity (R-23)
+
+The digest you verified in steps 1–4 MUST be the same digest that:
+
+1. the `:edge` tag currently points at, and
+2. the throwaway-CI ring (E2E-01) tested, and
+3. any subsequent promotion (`:edge → :stable`, Story 2.3) retags.
+
+```bash
+# The digest behind the moving :edge tag must equal $DIGEST_REF's digest.
+docker buildx imagetools inspect ghcr.io/wave-engineering/oakandwave-workflow:edge \
+  --format '{{.Manifest.Digest}}'
+```
+
+If these diverge, **stop** — a rebuild has occurred between test and promotion and
+the provenance chain is broken. Promotion is a digest retag, never a rebuild.
+
+---
+
+## 6. Sign-off
+
+A candidate passes deployment verification only when **all** of §1–§5 pass:
+labels correct, signature verifies against the workflow identity, SPDX SBOM
+attested, fleet can pull at the intended visibility, and the digest is continuous
+from build → edge → (eventual) stable. Record the verified `DIGEST_REF` and the
+date; that digest — and only that digest — is eligible for the promotion gate
+(Story 2.3, R-07).

--- a/scripts/ci/build-oakandwave-image.sh
+++ b/scripts/ci/build-oakandwave-image.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# build-oakandwave-image.sh — build the oakandwave-workflow image, stamp the OCI
+# provenance labels, push it to the registry, and emit the resulting digest
+# (Story 2.1 / #966, R-05/R-24).
+#
+# This is the procedural half of the image workflow (DM-03): the CI/CD YAML calls
+# it in one line so no build logic lives in the workflow (project rule: "No
+# Procedural Logic in CI/CD YAML"). The labels come from oakandwave-oci-labels.sh
+# — the same producer the provenance oracle reads — so the pushed image carries
+# exactly the labels the test asserts.
+#
+# The digest is written to $GITHUB_OUTPUT (as `digest=`) and to stdout so the
+# throwaway-CI ring (Story 2.2) can pull *by digest*, never by a moving tag —
+# the digest tested is the digest promoted (R-23).
+#
+# Inputs (env):
+#   IMAGE        registry image name, e.g. ghcr.io/wave-engineering/oakandwave-workflow
+#                (required).
+#   TAG          moving tag to publish (default: edge).
+#   BASE_IMAGE   override the FROM base (default: the Dockerfile ARG default).
+#   PUSH         "true" (default) pushes to the registry; "false" builds+loads
+#                locally (for a no-push PR validation lane).
+#   Plus every input honored by oakandwave-oci-labels.sh (OAKANDWAVE_VERSION,
+#   GITHUB_SHA, GITHUB_REPOSITORY, OAKANDWAVE_CREATED, …).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+DOCKERFILE="$REPO_DIR/containers/oakandwave-workflow/Dockerfile"
+
+: "${IMAGE:?IMAGE must be set (e.g. ghcr.io/<org>/oakandwave-workflow)}"
+# ghcr (and the OCI distribution spec) require the repository path to be
+# lowercase; GITHUB_REPOSITORY_OWNER can carry capitals (Wave-Engineering).
+IMAGE="${IMAGE,,}"
+TAG="${TAG:-edge}"
+PUSH="${PUSH:-true}"
+REF="${IMAGE}:${TAG}"
+
+# --- Assemble the OCI provenance labels (single source of truth) --------------
+label_args=()
+while IFS= read -r line; do
+	[[ -n "$line" ]] || continue
+	label_args+=(--label "$line")
+done < <("$HERE/oakandwave-oci-labels.sh")
+
+build_args=()
+if [[ -n "${BASE_IMAGE:-}" ]]; then
+	build_args+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
+fi
+
+# --- Build → push, capturing the pushed digest --------------------------------
+# buildx writes the image manifest digest to the metadata file under the
+# "containerimage.digest" key; that is the immutable handle the ring pulls by.
+metadata_file="$(mktemp -t oakandwave-buildmeta.XXXXXX.json)"
+trap 'rm -f "$metadata_file"' EXIT
+
+output_flag="--load"
+[[ "$PUSH" == "true" ]] && output_flag="--push"
+
+echo "==> docker buildx build $output_flag -t $REF (${#label_args[@]} labels)"
+docker buildx build \
+	"$output_flag" \
+	--metadata-file "$metadata_file" \
+	-f "$DOCKERFILE" \
+	-t "$REF" \
+	"${label_args[@]}" \
+	"${build_args[@]}" \
+	"$REPO_DIR"
+
+# --- Extract + publish the digest ---------------------------------------------
+digest="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("containerimage.digest",""))' "$metadata_file")"
+
+if [[ -z "$digest" ]]; then
+	if [[ "$PUSH" == "true" ]]; then
+		echo "  [!] no containerimage.digest in buildx metadata — push likely failed" >&2
+		exit 1
+	fi
+	# Local --load builds have no manifest push digest; fall back to the image ID.
+	digest="$(docker image inspect --format '{{.Id}}' "$REF")"
+fi
+
+echo "==> image digest: $digest"
+echo "digest_ref=${IMAGE}@${digest}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "digest=${digest}"
+		echo "digest_ref=${IMAGE}@${digest}"
+		echo "ref=${REF}"
+	} >>"$GITHUB_OUTPUT"
+fi

--- a/scripts/ci/oakandwave-oci-labels.sh
+++ b/scripts/ci/oakandwave-oci-labels.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# oakandwave-oci-labels.sh — emit the OCI provenance labels for the
+# oakandwave-workflow image (Story 2.1 / #966, R-24).
+#
+# Single source of truth for the four provenance facts R-24 requires — semver,
+# source repo, git revision, build timestamp — plus the image title. The build
+# script (build-oakandwave-image.sh) consumes each `key=value` line as a
+# `docker build --label`; the unit oracle (tests/contained-workflow/
+# test_provenance.py::test_oci_labels) consumes the same lines and asserts every
+# required key is present with a sane value. One producer, two consumers: the
+# label set CI stamps is exactly the label set the test verifies.
+#
+# Output: one `key=value` line per label on stdout, nothing else. Deterministic
+# and hermetic — no docker, no network — so the oracle runs in the stock pytest
+# lane.
+#
+# Inputs (all optional; each has a fail-safe fallback):
+#   OAKANDWAVE_VERSION   semver for org.opencontainers.image.version.
+#                        Falls back to `git describe --tags` then 0.0.0-dev.
+#   GIT_REVISION / GITHUB_SHA
+#                        git revision for ...image.revision (else `git rev-parse HEAD`).
+#   OAKANDWAVE_SOURCE / GITHUB_REPOSITORY
+#                        source repo for ...image.source (a repo slug becomes a
+#                        https://github.com/<slug> URL; else the git origin URL).
+#   OAKANDWAVE_CREATED   RFC3339 build timestamp for ...image.created (else now, UTC).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+_git() { git -C "$REPO_DIR" "$@" 2>/dev/null; }
+
+# --- semver -------------------------------------------------------------------
+version="${OAKANDWAVE_VERSION:-}"
+if [[ -z "$version" ]]; then
+	version="$(_git describe --tags --always --dirty)" || version=""
+fi
+[[ -n "$version" ]] || version="0.0.0-dev"
+# Strip a leading v (tags are vX.Y.Z; the OCI version label is bare semver).
+version="${version#v}"
+
+# --- git revision -------------------------------------------------------------
+revision="${GIT_REVISION:-${GITHUB_SHA:-}}"
+if [[ -z "$revision" ]]; then
+	revision="$(_git rev-parse HEAD)" || revision=""
+fi
+[[ -n "$revision" ]] || revision="unknown"
+
+# --- source repo --------------------------------------------------------------
+source="${OAKANDWAVE_SOURCE:-}"
+if [[ -z "$source" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+	source="https://github.com/${GITHUB_REPOSITORY}"
+fi
+if [[ -z "$source" ]]; then
+	source="$(_git remote get-url origin)" || source=""
+fi
+[[ -n "$source" ]] || source="https://github.com/Wave-Engineering/claudecode-workflow"
+
+# --- build timestamp (RFC3339, UTC) -------------------------------------------
+created="${OAKANDWAVE_CREATED:-}"
+[[ -n "$created" ]] || created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf 'org.opencontainers.image.title=%s\n' "oakandwave-workflow"
+printf 'org.opencontainers.image.version=%s\n' "$version"
+printf 'org.opencontainers.image.source=%s\n' "$source"
+printf 'org.opencontainers.image.revision=%s\n' "$revision"
+printf 'org.opencontainers.image.created=%s\n' "$created"

--- a/scripts/ci/sign-oakandwave-image.sh
+++ b/scripts/ci/sign-oakandwave-image.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# sign-oakandwave-image.sh — attach a cosign signature and a syft SBOM to the
+# pushed oakandwave-workflow digest (Story 2.1 / #966, R-24).
+#
+# Runs after build-oakandwave-image.sh. Both provenance artifacts bind to the
+# *digest*, never a moving tag, so the signature/SBOM the throwaway-CI ring
+# verifies (Story 2.2, E2E-01) attest the exact bytes that were built and will be
+# promoted (R-23).
+#
+# Keyless (Fulcio/Rekor) signing: no long-lived key material. In GitHub Actions
+# this consumes the workflow's OIDC token (permissions: id-token: write). cosign
+# and syft are installed by the workflow via their `uses:` installer actions; this
+# script only orchestrates them, keeping the CI/CD YAML free of procedural logic.
+#
+# Inputs (env):
+#   DIGEST_REF   the immutable pin `registry/image@sha256:…` to sign + SBOM
+#                (required; build-oakandwave-image.sh emits it as `digest_ref=`).
+#   COSIGN_YES   passed through as `cosign --yes` (default: true — non-interactive CI).
+
+set -euo pipefail
+
+: "${DIGEST_REF:?DIGEST_REF must be set (registry/image@sha256:...)}"
+
+if [[ "$DIGEST_REF" != *"@sha256:"* ]]; then
+	echo "  [!] refusing to sign a non-digest ref: $DIGEST_REF" >&2
+	echo "      (sign the immutable digest, never a moving tag — R-23)" >&2
+	exit 1
+fi
+
+for tool in cosign syft; do
+	command -v "$tool" >/dev/null 2>&1 || {
+		echo "  [!] $tool not found on PATH — install it before signing" >&2
+		exit 1
+	}
+done
+
+cosign_yes=()
+[[ "${COSIGN_YES:-true}" == "true" ]] && cosign_yes=(--yes)
+
+# --- cosign: keyless signature attached to the digest -------------------------
+echo "==> cosign sign (keyless) $DIGEST_REF"
+cosign sign "${cosign_yes[@]}" "$DIGEST_REF"
+
+# --- syft: generate an SPDX SBOM, cosign: attest it to the digest -------------
+sbom_file="$(mktemp -t oakandwave-sbom.XXXXXX.spdx.json)"
+trap 'rm -f "$sbom_file"' EXIT
+
+echo "==> syft SBOM (spdx-json) for $DIGEST_REF"
+syft "$DIGEST_REF" -o spdx-json="$sbom_file"
+
+echo "==> cosign attest SBOM -> $DIGEST_REF"
+cosign attest "${cosign_yes[@]}" \
+	--predicate "$sbom_file" \
+	--type spdxjson \
+	"$DIGEST_REF"
+
+echo "==> signature + SBOM attached to $DIGEST_REF"

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -25,5 +25,27 @@ export PYTHONPATH="$ROOT/src${PYTHONPATH:+:$PYTHONPATH}"
 # is set (skipif in tests/test_install.py, cc-workflow#795) — so it's skipped by
 # default here AND on a stock dev box; no runner-level deselect needed, and the
 # skip is visible in the test output with its reason.
+pytest_args=(tests/ -q)
+
+# DM-05 / DM-06 (Story 2.1, #966): when CC_TEST_REPORTS_DIR is set, additionally
+# emit a JUnit XML report and (if pytest-cov is installed) an XML coverage report
+# into that dir. Coverage is a COMPLETENESS SIGNAL, not a gate — no
+# --cov-fail-under — so report generation never changes this script's pass/fail.
+# The block is inert when the env var is unset, so the pre-push test hook and the
+# stock `./scripts/ci/test.sh` invocation are byte-for-byte unchanged.
+if [[ -n "${CC_TEST_REPORTS_DIR:-}" ]]; then
+	mkdir -p "$CC_TEST_REPORTS_DIR"
+	pytest_args+=("--junitxml=${CC_TEST_REPORTS_DIR}/junit.xml")
+	if python3 -c 'import pytest_cov' >/dev/null 2>&1; then
+		pytest_args+=(
+			"--cov=src"
+			"--cov=containers/oakandwave-workflow"
+			"--cov-report=xml:${CC_TEST_REPORTS_DIR}/coverage.xml"
+		)
+	else
+		echo "==> pytest-cov not installed — emitting JUnit only (coverage skipped)" >&2
+	fi
+fi
+
 echo "==> pytest tests/ (PYTHONPATH=src)"
-python3 -m pytest tests/ -q
+python3 -m pytest "${pytest_args[@]}"

--- a/tests/contained-workflow/test_provenance.py
+++ b/tests/contained-workflow/test_provenance.py
@@ -1,0 +1,210 @@
+"""Oracle for Story 2.1 (#966) — the CI image pipeline stamps the required OCI
+provenance and wires the sign/SBOM/coverage plumbing (R-24, R-06 / DM-05, DM-06).
+
+The authoritative end-to-end proof is E2E-01 (Story 2.2): pull the pushed digest
+from ghcr and inspect its labels/signature/SBOM. That cannot run in the stock
+pytest lane (no ghcr push, no ~10 GB image), so this module verifies the two
+halves that *can* be checked hermetically:
+
+1. ``test_oci_labels`` (the story's named oracle) — drives the single source of
+   truth for the provenance labels (``scripts/ci/oakandwave-oci-labels.sh``) with
+   a fixture environment and asserts every R-24 label key is present with a sane
+   value. Because the build script stamps *these exact lines* as ``docker build
+   --label`` args, verifying the producer verifies what lands on the image.
+
+2. Wiring guards — the sign/SBOM script and the workflows are parsed to prove the
+   cosign signature, syft SBOM, and coverage-regardless-of-gates plumbing are
+   actually connected (config exists != config works, at the unit tier).
+
+A real-image ``docker inspect`` branch (skip-gated exactly like ``test_image.py``)
+asserts the static labels the Dockerfile bakes, when the image happens to exist.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LABELS_SCRIPT = REPO_ROOT / "scripts" / "ci" / "oakandwave-oci-labels.sh"
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "ci" / "build-oakandwave-image.sh"
+SIGN_SCRIPT = REPO_ROOT / "scripts" / "ci" / "sign-oakandwave-image.sh"
+IMAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "oakandwave-workflow-image.yml"
+VALIDATE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "validate.yml"
+
+# The provenance facts R-24 mandates: semver, source repo, git revision, build
+# timestamp. Expressed as the canonical OCI label keys the image must carry.
+REQUIRED_OCI_LABEL_KEYS = (
+    "org.opencontainers.image.version",  # semver
+    "org.opencontainers.image.source",  # source repo
+    "org.opencontainers.image.revision",  # git revision
+    "org.opencontainers.image.created",  # build timestamp
+)
+
+
+def _run_labels_script(env_overrides: dict[str, str]) -> dict[str, str]:
+    """Run the labels script with a clean-ish env and parse `key=value` lines."""
+    env = dict(os.environ)
+    # Drop any ambient provenance env so the fixture is deterministic.
+    for k in (
+        "OAKANDWAVE_VERSION",
+        "OAKANDWAVE_SOURCE",
+        "OAKANDWAVE_CREATED",
+        "GIT_REVISION",
+        "GITHUB_SHA",
+        "GITHUB_REPOSITORY",
+    ):
+        env.pop(k, None)
+    env.update(env_overrides)
+
+    proc = subprocess.run(
+        ["bash", str(LABELS_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"labels script failed:\n{proc.stderr}"
+
+    labels: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        labels[key] = value
+    return labels
+
+
+def test_oci_labels() -> None:
+    """The provenance producer emits every required OCI label with a sane value.
+
+    Feeds a fully-specified fixture environment so each of the four R-24 facts is
+    exercised end-to-end: the semver, source, revision, and timestamp we pass must
+    reappear verbatim under the canonical OCI keys.
+    """
+    labels = _run_labels_script(
+        {
+            "OAKANDWAVE_VERSION": "v2.4.1",
+            "GITHUB_SHA": "0123456789abcdef0123456789abcdef01234567",
+            "GITHUB_REPOSITORY": "Wave-Engineering/claudecode-workflow",
+            "OAKANDWAVE_CREATED": "2026-07-22T12:00:00Z",
+        }
+    )
+
+    for key in REQUIRED_OCI_LABEL_KEYS:
+        assert key in labels, f"missing required OCI label {key!r}; got {sorted(labels)}"
+        assert labels[key], f"OCI label {key!r} is empty"
+
+    # The leading `v` is stripped — the OCI version label is bare semver.
+    assert labels["org.opencontainers.image.version"] == "2.4.1"
+    assert (
+        labels["org.opencontainers.image.revision"]
+        == "0123456789abcdef0123456789abcdef01234567"
+    )
+    assert (
+        labels["org.opencontainers.image.source"]
+        == "https://github.com/Wave-Engineering/claudecode-workflow"
+    )
+    assert labels["org.opencontainers.image.created"] == "2026-07-22T12:00:00Z"
+
+
+def test_oci_labels_have_failsafe_fallbacks() -> None:
+    """With no provenance env at all, the producer still emits every key non-empty.
+
+    Provenance must never silently drop a label just because CI forgot to export a
+    variable — a fail-safe default (git describe / HEAD / origin / now) fills each.
+    """
+    labels = _run_labels_script({})
+    for key in REQUIRED_OCI_LABEL_KEYS:
+        assert labels.get(key), f"fallback did not populate {key!r}: {labels}"
+
+
+def test_build_script_stamps_labels_from_the_producer() -> None:
+    """The build script sources its --label args from the single-source producer.
+
+    Guards against a drift where the pipeline hand-rolls labels that diverge from
+    what the oracle checks.
+    """
+    text = BUILD_SCRIPT.read_text()
+    assert "oakandwave-oci-labels.sh" in text, "build script must call the labels producer"
+    assert "--label" in text, "build script must pass labels to docker build"
+    assert "--push" in text, "build script must push to the registry (R-05)"
+    assert "containerimage.digest" in text, "build script must capture the pushed digest (R-23)"
+
+
+def test_sign_script_wires_cosign_and_syft() -> None:
+    """The sign step attaches BOTH a cosign signature and a syft SBOM (R-24, AC2)."""
+    text = SIGN_SCRIPT.read_text()
+    assert "cosign sign" in text, "must attach a cosign signature"
+    assert "syft " in text, "must generate a syft SBOM"
+    assert "cosign attest" in text, "must attest the SBOM to the digest"
+    # The signature/SBOM must bind to the immutable digest, never a moving tag.
+    assert "@sha256:" in text, "sign script must guard for a digest ref (R-23)"
+
+
+def test_image_workflow_runs_sign_after_build() -> None:
+    """The image workflow builds then signs, keyless via OIDC (id-token: write)."""
+    text = IMAGE_WORKFLOW.read_text()
+    assert "build-oakandwave-image.sh" in text, "workflow must call the build script"
+    assert "sign-oakandwave-image.sh" in text, "workflow must call the sign script"
+    assert "id-token: write" in text, "keyless cosign needs OIDC token permission"
+    assert "packages: write" in text, "pushing to ghcr needs packages: write"
+
+
+def test_coverage_uploaded_regardless_of_repo_gates() -> None:
+    """Coverage + JUnit are emitted and uploaded even when the suite is red (DM-06).
+
+    R-06/DM-06 call coverage a completeness signal reported *regardless of repo
+    gates*: the report env is wired and the upload runs `if: always()`.
+    """
+    text = VALIDATE_WORKFLOW.read_text()
+    assert "CC_TEST_REPORTS_DIR" in text, "test run must be told to emit reports"
+    assert "pytest-cov" in text, "coverage report needs pytest-cov installed"
+    assert "if: always()" in text, "artifact upload must run regardless of the test gate"
+    assert "coverage.xml" in text and "junit.xml" in text, "must upload DM-05 + DM-06"
+
+
+# --- Real-image branch (skip-gated, mirrors test_image.py) --------------------
+
+DEFAULT_IMAGE = "oakandwave-workflow:edge"
+
+
+def _resolve_image_or_skip() -> tuple[str, str]:
+    docker = shutil.which("docker")
+    require = bool(os.environ.get("OAKANDWAVE_REQUIRE_IMAGE"))
+    if docker is None:
+        msg = "docker binary not found on PATH"
+        pytest.fail(msg) if require else pytest.skip(msg)
+    ref = os.environ.get("OAKANDWAVE_IMAGE", DEFAULT_IMAGE)
+    present = subprocess.run(
+        [docker, "image", "inspect", ref], capture_output=True, text=True
+    )
+    if present.returncode != 0:
+        msg = f"image {ref!r} not built locally"
+        pytest.fail(msg) if require else pytest.skip(msg)
+    return docker, ref
+
+
+def test_built_image_carries_static_labels() -> None:
+    """When the image is present, it carries the Dockerfile's static OCI labels.
+
+    The dynamic provenance (version/revision/created) is stamped by CI at
+    build-push time (test_oci_labels covers that producer); the title/source/base
+    labels are baked in the Dockerfile and must be inspectable on any local build.
+    """
+    docker, ref = _resolve_image_or_skip()
+    fmt = "{{json .Config.Labels}}"
+    proc = subprocess.run(
+        [docker, "image", "inspect", "--format", fmt, ref],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "org.opencontainers.image.title" in proc.stdout
+    assert "org.opencontainers.image.source" in proc.stdout


### PR DESCRIPTION
## Summary
Wave P2W1 flight for Story 2.1 (#966): CI workflow-image build, push, and cosign/syft provenance for the contained workflow. Integrated by the P2W1 PRIME reconcile node into `kahuna/959-P2W1`.

## Changes
- New workflow `.github/workflows/oakandwave-workflow-image.yml` — build + push OaW workflow image.
- CI scripts: `scripts/ci/build-oakandwave-image.sh`, `oakandwave-oci-labels.sh`, `sign-oakandwave-image.sh` (cosign + syft/SBOM).
- `validate.yml`: install `pytest-cov`, set `CC_TEST_REPORTS_DIR=reports`, upload JUnit + coverage artifacts with `if: always()` (DM-05/DM-06, R-06).
- `scripts/ci/test.sh`: optional JUnit + XML coverage emission gated on `CC_TEST_REPORTS_DIR` (inert when unset — stock invocation and pre-push hook byte-for-byte unchanged; coverage is a completeness signal, not a gate).
- `.gitignore`: ignore generated `reports/` and `.coverage`.
- Docs: `docs/contained-workflow/deployment-verification.md`.
- Tests: `tests/contained-workflow/test_provenance.py` (210 lines).

## Linked Issues
Closes #966

## Test Plan
- Full suite (`./scripts/ci/test.sh`) run locally on the merged (fast-forward) tree: `1734 passed, 4 skipped, 64 xfailed, 2 xpassed, 26 subtests passed` (exit 0).
- `commutativity_verify` single-target vs `kahuna/959-P2W1`: `ORACLE_REQUIRED` — by-design for infra/CI files (not PROBE_UNAVAILABLE); reconcile oracle confirms the composed diff is safe (clean fast-forward, merge-base == kahuna HEAD, purely additive CI/infra + tests + doc, no shared-interface collision).