### PR TITLE
fix(flightdeck-emit): sessions attributed to Dev-Name, presence shape, e2e leak

### DIFF
--- a/scripts/flightdeck-session-emit.sh
+++ b/scripts/flightdeck-session-emit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# flightdeck-session-emit.sh — emit a FlightDeck session-lifecycle event (S1.7 / #857).
+# flightdeck-session-emit.sh — emit a FlightDeck session-lifecycle event (S1.7 / #857, #947).
 #
 # Wired as SessionStart / Stop / SessionEnd hooks in config/settings.template.json.
 # Emits session open / idle / close as a FlightDeck event via the emit CLI, so the
@@ -7,8 +7,14 @@
 #
 # Fire-and-forget: it ALWAYS exits 0 (a hook must never fail a turn) and never
 # blocks the session (emit ships in a background thread; unset FLIGHTDECK_INGEST_URL
-# ⇒ buffer-only). Claude Code passes the hook JSON on stdin; session_id is read
-# from it best-effort.
+# ⇒ buffer-only). Claude Code passes the hook JSON on stdin; session_id and cwd are
+# read from it best-effort.
+#
+# Session events are PRESENCE, not work (#947): they carry `activityType: session`
+# so the deck renders them in the agent-presence strip, never as campaign cards,
+# and `agent` is the Dev-Name from .claude/agent-identity.json (hostname only as
+# the visible degradation when identity is absent). The hostname always rides in
+# its own `host` field.
 #
 # Usage: flightdeck-session-emit.sh [open|idle|close]   (default: idle)
 
@@ -23,20 +29,39 @@ close) kind="activity_end" ;;
 idle | *) kind="step" ;;
 esac
 
-# Best-effort session id: hook stdin JSON (.session_id) → env → cwd basename.
+# Best-effort session id + project root: hook stdin JSON (.session_id/.cwd) →
+# env → cwd basename.
 session=""
+root=""
 if [ ! -t 0 ]; then
 	payload="$(cat 2>/dev/null || true)"
 	if [ -n "$payload" ] && command -v jq >/dev/null 2>&1; then
 		session="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null || true)"
+		root="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
 	fi
 fi
 if [ -z "$session" ]; then
 	session="${FLIGHTDECK_SESSION_ID:-${CLAUDE_SESSION_ID:-$(basename "$PWD")}}"
 fi
+[ -n "$root" ] || root="$PWD"
 
 activity="session:${session}"
 host="$(hostname 2>/dev/null || echo unknown)"
+
+# Agent identity (#947 defect 2): attribute the session to a Dev-Name, not the
+# hostname. Canonical file: <root>/.claude/agent-identity.json; read-fallback to
+# the legacy /tmp/claude-agent-<md5(root)>.json while the fleet cycles. Missing or
+# unreadable ⇒ agent stays the hostname — a VISIBLE degradation on the deck (the
+# chip shows the host), never a silent failure and never a non-zero exit.
+agent="$host"
+identity="${root}/.claude/agent-identity.json"
+if [ ! -r "$identity" ] && command -v md5sum >/dev/null 2>&1; then
+	identity="/tmp/claude-agent-$(printf '%s' "$root" | md5sum | cut -d' ' -f1).json"
+fi
+if [ -r "$identity" ] && command -v jq >/dev/null 2>&1; then
+	dev_name="$(jq -r '.dev_name // empty' "$identity" 2>/dev/null || true)"
+	[ -n "$dev_name" ] && agent="$dev_name"
+fi
 
 # Locate the emit CLI. FLIGHTDECK_EMIT_CMD overrides (DI-seam for tests / a
 # pinned interpreter); else the installed console command; else the module.
@@ -51,10 +76,20 @@ emit_event() {
 	fi
 }
 
+# --activity-type / --host are additive (#947). An older installed emit CLI
+# rejects unknown flags (argparse exits 2), so retry with the legacy argument set
+# rather than silently losing the event during the install window.
 emit_event "$kind" \
 	--activity-id "$activity" \
-	--agent "$host" \
+	--activity-type "session" \
+	--agent "$agent" \
+	--host "$host" \
 	--phase "session" \
-	--label "session-${phase}" >/dev/null 2>&1 || true
+	--label "session-${phase}" >/dev/null 2>&1 ||
+	emit_event "$kind" \
+		--activity-id "$activity" \
+		--agent "$agent" \
+		--phase "session" \
+		--label "session-${phase}" >/dev/null 2>&1 || true
 
 exit 0

