### PR TITLE
feat(contained-workflow): throwaway-CI ring — E2E-01 (Story 2.2)

### DIFF
--- a/.github/workflows/oakandwave-workflow-image.yml
+++ b/.github/workflows/oakandwave-workflow-image.yml
@@ -35,6 +35,11 @@ jobs:
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/oakandwave-workflow
       TAG: edge
+    # Expose the pushed digest so the throwaway-CI ring (smoke) pulls the exact
+    # bytes this job built + signed — the digest tested is the digest promoted
+    # (R-23), never a moving tag.
+    outputs:
+      digest_ref: ${{ steps.build.outputs.digest_ref }}
     steps:
       - uses: actions/checkout@v4
 
@@ -66,3 +71,41 @@ jobs:
         env:
           DIGEST_REF: ${{ steps.build.outputs.digest_ref }}
         run: ./scripts/ci/sign-oakandwave-image.sh
+
+  # Throwaway-CI ring (Story 2.2, E2E-01 — Dev Spec §6.3, R-05/R-23/R-24). Pulls
+  # the candidate BY DIGEST from ghcr, verifies labels/permissions/signature/SBOM,
+  # installs from zero, runs the smoke suite, tears down. A red smoke — or any
+  # failed provenance check — fails this job and blocks the digest from promotion.
+  # It never rebuilds locally: the digest tested is the digest the build job
+  # pushed and signed (R-23).
+  smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read # pull the candidate digest from ghcr
+    steps:
+      - uses: actions/checkout@v4 # the ring script + the smoke suite
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install smoke-suite dependencies
+        run: pip install pytest
+
+      - name: Throwaway-CI ring — verify provenance, install-from-zero, smoke
+        env:
+          DIGEST_REF: ${{ needs.build.outputs.digest_ref }}
+        run: ./scripts/ci/throwaway-ci-ring.sh

