### PR TITLE
chore(968): P2W2 flight — mechanical promotion gate (Story 2.3)

### DIFF
--- a/containers/oakandwave-workflow/promotion_gate.py
+++ b/containers/oakandwave-workflow/promotion_gate.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Mechanical promotion gate — Story 2.3 (#968), Plan #959, Dev Spec §4.4 / §5.6.
+
+The gate that decides whether a candidate `:edge` digest may be promoted to
+`:stable`. It is a **conjunctive query over FlightDeck + CI** (§5.6): the four
+mechanical conditions — throwaway-CI E2E-01 green, dogfood soak met, zero
+quarantines, zero open Sev-1 — must **all** be green before promotion is
+permitted, and promotion retags the **exact digest E2E-01 tested**.
+
+Requirements this module is the guard for:
+
+* **R-07** — WHEN all mechanical conditions are green THEN `:edge → :stable`
+  promotion is permitted, retagging the exact digest E2E-01 tested; a human ACK
+  shall only *confirm* a green gate, never *substitute* for it. (PC-6: promotion
+  is mechanical, not a feeling.)
+* **R-23** — the digest E2E-01 tested, the digest promoted, and the digest the
+  fleet pulls are identical. Folded into the conjunction: the throwaway-CI
+  condition is green only when CI passed *for the digest being promoted*, so a
+  green result for a different digest cannot promote this one.
+
+Design — **one green path, fail-closed** (assertion-liveness, D7):
+
+* A condition is green **only** when its signal is explicitly, affirmatively
+  green. A missing, unknown, ``None``, or non-conforming signal is **RED**, never
+  assumed green. There is no override, no ack, and no missing-data shortcut that
+  can move a red gate to green.
+* :func:`promote` is the **only** code path that yields a promotable digest. It
+  raises :class:`GateError` unless (in this order) the mechanical conjunction is
+  green **and** the operator ACK confirms it. Checking the conjunction *before*
+  the ack is load-bearing: it encodes "the ACK can only fire after the query is
+  green" and "a human ACK can never substitute for a red condition" (R-07).
+* The digest it returns is exactly ``report.target_digest`` — never a re-resolved
+  moving tag — so the caller retags precisely the bytes E2E-01 tested (R-23).
+
+The module never touches the network or a registry; it reasons purely over the
+signals handed to it. Sourcing those signals (a FlightDeck query for soak /
+quarantines / Sev-1, the CI result for the throwaway-CI ring) and performing the
+exact-digest retag live in ``scripts/ci/promote-oakandwave-image.sh``.
+
+CLI::
+
+    python3 promotion_gate.py --target-digest ghcr.io/o/w@sha256:… \\
+        --ci-passed true --ci-digest ghcr.io/o/w@sha256:… \\
+        --soak-hours 48 --soak-required-hours 24 \\
+        --quarantines 0 --open-sev1 0 --ack
+
+Prints the digest to promote on stdout and exits 0 only when the gate is green
+and the ACK confirms it; otherwise prints the red summary to stderr and exits 2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+
+# The four mechanical conditions of the promotion gate (§5.6), in report order.
+CONDITION_ORDER = ("throwaway_ci", "soak", "quarantines", "sev1")
+
+CONDITION_LABELS = {
+    "throwaway_ci": "throwaway-CI E2E-01 smoke green for the tested digest",
+    "soak": "dogfood soak requirement met",
+    "quarantines": "zero quarantines",
+    "sev1": "zero open Sev-1",
+}
+
+# A full, immutable registry digest pin: `registry/path@sha256:<64 hex>`. A
+# moving tag (`…:edge`) has no `@sha256:` and is refused — the gate promotes the
+# content-addressed digest E2E-01 tested, never a re-resolvable tag (R-23).
+_DIGEST_RE = re.compile(r"^[^@\s]+@sha256:[0-9a-fA-F]{64}$")
+
+
+class GateError(ValueError):
+    """A promotion-gate contract violation. Raised LOUD, never swallowed."""
+
+
+def _is_digest_ref(ref: object) -> bool:
+    """True iff ``ref`` is a full immutable ``…@sha256:<64hex>`` registry pin."""
+    return isinstance(ref, str) and bool(_DIGEST_RE.match(ref.strip()))
+
+
+def _same_digest(a: object, b: object) -> bool:
+    """True iff ``a`` and ``b`` are the same immutable digest ref (R-23).
+
+    Both must be full digest pins; comparison is case-insensitive and
+    whitespace-trimmed (registry paths are lowercased at build time). A bare
+    ``sha256:…`` or a moving tag never matches a full ref — fail-closed."""
+    if not (_is_digest_ref(a) and _is_digest_ref(b)):
+        return False
+    assert isinstance(a, str) and isinstance(b, str)  # narrowed by _is_digest_ref
+    return a.strip().lower() == b.strip().lower()
+
+
+def _require_digest(ref: str) -> None:
+    if not _is_digest_ref(ref):
+        raise GateError(
+            f"target digest must be an immutable registry pin "
+            f"(registry/image@sha256:<64hex>), got {ref!r} — the gate promotes "
+            f"the exact digest E2E-01 tested, never a moving tag (R-23)"
+        )
+
+
+@dataclass(frozen=True)
+class Condition:
+    """One mechanical condition and whether it is affirmatively green."""
+
+    name: str
+    green: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class GateReport:
+    """The evaluated gate for a specific candidate digest."""
+
+    target_digest: str
+    conditions: tuple[Condition, ...]
+
+    @property
+    def green(self) -> bool:
+        """The conjunction, **fail-closed**: green iff every one of the four
+        mechanical conditions is present AND affirmatively green. A missing or
+        extra condition makes the gate red — the set must be exactly the four."""
+        names = {c.name for c in self.conditions}
+        if names != set(CONDITION_ORDER):
+            return False
+        return all(c.green for c in self.conditions)
+
+    def red(self) -> list[Condition]:
+        """The conditions blocking promotion (empty iff :attr:`green`)."""
+        return [c for c in self.conditions if not c.green]
+
+    def summary(self) -> str:
+        lines = [f"promotion gate for {self.target_digest}:"]
+        for c in self.conditions:
+            mark = "green" if c.green else "RED"
+            label = CONDITION_LABELS.get(c.name, c.name)
+            suffix = f" — {c.detail}" if c.detail else ""
+            lines.append(f"  [{mark}] {label}{suffix}")
+        verdict = "GREEN — promotion permitted (pending operator ACK)" if self.green \
+            else "RED — promotion refused"
+        lines.append(f"  => {verdict}")
+        return "\n".join(lines)
+
+
+def evaluate_gate(
+    *,
+    target_digest: str,
+    ci_passed: bool | None,
+    ci_digest: str | None,
+    soak_hours: float | None,
+    soak_required_hours: float,
+    quarantine_count: int | None,
+    open_sev1_count: int | None,
+) -> GateReport:
+    """Evaluate the four mechanical conditions for ``target_digest``.
+
+    Every condition is **fail-closed**: it is green only on an explicit, correct
+    signal; ``None`` / missing / malformed ⇒ red. The throwaway-CI condition
+    additionally requires the CI result to be *for this digest* (R-23), so a
+    green for a different digest cannot carry this one.
+    """
+    _require_digest(target_digest)
+
+    # 1. throwaway-CI E2E-01 green — AND bound to THIS digest (R-23).
+    if ci_passed is not True:
+        ci_green, ci_detail = False, "E2E-01 has not reported a green smoke"
+    elif not _is_digest_ref(ci_digest):
+        ci_green, ci_detail = False, "E2E-01 result carries no immutable digest ref"
+    elif not _same_digest(ci_digest, target_digest):
+        ci_green = False
+        ci_detail = (
+            f"E2E-01 tested {ci_digest!r} but promotion targets "
+            f"{target_digest!r} — refusing (R-23: the digest tested is the "
+            f"digest promoted)"
+        )
+    else:
+        ci_green, ci_detail = True, f"E2E-01 green for {target_digest}"
+
+    # 2. dogfood soak met.
+    if not isinstance(soak_hours, (int, float)) or isinstance(soak_hours, bool):
+        soak_green = False
+        soak_detail = "soak telemetry unavailable"
+    elif soak_hours >= soak_required_hours:
+        soak_green = True
+        soak_detail = f"{soak_hours:g}h ≥ {soak_required_hours:g}h required"
+    else:
+        soak_green = False
+        soak_detail = f"{soak_hours:g}h < {soak_required_hours:g}h required"
+
+    # 3. zero quarantines.
+    if not isinstance(quarantine_count, int) or isinstance(quarantine_count, bool):
+        quar_green, quar_detail = False, "quarantine telemetry unavailable"
+    elif quarantine_count == 0:
+        quar_green, quar_detail = True, "0 quarantines"
+    else:
+        quar_green, quar_detail = False, f"{quarantine_count} quarantine(s) during soak"
+
+    # 4. zero open Sev-1.
+    if not isinstance(open_sev1_count, int) or isinstance(open_sev1_count, bool):
+        sev_green, sev_detail = False, "Sev-1 telemetry unavailable"
+    elif open_sev1_count == 0:
+        sev_green, sev_detail = True, "0 open Sev-1"
+    else:
+        sev_green, sev_detail = False, f"{open_sev1_count} open Sev-1"
+
+    return GateReport(
+        target_digest=target_digest.strip(),
+        conditions=(
+            Condition("throwaway_ci", ci_green, ci_detail),
+            Condition("soak", soak_green, soak_detail),
+            Condition("quarantines", quar_green, quar_detail),
+            Condition("sev1", sev_green, sev_detail),
+        ),
+    )
+
+
+def promote(report: GateReport, *, operator_ack: bool) -> str:
+    """The **only** path to a promotable digest.
+
+    Returns the digest to retag ``:edge → :stable`` — exactly
+    ``report.target_digest``, the bytes E2E-01 tested (R-23). Raises
+    :class:`GateError` unless the mechanical gate is green **and** the operator
+    ACK confirms it.
+
+    Order is load-bearing: the conjunction is checked **before** the ACK, so a
+    red condition raises regardless of the ACK. The ACK can only *confirm* an
+    already-green gate; it can never *substitute* for a red condition (R-07).
+    """
+    if not report.green:
+        blocked = ", ".join(
+            f"{c.name} ({c.detail})" if c.detail else c.name for c in report.red()
+        )
+        raise GateError(
+            "promotion refused — mechanical gate is RED; failing condition(s): "
+            f"{blocked}. A human ACK cannot substitute for a red condition (R-07)."
+        )
+    if operator_ack is not True:
+        raise GateError(
+            "mechanical gate is green but the operator ACK has not confirmed it — "
+            "promotion requires an explicit ACK, and only AFTER the query is "
+            "green (R-07)."
+        )
+    return report.target_digest
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def _tri_bool(value: str | None) -> bool | None:
+    """Parse a tri-state signal: true/false → bool, anything else → None (red)."""
+    if value is None:
+        return None
+    v = value.strip().lower()
+    if v in ("true", "1", "yes", "pass", "passed", "green"):
+        return True
+    if v in ("false", "0", "no", "fail", "failed", "red"):
+        return False
+    return None
+
+
+def _opt_number(value: str | None, cast):
+    """Parse an optional count/hours signal; unparsable/absent → None (red)."""
+    if value is None:
+        return None
+    try:
+        return cast(value.strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--target-digest",
+        required=True,
+        help="the candidate digest to promote (registry/image@sha256:…)",
+    )
+    parser.add_argument("--ci-passed", default=None, help="E2E-01 smoke result (true/false)")
+    parser.add_argument("--ci-digest", default=None, help="the digest E2E-01 tested")
+    parser.add_argument("--soak-hours", default=None, help="accrued dogfood soak hours")
+    parser.add_argument(
+        "--soak-required-hours", default="24", help="soak hours required (default 24)"
+    )
+    parser.add_argument("--quarantines", default=None, help="quarantine count during soak")
+    parser.add_argument("--open-sev1", default=None, help="open Sev-1 count")
+    parser.add_argument(
+        "--ack",
+        action="store_true",
+        help="operator ACK — only confirms an already-green gate, never substitutes",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = evaluate_gate(
+            target_digest=args.target_digest,
+            ci_passed=_tri_bool(args.ci_passed),
+            ci_digest=args.ci_digest,
+            soak_hours=_opt_number(args.soak_hours, float),
+            soak_required_hours=float(args.soak_required_hours),
+            quarantine_count=_opt_number(args.quarantines, int),
+            open_sev1_count=_opt_number(args.open_sev1, int),
+        )
+    except GateError as exc:
+        print(f"promotion-gate error: {exc}", file=sys.stderr)
+        return 2
+
+    print(report.summary(), file=sys.stderr)
+
+    try:
+        digest = promote(report, operator_ack=args.ack)
+    except GateError as exc:
+        print(f"promotion-gate: {exc}", file=sys.stderr)
+        return 2
+
+    # The one line stdout emits is the digest to retag — the exact bytes E2E-01
+    # tested (R-23). The wrapper consumes this and retags :edge → :stable.
+    print(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/promote-oakandwave-image.sh
+++ b/scripts/ci/promote-oakandwave-image.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# promote-oakandwave-image.sh — the mechanical promotion gate + exact-digest
+# retag (Story 2.3 / #968, Dev Spec §4.4 / §5.6, R-07/R-23).
+#
+# Promotion is a two-part contract:
+#
+#   1. A mechanical conjunction over FlightDeck + CI must be green — throwaway-CI
+#      E2E-01 pass, dogfood soak met, zero quarantines, zero open Sev-1 (R-07).
+#   2. The operator ACK confirms the green gate; promotion then retags the EXACT
+#      digest E2E-01 tested `:edge → :stable` — no rebuild, same bytes (R-23).
+#
+# The DECISION lives in the unit-tested gate module
+# (containers/oakandwave-workflow/promotion_gate.py): this wrapper only *gathers*
+# the four signals and, on a green+ACK'd verdict, performs the retag. Keeping the
+# conjunction in Python (not in this shell, and never in CI/CD YAML) is what makes
+# "no code path promotes without all conditions green" a tested guarantee.
+#
+# Fail-closed: any signal that is missing, unknown, or malformed is RED. A red
+# gate — or a green gate with no ACK — exits non-zero and retags nothing. The ACK
+# can only confirm an already-green gate; it can never substitute for a red
+# condition (PC-6: promotion is mechanical, not a feeling).
+#
+# Signals (env). The soak / quarantine / Sev-1 conditions are FlightDeck (#854)
+# telemetry; the throwaway-CI condition is E2E-01's result. Each is injected here
+# so a caller (the E2E-02 promotion cycle, or the operator runbook) supplies them
+# from the live sources. An optional GATE_SIGNALS_CMD DI-seam (mirrors the emit
+# script's FLIGHTDECK_EMIT_CMD) is sourced first to populate them from a
+# FlightDeck query; if it is unset or yields nothing, the corresponding condition
+# stays RED.
+#
+#   DIGEST_REF          the candidate digest to promote, registry/image@sha256:…
+#                       (required; the build job emits it, the ring tests it).
+#   OPERATOR_ACK        "true" ⇒ the operator confirms the green gate (default:
+#                       false ⇒ no promotion even when the gate is green).
+#   GATE_SIGNALS_CMD    optional command emitting `KEY=VALUE` lines (a FlightDeck
+#                       query seam); its output is sourced before reading signals.
+#   THROWAWAY_CI_PASSED E2E-01 smoke result for DIGEST_REF (true/false).
+#   THROWAWAY_CI_DIGEST the digest E2E-01 tested (defaults to DIGEST_REF; the gate
+#                       still requires it to equal the promotion target — R-23).
+#   SOAK_HOURS          accrued dogfood soak hours.
+#   SOAK_REQUIRED_HOURS soak hours required (default 24).
+#   QUARANTINE_COUNT    quarantines during soak (0 to pass).
+#   OPEN_SEV1_COUNT     open Sev-1 (0 to pass).
+#   STABLE_TAG          moving tag to publish (default: stable).
+#   PROMOTE_DRY_RUN     "true" ⇒ evaluate the gate + print the retag, do NOT push.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+GATE_PY="$REPO_DIR/containers/oakandwave-workflow/promotion_gate.py"
+
+: "${DIGEST_REF:?DIGEST_REF must be set (registry/image@sha256:...)}"
+
+# --- Optional FlightDeck-query seam: populate signal env from its KV output ---
+if [[ -n "${GATE_SIGNALS_CMD:-}" ]]; then
+	while IFS= read -r kv; do
+		[[ "$kv" == *=* ]] || continue
+		export "${kv?}"
+	done < <(eval "$GATE_SIGNALS_CMD" || true)
+fi
+
+# --- Assemble the gate CLI invocation (fail-closed: omit ⇒ the gate reads red) -
+gate_args=(--target-digest "$DIGEST_REF")
+
+[[ -n "${THROWAWAY_CI_PASSED:-}" ]] && gate_args+=(--ci-passed "$THROWAWAY_CI_PASSED")
+# The digest E2E-01 tested defaults to the promotion target; the gate still
+# enforces they are equal (R-23), so a caller cannot silently widen this.
+gate_args+=(--ci-digest "${THROWAWAY_CI_DIGEST:-$DIGEST_REF}")
+[[ -n "${SOAK_HOURS:-}" ]] && gate_args+=(--soak-hours "$SOAK_HOURS")
+gate_args+=(--soak-required-hours "${SOAK_REQUIRED_HOURS:-24}")
+[[ -n "${QUARANTINE_COUNT:-}" ]] && gate_args+=(--quarantines "$QUARANTINE_COUNT")
+[[ -n "${OPEN_SEV1_COUNT:-}" ]] && gate_args+=(--open-sev1 "$OPEN_SEV1_COUNT")
+[[ "${OPERATOR_ACK:-false}" == "true" ]] && gate_args+=(--ack)
+
+echo "==> evaluating the mechanical promotion gate for $DIGEST_REF"
+
+# The gate CLI prints the digest-to-promote on stdout and exits 0 ONLY when the
+# conjunction is green AND the ACK confirms it; otherwise it exits non-zero and
+# prints the red summary to stderr. `set -e` turns a red gate into a hard stop,
+# so nothing below (the retag) runs unless the gate said promote.
+promoted_digest="$(python3 "$GATE_PY" "${gate_args[@]}")"
+
+if [[ -z "$promoted_digest" ]]; then
+	echo "  [!] gate returned no digest — refusing to promote" >&2
+	exit 1
+fi
+
+# Belt-and-suspenders (R-23): the digest we retag must be the digest the gate
+# blessed, which is the digest E2E-01 tested. They are the same object; assert it.
+if [[ "$promoted_digest" != "$DIGEST_REF" ]]; then
+	echo "  [!] gate blessed $promoted_digest but target is $DIGEST_REF — aborting" >&2
+	exit 1
+fi
+
+# --- Retag the EXACT digest :edge → :stable — no rebuild (R-07/R-23) -----------
+# `docker buildx imagetools create --tag <repo>:stable <repo>@sha256:…` points the
+# moving :stable tag at the *same manifest digest*. Because the digest is
+# unchanged, the cosign signature and syft SBOM (both digest-bound) remain valid
+# for :stable — the fleet pulls the exact bytes E2E-01 tested and the operator
+# ACK'd.
+image_repo="${promoted_digest%@*}"
+stable_ref="${image_repo}:${STABLE_TAG:-stable}"
+
+if [[ "${PROMOTE_DRY_RUN:-false}" == "true" ]]; then
+	echo "==> [dry-run] would retag $promoted_digest → $stable_ref"
+	exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || {
+	echo "  [!] docker not found — needed to retag the digest to :stable" >&2
+	exit 1
+}
+
+echo "==> promote: retag $promoted_digest → $stable_ref (exact digest, no rebuild)"
+docker buildx imagetools create --tag "$stable_ref" "$promoted_digest"
+
+echo "==> promoted: $stable_ref now points at the digest E2E-01 tested"

--- a/tests/contained-workflow/test_gate.py
+++ b/tests/contained-workflow/test_gate.py
@@ -1,0 +1,311 @@
+"""Oracle for Story 2.3 (#968) — the mechanical promotion gate (R-07/R-23).
+
+The gate (``containers/oakandwave-workflow/promotion_gate.py``) decides whether a
+candidate ``:edge`` digest may be promoted to ``:stable``. Two acceptance
+criteria, both proved here as *pure* unit oracles (no docker, no registry, no
+FlightDeck) so they run for real in the stock ``pytest tests/`` lane:
+
+* **AC1 [R-07]** — *no code path promotes without all conditions green.* The
+  named story oracle, :func:`test_gate_conjunction`, drives every single-red
+  combination of the four mechanical conditions and asserts :func:`promote`
+  refuses each one; the all-green case promotes only with the ACK. Fail-closed:
+  a missing / unknown / malformed signal is RED, never assumed green.
+* **AC2 [R-07, R-23]** — *the promoted digest equals the digest E2E-01 tested.*
+  A green CI result for a *different* digest cannot carry this one, and
+  :func:`promote` returns exactly the tested digest — never a re-resolved tag.
+
+Plus guards on the ACK semantics (confirm-only, never a substitute) and on the
+wrapper/CLI wiring that the promotion mechanism rides.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+GATE_PY = CONTAINER_DIR / "promotion_gate.py"
+PROMOTE_SCRIPT = REPO_ROOT / "scripts" / "ci" / "promote-oakandwave-image.sh"
+
+# The resolver-style path import (no PYTHONPATH dependency), mirroring
+# test_mounts.py — the gate module is colocated with the container assets.
+sys.path.insert(0, str(CONTAINER_DIR))
+import promotion_gate as pg  # noqa: E402
+
+# Two distinct, well-formed immutable digest pins.
+DIGEST_A = "ghcr.io/wave-engineering/oakandwave-workflow@sha256:" + "a" * 64
+DIGEST_B = "ghcr.io/wave-engineering/oakandwave-workflow@sha256:" + "b" * 64
+MOVING_TAG = "ghcr.io/wave-engineering/oakandwave-workflow:edge"
+
+# A fully-green signal set for DIGEST_A. Individual tests knock ONE condition red.
+GREEN_SIGNALS = dict(
+    target_digest=DIGEST_A,
+    ci_passed=True,
+    ci_digest=DIGEST_A,
+    soak_hours=48.0,
+    soak_required_hours=24.0,
+    quarantine_count=0,
+    open_sev1_count=0,
+)
+
+# For each condition, the signal override(s) that turn JUST that condition red —
+# including the fail-closed "unavailable" (None) shape.
+RED_OVERRIDES: dict[str, list[dict]] = {
+    "throwaway_ci": [
+        {"ci_passed": False},  # E2E-01 red
+        {"ci_passed": None},  # no CI result at all (fail-closed)
+        {"ci_digest": DIGEST_B},  # green, but for a DIFFERENT digest (R-23)
+        {"ci_digest": None},  # green, but no digest attested (fail-closed)
+        {"ci_digest": MOVING_TAG},  # green, but attested a moving tag (R-23)
+    ],
+    "soak": [
+        {"soak_hours": 12.0},  # under the required soak
+        {"soak_hours": None},  # soak telemetry unavailable (fail-closed)
+    ],
+    "quarantines": [
+        {"quarantine_count": 1},  # a quarantine tripped
+        {"quarantine_count": None},  # quarantine telemetry unavailable
+    ],
+    "sev1": [
+        {"open_sev1_count": 3},  # open Sev-1
+        {"open_sev1_count": None},  # Sev-1 telemetry unavailable
+    ],
+}
+
+
+def _report(**overrides) -> pg.GateReport:
+    signals = {**GREEN_SIGNALS, **overrides}
+    return pg.evaluate_gate(**signals)
+
+
+# --- AC1 [R-07]: the named story oracle — no promotion unless ALL green -------
+
+
+def test_gate_conjunction() -> None:
+    """No code path promotes without all four mechanical conditions green (R-07).
+
+    Drive every single-condition-red shape (including the fail-closed "signal
+    unavailable" shapes) and assert the gate reads red AND :func:`promote`
+    refuses. Then the all-green case: it promotes — but only once the ACK
+    confirms it.
+    """
+    for condition, overrides_list in RED_OVERRIDES.items():
+        for override in overrides_list:
+            report = _report(**override)
+            assert not report.green, (
+                f"{condition} red via {override} must leave the gate RED, "
+                f"got green:\n{report.summary()}"
+            )
+            # Even WITH the operator ACK, a red condition must never promote —
+            # the ACK cannot substitute for a red condition.
+            with pytest.raises(pg.GateError):
+                pg.promote(report, operator_ack=True)
+            assert any(c.name == condition for c in report.red()), (
+                f"the RED condition should be {condition}; report:\n{report.summary()}"
+            )
+
+    # All-green: the gate is green and promotes the tested digest — with the ACK.
+    green = _report()
+    assert green.green, f"the fully-green signal set must be green:\n{green.summary()}"
+    assert pg.promote(green, operator_ack=True) == DIGEST_A
+
+
+def test_multiple_red_conditions_still_refused() -> None:
+    """Every non-all-green combination refuses, ACK or not (exhaustive over the
+    2^4 truth table of the four conditions)."""
+    knobs = {
+        "throwaway_ci": {"ci_passed": False},
+        "soak": {"soak_hours": 1.0},
+        "quarantines": {"quarantine_count": 2},
+        "sev1": {"open_sev1_count": 1},
+    }
+    names = list(knobs)
+    for greens in itertools.product([True, False], repeat=len(names)):
+        overrides: dict = {}
+        for name, keep_green in zip(names, greens):
+            if not keep_green:
+                overrides.update(knobs[name])
+        report = _report(**overrides)
+        all_green = all(greens)
+        assert report.green is all_green, (
+            f"gate green={report.green} but expected {all_green} for {greens}"
+        )
+        if not all_green:
+            with pytest.raises(pg.GateError):
+                pg.promote(report, operator_ack=True)
+
+
+# --- AC2 [R-07, R-23]: the promoted digest is the digest E2E-01 tested --------
+
+
+def test_promoted_digest_equals_tested_digest() -> None:
+    """A green E2E-01 for a DIFFERENT digest cannot promote this one (R-23)."""
+    # CI passed, but against DIGEST_B while we target DIGEST_A.
+    report = pg.evaluate_gate(
+        **{**GREEN_SIGNALS, "target_digest": DIGEST_A, "ci_digest": DIGEST_B}
+    )
+    assert not report.green
+    ci = next(c for c in report.conditions if c.name == "throwaway_ci")
+    assert not ci.green and "R-23" in ci.detail
+    with pytest.raises(pg.GateError):
+        pg.promote(report, operator_ack=True)
+
+    # The matched case returns EXACTLY the tested digest, not a moving tag.
+    matched = pg.evaluate_gate(**GREEN_SIGNALS)
+    promoted = pg.promote(matched, operator_ack=True)
+    assert promoted == DIGEST_A == GREEN_SIGNALS["ci_digest"]
+    assert "@sha256:" in promoted, "the promoted ref must be the immutable digest"
+
+
+def test_gate_refuses_a_moving_tag_target() -> None:
+    """The promotion target must be an immutable digest, never a moving tag (R-23)."""
+    with pytest.raises(pg.GateError):
+        pg.evaluate_gate(**{**GREEN_SIGNALS, "target_digest": MOVING_TAG})
+
+
+# --- ACK semantics: confirm-only, never a substitute (R-07) -------------------
+
+
+def test_ack_cannot_promote_a_red_gate() -> None:
+    """The ACK confirms a green gate; it can never rescue a red one (R-07)."""
+    report = _report(soak_hours=0.0)
+    assert not report.green
+    with pytest.raises(pg.GateError):
+        pg.promote(report, operator_ack=True)
+
+
+def test_green_gate_still_needs_the_ack() -> None:
+    """A green gate does NOT auto-promote — the operator ACK is required, and it
+    is consulted only after the query is green."""
+    report = _report()
+    assert report.green
+    with pytest.raises(pg.GateError):
+        pg.promote(report, operator_ack=False)
+    assert pg.promote(report, operator_ack=True) == DIGEST_A
+
+
+# --- CLI: the wrapper's decision surface (fail-closed) ------------------------
+
+
+def _run_gate_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GATE_PY), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_cli_promotes_only_on_green_plus_ack() -> None:
+    """The CLI prints the digest and exits 0 only on a green gate WITH --ack."""
+    base = [
+        "--target-digest", DIGEST_A,
+        "--ci-passed", "true", "--ci-digest", DIGEST_A,
+        "--soak-hours", "48", "--soak-required-hours", "24",
+        "--quarantines", "0", "--open-sev1", "0",
+    ]
+    # Green but no ACK → refuse (non-zero), print nothing promotable on stdout.
+    no_ack = _run_gate_cli(*base)
+    assert no_ack.returncode != 0
+    assert DIGEST_A not in no_ack.stdout
+
+    # Green + ACK → promote: stdout is exactly the tested digest.
+    acked = _run_gate_cli(*base, "--ack")
+    assert acked.returncode == 0, acked.stderr
+    assert acked.stdout.strip() == DIGEST_A
+
+
+def test_cli_is_fail_closed_on_missing_signals() -> None:
+    """Omitting a signal (unknown telemetry) leaves the gate RED, even with --ack."""
+    # No soak / quarantine / sev1 signals at all → every one reads red.
+    proc = _run_gate_cli(
+        "--target-digest", DIGEST_A,
+        "--ci-passed", "true", "--ci-digest", DIGEST_A,
+        "--ack",
+    )
+    assert proc.returncode != 0, "missing telemetry must fail-closed, not promote"
+    assert DIGEST_A not in proc.stdout
+
+
+def test_cli_refuses_ci_green_for_a_different_digest() -> None:
+    """CLI: E2E-01 green for another digest cannot promote the target (R-23)."""
+    proc = _run_gate_cli(
+        "--target-digest", DIGEST_A,
+        "--ci-passed", "true", "--ci-digest", DIGEST_B,
+        "--soak-hours", "48", "--quarantines", "0", "--open-sev1", "0",
+        "--ack",
+    )
+    assert proc.returncode != 0
+    assert DIGEST_A not in proc.stdout
+
+
+# --- Wrapper wiring: the promote script rides the tested gate + retags exactly -
+
+
+def test_promote_script_is_executable() -> None:
+    """The workflow / operator invokes the wrapper directly, so it must be +x."""
+    assert PROMOTE_SCRIPT.exists(), f"promote script missing: {PROMOTE_SCRIPT}"
+    assert os.access(PROMOTE_SCRIPT, os.X_OK), "promote script must be executable"
+
+
+def test_promote_script_delegates_the_decision_to_the_gate() -> None:
+    """The wrapper must NOT reimplement the conjunction — it calls the gate CLI
+    and only retags on a green+ACK'd verdict (the decision is unit-tested)."""
+    text = PROMOTE_SCRIPT.read_text()
+    assert "promotion_gate.py" in text, "wrapper must call the gate module"
+    # It retags by the EXACT digest with imagetools create — never a rebuild.
+    assert "docker buildx imagetools create" in text, "wrapper must retag by digest"
+    # No real build: `docker build`/`buildx build` (but `docker buildx imagetools`
+    # is the retag, not a build — so match `docker build` NOT followed by `x`).
+    assert re.search(r"docker build(?!x)", text) is None, "wrapper must NOT build (R-23)"
+    assert "buildx build" not in text, "wrapper must NOT build (R-23)"
+
+
+def test_promote_script_dry_run_requires_green_and_ack(tmp_path) -> None:
+    """End-to-end through the wrapper (dry-run, no docker): a red or un-ACK'd
+    gate retags nothing; green + ACK prints the exact-digest retag."""
+    env = dict(os.environ)
+    env.update(
+        DIGEST_REF=DIGEST_A,
+        THROWAWAY_CI_PASSED="true",
+        THROWAWAY_CI_DIGEST=DIGEST_A,
+        SOAK_HOURS="48",
+        SOAK_REQUIRED_HOURS="24",
+        QUARANTINE_COUNT="0",
+        OPEN_SEV1_COUNT="0",
+        PROMOTE_DRY_RUN="true",
+    )
+    # Clear any ambient signal that would leak in.
+    env.pop("OPERATOR_ACK", None)
+
+    def _run(e):
+        return subprocess.run(
+            ["bash", str(PROMOTE_SCRIPT)],
+            capture_output=True, text=True, env=e, timeout=60,
+        )
+
+    # Green gate, but no ACK → wrapper exits non-zero, retags nothing.
+    no_ack = _run(env)
+    assert no_ack.returncode != 0, "a green gate must not promote without the ACK"
+    assert "would retag" not in no_ack.stdout
+
+    # Green + ACK → dry-run announces the exact-digest retag to :stable.
+    env_ack = {**env, "OPERATOR_ACK": "true"}
+    acked = _run(env_ack)
+    assert acked.returncode == 0, acked.stderr
+    assert "would retag" in acked.stdout
+    assert DIGEST_A in acked.stdout
+    assert ":stable" in acked.stdout
+
+    # A red condition (a quarantine) never promotes, ACK or not.
+    env_red = {**env_ack, "QUARANTINE_COUNT": "1"}
+    red = _run(env_red)
+    assert red.returncode != 0, "a quarantine must block promotion despite the ACK"
+    assert "would retag" not in red.stdout


### PR DESCRIPTION
## Summary

P2W2 reconcile-node integration of flight #968 into `kahuna/959-P2W2`. Lands the mechanical promotion gate (Story 2.3, Plan #959, Dev Spec §4.4 / §5.6): the conjunctive, fail-closed query over FlightDeck + CI that decides whether a candidate `:edge` digest may be promoted to `:stable`, retagging the exact digest E2E-01 tested (R-07, R-23).

## Changes

- `containers/oakandwave-workflow/promotion_gate.py` — standalone fail-closed gate module + CLI (753 LOC across the flight).
- `scripts/ci/promote-oakandwave-image.sh` — wrapper that gathers signals and performs the exact-digest retag.
- `tests/contained-workflow/test_gate.py` — 12 gate tests.

## Linked Issues

Closes #968

## Test Plan

- `scripts/ci/validate.sh` → 193 passed, 0 failed.
- `scripts/ci/test.sh` (full pytest) → 1754 passed, 5 skipped, 64 xfailed, 2 xpassed, 26 subtests passed.
- `commutativity_verify` single-target vs `kahuna/959-P2W2` → STRONG (safe to land).
- Pure additions (3 new files, +753); no collision with existing kahuna files; gate module is self-contained (no dependency on P1W2 `mount_resolver`/`bootstrap`).