--- a/src/wave_status/events/emit.py
+++ b/src/wave_status/events/emit.py
@@ -53,6 +53,10 @@ __all__ = [
 _UNSET = object()
 
 # Map the ergonomic snake_case emit() kwargs to the schema's camelCase keys.
+# ``activity_type`` and ``host`` (#947) are additive convention fields — the
+# schema's ``additionalProperties: true`` carries them; both validators ignore
+# unknown keys. ``activityType: session`` marks presence (never a campaign card);
+# ``host`` is the emitting machine, distinct from ``agent`` (Dev-Name).
 _FIELD_KEYS: dict[str, str] = {
     "wave": "wave",
     "phase": "phase",
@@ -66,6 +70,8 @@ _FIELD_KEYS: dict[str, str] = {
     "action": "action",
     "label": "label",
     "detail": "detail",
+    "activity_type": "activityType",
+    "host": "host",
 }
 
 
@@ -245,6 +251,8 @@ def emit(
     action: str | None = None,
     label: str | None = None,
     detail: object = None,
+    activity_type: str | None = None,
+    host: str | None = None,
     buffer: Path | None = None,
     ship_now: bool = True,
 ) -> dict | None:
@@ -262,7 +270,7 @@ def emit(
         "wave": wave, "phase": phase, "flight": flight, "agent": agent,
         "log_ref": log_ref, "concern_kind": concern_kind, "source": source,
         "metric": metric, "unit": unit, "action": action, "label": label,
-        "detail": detail,
+        "detail": detail, "activity_type": activity_type, "host": host,
     }
     for snake, val in local.items():
         if val is not None:
@@ -317,6 +325,7 @@ def _build_arg_fields(args) -> dict:
     for name in (
         "wave", "phase", "flight", "agent", "log_ref", "concern_kind",
         "source", "metric", "unit", "action", "label", "detail",
+        "activity_type", "host",
     ):
         val = getattr(args, name, None)
         if val is not None:
@@ -367,6 +376,10 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--action", default=None)
     p.add_argument("--label", default=None)
     p.add_argument("--detail", default=None)
+    p.add_argument("--activity-type", dest="activity_type", default=None,
+                   help="convention field: campaign|float|session (#947)")
+    p.add_argument("--host", default=None,
+                   help="emitting host — distinct from --agent (Dev-Name)")
     p.add_argument("--no-ship", dest="ship_now", action="store_false", default=True)
     args = p.parse_args(argv)
 

--- a/tests/regression/test_wave_engine_e2e_smoke.sh
+++ b/tests/regression/test_wave_engine_e2e_smoke.sh
@@ -23,6 +23,7 @@ set -uo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 SETTINGS="$REPO_DIR/config/settings.template.json"
 
+
 FAILS=0
 fail() {
 	echo "  [FAIL] $*"
@@ -53,6 +54,14 @@ fi
 
 FIX="$(mktemp -d)"
 trap 'rm -rf "$FIX"' EXIT
+
+# FlightDeck emit isolation (#947 defect 3): the REAL CLI this harness drives
+# emits FlightDeck events as a side effect. Without isolation they land in the
+# operator's durable buffer (~/.claude/status/events.jsonl) and ship to the LIVE
+# deck as fake "e2e-smoke" campaigns — exactly the test residue #947 found in the
+# closed lane. Point the buffer into the throwaway fixture and never ship.
+export FLIGHTDECK_EVENTS_PATH="$FIX/flightdeck-events.jsonl"
+unset FLIGHTDECK_INGEST_URL
 # wave-status resolves its root via `git rev-parse` — the fixture must be a repo.
 git -C "$FIX" init -q
 git -C "$FIX" config user.email smoke@example.com

--- a/tests/test_session_hook_emit.py
+++ b/tests/test_session_hook_emit.py
@@ -28,6 +28,7 @@ def _run(phase: str, events_path: Path, stdin: str = ""):
     env["FLIGHTDECK_EMIT_CMD"] = "python3 -m wave_status.events.emit"
     env["FLIGHTDECK_SESSION_ID"] = "sess-abc"
     env.pop("FLIGHTDECK_INGEST_URL", None)
+    env.pop("FLIGHTDECK_EMIT_DISABLED", None)
     return subprocess.run(
         ["bash", str(_SCRIPT), phase],
         input=stdin, capture_output=True, text=True, env=env,
@@ -37,6 +38,11 @@ def _run(phase: str, events_path: Path, stdin: str = ""):
 def _last_event(events_path: Path) -> dict:
     lines = events_path.read_text(encoding="utf-8").splitlines()
     return json.loads(lines[-1])
+
+
+def _has_jq() -> bool:
+    from shutil import which
+    return which("jq") is not None
 
 
 class TestScriptEmits:
@@ -62,6 +68,7 @@ class TestScriptEmits:
         env["FLIGHTDECK_EMIT_CMD"] = "python3 -m wave_status.events.emit"
         env["FLIGHTDECK_SESSION_ID"] = "s"
         env.pop("FLIGHTDECK_INGEST_URL", None)
+        env.pop("FLIGHTDECK_EMIT_DISABLED", None)
         r = subprocess.run(["bash", str(_SCRIPT)], input="", capture_output=True, text=True, env=env)
         assert r.returncode == 0
         assert _last_event(ep)["kind"] == "step"
@@ -74,6 +81,7 @@ class TestScriptEmits:
         env["FLIGHTDECK_EMIT_CMD"] = "python3 -m wave_status.events.emit"
         env.pop("FLIGHTDECK_SESSION_ID", None)
         env.pop("FLIGHTDECK_INGEST_URL", None)
+        env.pop("FLIGHTDECK_EMIT_DISABLED", None)
         # Claude Code passes the hook payload as JSON on stdin.
         payload = json.dumps({"session_id": "from-stdin", "hook_event_name": "Stop"})
         r = subprocess.run(
@@ -95,13 +103,103 @@ class TestScriptEmits:
         env["FLIGHTDECK_EMIT_CMD"] = "false"  # force the emit command to fail
         env["FLIGHTDECK_SESSION_ID"] = "s"
         env.pop("FLIGHTDECK_INGEST_URL", None)
+        env.pop("FLIGHTDECK_EMIT_DISABLED", None)
         r = subprocess.run(["bash", str(_SCRIPT), "idle"], input="", capture_output=True, text=True, env=env)
         assert r.returncode == 0  # fire-and-forget: a hook must never fail a turn
 
+    def test_session_events_are_presence_shaped(self, tmp_path):
+        # #947 defect 1: every session event declares activityType "session" and
+        # carries the hostname in its own `host` field (never as `agent` when an
+        # identity exists — see TestAgentIdentity).
+        ep = tmp_path / "events.jsonl"
+        r = _run("idle", ep)
+        assert r.returncode == 0, r.stderr
+        ev = _last_event(ep)
+        assert ev["activityType"] == "session"
+        assert ev["host"]  # non-empty hostname
 
-def _has_jq() -> bool:
-    from shutil import which
-    return which("jq") is not None
+    def test_legacy_emit_cli_fallback(self, tmp_path):
+        # #947 deploy-ordering: an OLDER installed emit CLI rejects the additive
+        # --activity-type/--host flags (argparse exit 2). The hook must retry with
+        # the legacy argument set rather than silently losing the event.
+        ep = tmp_path / "events.jsonl"
+        stub = tmp_path / "old-cli.sh"
+        stub.write_text(
+            "#!/usr/bin/env bash\n"
+            'for a in "$@"; do\n'
+            '  case "$a" in --activity-type|--host) echo "unrecognized arguments" >&2; exit 2 ;; esac\n'
+            "done\n"
+            f'exec python3 -m wave_status.events.emit "$@"\n',
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _SRC + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+        env["FLIGHTDECK_EVENTS_PATH"] = str(ep)
+        env["FLIGHTDECK_EMIT_CMD"] = f"bash {stub}"
+        env["FLIGHTDECK_SESSION_ID"] = "sess-old"
+        env.pop("FLIGHTDECK_INGEST_URL", None)
+        env.pop("FLIGHTDECK_EMIT_DISABLED", None)
+        r = subprocess.run(["bash", str(_SCRIPT), "idle"], input="", capture_output=True, text=True, env=env)
+        assert r.returncode == 0
+        ev = _last_event(ep)  # the event STILL landed, in the legacy shape
+        assert ev["activityId"] == "session:sess-old"
+        assert "activityType" not in ev
+
+
+class TestAgentIdentity:
+    """#947 defect 2: `agent` is the Dev-Name from .claude/agent-identity.json;
+    the hostname is only the VISIBLE degradation when identity is absent."""
+
+    def _run_with_root(self, root: Path, events_path: Path):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _SRC + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+        env["FLIGHTDECK_EVENTS_PATH"] = str(events_path)
+        env["FLIGHTDECK_EMIT_CMD"] = "python3 -m wave_status.events.emit"
+        env.pop("FLIGHTDECK_INGEST_URL", None)
+        env.pop("FLIGHTDECK_EMIT_DISABLED", None)
+        env.pop("FLIGHTDECK_SESSION_ID", None)
+        # Claude Code hook payload carries the project cwd.
+        payload = json.dumps({"session_id": "sess-id", "cwd": str(root)})
+        return subprocess.run(
+            ["bash", str(_SCRIPT), "idle"],
+            input=payload, capture_output=True, text=True, env=env,
+        )
+
+    @pytest.mark.skipif(not _has_jq(), reason="identity resolution requires jq")
+    def test_identity_file_present_attributes_dev_name(self, tmp_path):
+        root = tmp_path / "proj"
+        (root / ".claude").mkdir(parents=True)
+        (root / ".claude" / "agent-identity.json").write_text(
+            json.dumps({"dev_team": "oaw", "dev_name": "babelfish", "dev_avatar": "🐠"}),
+            encoding="utf-8",
+        )
+        ep = tmp_path / "events.jsonl"
+        r = self._run_with_root(root, ep)
+        assert r.returncode == 0, r.stderr
+        ev = _last_event(ep)
+        assert ev["agent"] == "babelfish"
+        assert ev["host"] != "babelfish"  # hostname rides separately
+
+    @pytest.mark.skipif(not _has_jq(), reason="identity resolution requires jq")
+    def test_identity_missing_degrades_to_hostname_visibly(self, tmp_path):
+        root = tmp_path / "proj-no-identity"
+        root.mkdir()
+        ep = tmp_path / "events.jsonl"
+        r = self._run_with_root(root, ep)
+        assert r.returncode == 0, r.stderr
+        ev = _last_event(ep)
+        assert ev["agent"] == ev["host"]  # degraded: agent IS the hostname
+
+    @pytest.mark.skipif(not _has_jq(), reason="identity resolution requires jq")
+    def test_identity_malformed_degrades_not_fails(self, tmp_path):
+        root = tmp_path / "proj-bad-identity"
+        (root / ".claude").mkdir(parents=True)
+        (root / ".claude" / "agent-identity.json").write_text("{not json", encoding="utf-8")
+        ep = tmp_path / "events.jsonl"
+        r = self._run_with_root(root, ep)
+        assert r.returncode == 0, r.stderr  # never fails the turn
+        assert _last_event(ep)["agent"] == _last_event(ep)["host"]
 
 
 class TestSettingsWiring:


### PR DESCRIPTION
## Summary

Emit-side half of the #947 seam fix: the session hook now attributes sessions to a Dev-Name (`.claude/agent-identity.json`, hostname as the visible degradation), declares the presence shape (`activityType: session`, separate `host` field), and the e2e-smoke regression harness stops leaking fake campaigns into the operator's live buffer. Render-side half: Wave-Engineering/flightdeck#7 (PR pending). Either side is safe to deploy alone, in either order.

## Changes

- `scripts/flightdeck-session-emit.sh` — resolve `agent` from `<cwd>/.claude/agent-identity.json` (legacy `/tmp/claude-agent-<md5>.json` read-fallback); hostname degradation stays visible; emit `--host` always and `--activity-type session` on every session event; retry with the legacy argument set when the installed emit CLI predates the new flags (argparse exit 2 → no silent event loss during the install window)
- `src/wave_status/events/emit.py` — additive `--activity-type` / `--host` CLI args → `activityType`/`host` convention fields (`additionalProperties: true`; both validators ignore unknown keys — no schema change)
- `tests/regression/test_wave_engine_e2e_smoke.sh` — export `FLIGHTDECK_EVENTS_PATH` into the throwaway fixture + unset `FLIGHTDECK_INGEST_URL` (#947 defect 3: the harness's events were landing in `~/.claude/status/events.jsonl` and shipping to the live deck)
- `tests/test_session_hook_emit.py` — presence-shape assertions, identity present/missing/malformed resolution, legacy-CLI fallback (faithful old-CLI stub), hermeticity pops

## Linked Issues

Closes #947

## Test Plan (actually ran)

- `./scripts/ci/validate.sh` — 191 passed, 0 failed
- `./scripts/ci/test.sh` — 1747 passed, 5 skipped, 64 xfailed
- `tests/regression/test_wave_engine_e2e_smoke.sh` — all checks pass; real-buffer `e2e-smoke` line count identical before/after the run (leak sealed, measured)
- Code review (Opus): 0 critical/important; 1 minor fixed

Deploy note (BJ): this is kit-side only — `~/.claude/scripts/flightdeck-session-emit.sh` and the installed `wave-status` pick it up at next kit install; ship both together (the script's legacy retry covers any window). No deployed-service change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017q11gLgRRSFuJj2V4K6ddd