--- a/docs/contained-workflow/deployment-verification.md
+++ b/docs/contained-workflow/deployment-verification.md
@@ -15,7 +15,13 @@ the digest promoted), R-24 (OCI labels + registry permissions + cosign signature
 
 Pipeline under verification: `.github/workflows/oakandwave-workflow-image.yml`
 → `scripts/ci/build-oakandwave-image.sh` (build + label + push, emits the digest)
-→ `scripts/ci/sign-oakandwave-image.sh` (cosign sign + syft SBOM attest).
+→ `scripts/ci/sign-oakandwave-image.sh` (cosign sign + syft SBOM attest)
+→ `scripts/ci/throwaway-ci-ring.sh` (the `smoke` job — this runbook's §1–§5,
+automated, plus install-from-zero and the smoke suite; a red blocks the digest).
+
+The steps below are the manual companion to that ring: run them by hand to audit
+a candidate the operator wants to inspect directly. The ring performs the same
+provenance checks (labels, permissions, signature, SBOM) *before* it smokes.
 
 ---
 

--- a/scripts/ci/throwaway-ci-ring.sh
+++ b/scripts/ci/throwaway-ci-ring.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# throwaway-ci-ring.sh — the E2E-01 throwaway-CI ring (Story 2.2 / #967,
+# Dev Spec §6.3, R-05/R-23/R-24).
+#
+# Pull the candidate FROM THE REGISTRY BY DIGEST — never a local build (R-23) —
+# verify its provenance (OCI labels + registry permissions + cosign signature +
+# syft SBOM), install from zero, run the smoke suite, tear down. Any verification
+# or smoke failure exits non-zero, which fails the digest and blocks it from
+# promotion (R-05/R-23).
+#
+# Ordering is load-bearing (R-24, AC2): every provenance check — signature, SBOM,
+# pullability/permissions, labels — runs BEFORE the smoke suite. Signature and
+# SBOM are verified registry-side first, so we never pull bytes we have not
+# attested; the pull that follows is both the permissions proof and the
+# install-from-zero (a fresh registry pull, no local build in sight).
+#
+# This is the automated companion to the operator runbook
+# docs/contained-workflow/deployment-verification.md (DM-12), which performs the
+# same §1–§5 checks by hand. Keep the two in step.
+#
+# All ring logic lives here, not in the workflow YAML (project rule: No Procedural
+# Logic in CI/CD YAML); .github/workflows/oakandwave-workflow-image.yml calls this
+# in one line from the `smoke` job (needs: build).
+#
+# Inputs (env):
+#   DIGEST_REF                  the immutable pin registry/image@sha256:… to test
+#                               (required; the build job emits it as digest_ref).
+#   COSIGN_CERT_IDENTITY_REGEXP cosign --certificate-identity-regexp: the workflow
+#                               identity that must have signed the digest. Default
+#                               derives from GITHUB_REPOSITORY (the image workflow
+#                               path). A bare verify that ignores identity is not
+#                               sufficient — anyone can sign a public digest.
+#   COSIGN_OIDC_ISSUER          cosign --certificate-oidc-issuer (default: GitHub
+#                               Actions OIDC).
+#   SMOKE_SUITE                 pytest target for the smoke suite (default: the
+#                               image toolchain oracle tests/contained-workflow/
+#                               test_image.py). Run with OAKANDWAVE_REQUIRE_IMAGE
+#                               so a missing/broken image is a hard fail, never a
+#                               silent skip — that is what makes a red smoke block
+#                               the digest.
+#   RING_SKIP_TEARDOWN          "true" leaves the pulled image in place (debug).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+
+# --- 0. Guard: a real registry DIGEST, never a local build (R-23) -------------
+# This runs before any tool is required, so the guard is unit-testable without
+# docker/cosign present.
+: "${DIGEST_REF:?DIGEST_REF must be set (registry/image@sha256:...)}"
+
+if [[ "$DIGEST_REF" != *"@sha256:"* ]]; then
+	echo "  [!] refusing to test a non-digest ref: $DIGEST_REF" >&2
+	echo "      E2E-01 tests the registry artifact BY DIGEST, never a local" >&2
+	echo "      build or a moving tag (R-23)." >&2
+	exit 1
+fi
+
+repo_slug="${GITHUB_REPOSITORY:-Wave-Engineering/claudecode-workflow}"
+cert_identity_regexp="${COSIGN_CERT_IDENTITY_REGEXP:-https://github.com/${repo_slug}/.github/workflows/oakandwave-workflow-image.yml@.*}"
+oidc_issuer="${COSIGN_OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
+smoke_suite="${SMOKE_SUITE:-$REPO_DIR/tests/contained-workflow/test_image.py}"
+
+# --- Required tooling ---------------------------------------------------------
+for tool in docker cosign python3; do
+	command -v "$tool" >/dev/null 2>&1 || {
+		echo "  [!] $tool not found on PATH — the ring needs it" >&2
+		exit 1
+	}
+done
+
+# --- Teardown: drop the pulled candidate on any exit (install-from-zero means
+# nothing lingers between runs) ------------------------------------------------
+teardown() {
+	[[ "${RING_SKIP_TEARDOWN:-false}" == "true" ]] && return 0
+	docker image rm "$DIGEST_REF" >/dev/null 2>&1 || true
+}
+trap teardown EXIT
+
+echo "==> E2E-01 throwaway-CI ring against $DIGEST_REF"
+
+# --- 1. cosign signature (R-24) — verified registry-side, before we pull ------
+# Identity-bound: the signer must be THIS repo's image workflow via GitHub OIDC.
+echo "[ring] verify-signature (cosign, identity-bound)"
+cosign verify \
+	--certificate-identity-regexp "$cert_identity_regexp" \
+	--certificate-oidc-issuer "$oidc_issuer" \
+	"$DIGEST_REF" >/dev/null
+
+# --- 2. syft SBOM (R-24) — SPDX attestation bound to the digest ---------------
+echo "[ring] verify-sbom (cosign attestation, spdxjson)"
+cosign verify-attestation \
+	--type spdxjson \
+	--certificate-identity-regexp "$cert_identity_regexp" \
+	--certificate-oidc-issuer "$oidc_issuer" \
+	"$DIGEST_REF" >/dev/null
+
+# --- 3. registry permissions + install-from-zero (R-24) -----------------------
+# A successful pull from a clean local store proves the candidate is
+# fleet-pullable AND installs the release from zero (the image digest IS the
+# release, R-05) — no local build involved (R-23).
+echo "[ring] verify-pullable (docker pull — permissions + install-from-zero)"
+docker pull "$DIGEST_REF" >/dev/null
+
+# --- 4. OCI provenance labels (R-24) ------------------------------------------
+# All four provenance facts — semver, source, revision, created — present and
+# non-empty on the PULLED image (the same producer test_provenance.py checks).
+echo "[ring] verify-labels (OCI provenance)"
+labels_json="$(docker image inspect --format '{{json .Config.Labels}}' "$DIGEST_REF")"
+missing=()
+for key in \
+	org.opencontainers.image.version \
+	org.opencontainers.image.source \
+	org.opencontainers.image.revision \
+	org.opencontainers.image.created; do
+	value="$(printf '%s' "$labels_json" | python3 -c 'import json,sys; print((json.load(sys.stdin) or {}).get(sys.argv[1]) or "")' "$key")"
+	[[ -n "$value" ]] || missing+=("$key")
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+	echo "  [!] missing/empty OCI provenance label(s): ${missing[*]}" >&2
+	echo "      labels on digest: $labels_json" >&2
+	exit 1
+fi
+
+# --- 5. smoke suite (R-05) — ONLY after every provenance check has passed -----
+# The smoke suite is the image toolchain oracle run against the pulled DIGEST.
+# OAKANDWAVE_REQUIRE_IMAGE turns a missing/broken image into a hard failure
+# (never a skip), so a red smoke reliably blocks the digest from promotion.
+echo "[ring] smoke (install-from-zero toolchain oracle against the digest)"
+OAKANDWAVE_IMAGE="$DIGEST_REF" \
+	OAKANDWAVE_REQUIRE_IMAGE=1 \
+	python3 -m pytest "$smoke_suite" -q
+
+echo "==> ring PASS: $DIGEST_REF is provenance-clean and smoked green"

--- a/tests/contained-workflow/test_throwaway_ci_ring.py
+++ b/tests/contained-workflow/test_throwaway_ci_ring.py
@@ -1,0 +1,196 @@
+"""Oracle for Story 2.2 (#967) — the throwaway-CI ring (E2E-01, R-05/R-23/R-24).
+
+The authoritative end-to-end proof is E2E-01 itself: pull the candidate digest
+from ghcr, verify labels/permissions/signature/SBOM, install-from-zero, smoke.
+That needs a real registry push + a signed digest, so it cannot run in the stock
+pytest lane (mirrors test_provenance.py). This module verifies, hermetically, the
+properties that make the ring correct:
+
+1. It refuses anything that is not a registry digest — E2E-01 tests the registry
+   artifact BY DIGEST, never a local build (R-23). This is a *behavioral* test:
+   the guard runs before any tool is required, so it fires with no docker/cosign.
+2. Every provenance check (signature, SBOM, pullability/permissions, labels) is
+   ordered strictly BEFORE the smoke suite (R-24, AC2).
+3. The smoke runs with OAKANDWAVE_REQUIRE_IMAGE, so a red smoke is a hard fail
+   that blocks the digest — never a silent skip (R-05/R-23, AC3).
+4. The signature check is identity-bound (not a bare `cosign verify`).
+5. The image workflow runs the ring as a `smoke` job after `build`, fed the exact
+   digest the build job pushed (R-23).
+
+A real-registry branch (skip-gated exactly like test_image.py) runs the whole
+ring against a live digest when OAKANDWAVE_RING_DIGEST is set.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RING_SCRIPT = REPO_ROOT / "scripts" / "ci" / "throwaway-ci-ring.sh"
+IMAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "oakandwave-workflow-image.yml"
+SMOKE_SUITE = REPO_ROOT / "tests" / "contained-workflow" / "test_image.py"
+
+# The provenance-check phase markers the ring emits, in the order R-24 requires,
+# and the smoke marker that must follow ALL of them.
+PROVENANCE_MARKERS = (
+    "[ring] verify-signature",
+    "[ring] verify-sbom",
+    "[ring] verify-pullable",
+    "[ring] verify-labels",
+)
+SMOKE_MARKER = "[ring] smoke"
+
+
+def _run_ring(digest_ref: str | None) -> subprocess.CompletedProcess[str]:
+    """Run the ring script with a controlled DIGEST_REF (or unset) and no ambient
+    provenance env. The digest guard runs before any tool is required, so this is
+    hermetic for the guard-behavior tests."""
+    env = dict(os.environ)
+    for k in ("DIGEST_REF", "SMOKE_SUITE", "RING_SKIP_TEARDOWN"):
+        env.pop(k, None)
+    if digest_ref is not None:
+        env["DIGEST_REF"] = digest_ref
+    return subprocess.run(
+        ["bash", str(RING_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+def test_ring_script_is_executable() -> None:
+    """The workflow invokes the ring directly (./scripts/ci/...), so it must be +x."""
+    assert RING_SCRIPT.exists(), f"ring script missing: {RING_SCRIPT}"
+    assert os.access(RING_SCRIPT, os.X_OK), "ring script must be executable"
+
+
+def test_ring_refuses_a_moving_tag_ref() -> None:
+    """A non-digest ref (a moving tag) is rejected before anything runs (R-23).
+
+    E2E-01 tests the registry artifact by digest, never a local build or a tag —
+    the guard fails the ring loud and early, with no docker/cosign needed.
+    """
+    proc = _run_ring("ghcr.io/wave-engineering/oakandwave-workflow:edge")
+    assert proc.returncode != 0, "ring must reject a non-digest (moving-tag) ref"
+    combined = proc.stdout + proc.stderr
+    assert "non-digest" in combined, f"expected an R-23 refusal message; got:\n{combined}"
+
+
+def test_ring_requires_a_digest_ref() -> None:
+    """With no DIGEST_REF at all, the ring fails loud (fail-closed), never no-ops."""
+    proc = _run_ring(None)
+    assert proc.returncode != 0, "ring must fail when DIGEST_REF is unset"
+    assert "DIGEST_REF" in (proc.stdout + proc.stderr)
+
+
+def test_ring_never_builds_locally() -> None:
+    """The ring pulls by digest and must never build an image (R-23).
+
+    A `docker build`/`buildx build` in the ring would mean testing bytes other
+    than the pushed digest — the exact thing R-23 forbids.
+    """
+    text = RING_SCRIPT.read_text()
+    assert "docker pull" in text, "ring must PULL the candidate by digest"
+    assert "@sha256:" in text, "ring must guard for a digest ref (R-23)"
+    assert "docker build" not in text, "ring must NOT build locally (R-23)"
+    assert "buildx build" not in text, "ring must NOT build locally (R-23)"
+
+
+def test_provenance_is_verified_before_smoke() -> None:
+    """Signature, SBOM, permissions, and labels are all checked BEFORE smoke.
+
+    R-24 (AC2): 'Labels, permissions, signature, and SBOM are verified before
+    smoke.' Enforced mechanically off the ring's own phase markers — the smoke
+    marker must appear after every provenance marker.
+    """
+    text = RING_SCRIPT.read_text()
+
+    smoke_at = text.find(SMOKE_MARKER)
+    assert smoke_at != -1, f"ring must emit a smoke marker {SMOKE_MARKER!r}"
+
+    for marker in PROVENANCE_MARKERS:
+        at = text.find(marker)
+        assert at != -1, f"ring must emit provenance marker {marker!r}"
+        assert at < smoke_at, (
+            f"provenance check {marker!r} must run BEFORE the smoke suite (R-24)"
+        )
+
+
+def test_smoke_hard_fails_never_skips() -> None:
+    """The smoke runs with OAKANDWAVE_REQUIRE_IMAGE so a red smoke blocks (AC3).
+
+    test_image.py *skips* when the image is absent unless OAKANDWAVE_REQUIRE_IMAGE
+    is set; the ring must set it, or a broken/missing candidate would pass as a
+    skip instead of blocking the digest (R-05/R-23).
+    """
+    text = RING_SCRIPT.read_text()
+    assert "OAKANDWAVE_REQUIRE_IMAGE=1" in text, (
+        "smoke must be REQUIRE_IMAGE so a red/missing image fails, never skips"
+    )
+    assert "OAKANDWAVE_IMAGE=" in text, "smoke must target the pulled DIGEST_REF"
+    assert "test_image.py" in text or "SMOKE_SUITE" in text, (
+        "smoke must invoke the image toolchain oracle"
+    )
+
+
+def test_signature_check_is_identity_bound() -> None:
+    """The cosign verify binds to a signer identity + issuer, not a bare verify.
+
+    A bare `cosign verify` accepts ANY signature on a public digest; the security
+    property is that THIS repo's image workflow signed it (deployment-verification
+    §2, R-24).
+    """
+    text = RING_SCRIPT.read_text()
+    assert "cosign verify" in text, "ring must verify the cosign signature"
+    assert "--certificate-identity-regexp" in text, "signature check must bind an identity"
+    assert "--certificate-oidc-issuer" in text, "signature check must bind the OIDC issuer"
+    assert "cosign verify-attestation" in text, "ring must verify the SBOM attestation"
+    assert "spdxjson" in text, "SBOM attestation must be the SPDX predicate"
+
+
+def test_image_workflow_runs_smoke_after_build() -> None:
+    """The image workflow wires the ring as a `smoke` job after `build` (R-23)."""
+    text = IMAGE_WORKFLOW.read_text()
+    assert "throwaway-ci-ring.sh" in text, "workflow must call the ring script"
+    assert re.search(r"^\s*smoke:\s*$", text, re.MULTILINE), "workflow needs a `smoke` job"
+    assert "needs: build" in text, "smoke must depend on the build job"
+    # The build job must export the digest, and smoke must consume THAT digest —
+    # the digest tested is the digest built (R-23), never a re-resolved tag.
+    assert "digest_ref: ${{ steps.build.outputs.digest_ref }}" in text, (
+        "build job must expose the pushed digest as an output"
+    )
+    assert "needs.build.outputs.digest_ref" in text, (
+        "smoke must pull the exact digest the build job pushed"
+    )
+
+
+# --- Real-registry branch (skip-gated, mirrors test_image.py) -----------------
+
+
+def test_ring_against_live_digest() -> None:
+    """Run the whole ring against a real signed digest when one is provided.
+
+    Set OAKANDWAVE_RING_DIGEST to a pushed+signed
+    `ghcr.io/<org>/oakandwave-workflow@sha256:…` (and be logged in to ghcr) to
+    exercise E2E-01 for real: provenance verification + install-from-zero + smoke.
+    Absent that, this skips — the stock lane has no registry artifact to test.
+    """
+    digest = os.environ.get("OAKANDWAVE_RING_DIGEST")
+    if not digest:
+        pytest.skip("set OAKANDWAVE_RING_DIGEST to a live signed digest to run E2E-01")
+    for tool in ("docker", "cosign", "python3"):
+        if shutil.which(tool) is None:
+            pytest.fail(f"OAKANDWAVE_RING_DIGEST set but {tool} not on PATH")
+
+    proc = _run_ring(digest)
+    assert proc.returncode == 0, (
+        f"ring failed against {digest}:\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )


### PR DESCRIPTION
## Summary

Integrates the Story 2.2 throwaway-CI ring (E2E-01, #967) into the P2W1 kahuna sandbox. The ring pulls the candidate image from ghcr BY DIGEST, verifies provenance (OCI labels, registry permissions, cosign signature, syft SBOM) before smoking it, installs from zero, runs the smoke suite, and tears down — a red smoke or any failed provenance check blocks the digest from promotion.

## Changes

- `.github/workflows/oakandwave-workflow-image.yml`: expose `digest_ref` as a `build`-job output; add a `smoke` job (`needs: build`) that runs the ring against the exact pushed+signed digest (R-23).
- `scripts/ci/throwaway-ci-ring.sh` (new): the ring — digest-only guard, ordered provenance checks (signature → SBOM → pullable → labels) before install-from-zero + smoke, identity-bound cosign verify.
- `tests/contained-workflow/test_throwaway_ci_ring.py` (new): hermetic oracle for the ring's correctness properties (digest-refusal guard, provenance-before-smoke ordering, require-image hard-fail, identity-bound signature, workflow wiring).
- `docs/contained-workflow/deployment-verification.md`: document the ring as the automated companion to the manual runbook.

## Cross-flight integration note

Clean fast-forward extension of Story 2.1 (#966). The ring consumes `steps.build.outputs.digest_ref`, which #966's build job emits — interface extended, not broken. Composed-diff safety confirmed as PRIME reconcile oracle (commutativity single-target verdict ORACLE_REQUIRED is by-design for infra/config files).

## Linked Issues

Closes #967

## Test Plan

- `./scripts/ci/validate.sh` — 191 passed, 0 failed
- `./scripts/ci/test.sh` (pytest `tests/`) — 1742 passed, 5 skipped, 64 xfailed, 2 xpassed, 26 subtests passed in 534.48s