### PR TITLE
feat(flight-surgeon): host-side health probe (P3W1 #970)

### DIFF
--- a/docs/contained-workflow/manual-verification.md
+++ b/docs/contained-workflow/manual-verification.md
@@ -12,9 +12,9 @@ own them and are all executed and recorded in the closing story (4.3, #976).
 | MV-01 | Files land `bakerb`-owned under the me-ful config (isolated profile) | R-04 | Story 1.2 (#962) |
 | MV-02 | Live `~/.claude` not exposed under the full custom mount set | R-01, R-03 | Story 1.3+ |
 | MV-03 | Network egress reaches scream-hole / discord / github from inside | R-05 | later |
-| MV-04 | `aoe send` reaches into a running container (control-plane ingress) | R-15 | later |
+| MV-04 | `aoe send` reaches into a running container (control-plane ingress) | R-15 | Story 3.1 (#970) |
 | MV-05 | A broken container quarantines and recreates on `:stable`, zero loss | R-02, R-17 | Story 3.2+ |
-| MV-06 | A wedged/OOM-killed `claude` still flushed its transcript | R-15 | later |
+| MV-06 | A wedged/OOM-killed `claude` still flushed its transcript | R-15 | Story 3.1 (#970) |
 | MV-07 | A secret added mid-session is usable with no container restart | R-13 | Story 1.5 (#965) |
 
 ---
@@ -241,4 +241,196 @@ rm -rf /tmp/meful-secrets
 
 | Date | Operator | Image digest / ID | step-3 read | step-4 write | step-6 read | PASS/FAIL | Notes |
 |------|----------|-------------------|-------------|--------------|-------------|-----------|-------|
+| _pending_ | _pending_ | _pending_ | | | | | Executed and recorded in closing story 4.3 (#976) |
+
+---
+
+## MV-04 — `aoe send` reaches into a running container (control-plane ingress) `[R-15]`
+
+**Goal.** Prove the host can reach a **control-plane message** into a *running*
+sandbox session — `aoe send <session> "<text>"` is delivered to the agent inside
+the container. This is the ingress the flight surgeon's remediation and the
+quarantine step (Story 3.2, #971) ride: the probe *detects* from outside by
+reading the transcript (R-15, no ingress needed), but nudging or stopping a
+wedged agent needs a proven host→container control path (Dev Spec TC-7 / §5.N#5 —
+the AoE bootstrap/ingress seam is UNPROVEN).
+
+**Why manual.** The surgeon's *detection* is unit-proven
+(`tests/contained-workflow/test_surgeon.py`) and reads only the host-backed
+transcript — it never sends into the container. But whether `aoe send` traverses
+the host↔container boundary at all is a live aoe + docker property (no automated
+harness can stand up a real sandbox session in the pytest lane).
+
+### Preconditions
+
+- **aoe 1.13.0**, **rootful docker** — as MV-01.
+- Image built locally:
+  `make -C containers/oakandwave-workflow build` → `oakandwave-workflow:edge`.
+- An isolated aoe profile (as MV-01) so no fleet session is touched.
+
+### Procedure
+
+1. **Launch a sandbox session** on the image in the isolated profile:
+
+   ```bash
+   aoe -p meful-test add --sandbox --sandbox-image oakandwave-workflow:edge \
+     --launch /tmp/meful-ws
+   ```
+
+2. **Note the session id** and confirm it is `running` (or `idle`, i.e. up):
+
+   ```bash
+   aoe -p meful-test list --json | jq -r '.[] | "\(.id)\t\(.title)"'
+   aoe -p meful-test status -v
+   ```
+
+3. **Send a control-plane message** from the host into that session:
+
+   ```bash
+   aoe -p meful-test send <session-id> "flight-surgeon ping: reply PONG"
+   ```
+
+4. **Confirm the message was delivered** — the agent received the text (visible
+   in the attached TUI, or as a new user-turn in the session's **host-backed
+   transcript** the surgeon reads):
+
+   ```bash
+   # from the host, tail the session's host-backed .jsonl and look for the ping
+   python3 scripts/flight-surgeon/surgeon.py --live \
+     --transcripts-root ~/.claude/projects   # locates the transcript path
+   ```
+
+   **EXPECT:** the sent text appears as a new user turn in the transcript (and/or
+   the agent reacts). A "session not found" / no-delivery is a **FAIL** — the
+   host→container control path is not available, and Story 3.2's active
+   remediation must fall back to a docker-level stop (`docker stop <cid>`) rather
+   than an in-band `aoe send`.
+
+5. **Record** the result: date, operator, image digest/ID, the send command's
+   exit, whether the text landed in the transcript, and PASS/FAIL.
+
+### Cleanup
+
+```bash
+aoe -p meful-test remove <session-id>
+```
+
+### Failure handling
+
+- **`aoe send` errors or the text never lands.** Capture the container id and
+  aoe's log (`aoe logs`), and confirm the container is up
+  (`docker inspect --format '{{.State.Status}}' <cid>`). A missing ingress path is
+  the §5.N#5 seam resolving to "no in-band ingress" — record it and route Story
+  3.2 to the docker-level stop path. Open a note against Story 3.2 (#971).
+
+### Result log
+
+| Date | Operator | Image digest / ID | `aoe send` exit | landed in transcript? | PASS/FAIL | Notes |
+|------|----------|-------------------|-----------------|-----------------------|-----------|-------|
+| _pending_ | _pending_ | _pending_ | | | | Executed and recorded in closing story 4.3 (#976) |
+
+---
+
+## MV-06 — A wedged/OOM-killed `claude` still flushed its transcript `[R-15]`
+
+**Goal.** Prove the surgeon's core assumption: when a `claude` process is
+**hard-killed** (SIGKILL / OOM) inside a running container, the host-backed
+`.jsonl` transcript still reflects work up to (near) the failure boundary — so the
+host-side probe can read it and classify the container. This is the **F1
+transcript-flush keystone** (Dev Spec §5.N#2).
+
+**Why manual.** It needs a real container, a real running agent, and a real
+hard-kill; the transcript-flush behaviour of the harness under SIGKILL cannot be
+exercised in the pytest lane. The surgeon's *parsing* of a truncated tail **is**
+unit-proven (`test_read_transcript_tolerates_a_truncated_tail`) — this procedure
+proves the upstream fact that a hard-kill leaves a *usable* transcript at all.
+
+**Fail-safe note.** The surgeon is **fail-safe** with respect to this probe: if a
+hard-kill loses the last turn, the transcript simply stops growing *earlier*, so
+the probe detects the stall **sooner**, never misses it. A lost last-turn cannot
+turn a broken container into a "healthy" verdict. Operator field experience (many
+hard-kills, never a flush problem) indicates this is likely-ok; this procedure
+confirms it and records the boundary behaviour.
+
+### Preconditions
+
+- **aoe 1.13.0**, **rootful docker** — as MV-01.
+- Image built locally:
+  `make -C containers/oakandwave-workflow build` → `oakandwave-workflow:edge`.
+- An isolated aoe profile (as MV-01).
+
+### Procedure
+
+1. **Launch a sandbox session** on the image (isolated profile) and give the agent
+   a small task so the transcript is actively growing:
+
+   ```bash
+   aoe -p meful-test add --sandbox --sandbox-image oakandwave-workflow:edge \
+     --launch /tmp/meful-ws
+   aoe -p meful-test send <session-id> "run: for i in 1 2 3; do echo $i; sleep 2; done"
+   ```
+
+2. **Confirm the transcript is growing** on the host (record its size/last line):
+
+   ```bash
+   python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.claude/projects
+   # note the resolved transcript path P from the summary, then:
+   wc -l "$P"; tail -1 "$P"
+   ```
+
+3. **Hard-kill the in-container `claude` process** (SIGKILL — simulate a wedge/OOM,
+   NOT a graceful stop):
+
+   ```bash
+   cid=$(docker ps --filter name=<session> --format '{{.ID}}')
+   docker exec "$cid" bash -lc 'pkill -9 -f claude || kill -9 $(pgrep -o claude)'
+   # (or, to simulate OOM at the container level: docker kill --signal=KILL "$cid")
+   ```
+
+4. **Read the transcript from the HOST** (the container may be dead) and confirm
+   it retained work up to near the kill boundary:
+
+   ```bash
+   wc -l "$P"; tail -3 "$P"
+   ```
+
+   **EXPECT:** the transcript still parses and reflects the work performed before
+   the kill (the last one or two turns may be absent — that is acceptable and
+   fail-safe). A **completely empty or unparseable** transcript after real work
+   was done is a **FAIL** (the flush keystone does not hold; escalate).
+
+5. **Confirm the surgeon classifies it** — with the process dead the session goes
+   `stopped`/`error`, or if aoe still reports `running` the flat transcript trips
+   the stall after the threshold:
+
+   ```bash
+   python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.claude/projects
+   ```
+
+   **EXPECT:** the container is not reported healthy-and-progressing — either a
+   non-running status, or (if still `running`) a stall once N minutes elapse.
+
+6. **Record** the result: date, operator, image digest/ID, the pre-kill and
+   post-kill line counts, whether the transcript remained parseable, the surgeon's
+   verdict, and PASS/FAIL.
+
+### Cleanup
+
+```bash
+aoe -p meful-test remove <session-id>
+```
+
+### Failure handling
+
+- **Transcript empty/unparseable after a hard-kill.** The flush keystone
+  (§5.N#2) does not hold for this harness/kill mode — capture the kill signal, the
+  container's last logs (`docker logs <cid>`), and the transcript bytes, and open a
+  bug against Story 3.1 (#970). The surgeon's stall path still fires (the
+  transcript stops growing), so detection is not lost — but the boundary evidence
+  is, which this procedure exists to catch.
+
+### Result log
+
+| Date | Operator | Image digest / ID | pre-kill lines | post-kill lines | parseable? | surgeon verdict | PASS/FAIL |
+|------|----------|-------------------|----------------|-----------------|------------|-----------------|-----------|
 | _pending_ | _pending_ | _pending_ | | | | | Executed and recorded in closing story 4.3 (#976) |

--- a/scripts/flight-surgeon/README.md
+++ b/scripts/flight-surgeon/README.md
@@ -1,0 +1,86 @@
+# Flight surgeon — host-side health probe
+
+Story 3.1 (#970), Plan #959 — Contained Workflow Dev Spec §5.7.
+
+A **host-side** probe that watches each `:edge` dogfood container and decides
+whether it is **broken**, by reading the container's **host-backed `.jsonl`
+transcript directly**. The transcript is written by the harness *below* the kit,
+so the probe is **fate-independent** (R-15): a wedged, looping, or OOM-killed
+agent cannot corrupt the signal, and the probe needs **nothing from inside the
+container** — no `docker exec`, no kit import, no MCP call.
+
+## What it detects (R-16)
+
+While a container's aoe status is **`running`**:
+
+- **Stall** — the transcript has not grown for N minutes (default 15).
+- **Loop** — the same tool action repeats at the tail, or a short tool cycle
+  repeats (default: 5 consecutive, cycle period ≤ 4) — "no forward progress".
+
+Both signals are **gated on `running`**: a flat or repetitive transcript while
+`idle` / `waiting` / `stopped` / `error` is normal (the agent finished or awaits
+input), never a break.
+
+## Profile filter (R-22)
+
+The probe filters on the container's **profile label**. A broken **dev-mode**
+container is still reported broken (visible) but is marked
+`should_quarantine = false` — dev-mode breakages never trip quarantine or count
+toward soak. Exclusion requires an **explicit** `dev-mode` label; an unlabeled or
+unknown-profile candidate stays quarantine-**eligible** so a broken candidate
+can never escape the probe by lacking a label. The label mechanism itself is
+Story 4.1 (#974); this probe *consumes* it.
+
+## Scope — detection only
+
+This story **detects and classifies**. It performs **no quarantine action**
+(stop / `docker rm` / recreate on `:stable`) — that is Story 3.2 (#971), which
+consumes this module's `should_quarantine` verdict.
+
+## Usage
+
+```bash
+# classify an explicit manifest of observations (deterministic; '-' = stdin)
+python3 scripts/flight-surgeon/surgeon.py --observations obs.json
+
+# best-effort live gather over aoe sessions (flags the UNPROVEN seams)
+python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.claude/projects
+
+# a watcher/cron signal: non-zero exit if any quarantine-eligible break
+python3 scripts/flight-surgeon/surgeon.py --observations obs.json --fail-on-quarantine
+```
+
+Emits a JSON report on stdout (one assessment per container) and a human summary
+on stderr. Exit `0` normally, `3` with `--fail-on-quarantine` when a
+quarantine-eligible break is present, `2` on a usage/parse error.
+
+### Observation manifest
+
+A JSON list (or `{ "observations": [...] }`) of records:
+
+```json
+[
+  {
+    "container_id": "abc123",
+    "title": "dogbox",
+    "status": "running",
+    "profile": "dogfood",
+    "transcript": "/host/path/to/session.jsonl"
+  }
+]
+```
+
+`transcript` (a host path, read directly) may be replaced by inline `entries`
+(a list of parsed transcript objects, for testing). An optional `last_growth`
+(ISO-8601) supplies a watcher's file-mtime probe when the transcript itself
+carries no fresh timestamp.
+
+## The live seam (UNPROVEN — MV-04 / MV-06)
+
+`--live` maps an aoe session to its host-backed transcript path and reads its
+profile label. Both depend on aoe's sandbox mount/label layout, which cannot be
+proven without a running sandbox (Dev Spec TC-7 / §5.N). The pure classifier is
+the story's canonical oracle (`tests/contained-workflow/test_surgeon.py`); the
+live wiring is exercised by the manual procedures MV-04 (control-plane ingress)
+and MV-06 (transcript-flush-at-failure) in
+`docs/contained-workflow/manual-verification.md`.

--- a/scripts/flight-surgeon/surgeon.py
+++ b/scripts/flight-surgeon/surgeon.py
@@ -1,0 +1,713 @@
+#!/usr/bin/env python3
+"""Flight surgeon — host-side health probe. Story 3.1 (#970), Plan #959, Dev Spec §5.7.
+
+The flight surgeon is a **host-side** process (running ``:stable`` or bare) that
+watches each ``:edge`` dogfood container and decides whether it is broken — by
+reading the container's **host-backed ``.jsonl`` transcript directly**. The
+transcript is written by the harness *below* the kit, so the probe is
+**fate-independent**: a wedged, looping, or OOM-killed agent cannot corrupt the
+signal the surgeon reads, and the surgeon needs **nothing from inside the
+container** — no ``docker exec``, no kit import, no MCP call (R-15).
+
+Requirements this module is the guard for:
+
+* **R-15** — a host-side probe detects a broken ``:edge`` container by reading its
+  host-backed transcript directly, **without depending on the container's kit**.
+  Realised here as: :func:`read_transcript` parses the ``.jsonl`` straight off the
+  host filesystem, and the whole module imports **only the Python standard
+  library** — there is no path by which a broken container's kit can shape the
+  verdict.
+* **R-16** — WHILE a container's aoe status is ``running`` AND its transcript has
+  not grown for N minutes (**stall**), OR it shows a **loop** signal, the probe
+  classifies it broken. Both signals are gated on ``running`` (:func:`classify_health`):
+  a flat or repetitive transcript while the agent is ``idle``/``waiting``/``stopped``
+  is normal (it finished, or is awaiting input), never a break.
+* **R-22** — the probe filters on the **profile label**; **dev-mode** runs and
+  breakages do **not** trip quarantine (:func:`quarantine_eligible`). A broken
+  dev-mode container is still *classified* broken (visible), but is marked
+  ``should_quarantine = False`` so it never trips quarantine or pollutes the soak.
+
+Design — **fail-safe toward detection** (assertion-liveness, D7):
+
+* A break is only asserted on an explicit, positive signal (running + timed-flat,
+  or a concrete repeating tool cycle). Ambiguity (no timestamps yet, a just-
+  launched container) is **not** a break — the probe must not false-quarantine a
+  healthy agent that is legitimately mid-thought.
+* Conversely, **quarantine exclusion requires an explicit ``dev-mode`` label**. An
+  unlabeled or unknown-profile candidate is treated as quarantine-*eligible*, so a
+  broken candidate can never silently escape the probe merely by lacking a label
+  (the profile-label mechanism itself is Story 4.1 / #974; this probe *consumes*
+  it — R-21/R-22).
+
+Separation of concerns — this module **detects and classifies only**. It performs
+**no quarantine action** (stop / ``docker rm`` / recreate on ``:stable``): that is
+Story 3.2 (#971), which consumes this module's ``should_quarantine`` verdict. The
+live discovery seams (mapping a sandbox container to its host-backed transcript
+path, and reading the ``oaw.profile`` label) are UNPROVEN against a real sandbox
+(Dev Spec TC-7 / §5.N) and are exercised by MV-04/MV-06; the pure classifier below
+is the story's canonical oracle (``tests/contained-workflow/test_surgeon.py``).
+
+CLI::
+
+    # classify a set of observations (each names its host-backed transcript path)
+    python3 surgeon.py --observations obs.json
+
+    # best-effort live gather over aoe sessions (flags the UNPROVEN seams)
+    python3 surgeon.py --live --transcripts-root ~/.claude/projects
+
+Emits a JSON report on stdout (one assessment per container) and a human summary
+on stderr; exits 0 normally, or non-zero with ``--fail-on-quarantine`` if any
+container is a quarantine-eligible break (a signal a watcher/cron can act on).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# --- tunable thresholds (all overridable at the CLI) --------------------------
+
+# A `running` container whose transcript has not grown for this long is stalled
+# (R-16 "flat-for-N-min"). Generous by default: a legitimately long tool call or
+# a deep think must not trip it — a running agent silent for 15 min is dead.
+DEFAULT_STALL_SECONDS = 15 * 60
+
+# Loop signal: the same tool action (name + input) repeated this many times at the
+# transcript tail, or a short cycle repeated this many times, is "no forward
+# progress" (Dev Spec §5.7 "same tool K times").
+DEFAULT_LOOP_MIN_REPEATS = 5
+# The longest repeating cycle length considered (e.g. period 2 = A B A B ...).
+DEFAULT_LOOP_MAX_PERIOD = 4
+
+
+# --- aoe run states -----------------------------------------------------------
+
+RUNNING = "running"
+WAITING = "waiting"
+IDLE = "idle"
+STOPPED = "stopped"
+ERROR = "error"
+STATUS_UNKNOWN = "unknown"
+
+_RUN_STATES = {RUNNING, WAITING, IDLE, STOPPED, ERROR, STATUS_UNKNOWN}
+
+
+def normalize_status(value: object) -> str:
+    """Normalize an aoe session state (the ``aoe status -v`` headers RUNNING /
+    WAITING / IDLE / STOPPED / ERROR) to a lowercase token; anything else →
+    ``unknown``. Unknown is treated as *not running*, so the break signals — which
+    are gated on ``running`` (R-16) — never fire on an unrecognised state."""
+    if not isinstance(value, str):
+        return STATUS_UNKNOWN
+    v = value.strip().lower()
+    return v if v in _RUN_STATES else STATUS_UNKNOWN
+
+
+# --- profiles (R-21 / R-22) ---------------------------------------------------
+
+DOGFOOD = "dogfood"  # candidate — feeds the gate, quarantine-eligible
+DEV_MODE = "dev-mode"  # skills-overlay ON, non-candidate — EXCLUDED from quarantine
+PROFILE_UNKNOWN = "unknown"
+
+_DEV_MODE_ALIASES = {"dev-mode", "dev_mode", "devmode", "dev"}
+_DOGFOOD_ALIASES = {"dogfood", "dogfood-ring", "candidate"}
+
+
+def normalize_profile(value: object) -> str:
+    """Normalize a container's profile label to ``dev-mode`` / ``dogfood`` /
+    ``unknown``. The label key/values are owned by Story 4.1 (#974); this probe
+    consumes them. Only an explicit dev-mode marker excludes from quarantine."""
+    if not isinstance(value, str):
+        return PROFILE_UNKNOWN
+    v = value.strip().lower()
+    if v in _DEV_MODE_ALIASES:
+        return DEV_MODE
+    if v in _DOGFOOD_ALIASES:
+        return DOGFOOD
+    return PROFILE_UNKNOWN
+
+
+def quarantine_eligible(profile: object) -> bool:
+    """dev-mode is EXCLUDED from quarantine (R-22); everything else is eligible.
+
+    Exclusion requires an **explicit** ``dev-mode`` label: an unlabeled/unknown
+    candidate stays quarantine-eligible so a broken candidate can never escape the
+    probe simply by carrying no label. (R-21: dev-mode is the *labeled*
+    non-candidate; absence of that label means "candidate".)"""
+    return normalize_profile(profile) != DEV_MODE
+
+
+# --- transcript parsing (host-side, kit-independent) --------------------------
+
+
+def parse_timestamp(value: object) -> datetime | None:
+    """Parse an ISO-8601 transcript timestamp to an aware UTC datetime, or None.
+
+    Tolerates the trailing ``Z`` and naive stamps (assumed UTC). A malformed or
+    missing stamp is ``None`` — never an exception (a partially flushed tail must
+    not crash the probe)."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def read_transcript(path: object) -> list[dict]:
+    """Parse a host-backed Claude Code ``.jsonl`` transcript into a list of entries.
+
+    Reads the file **directly off the host filesystem** — no container exec, no kit
+    import (R-15). Each line is one JSON object; blank and malformed lines are
+    skipped (fate-independent: a truncated last line from a hard-killed agent must
+    degrade the signal, not crash the probe). A missing file yields ``[]``."""
+    p = Path(str(path)).expanduser()
+    if not p.is_file():
+        return []
+    entries: list[dict] = []
+    with p.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                entries.append(obj)
+    return entries
+
+
+def last_activity(entries: list[dict]) -> datetime | None:
+    """The most recent entry timestamp across the transcript, or None if none carry
+    a parseable timestamp. Uses the max (not merely the last line) so an
+    out-of-order or malformed tail cannot understate freshness."""
+    latest: datetime | None = None
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        ts = parse_timestamp(e.get("timestamp"))
+        if ts is not None and (latest is None or ts > latest):
+            latest = ts
+    return latest
+
+
+def _stable_input_key(obj: object) -> str:
+    """A canonical, order-stable key for a tool_use ``input`` so two identical
+    calls compare equal regardless of dict key order."""
+    try:
+        return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+    except (TypeError, ValueError):
+        return repr(obj)
+
+
+def tool_signatures(entries: list[dict]) -> list[str]:
+    """The chronological sequence of tool-use signatures (``name:input``) across the
+    transcript. Loop detection runs on **tool actions only** — the Dev Spec's
+    "same tool K times" heuristic (§5.7) — deliberately ignoring assistant/user
+    prose so ordinary repeated phrasing can never be mistaken for a loop."""
+    sigs: list[str] = []
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        msg = e.get("message")
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                name = block.get("name", "?")
+                sigs.append(f"{name}:{_stable_input_key(block.get('input'))}")
+    return sigs
+
+
+@dataclass(frozen=True)
+class LoopResult:
+    looping: bool
+    detail: str = ""
+
+
+def detect_loop(
+    signatures: list[str],
+    *,
+    min_repeats: int = DEFAULT_LOOP_MIN_REPEATS,
+    max_period: int = DEFAULT_LOOP_MAX_PERIOD,
+) -> LoopResult:
+    """Detect a "no forward progress" loop in a tool-signature sequence.
+
+    Two shapes, checked at the **tail** (the live edge of the transcript):
+
+    * a single action repeated ``min_repeats`` times in a row (period-1); and
+    * a period-``p`` cycle (2..``max_period``) repeated ``min_repeats`` times —
+      e.g. an ``A B A B A B`` two-tool ping-pong.
+
+    Conservative by construction: it needs ``min_repeats`` *consecutive* identical
+    blocks ending at the tail, so a loop that has since broken (forward progress
+    resumed) does not read as looping."""
+    n = len(signatures)
+    if min_repeats < 1 or n < min_repeats:
+        return LoopResult(False)
+
+    # period-1: the same action repeated at the tail.
+    last = signatures[-1]
+    run = 0
+    for s in reversed(signatures):
+        if s == last:
+            run += 1
+        else:
+            break
+    if run >= min_repeats:
+        return LoopResult(True, f"the same tool action repeated {run}x at the tail: {last}")
+
+    # period-p cycle repeated at the tail.
+    for period in range(2, max_period + 1):
+        if n < period * min_repeats:
+            continue
+        block = signatures[-period:]
+        reps = 0
+        idx = n
+        while idx - period >= 0 and signatures[idx - period : idx] == block:
+            reps += 1
+            idx -= period
+        if reps >= min_repeats:
+            return LoopResult(
+                True, f"a period-{period} tool cycle repeated {reps}x at the tail"
+            )
+    return LoopResult(False)
+
+
+# --- health classification (R-16) ---------------------------------------------
+
+HEALTHY = "healthy"
+STALLED = "stalled"
+LOOPING = "looping"
+
+
+@dataclass(frozen=True)
+class HealthVerdict:
+    status: str
+    broken: bool
+    stalled: bool
+    looping: bool
+    reasons: tuple[str, ...]
+    idle_seconds: float | None
+    last_activity: datetime | None
+
+    @property
+    def state(self) -> str:
+        if self.stalled and self.looping:
+            return "stalled+looping"
+        if self.stalled:
+            return STALLED
+        if self.looping:
+            return LOOPING
+        return HEALTHY
+
+    def as_dict(self) -> dict:
+        return {
+            "status": self.status,
+            "state": self.state,
+            "broken": self.broken,
+            "stalled": self.stalled,
+            "looping": self.looping,
+            "idle_seconds": self.idle_seconds,
+            "last_activity": self.last_activity.isoformat() if self.last_activity else None,
+            "reasons": list(self.reasons),
+        }
+
+
+def classify_health(
+    *,
+    entries: list[dict],
+    status: object,
+    now: datetime | None = None,
+    last_growth: datetime | None = None,
+    stall_after_seconds: float = DEFAULT_STALL_SECONDS,
+    loop_min_repeats: int = DEFAULT_LOOP_MIN_REPEATS,
+    loop_max_period: int = DEFAULT_LOOP_MAX_PERIOD,
+) -> HealthVerdict:
+    """Classify one container's health from its transcript + aoe status (R-16).
+
+    Both break signals are **gated on ``running``**: a flat or repetitive
+    transcript while ``idle``/``waiting``/``stopped``/``error``/``unknown`` is not a
+    break — the agent is not executing, so silence is expected. While ``running``:
+
+    * **stall** — the transcript has not grown for ``stall_after_seconds``. Growth
+      time is ``max`` of the last entry's timestamp and any externally observed
+      ``last_growth`` (a watcher's file-mtime probe). With neither available the
+      stall dimension is *unevaluated* (never asserted) — a just-launched container
+      must not read as stalled.
+    * **loop** — :func:`detect_loop` finds a repeating tool cycle at the tail.
+    """
+    now = now or datetime.now(timezone.utc)
+    st = normalize_status(status)
+
+    growth = last_activity(entries)
+    if last_growth is not None and (growth is None or last_growth > growth):
+        growth = last_growth
+    idle_seconds = (now - growth).total_seconds() if growth is not None else None
+
+    if st != RUNNING:
+        return HealthVerdict(
+            status=st,
+            broken=False,
+            stalled=False,
+            looping=False,
+            reasons=(
+                f"status={st}: not running — a flat or repetitive transcript is "
+                f"not a stall/loop while the agent is not executing (R-16 gates "
+                f"both signals on running)",
+            ),
+            idle_seconds=idle_seconds,
+            last_activity=growth,
+        )
+
+    reasons: list[str] = []
+
+    stalled = idle_seconds is not None and idle_seconds >= stall_after_seconds
+    if stalled:
+        reasons.append(
+            f"running + transcript flat for {idle_seconds / 60:.1f} min "
+            f"(>= {stall_after_seconds / 60:.0f} min threshold) [R-16 stall]"
+        )
+    elif idle_seconds is None:
+        reasons.append(
+            "running but no timestamped activity yet — stall not timed "
+            "(possibly just launched); not asserting a break"
+        )
+
+    loop = detect_loop(
+        tool_signatures(entries),
+        min_repeats=loop_min_repeats,
+        max_period=loop_max_period,
+    )
+    looping = loop.looping
+    if looping:
+        reasons.append(f"running + loop signal: {loop.detail} [R-16 loop]")
+
+    broken = stalled or looping
+    if not broken:
+        reasons.append(
+            f"running + transcript progressing "
+            f"({'idle %.1f min < threshold' % (idle_seconds / 60) if idle_seconds is not None else 'active'}), "
+            f"no loop signal — healthy"
+        )
+
+    return HealthVerdict(
+        status=st,
+        broken=broken,
+        stalled=stalled,
+        looping=looping,
+        reasons=tuple(reasons),
+        idle_seconds=idle_seconds,
+        last_activity=growth,
+    )
+
+
+# --- container assessment (health + profile filter) ---------------------------
+
+
+@dataclass(frozen=True)
+class Assessment:
+    container_id: str
+    title: str
+    profile: str
+    health: HealthVerdict
+    quarantine_eligible: bool
+    should_quarantine: bool
+    reasons: tuple[str, ...]
+
+    def as_dict(self) -> dict:
+        return {
+            "container_id": self.container_id,
+            "title": self.title,
+            "profile": self.profile,
+            "quarantine_eligible": self.quarantine_eligible,
+            "should_quarantine": self.should_quarantine,
+            "health": self.health.as_dict(),
+            "reasons": list(self.reasons),
+        }
+
+
+def assess(
+    *,
+    container_id: str,
+    title: str,
+    status: object,
+    profile: object,
+    entries: list[dict],
+    now: datetime | None = None,
+    last_growth: datetime | None = None,
+    stall_after_seconds: float = DEFAULT_STALL_SECONDS,
+    loop_min_repeats: int = DEFAULT_LOOP_MIN_REPEATS,
+    loop_max_period: int = DEFAULT_LOOP_MAX_PERIOD,
+) -> Assessment:
+    """Assess one container: classify health (R-16), then apply the profile filter
+    (R-22). ``should_quarantine`` is True **iff** the container is broken AND
+    quarantine-eligible; a broken **dev-mode** container is reported broken but
+    excluded (``should_quarantine = False``), never tripping quarantine or soak."""
+    health = classify_health(
+        entries=entries,
+        status=status,
+        now=now,
+        last_growth=last_growth,
+        stall_after_seconds=stall_after_seconds,
+        loop_min_repeats=loop_min_repeats,
+        loop_max_period=loop_max_period,
+    )
+    prof = normalize_profile(profile)
+    eligible = quarantine_eligible(profile)
+    reasons = list(health.reasons)
+    if health.broken and not eligible:
+        reasons.append(
+            f"profile={prof}: dev-mode is EXCLUDED from quarantine — this breakage "
+            f"does not trip quarantine or count toward soak [R-22]"
+        )
+    return Assessment(
+        container_id=str(container_id),
+        title=str(title),
+        profile=prof,
+        health=health,
+        quarantine_eligible=eligible,
+        should_quarantine=bool(health.broken and eligible),
+        reasons=tuple(reasons),
+    )
+
+
+def assess_record(rec: dict, *, now: datetime | None = None, **params) -> Assessment:
+    """Assess one observation record from the ``--observations`` manifest.
+
+    Each record: ``container_id``, ``title``, ``status``, ``profile``, and either a
+    ``transcript`` (host path — read directly, R-15) or inline ``entries``. An
+    optional ``last_growth`` (ISO-8601) supplies a watcher's file-mtime probe."""
+    if not isinstance(rec, dict):
+        raise SurgeonError(f"observation must be an object, got {type(rec).__name__}")
+    if "entries" in rec:
+        entries = rec["entries"] if isinstance(rec["entries"], list) else []
+    else:
+        entries = read_transcript(rec.get("transcript", ""))
+    return assess(
+        container_id=rec.get("container_id", rec.get("id", "?")),
+        title=rec.get("title", "?"),
+        status=rec.get("status"),
+        profile=rec.get("profile"),
+        entries=entries,
+        now=now,
+        last_growth=parse_timestamp(rec.get("last_growth")),
+        **params,
+    )
+
+
+class SurgeonError(ValueError):
+    """A flight-surgeon contract violation. Raised LOUD, never swallowed."""
+
+
+# --- aoe-side discovery helpers (the live seam) -------------------------------
+
+
+def parse_status_table(text: str) -> dict[str, str]:
+    """Parse ``aoe status -v`` (human output) into ``{session_title: state}``.
+
+    The output groups sessions under uppercase state headers — ``RUNNING (1):``,
+    ``IDLE (8):``, ``STOPPED (20):``, and (when present) ``WAITING`` / ``ERROR`` —
+    followed by ``  <spinner> <title> <tool> <path>`` lines. This maps each title
+    to its lowercased state so the gather step can correlate a session's state with
+    its transcript (R-16 needs the ``running`` gate)."""
+    states: dict[str, str] = {}
+    current: str | None = None
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        stripped = line.strip()
+        header = stripped.split(" ", 1)[0].rstrip(":").lower()
+        # A header line starts at column 0 and names a known state.
+        if not line[0].isspace() and header in _RUN_STATES:
+            current = header
+            continue
+        if current is None:
+            continue
+        # A session row: "<spinner> <title> <tool> <path>". Drop the leading
+        # spinner glyph, then take the first whitespace-delimited field as title.
+        parts = stripped.split()
+        if not parts:
+            continue
+        # The first token is a spinner glyph (non-word); the title follows.
+        fields = parts[1:] if len(parts) > 1 else parts
+        if fields:
+            states[fields[0]] = current
+    return states
+
+
+def _run(cmd: list[str], *, timeout: float = 30.0) -> str:
+    """Run a command and return stdout (empty string on any failure — the live
+    gather is best-effort; the deterministic contract is the observations path)."""
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def discover_sessions(runner=_run) -> list[dict]:
+    """List aoe sessions via ``aoe list --json`` (id/title/path/profile/...)."""
+    out = runner(["aoe", "list", "--json"])
+    if not out.strip():
+        return []
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return []
+    return [s for s in data if isinstance(s, dict)] if isinstance(data, list) else []
+
+
+# --- reporting / CLI ----------------------------------------------------------
+
+
+def report_summary(assessments: list[Assessment]) -> str:
+    lines = ["flight surgeon — health report:"]
+    for a in assessments:
+        mark = "QUARANTINE" if a.should_quarantine else ("BROKEN(excluded)" if a.health.broken else "ok")
+        lines.append(
+            f"  [{mark}] {a.title} ({a.container_id}) "
+            f"status={a.health.status} profile={a.profile} state={a.health.state}"
+        )
+        for r in a.reasons:
+            lines.append(f"      - {r}")
+    n_q = sum(1 for a in assessments if a.should_quarantine)
+    lines.append(f"  => {len(assessments)} watched, {n_q} quarantine-eligible break(s)")
+    return "\n".join(lines)
+
+
+def _load_observations(path: str) -> list[dict]:
+    text = sys.stdin.read() if path == "-" else Path(path).expanduser().read_text()
+    data = json.loads(text)
+    if isinstance(data, dict) and isinstance(data.get("observations"), list):
+        data = data["observations"]
+    if not isinstance(data, list):
+        raise SurgeonError("observations must be a JSON list (or {observations: [...]})")
+    return data
+
+
+def _gather_live(args, runner=_run) -> list[dict]:
+    """Best-effort live gather over aoe sessions.
+
+    UNPROVEN seam (Dev Spec TC-7 / §5.N, exercised by MV-04/MV-06): mapping a
+    sandbox session to its host-backed transcript path and its ``oaw.profile``
+    label depends on aoe's sandbox mount/label layout, which cannot be proven
+    without a running sandbox. This resolves the transcript path under a
+    configurable ``--transcripts-root`` (best-effort, newest ``.jsonl`` under the
+    session's project) and leaves the profile ``unknown`` unless a label is wired.
+    """
+    sessions = discover_sessions(runner)
+    states = parse_status_table(runner(["aoe", "status", "-v"]))
+    root = Path(args.transcripts_root).expanduser()
+    records: list[dict] = []
+    for s in sessions:
+        title = s.get("title", "?")
+        transcript = _newest_transcript_for(root, s.get("path", ""))
+        records.append(
+            {
+                "container_id": s.get("id", "?"),
+                "title": title,
+                "status": states.get(title, STATUS_UNKNOWN),
+                "profile": s.get("profile_label", PROFILE_UNKNOWN),
+                "transcript": str(transcript) if transcript else "",
+            }
+        )
+    return records
+
+
+def _newest_transcript_for(root: Path, project_path: str) -> Path | None:
+    """Best-effort: the newest ``.jsonl`` under ``root`` whose name encodes
+    ``project_path`` (Claude Code escapes the project path into the dir name).
+    Returns None if nothing matches — the seam MV-04/MV-06 nail down."""
+    if not root.is_dir() or not project_path:
+        return None
+    slug = project_path.strip("/").replace("/", "-")
+    best: Path | None = None
+    best_mtime = -1.0
+    for jsonl in root.rglob("*.jsonl"):
+        if slug and slug not in str(jsonl):
+            continue
+        try:
+            m = jsonl.stat().st_mtime
+        except OSError:
+            continue
+        if m > best_mtime:
+            best, best_mtime = jsonl, m
+    return best
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--observations",
+        metavar="FILE",
+        help="JSON manifest of container observations ('-' for stdin)",
+    )
+    src.add_argument(
+        "--live",
+        action="store_true",
+        help="best-effort live gather over aoe sessions (flags the UNPROVEN seams)",
+    )
+    parser.add_argument(
+        "--transcripts-root",
+        default="~/.claude/projects",
+        help="root to resolve host-backed transcripts under (--live)",
+    )
+    parser.add_argument(
+        "--stall-seconds", type=float, default=DEFAULT_STALL_SECONDS,
+        help=f"stall threshold in seconds (default {DEFAULT_STALL_SECONDS})",
+    )
+    parser.add_argument(
+        "--loop-min-repeats", type=int, default=DEFAULT_LOOP_MIN_REPEATS,
+        help=f"loop: min consecutive repeats (default {DEFAULT_LOOP_MIN_REPEATS})",
+    )
+    parser.add_argument(
+        "--loop-max-period", type=int, default=DEFAULT_LOOP_MAX_PERIOD,
+        help=f"loop: max cycle period (default {DEFAULT_LOOP_MAX_PERIOD})",
+    )
+    parser.add_argument(
+        "--fail-on-quarantine", action="store_true",
+        help="exit non-zero if any container is a quarantine-eligible break",
+    )
+    args = parser.parse_args(argv)
+
+    params = dict(
+        stall_after_seconds=args.stall_seconds,
+        loop_min_repeats=args.loop_min_repeats,
+        loop_max_period=args.loop_max_period,
+    )
+
+    try:
+        records = _gather_live(args) if args.live else _load_observations(args.observations)
+        now = datetime.now(timezone.utc)
+        assessments = [assess_record(r, now=now, **params) for r in records]
+    except (SurgeonError, OSError, json.JSONDecodeError) as exc:
+        print(f"flight-surgeon error: {exc}", file=sys.stderr)
+        return 2
+
+    print(report_summary(assessments), file=sys.stderr)
+    print(json.dumps([a.as_dict() for a in assessments], indent=2))
+
+    if args.fail_on_quarantine and any(a.should_quarantine for a in assessments):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contained-workflow/test_surgeon.py
+++ b/tests/contained-workflow/test_surgeon.py
@@ -1,0 +1,372 @@
+"""Oracle for Story 3.1 (#970) — the flight surgeon health probe (R-15/R-16/R-22).
+
+The surgeon (``scripts/flight-surgeon/surgeon.py``) is a **host-side** probe that
+reads each ``:edge`` container's host-backed ``.jsonl`` transcript directly and
+classifies it broken (stall or loop) while correlating with aoe status, filtering
+dev-mode out of quarantine. All three acceptance criteria are proved here as pure
+unit oracles (no docker, no aoe, no live container), so they run for real in the
+stock ``pytest tests/`` lane:
+
+* **AC1 [R-15]** — the probe detects a stall by reading the transcript **directly**,
+  without the container's kit. :func:`test_probe_reads_transcript_directly` writes a
+  real ``.jsonl`` to disk and the surgeon reads+classifies it with nothing from any
+  container; :func:`test_module_is_kit_independent` proves the module imports only
+  the standard library.
+* **AC2 [R-16]** — ``running`` + flat-for-N-min AND loop signals both classify
+  broken. The named story oracle :func:`test_stall_and_loop` drives flat and
+  repetitive transcripts; :func:`test_status_gate` proves both signals fire ONLY
+  while running.
+* **AC3 [R-22]** — dev-mode containers are excluded from quarantine.
+  :func:`test_dev_mode_excluded_from_quarantine`.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SURGEON_DIR = REPO_ROOT / "scripts" / "flight-surgeon"
+SURGEON_PY = SURGEON_DIR / "surgeon.py"
+
+# Path-style import (no PYTHONPATH dependency), mirroring test_gate.py.
+sys.path.insert(0, str(SURGEON_DIR))
+import surgeon as fs  # noqa: E402
+
+NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- transcript fixtures ------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def tool_entry(ts: datetime, name: str, tool_input: dict) -> dict:
+    """A Claude Code assistant transcript entry carrying one tool_use block."""
+    return {
+        "type": "assistant",
+        "timestamp": _iso(ts),
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": name, "input": tool_input}],
+        },
+    }
+
+
+def text_entry(ts: datetime, text: str) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": _iso(ts),
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def flat_transcript(last_seconds_ago: float, anchor: datetime = NOW) -> list[dict]:
+    """A progressing-then-quiet transcript whose LAST activity is N seconds before
+    ``anchor`` (the reference "now")."""
+    base = anchor - timedelta(seconds=last_seconds_ago)
+    return [
+        text_entry(base - timedelta(minutes=5), "starting work"),
+        tool_entry(base - timedelta(minutes=3), "Read", {"path": "/a"}),
+        tool_entry(base, "Bash", {"cmd": "make test"}),
+    ]
+
+
+def looping_transcript(reps: int, seconds_ago: float = 30.0, anchor: datetime = NOW) -> list[dict]:
+    """A RECENT but repetitive transcript: the same tool call ``reps`` times, so it
+    is not stalled (fresh) yet shows no forward progress (loop)."""
+    base = anchor - timedelta(seconds=seconds_ago)
+    entries = [text_entry(base - timedelta(minutes=2), "working")]
+    for i in range(reps):
+        entries.append(
+            tool_entry(base + timedelta(seconds=i), "Bash", {"cmd": "git status"})
+        )
+    return entries
+
+
+# --- AC2 [R-16]: the named story oracle — stall AND loop both classify broken -
+
+
+def test_stall_and_loop() -> None:
+    """``running`` + flat-for-N-min and loop signals BOTH classify broken (R-16),
+    and neither fires on a fresh, progressing transcript.
+    """
+    # 1. STALL: running + last activity 20 min ago (> 15 min threshold) → broken.
+    stalled = fs.classify_health(
+        entries=flat_transcript(last_seconds_ago=20 * 60), status="running", now=NOW
+    )
+    assert stalled.broken and stalled.stalled and not stalled.looping
+    assert stalled.state == fs.STALLED
+
+    # 2. NOT stalled: running + fresh activity (1 min ago) → healthy.
+    fresh = fs.classify_health(
+        entries=flat_transcript(last_seconds_ago=60), status="running", now=NOW
+    )
+    assert not fresh.broken and fresh.state == fs.HEALTHY
+
+    # 3. LOOP: running + fresh but the same tool 6× → broken via loop, NOT stall.
+    looping = fs.classify_health(
+        entries=looping_transcript(reps=6), status="running", now=NOW
+    )
+    assert looping.broken and looping.looping and not looping.stalled
+    assert looping.state == fs.LOOPING
+
+    # 4. NOT looping: running + fresh, varied tool calls → healthy.
+    varied = [
+        tool_entry(NOW - timedelta(seconds=90), "Read", {"path": "/a"}),
+        tool_entry(NOW - timedelta(seconds=60), "Bash", {"cmd": "ls"}),
+        tool_entry(NOW - timedelta(seconds=30), "Edit", {"path": "/b"}),
+        tool_entry(NOW - timedelta(seconds=10), "Bash", {"cmd": "make"}),
+    ]
+    healthy = fs.classify_health(entries=varied, status="running", now=NOW)
+    assert not healthy.broken and healthy.state == fs.HEALTHY
+
+
+def test_status_gate() -> None:
+    """Both break signals are gated on ``running`` (R-16): the identical flat /
+    repetitive transcript is NOT a break while idle / waiting / stopped."""
+    for non_running in ("idle", "waiting", "stopped", "error", "unknown"):
+        stall_shape = fs.classify_health(
+            entries=flat_transcript(last_seconds_ago=60 * 60),
+            status=non_running,
+            now=NOW,
+        )
+        assert not stall_shape.broken, f"flat while {non_running} must not be a break"
+
+        loop_shape = fs.classify_health(
+            entries=looping_transcript(reps=10), status=non_running, now=NOW
+        )
+        assert not loop_shape.broken, f"repetitive while {non_running} must not break"
+
+
+def test_stall_threshold_boundary() -> None:
+    """The stall fires at/after the threshold, not before."""
+    under = fs.classify_health(
+        entries=flat_transcript(last_seconds_ago=14 * 60), status="running", now=NOW
+    )
+    assert not under.stalled
+    over = fs.classify_health(
+        entries=flat_transcript(last_seconds_ago=16 * 60), status="running", now=NOW
+    )
+    assert over.stalled and over.broken
+
+
+def test_just_launched_running_is_not_stalled() -> None:
+    """A running container with no timestamped activity yet must NOT read as a
+    stall (fail-safe toward not false-quarantining a just-launched agent)."""
+    v = fs.classify_health(entries=[], status="running", now=NOW)
+    assert not v.broken and not v.stalled
+
+
+# --- loop detector shapes (conservative) --------------------------------------
+
+
+def test_loop_detection_shapes() -> None:
+    same = [f"Bash:{json.dumps({'cmd': 'git status'})}"] * 5
+    assert fs.detect_loop(same, min_repeats=5).looping
+
+    just_under = same[:4]
+    assert not fs.detect_loop(just_under, min_repeats=5).looping
+
+    # A period-2 ping-pong repeated ≥ min_repeats at the tail.
+    pingpong = ["A:{}", "B:{}"] * 3
+    assert fs.detect_loop(pingpong, min_repeats=3, max_period=4).looping
+
+    # A loop that has since resolved (forward progress at the tail) → NOT looping.
+    resolved = (["A:{}"] * 6) + ["B:{}", "C:{}"]
+    assert not fs.detect_loop(resolved, min_repeats=5).looping
+
+    # Varied, progressing sequence → never a loop.
+    varied = ["A:{}", "B:{}", "C:{}", "D:{}", "E:{}"]
+    assert not fs.detect_loop(varied, min_repeats=3, max_period=4).looping
+
+
+# --- AC1 [R-15]: reads the transcript directly, kit-independently --------------
+
+
+def test_probe_reads_transcript_directly(tmp_path) -> None:
+    """The probe detects a stall by reading a real ``.jsonl`` off disk directly —
+    nothing from any container, no kit (R-15)."""
+    transcript = tmp_path / "session.jsonl"
+    lines = flat_transcript(last_seconds_ago=30 * 60)
+    transcript.write_text("\n".join(json.dumps(e) for e in lines) + "\n")
+
+    entries = fs.read_transcript(transcript)
+    assert len(entries) == len(lines)
+    verdict = fs.classify_health(entries=entries, status="running", now=NOW)
+    assert verdict.broken and verdict.stalled
+
+
+def test_read_transcript_tolerates_a_truncated_tail(tmp_path) -> None:
+    """A hard-killed agent may leave a truncated last line; the probe must skip it,
+    not crash (fate-independence, R-15)."""
+    transcript = tmp_path / "session.jsonl"
+    good = json.dumps(tool_entry(NOW - timedelta(minutes=40), "Bash", {"cmd": "x"}))
+    transcript.write_text(good + "\n" + '{"type":"assistant","truncat')  # no newline
+    entries = fs.read_transcript(transcript)
+    assert len(entries) == 1  # the good line survives, the torn one is dropped
+    assert fs.read_transcript(tmp_path / "nope.jsonl") == []  # missing file → []
+
+
+def test_module_is_kit_independent() -> None:
+    """R-15: the surgeon depends on nothing from the container's kit — the module
+    imports ONLY the Python standard library, so a broken container cannot shape
+    the verdict."""
+    tree = ast.parse(SURGEON_PY.read_text())
+    stdlib = {
+        "argparse", "json", "subprocess", "sys", "dataclasses",
+        "datetime", "pathlib", "__future__",
+    }
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported.add(node.module.split(".")[0])
+    leaked = imported - stdlib
+    assert not leaked, f"surgeon imports non-stdlib modules (kit dependency risk): {leaked}"
+
+
+# --- AC3 [R-22]: dev-mode excluded from quarantine ----------------------------
+
+
+def _broken_running():
+    return dict(status="running", entries=flat_transcript(last_seconds_ago=30 * 60))
+
+
+def test_dev_mode_excluded_from_quarantine() -> None:
+    """A broken dev-mode container is reported broken but NEVER quarantined (R-22);
+    a broken dogfood (or unlabeled) candidate IS quarantine-eligible."""
+    dev = fs.assess(container_id="c1", title="devbox", profile="dev-mode",
+                    now=NOW, **_broken_running())
+    assert dev.health.broken, "the break is still classified/visible"
+    assert not dev.quarantine_eligible
+    assert not dev.should_quarantine, "dev-mode must not trip quarantine (R-22)"
+    assert any("R-22" in r for r in dev.reasons)
+
+    dog = fs.assess(container_id="c2", title="dogbox", profile="dogfood",
+                    now=NOW, **_broken_running())
+    assert dog.health.broken and dog.quarantine_eligible and dog.should_quarantine
+
+    # Unlabeled / unknown profile is treated as a candidate — eligible, so a broken
+    # one cannot escape the probe by lacking a label.
+    for prof in (None, "", "weird"):
+        unk = fs.assess(container_id="c3", title="unlabeled", profile=prof,
+                        now=NOW, **_broken_running())
+        assert unk.quarantine_eligible and unk.should_quarantine
+
+    # A HEALTHY dogfood container is never quarantined.
+    ok = fs.assess(container_id="c4", title="healthy", profile="dogfood", status="running",
+                   entries=flat_transcript(last_seconds_ago=30), now=NOW)
+    assert not ok.health.broken and not ok.should_quarantine
+
+
+def test_profile_and_status_normalization() -> None:
+    assert fs.normalize_profile("DEV-MODE") == fs.DEV_MODE
+    assert fs.normalize_profile("Dogfood") == fs.DOGFOOD
+    assert fs.normalize_profile(None) == fs.PROFILE_UNKNOWN
+    assert fs.quarantine_eligible("dev") is False
+    assert fs.quarantine_eligible("dogfood") is True
+    assert fs.normalize_status("RUNNING") == fs.RUNNING
+    assert fs.normalize_status("bogus") == fs.STATUS_UNKNOWN
+
+
+# --- aoe status-table parser (the live-gather seam, unit-tested) --------------
+
+
+def test_parse_status_table() -> None:
+    sample = (
+        "RUNNING (1):\n"
+        "  ⠋ babelfish        claude     ~/sandbox/github/claudecode-workflow\n"
+        "\n"
+        "IDLE (2):\n"
+        "  ⠒ cerberus         claude     ~/sysadmin\n"
+        "  ⠒ moho             claude     ~/sandbox/x\n"
+        "\n"
+        "STOPPED (1):\n"
+        "  ⠒ cacophonix       claude     ~/sandbox/github/scream-hole\n"
+    )
+    states = fs.parse_status_table(sample)
+    assert states["babelfish"] == "running"
+    assert states["cerberus"] == "idle"
+    assert states["moho"] == "idle"
+    assert states["cacophonix"] == "stopped"
+
+
+# --- CLI: the report surface --------------------------------------------------
+
+
+def _run_cli(*args, stdin=None):
+    return subprocess.run(
+        [sys.executable, str(SURGEON_PY), *args],
+        capture_output=True, text=True, timeout=30, input=stdin,
+    )
+
+
+def test_cli_observations_report(tmp_path) -> None:
+    """End-to-end through the CLI: a manifest of observations yields a JSON report
+    with the right per-container verdicts, and --fail-on-quarantine signals.
+
+    The CLI classifies against the real wall clock, so fixtures here anchor to
+    ``datetime.now`` (not the fixed NOW the pure-function tests use)."""
+    real_now = datetime.now(timezone.utc)
+    transcript = tmp_path / "dog.jsonl"
+    transcript.write_text(
+        "\n".join(
+            json.dumps(e) for e in flat_transcript(last_seconds_ago=30 * 60, anchor=real_now)
+        )
+        + "\n"
+    )
+    manifest = [
+        # broken dogfood, read from a real host-backed transcript file (R-15)
+        {"container_id": "d1", "title": "dog", "status": "running",
+         "profile": "dogfood", "transcript": str(transcript)},
+        # broken dev-mode (inline entries) → excluded from quarantine (R-22)
+        {"container_id": "v1", "title": "dev", "status": "running",
+         "profile": "dev-mode",
+         "entries": flat_transcript(last_seconds_ago=30 * 60, anchor=real_now)},
+        # healthy dogfood
+        {"container_id": "h1", "title": "ok", "status": "running",
+         "profile": "dogfood",
+         "entries": flat_transcript(last_seconds_ago=30, anchor=real_now)},
+    ]
+    obs = tmp_path / "obs.json"
+    obs.write_text(json.dumps(manifest))
+
+    proc = _run_cli("--observations", str(obs), "--fail-on-quarantine")
+    assert proc.returncode == 3, proc.stderr  # one quarantine-eligible break (the dog)
+    report = {a["container_id"]: a for a in json.loads(proc.stdout)}
+    assert report["d1"]["should_quarantine"] is True
+    assert report["v1"]["health"]["broken"] is True
+    assert report["v1"]["should_quarantine"] is False  # dev-mode excluded
+    assert report["h1"]["health"]["broken"] is False
+
+    # Without --fail-on-quarantine the probe reports and exits 0.
+    ok = _run_cli("--observations", str(obs))
+    assert ok.returncode == 0, ok.stderr
+
+
+def test_cli_reads_manifest_from_stdin() -> None:
+    manifest = [{"container_id": "s1", "title": "s", "status": "idle",
+                 "profile": "dogfood", "entries": []}]
+    proc = _run_cli("--observations", "-", stdin=json.dumps(manifest))
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)[0]["container_id"] == "s1"
+
+
+def test_surgeon_is_executable() -> None:
+    """A watcher/cron invokes the probe directly, so it must be executable with a
+    shebang."""
+    import os
+
+    assert SURGEON_PY.exists()
+    assert os.access(SURGEON_PY, os.X_OK), "surgeon.py must be executable"
+    assert SURGEON_PY.read_text().startswith("#!"), "surgeon.py needs a shebang"


### PR DESCRIPTION
## Summary
Wave P3W1 flight for issue #970 — host-side flight-surgeon health probe: stall/loop classification and profile filter. Integrated into the `kahuna/959-P3W1` per-wave sandbox by the PRIME reconcile node.

## Changes
- `scripts/flight-surgeon/surgeon.py` — new host-side health probe (stall/loop classify + profile filter)
- `scripts/flight-surgeon/README.md` — usage docs
- `tests/contained-workflow/test_surgeon.py` — 14 tests (all passing)
- `docs/contained-workflow/manual-verification.md` — verification steps

## Linked Issues
Closes #970

## Test Plan
- `pytest tests/contained-workflow/test_surgeon.py` → 14 passed
- `commutativity_verify` (single-target, base `kahuna/959-P3W1`) → STRONG
- Full suite (`pytest tests/`) run against composed state