### PR TITLE
feat(adoption): rolling per-agent :stable adoption at recreate (Story 2.4) (#969)

### DIFF
--- a/containers/oakandwave-workflow/README.md
+++ b/containers/oakandwave-workflow/README.md
@@ -81,6 +81,25 @@ Promotion is a digest retag (`:edge → :stable`), never a rebuild — the diges
 tested is the digest promoted (R-07/R-23). The build/push/sign pipeline and the
 throwaway-CI ring arrive in Phase 2 (Stories 2.1, 2.2).
 
+## Fleet adoption (Story 2.4)
+
+The fleet adopts `:stable` **per-agent, at container-recreate** — never
+mid-session, never a synchronized flip (R-08). At *its own* recreate boundary an
+agent runs `scripts/ci/adopt-stable.sh`, which resolves the moving `:stable` tag
+to its immutable digest + version and asks the unit-tested decision module
+(`adoption.py`) whether to adopt:
+
+- **same-major minor/patch** → adopt at recreate (safe by same-major compat,
+  R-18; an updated and a not-yet-updated agent coexist over one
+  `~/.oaw/state/<major>/` namespace);
+- **already current** → no-op (no redundant recreate);
+- **major cross** → held by default — an opt-in, deliberate cross (§5.8), never
+  automatic (`ALLOW_MAJOR_CROSS=true` opts in).
+
+A running container is pinned by digest, so a `:stable` retag can never reach it;
+only the next recreate resolves the tag. Rollback is a repoint at the prior digest
+— the wrapper keeps it in `~/.oaw/adoption/rollback` (§5.6).
+
 ## Deferred in this story
 
 - **Kit MCP servers are not baked.** `./install` runs with `--no-mcps`: the kit's

--- a/containers/oakandwave-workflow/adoption.py
+++ b/containers/oakandwave-workflow/adoption.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Rolling per-agent :stable adoption — Story 2.4 (#969), Plan #959, Dev Spec §4.5 / §5.8.
+
+The counterpart to the promotion gate (Story 2.3): 2.3 *publishes* :stable by
+retagging the exact tested digest; this module decides how a **fleet agent
+adopts** that :stable — per-agent, rolling, at container-recreate, never
+mid-session (R-08), with same-major coexistence (R-18).
+
+Requirements this module is the guard for:
+
+* **R-08** — WHEN a minor/patch :stable is published, the fleet adopts it
+  per-agent at container-recreate, **NOT by synchronized flip**. Adoption is a
+  pure decision evaluated against **this** agent's currently-running version at
+  **its own** recreate boundary; there is no fleet broadcast and no code path
+  that mutates a *running* container. A running container is pinned by digest, so
+  a :stable retag can never reach it — only the next recreate resolves the moving
+  tag and consumes this decision. Each agent adopts when *it* recreates:
+  rolling, per-agent, never a stop-the-world flip.
+
+* **R-18** — agents on the same major interoperate over shared state; within-major
+  shared-state changes are additive + forward-tolerant. The kit major partitions
+  the durable-state namespace (``~/.oaw/state/<major>/``, R-20 — the same seam the
+  mount resolver enforces), so an updated agent (new minor) and a not-yet-updated
+  agent (old minor) resolve the **same** namespace and coexist; different majors
+  resolve **different** namespaces (isolated, never corrupting). A **major** cross
+  is therefore never auto-adopted at recreate — it is an opt-in, deliberate cross
+  (§5.8: the developer decides when to cross a major).
+
+Design — one auto-adopt path, fail-loud (assertion-liveness, D7):
+
+* :func:`decide_adoption` is the **only** path that yields an ``adopt`` verdict,
+  and it does so ONLY for a same-major target. A different major ``hold``s unless
+  the caller explicitly opts into the cross. A malformed version is an
+  :class:`AdoptionError`, never silently skipped.
+* The module never touches docker, a registry, or the network — it reasons purely
+  over the ``(current, target)`` version pair handed to it. Resolving :stable to
+  its digest + version and performing the recreate live in the wrapper
+  (``scripts/ci/adopt-stable.sh``).
+
+CLI::
+
+    # decide (versions only): prints the verdict summary to stderr, action to stdout
+    python3 adoption.py --current-version 8.2.0 --target-version 8.3.0
+
+    # plan a recreate (with digests): stdout is the digest to launch at recreate
+    python3 adoption.py --current-ref REPO@sha256:… --current-version 8.2.0 \\
+        --target-ref REPO@sha256:… --target-version 8.3.0 --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+# The sandbox-scoped durable-state root, major-partitioned (R-20). This is the
+# SAME seam the mount resolver fences at (mount_resolver.STATE_ROOT_PARTS); a
+# colocated test asserts the two agree so the coexistence namespace and the mount
+# guard can never drift apart.
+STATE_ROOT_PARTS = (".oaw", "state")  # ~/.oaw/state/<major>/
+
+# Verdicts. `adopt` is the only one that moves the agent onto :stable.
+ADOPT = "adopt"
+NOOP = "noop"
+HOLD = "hold"
+
+# Coexistence classes for a (running, other) version pair.
+SHARED_COMPATIBLE = "shared-compatible"  # same major — one namespace, additive/forward-tolerant
+ISOLATED = "isolated"  # different major — separate namespaces, isolated not corrupting
+
+# A bare/tagged semver: major.minor.patch with an optional -prerelease / +build.
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+](?P<pre>[0-9A-Za-z.-]+))?$")
+# A content-addressed digest ref carries no semver — the caller must read the
+# image's OCI version label instead of parsing the ref.
+_DIGEST_RE = re.compile(r"@sha256:[0-9a-fA-F]{64}$")
+
+
+class AdoptionError(ValueError):
+    """An adoption-decision contract violation. Raised LOUD, never swallowed."""
+
+
+@dataclass(frozen=True, order=True)
+class SemVer:
+    """A (major, minor, patch) triple. Ordering compares only those three;
+    prerelease/build metadata is retained for display but excluded from ordering
+    (a promotion within a major is decided by the triple, per §5.8)."""
+
+    major: int
+    minor: int
+    patch: int
+    prerelease: str | None = field(default=None, compare=False)
+
+    def __str__(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        return f"{base}-{self.prerelease}" if self.prerelease else base
+
+    @property
+    def triple(self) -> tuple[int, int, int]:
+        return (self.major, self.minor, self.patch)
+
+
+def parse_semver(value: object) -> SemVer:
+    """Parse a semver from a bare version (``8.2.0``, ``v8.2.0``, ``0.0.0-dev``)
+    or a tagged image ref (``registry/img:8.2.0``). A digest ref (``…@sha256:…``)
+    carries no semver and is rejected — read the OCI version label instead.
+
+    Raises :class:`AdoptionError` on anything unparseable (fail-loud — a version
+    the fleet cannot reason about must never be silently adopted)."""
+    if isinstance(value, SemVer):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        raise AdoptionError(f"version must be a non-empty semver string, got {value!r}")
+    s = value.strip()
+    if _DIGEST_RE.search(s):
+        raise AdoptionError(
+            f"cannot parse a semver from the digest ref {s!r} — a digest carries "
+            f"no version; read the image's org.opencontainers.image.version label"
+        )
+    # If it's a tagged ref (has a '/' path then a ':tag'), take the tag part.
+    tail = s.rsplit("/", 1)[-1]
+    if ":" in tail:
+        s = tail.rsplit(":", 1)[-1]
+    s = s.lstrip("v")
+    m = _SEMVER_RE.match(s)
+    if not m:
+        raise AdoptionError(
+            f"unparseable semver {value!r} — expected major.minor.patch "
+            f"(optionally -prerelease), e.g. 8.3.0 or a registry/img:8.3.0 tag"
+        )
+    return SemVer(int(m.group(1)), int(m.group(2)), int(m.group(3)), m.group("pre"))
+
+
+def classify_coexistence(a: object, b: object) -> str:
+    """Classify how two agents' versions share durable state (R-18/R-20).
+
+    Same major ⇒ ``shared-compatible`` (one ``~/.oaw/state/<major>/`` namespace,
+    within-major changes additive + forward-tolerant, so updated and
+    not-yet-updated agents coexist). Different major ⇒ ``isolated`` (separate
+    namespaces — mixing majors is isolated, never corrupting)."""
+    va, vb = parse_semver(a), parse_semver(b)
+    return SHARED_COMPATIBLE if va.major == vb.major else ISOLATED
+
+
+def state_namespace(major: int | str, home: str | PurePosixPath = "~") -> str:
+    """The major-partitioned durable-state namespace ``<home>/.oaw/state/<major>/``.
+
+    The coexistence primitive: two agents map to the same namespace iff they share
+    a major. Mirrors the path the mount resolver's R-03 guard fences to."""
+    try:
+        m = int(str(major).split(".", 1)[0])
+    except ValueError as exc:
+        raise AdoptionError(f"major must be an int or semver, got {major!r}") from exc
+    root = PurePosixPath(str(home))
+    return str(root.joinpath(*STATE_ROOT_PARTS, str(m)))
+
+
+@dataclass(frozen=True)
+class AdoptionDecision:
+    """The per-agent adoption verdict for (current → target) at recreate."""
+
+    action: str  # adopt | noop | hold
+    current: SemVer
+    target: SemVer
+    coexistence: str  # shared-compatible | isolated
+    reason: str
+
+    @property
+    def adopt(self) -> bool:
+        return self.action == ADOPT
+
+    def as_dict(self) -> dict:
+        return {
+            "action": self.action,
+            "current": str(self.current),
+            "target": str(self.target),
+            "coexistence": self.coexistence,
+            "reason": self.reason,
+        }
+
+    def summary(self) -> str:
+        verb = {
+            ADOPT: "ADOPT at recreate",
+            NOOP: "NOOP — already current",
+            HOLD: "HOLD on current major",
+        }.get(self.action, self.action)
+        return (
+            f"adoption {self.current} -> {self.target}: {verb}\n"
+            f"  coexistence: {self.coexistence}\n"
+            f"  reason: {self.reason}"
+        )
+
+
+def decide_adoption(
+    current: object,
+    target: object,
+    *,
+    allow_major_cross: bool = False,
+) -> AdoptionDecision:
+    """Decide, for THIS agent, whether to adopt ``target`` (:stable) at its next
+    container-recreate — the single auto-adopt path (R-08).
+
+    * Same triple ⇒ ``noop`` (already on this :stable).
+    * Same major, different minor/patch ⇒ ``adopt`` at recreate — a minor/patch
+      bump, safe by same-major compat (R-18). This is the rolling, per-agent
+      adoption: it follows :stable in either direction (a rollback publishes a
+      prior digest to :stable; the agent adopts it at *its* next recreate).
+    * Different major ⇒ ``hold`` unless ``allow_major_cross`` — a major cross is
+      opt-in and deliberate (§5.8), never an automatic recreate-time flip. The two
+      agents coexist in isolated ``~/.oaw/state/<major>/`` namespaces meanwhile.
+
+    Malformed versions raise :class:`AdoptionError` (fail-loud)."""
+    cur = parse_semver(current)
+    tgt = parse_semver(target)
+    coex = classify_coexistence(cur, tgt)
+
+    if tgt.triple == cur.triple:
+        return AdoptionDecision(
+            NOOP, cur, tgt, coex,
+            f"already on :stable {tgt}; nothing to adopt at recreate",
+        )
+    if tgt.major == cur.major:
+        direction = "upgrade" if tgt.triple > cur.triple else "rollback"
+        return AdoptionDecision(
+            ADOPT, cur, tgt, coex,
+            f"same-major minor/patch {direction} ({cur} -> {tgt}) — adopt at the "
+            f"next container-recreate (rolling, per-agent; never mid-session). "
+            f"Same-major compat (R-18) lets it coexist with agents still on {cur}",
+        )
+    if allow_major_cross:
+        return AdoptionDecision(
+            ADOPT, cur, tgt, coex,
+            f"major cross {cur.major} -> {tgt.major} explicitly opted in (§5.8); "
+            f"the agent moves to the isolated {state_namespace(tgt.major)} namespace",
+        )
+    return AdoptionDecision(
+        HOLD, cur, tgt, coex,
+        f"target major {tgt.major} != current major {cur.major}: a major cross is "
+        f"opt-in and deliberate (§5.8), never an automatic recreate-time flip. "
+        f"Agents on {cur.major} and {tgt.major} coexist in isolated namespaces "
+        f"({state_namespace(cur.major)} vs {state_namespace(tgt.major)})",
+    )
+
+
+@dataclass(frozen=True)
+class RecreatePlan:
+    """What the recreate wrapper should launch, and what to keep for rollback."""
+
+    action: str  # adopt | noop | hold
+    launch_ref: str  # the image ref to run at recreate
+    prior_ref: str  # the ref the agent was on — retained so rollback is a repoint
+    decision: AdoptionDecision
+
+    def as_dict(self) -> dict:
+        d = self.decision.as_dict()
+        d.update(launch_ref=self.launch_ref, prior_ref=self.prior_ref)
+        return d
+
+
+def plan_recreate(
+    *,
+    current_ref: str,
+    current_version: object,
+    target_ref: str,
+    target_version: object,
+    allow_major_cross: bool = False,
+) -> RecreatePlan:
+    """Bind an :class:`AdoptionDecision` to concrete image refs for the wrapper.
+
+    On ``adopt`` the agent recreates on ``target_ref`` and ``prior_ref`` (the
+    pre-adoption digest) is what a rollback repoints to (§5.6 — rollback = repoint
+    at the prior :stable digest). On ``hold``/``noop`` it recreates on
+    ``current_ref`` (stays on its current major); a running session is never
+    touched — this only shapes the *next* launch."""
+    decision = decide_adoption(
+        current_version, target_version, allow_major_cross=allow_major_cross
+    )
+    launch = target_ref if decision.adopt else current_ref
+    return RecreatePlan(
+        action=decision.action,
+        launch_ref=launch,
+        prior_ref=current_ref,
+        decision=decision,
+    )
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--current-version", required=True, help="the agent's current semver")
+    parser.add_argument("--target-version", required=True, help=":stable's semver")
+    parser.add_argument("--current-ref", default=None, help="the agent's current image ref")
+    parser.add_argument("--target-ref", default=None, help=":stable's resolved image ref")
+    parser.add_argument(
+        "--allow-major-cross",
+        action="store_true",
+        help="opt into a major cross (§5.8) — never automatic at recreate",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("action", "json"),
+        default="action",
+        help="stdout shape: the bare action, or the full JSON plan/decision",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.current_ref and args.target_ref:
+            plan = plan_recreate(
+                current_ref=args.current_ref,
+                current_version=args.current_version,
+                target_ref=args.target_ref,
+                target_version=args.target_version,
+                allow_major_cross=args.allow_major_cross,
+            )
+            decision, payload = plan.decision, plan.as_dict()
+            machine = plan.launch_ref if args.format == "action" else json.dumps(payload)
+        else:
+            decision = decide_adoption(
+                args.current_version,
+                args.target_version,
+                allow_major_cross=args.allow_major_cross,
+            )
+            payload = decision.as_dict()
+            machine = decision.action if args.format == "action" else json.dumps(payload)
+    except AdoptionError as exc:
+        print(f"adoption error: {exc}", file=sys.stderr)
+        return 2
+
+    print(decision.summary(), file=sys.stderr)
+    print(machine)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/adopt-stable.sh
+++ b/scripts/ci/adopt-stable.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# adopt-stable.sh — rolling per-agent :stable adoption at container-recreate
+# (Story 2.4 / #969, Dev Spec §4.5 / §5.6 / §5.8, R-08/R-18).
+#
+# The fleet counterpart to promote-oakandwave-image.sh: promotion *publishes*
+# :stable; this runs at a single agent's **container-recreate** boundary and
+# adopts it — per-agent, rolling, never mid-session.
+#
+# This IS the recreate boundary. It resolves the moving :stable tag to its
+# immutable digest + version, asks the unit-tested decision module whether to
+# adopt, and — on adopt — records the prior digest (so rollback is a repoint,
+# §5.6) and emits the digest the next launch (aoe / docker run) should use. It
+# NEVER reaches into a running container: a running container is pinned by digest,
+# so a :stable retag cannot touch it; only this next-launch resolution adopts the
+# new digest. Two agents run this at their own recreate times → rolling, not a
+# synchronized flip (R-08).
+#
+# The DECISION lives in containers/oakandwave-workflow/adoption.py (fail-loud on a
+# malformed version, major-cross opt-in). This wrapper only *resolves* :stable and
+# *applies* the plan (pin + emit), keeping the adoption logic in Python, never in
+# this shell (project rule: decisions in a tested module, not the wrapper).
+#
+# Inputs (env):
+#   STABLE_REF          the :stable moving tag to resolve, registry/image:stable
+#                       (default: derived from IMAGE_REPO + STABLE_TAG).
+#   IMAGE_REPO          registry/image for the fleet image
+#                       (default: ghcr.io/wave-engineering/oakandwave-workflow).
+#   STABLE_TAG          the moving tag to adopt (default: stable).
+#   OAW_STATE_DIR       per-agent adoption state dir (default: ~/.oaw/adoption).
+#                       Holds `current` (the adopted digest) + `rollback` (the
+#                       prior digest, for a §5.6 repoint).
+#   ALLOW_MAJOR_CROSS   "true" ⇒ opt into a major cross (§5.8); default false ⇒ a
+#                       differing major HOLDs (agents coexist in isolated
+#                       ~/.oaw/state/<major>/ namespaces until a deliberate cross).
+#   ADOPT_DRY_RUN       "true" ⇒ resolve + decide + print the plan, do NOT pull,
+#                       pin, or recreate (unit-testable without docker).
+#
+# Injected resolution seams (used verbatim when set; else resolved via docker) —
+# these make the wrapper testable and let a caller supply already-resolved values:
+#   OAW_STABLE_RESOLVED_REF / OAW_STABLE_VERSION   :stable's digest + semver.
+#   OAW_CURRENT_REF        / OAW_CURRENT_VERSION   the agent's current digest +
+#                          semver (default: read from OAW_STATE_DIR/current, or —
+#                          on a first-ever adoption — empty ⇒ bootstrap-adopt).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+ADOPTION_PY="$REPO_DIR/containers/oakandwave-workflow/adoption.py"
+
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/wave-engineering/oakandwave-workflow}"
+STABLE_TAG="${STABLE_TAG:-stable}"
+STABLE_REF="${STABLE_REF:-${IMAGE_REPO}:${STABLE_TAG}}"
+OAW_STATE_DIR="${OAW_STATE_DIR:-$HOME/.oaw/adoption}"
+DRY_RUN="${ADOPT_DRY_RUN:-false}"
+
+allow_cross=()
+[[ "${ALLOW_MAJOR_CROSS:-false}" == "true" ]] && allow_cross=(--allow-major-cross)
+
+# --- Read the OCI version label off a resolved image ref ----------------------
+image_version() {
+	local ref="$1"
+	local labels
+	labels="$(docker image inspect --format '{{json .Config.Labels}}' "$ref" 2>/dev/null)" || return 1
+	printf '%s' "$labels" | python3 -c \
+		'import json,sys; print((json.load(sys.stdin) or {}).get("org.opencontainers.image.version") or "")'
+}
+
+# --- 1. Resolve :stable → immutable digest + version --------------------------
+# A moving tag is resolved to the digest it points at NOW (the "pull at recreate"),
+# so the agent adopts the exact bytes promotion blessed — never a re-moving tag.
+stable_ref="${OAW_STABLE_RESOLVED_REF:-}"
+stable_version="${OAW_STABLE_VERSION:-}"
+if [[ -z "$stable_ref" || -z "$stable_version" ]]; then
+	if [[ "$DRY_RUN" == "true" ]]; then
+		echo "  [!] ADOPT_DRY_RUN needs OAW_STABLE_RESOLVED_REF + OAW_STABLE_VERSION" >&2
+		exit 1
+	fi
+	command -v docker >/dev/null 2>&1 || {
+		echo "  [!] docker not found — needed to resolve $STABLE_REF at recreate" >&2
+		exit 1
+	}
+	echo "==> resolving $STABLE_REF at container-recreate (pull the moving tag)"
+	docker pull "$STABLE_REF" >/dev/null
+	# The digest :stable currently points at (registry/image@sha256:…).
+	stable_ref="$(docker image inspect --format '{{index .RepoDigests 0}}' "$STABLE_REF")"
+	stable_version="$(image_version "$STABLE_REF")"
+fi
+[[ -n "$stable_version" ]] || {
+	echo "  [!] $STABLE_REF carries no org.opencontainers.image.version label" >&2
+	exit 1
+}
+
+# --- 2. Determine the agent's CURRENT ref + version (per-agent state) ----------
+current_ref="${OAW_CURRENT_REF:-}"
+current_version="${OAW_CURRENT_VERSION:-}"
+if [[ -z "$current_ref" && -f "$OAW_STATE_DIR/current" ]]; then
+	current_ref="$(cat "$OAW_STATE_DIR/current")"
+fi
+if [[ -z "$current_version" && -f "$OAW_STATE_DIR/current-version" ]]; then
+	current_version="$(cat "$OAW_STATE_DIR/current-version")"
+fi
+
+# First-ever adoption: no prior version to reason about → bootstrap onto :stable.
+if [[ -z "$current_version" ]]; then
+	echo "==> no prior adoption recorded — bootstrap-adopt $stable_ref ($stable_version)"
+	action="adopt"
+	launch_ref="$stable_ref"
+	prior_ref=""
+else
+	# --- 3. Delegate the adopt/hold/noop decision to the tested module --------
+	plan_json="$(python3 "$ADOPTION_PY" \
+		--current-ref "$current_ref" --current-version "$current_version" \
+		--target-ref "$stable_ref" --target-version "$stable_version" \
+		--format json "${allow_cross[@]}")"
+	read -r action launch_ref prior_ref < <(
+		printf '%s' "$plan_json" | python3 -c \
+			'import json,sys; p=json.load(sys.stdin); print(p["action"], p["launch_ref"], p.get("prior_ref",""))'
+	)
+fi
+
+echo "==> adoption plan: action=$action launch=$launch_ref (current=${current_version:-none} -> stable=$stable_version)"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+	echo "==> [dry-run] would launch $launch_ref at recreate (no pin, no recreate)"
+	echo "$launch_ref"
+	exit 0
+fi
+
+# --- 4. Apply the plan: pin for rollback, record the adopted digest -----------
+# On adopt, `rollback` keeps the PRIOR digest so a §5.6 rollback is a plain
+# repoint; `current` records what this recreate launches. On hold/noop nothing
+# moves — the agent stays on its current major (coexistence preserved).
+mkdir -p "$OAW_STATE_DIR"
+if [[ "$action" == "adopt" ]]; then
+	[[ -n "$prior_ref" ]] && printf '%s\n' "$prior_ref" >"$OAW_STATE_DIR/rollback"
+	printf '%s\n' "$launch_ref" >"$OAW_STATE_DIR/current"
+	printf '%s\n' "$stable_version" >"$OAW_STATE_DIR/current-version"
+	echo "==> adopted $launch_ref ($stable_version); rollback pin -> ${prior_ref:-<none>}"
+else
+	echo "==> $action — staying on $current_ref ($current_version); :stable held for an opt-in cross"
+fi
+
+# The one line on stdout is the image ref the NEXT launch (aoe / docker run) uses
+# at this recreate — the recreate boundary consumes it; a running session never does.
+echo "$launch_ref"

--- a/tests/contained-workflow/test_adoption.py
+++ b/tests/contained-workflow/test_adoption.py
@@ -1,0 +1,309 @@
+"""Oracle for Story 2.4 (#969) — rolling per-agent :stable adoption (R-08/R-18).
+
+The adoption decision (``containers/oakandwave-workflow/adoption.py``) decides how
+a fleet agent adopts a promoted :stable at *its* container-recreate. Two
+acceptance criteria, both proved here as *pure* unit oracles (no docker, no
+registry) so they run for real in the stock ``pytest tests/`` lane:
+
+* **AC1 [R-08]** — *a minor/patch :stable is adopted at the next
+  container-recreate, not by synchronized flip.* The named oracle
+  :func:`test_minor_patch_adopted_at_recreate_not_flipped` proves a same-major
+  minor/patch bump verdicts ``adopt``; that the adoption takes effect only via a
+  recreate *plan* (the next launch ref), never by mutating a running/current ref;
+  and that the decision is a per-agent function of *this* agent's current version
+  — two agents on different currents each decide independently (rolling), so
+  there is no stop-the-world flip.
+
+* **AC2 [R-08, R-18]** — *updated and not-yet-updated agents coexist.*
+  :func:`test_updated_and_not_yet_updated_coexist` proves two same-major minors
+  classify ``shared-compatible`` and map to the SAME ``~/.oaw/state/<major>/``
+  namespace (coexist, additive/forward-tolerant), while a major bump classifies
+  ``isolated`` (separate namespaces) and is NOT auto-adopted at recreate — a major
+  cross is opt-in (§5.8).
+
+Plus fail-loud guards (a malformed / digest-only version raises) and the
+CLI/wrapper wiring the adoption mechanism rides.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+ADOPTION_PY = CONTAINER_DIR / "adoption.py"
+ADOPT_SCRIPT = REPO_ROOT / "scripts" / "ci" / "adopt-stable.sh"
+
+# Path import (no PYTHONPATH dependency), mirroring test_gate.py / test_mounts.py.
+sys.path.insert(0, str(CONTAINER_DIR))
+import adoption as ad  # noqa: E402
+import mount_resolver as mr  # noqa: E402
+
+# Two distinct, well-formed immutable digest pins for the same repo.
+REPO = "ghcr.io/wave-engineering/oakandwave-workflow"
+DIGEST_A = f"{REPO}@sha256:" + "a" * 64
+DIGEST_B = f"{REPO}@sha256:" + "b" * 64
+
+
+# --- AC1 [R-08] — adopt a minor/patch at recreate, not by synchronized flip ----
+
+
+def test_minor_patch_adopted_at_recreate_not_flipped():
+    """The named story oracle. A minor and a patch bump within the same major
+    both verdict ``adopt``; adoption manifests only as the *next* launch ref (a
+    recreate), never by mutating the running ref; and the decision is per-agent."""
+    # A minor bump and a patch bump are both adopted.
+    minor = ad.decide_adoption("8.2.0", "8.3.0")
+    patch = ad.decide_adoption("8.2.0", "8.2.1")
+    assert minor.action == ad.ADOPT and minor.adopt
+    assert patch.action == ad.ADOPT and patch.adopt
+
+    # "Not by synchronized flip": adoption takes effect ONLY through a recreate
+    # plan that changes the NEXT launch ref — the running/current ref is retained
+    # untouched (for rollback), never mutated in place. There is no push into a
+    # running container; only the recreate consumes the new digest.
+    plan = ad.plan_recreate(
+        current_ref=DIGEST_A,
+        current_version="8.2.0",
+        target_ref=DIGEST_B,
+        target_version="8.3.0",
+    )
+    assert plan.action == ad.ADOPT
+    assert plan.launch_ref == DIGEST_B  # the recreate launches the new digest
+    assert plan.prior_ref == DIGEST_A  # the old digest is preserved, not flipped
+
+    # Per-agent / rolling: the verdict is a function of THIS agent's current, so
+    # agents on different currents adopt independently at their own recreate —
+    # there is no fleet-wide, all-at-once flip.
+    ahead = ad.decide_adoption("8.3.0", "8.3.0")  # already updated → noop
+    behind = ad.decide_adoption("8.1.0", "8.3.0")  # not yet updated → adopts on recreate
+    assert ahead.action == ad.NOOP
+    assert behind.action == ad.ADOPT
+
+
+def test_already_on_stable_is_noop_no_recreate_churn():
+    """An agent already on the current :stable does not re-adopt — a NOOP, so a
+    published :stable never forces a redundant recreate on an up-to-date agent."""
+    d = ad.decide_adoption("8.3.0", "8.3.0")
+    assert d.action == ad.NOOP and not d.adopt
+    plan = ad.plan_recreate(
+        current_ref=DIGEST_A, current_version="8.3.0",
+        target_ref=DIGEST_A, target_version="8.3.0",
+    )
+    assert plan.action == ad.NOOP
+    assert plan.launch_ref == DIGEST_A  # stays on the same digest
+
+
+def test_same_major_rollback_is_followed_at_recreate():
+    """Rollback (§5.6) publishes a prior digest to :stable; a same-major agent
+    follows :stable in the DOWN direction too, at its next recreate."""
+    d = ad.decide_adoption("8.3.0", "8.2.0")
+    assert d.action == ad.ADOPT  # follows :stable downward within the major
+    assert "rollback" in d.reason
+
+
+# --- AC2 [R-08, R-18] — updated and not-yet-updated agents coexist -------------
+
+
+def test_updated_and_not_yet_updated_coexist():
+    """Two same-major minors are ``shared-compatible`` and resolve the SAME
+    major-partitioned namespace, so an updated (8.3.0) and a not-yet-updated
+    (8.2.0) agent coexist over one shared-state tree (R-18). A major bump is
+    ``isolated`` (separate namespaces) — mixing majors is isolated, not
+    corrupting, so it is never auto-adopted at recreate."""
+    updated, not_updated = "8.3.0", "8.2.0"
+    assert ad.classify_coexistence(updated, not_updated) == ad.SHARED_COMPATIBLE
+    assert ad.state_namespace(updated) == ad.state_namespace(not_updated)
+    assert ad.state_namespace(updated).endswith("/.oaw/state/8")
+
+    # A major bump: isolated namespaces, and not auto-adopted (opt-in, §5.8).
+    assert ad.classify_coexistence("8.9.9", "9.0.0") == ad.ISOLATED
+    assert ad.state_namespace("8.9.9") != ad.state_namespace("9.0.0")
+    hold = ad.decide_adoption("8.9.9", "9.0.0")
+    assert hold.action == ad.HOLD and not hold.adopt
+    assert hold.coexistence == ad.ISOLATED
+
+
+def test_major_cross_requires_explicit_opt_in():
+    """A major cross HOLDs by default and only adopts with an explicit opt-in
+    (§5.8: the developer decides when to cross a major)."""
+    default = ad.decide_adoption("8.5.0", "9.0.0")
+    opted = ad.decide_adoption("8.5.0", "9.0.0", allow_major_cross=True)
+    assert default.action == ad.HOLD
+    assert opted.action == ad.ADOPT
+    # The plan stays on the current major when held; a HELD agent never launches
+    # the cross-major digest at recreate.
+    held_plan = ad.plan_recreate(
+        current_ref=DIGEST_A, current_version="8.5.0",
+        target_ref=DIGEST_B, target_version="9.0.0",
+    )
+    assert held_plan.action == ad.HOLD
+    assert held_plan.launch_ref == DIGEST_A  # holds on current, not the cross digest
+
+
+def test_state_namespace_matches_mount_resolver_seam():
+    """The coexistence namespace and the mount resolver's R-03 guard must fence
+    the SAME path — one source of truth, so they can never drift apart."""
+    assert ad.STATE_ROOT_PARTS == mr.STATE_ROOT_PARTS
+    # And the concrete path agrees with the resolver's constant.
+    assert ad.state_namespace(8, home="/home/ubuntu") == "/home/ubuntu/.oaw/state/8"
+
+
+# --- Fail-loud parsing guards -------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-version", "8.2", "8", "v8.x.0", None, 8])
+def test_malformed_version_raises(bad):
+    with pytest.raises(ad.AdoptionError):
+        ad.parse_semver(bad)
+
+
+def test_digest_ref_carries_no_semver():
+    """A digest ref has no version — parsing one must fail-loud, forcing the
+    caller to read the OCI version label instead of guessing."""
+    with pytest.raises(ad.AdoptionError):
+        ad.parse_semver(DIGEST_A)
+
+
+def test_tagged_ref_and_v_prefix_parse():
+    assert ad.parse_semver(f"{REPO}:8.3.1").triple == (8, 3, 1)
+    assert ad.parse_semver("v8.3.1").triple == (8, 3, 1)
+    assert ad.parse_semver("0.0.0-dev").triple == (0, 0, 0)
+    assert ad.parse_semver("0.0.0-dev").prerelease == "dev"
+
+
+# --- CLI wiring ---------------------------------------------------------------
+
+
+def _run_cli(*args):
+    return subprocess.run(
+        [sys.executable, str(ADOPTION_PY), *args],
+        capture_output=True, text=True,
+    )
+
+
+def test_cli_action_and_json():
+    r = _run_cli("--current-version", "8.2.0", "--target-version", "8.3.0")
+    assert r.returncode == 0
+    assert r.stdout.strip() == "adopt"
+
+    r = _run_cli(
+        "--current-version", "8.2.0", "--target-version", "8.3.0", "--format", "json"
+    )
+    payload = json.loads(r.stdout)
+    assert payload["action"] == "adopt"
+    assert payload["coexistence"] == ad.SHARED_COMPATIBLE
+
+
+def test_cli_plan_emits_launch_ref():
+    """With both refs, stdout is the digest the recreate should launch (adopt →
+    the target; hold → the current)."""
+    r = _run_cli(
+        "--current-ref", DIGEST_A, "--current-version", "8.2.0",
+        "--target-ref", DIGEST_B, "--target-version", "8.3.0",
+    )
+    assert r.returncode == 0
+    assert r.stdout.strip() == DIGEST_B
+
+    r = _run_cli(
+        "--current-ref", DIGEST_A, "--current-version", "8.2.0",
+        "--target-ref", DIGEST_B, "--target-version", "9.0.0",
+    )
+    assert r.stdout.strip() == DIGEST_A  # major cross held → stays on current
+
+
+def test_cli_malformed_version_exits_2():
+    r = _run_cli("--current-version", "nope", "--target-version", "8.3.0")
+    assert r.returncode == 2
+    assert "adoption error" in r.stderr.lower()
+
+
+# --- Wrapper (adopt-stable.sh) dry-run wiring ---------------------------------
+
+
+def _run_wrapper(env_extra, tmp_path):
+    env = dict(os.environ)
+    env.update(
+        ADOPT_DRY_RUN="true",
+        OAW_STATE_DIR=str(tmp_path / "adoption"),
+    )
+    env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(ADOPT_SCRIPT)], capture_output=True, text=True, env=env
+    )
+
+
+def test_wrapper_dry_run_adopts_minor(tmp_path):
+    """The recreate wrapper, at a dry-run recreate, resolves the injected :stable
+    and emits the new digest to launch for a same-major minor bump — without
+    docker, and without touching a running container."""
+    r = _run_wrapper(
+        {
+            "OAW_STABLE_RESOLVED_REF": DIGEST_B,
+            "OAW_STABLE_VERSION": "8.3.0",
+            "OAW_CURRENT_REF": DIGEST_A,
+            "OAW_CURRENT_VERSION": "8.2.0",
+        },
+        tmp_path,
+    )
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip().splitlines()[-1] == DIGEST_B
+    # Dry-run pins nothing.
+    assert not (tmp_path / "adoption" / "current").exists()
+
+
+def test_wrapper_dry_run_holds_major(tmp_path):
+    """A cross-major :stable is HELD by default — the wrapper emits the current
+    digest, keeping the agent on its major (coexistence preserved)."""
+    r = _run_wrapper(
+        {
+            "OAW_STABLE_RESOLVED_REF": DIGEST_B,
+            "OAW_STABLE_VERSION": "9.0.0",
+            "OAW_CURRENT_REF": DIGEST_A,
+            "OAW_CURRENT_VERSION": "8.2.0",
+        },
+        tmp_path,
+    )
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip().splitlines()[-1] == DIGEST_A
+
+
+def test_wrapper_dry_run_bootstrap_adopts_when_no_current(tmp_path):
+    """A first-ever adoption (no recorded current) bootstraps onto :stable."""
+    r = _run_wrapper(
+        {
+            "OAW_STABLE_RESOLVED_REF": DIGEST_B,
+            "OAW_STABLE_VERSION": "8.3.0",
+        },
+        tmp_path,
+    )
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip().splitlines()[-1] == DIGEST_B
+
+
+def test_wrapper_apply_pins_current_and_rollback(tmp_path):
+    """Non-dry-run apply (still docker-free — refs injected) records the adopted
+    digest and keeps the PRIOR digest for a §5.6 rollback repoint."""
+    env = dict(os.environ)
+    state_dir = tmp_path / "adoption"
+    env.update(
+        ADOPT_DRY_RUN="false",
+        OAW_STATE_DIR=str(state_dir),
+        OAW_STABLE_RESOLVED_REF=DIGEST_B,
+        OAW_STABLE_VERSION="8.3.0",
+        OAW_CURRENT_REF=DIGEST_A,
+        OAW_CURRENT_VERSION="8.2.0",
+    )
+    r = subprocess.run(
+        ["bash", str(ADOPT_SCRIPT)], capture_output=True, text=True, env=env
+    )
+    assert r.returncode == 0, r.stderr
+    assert (state_dir / "current").read_text().strip() == DIGEST_B
+    assert (state_dir / "current-version").read_text().strip() == "8.3.0"
+    assert (state_dir / "rollback").read_text().strip() == DIGEST_A


### PR DESCRIPTION
## Summary

Wave P2W2 flight for Story 2.4 — rolling per-agent `:stable` adoption at container recreate. Integrates into the wave integration branch `kahuna/959-P2W2`.

## Changes

- `containers/oakandwave-workflow/adoption.py` — unit-tested adoption decision module (adopt same-major minor/patch at recreate; no-op when current; hold major cross unless `ALLOW_MAJOR_CROSS=true`).
- `scripts/ci/adopt-stable.sh` — recreate-boundary wrapper: resolves moving `:stable` tag to immutable digest+version, consults `adoption.py`, keeps a rollback pointer.
- `tests/contained-workflow/test_adoption.py` — decision-module unit tests.
- `containers/oakandwave-workflow/README.md` — Fleet adoption (Story 2.4) section.

## Linked Issues

Closes #969

## Test Plan

- `commutativity_verify` single-target gate against `kahuna/959-P2W2`: STRONG (safe to land).
- Full local suite (`scripts/ci/validate.sh` + `scripts/ci/test.sh`) run against the composed tree.
- Purely additive (4 files, 814 insertions, 0 deletions), no overlap with kahuna tip.