### PR TITLE
feat(quarantine): lossless quarantine + rollback to :stable (Story 3.2)

### DIFF
--- a/containers/oakandwave-workflow/quarantine.py
+++ b/containers/oakandwave-workflow/quarantine.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Quarantine + lossless rollback — Story 3.2 (#971), Plan #959, Dev Spec §4.6 / §5.7.
+
+The remediation half of the flight surgeon. Story 3.1 (``scripts/flight-surgeon/
+surgeon.py``) **detects and classifies** a broken ``:edge`` container and emits a
+``should_quarantine`` verdict; this module **acts on that verdict** — it plans the
+quarantine (stop → ``docker rm`` → recreate on ``:stable``) and, crucially, proves
+the rollback is **lossless** *before* it authorises the destructive ``docker rm``.
+
+Requirements this module is the guard for:
+
+* **R-17** — WHEN the probe detects a broken container, THEN it shall quarantine it
+  (stop + roll back to ``:stable``) **losslessly**. Realised as :func:`plan_quarantine`:
+  it consumes the surgeon's ``should_quarantine`` verdict as its **only** trigger
+  (refusing any container the surgeon did not flag — the documented §5.7 seam), then
+  emits the ordered ``stop → rm → recreate-on-:stable`` plan.
+* **R-02** — WHEN a container is removed and recreated, the system shall lose **no
+  durable state**. This is not a hope — it is **mechanically asserted**:
+  :func:`assert_lossless` proves every piece of durable RW state on the broken
+  container lives on a **host-backed bind-mount** (which a ``docker rm`` cannot
+  touch), and the recreate re-attaches those exact host sources by target. If the
+  container carries durable RW state that is **not** host-backed (a docker-managed
+  volume — the shape R-01 forbids), the plan **refuses** rather than proceed with a
+  lossy ``rm``. Fail-loud toward *not* losing work (assertion-liveness, D7).
+
+Why "lossless" is provable at all (Dev Spec §1.3 / §5.1 — the stateless-container
+invariant, R-01): the container filesystem is a **disposable RTE**; all durable
+state resides on host-backed mounts. So ``docker rm`` destroys only the writable
+layer — every host-backed bind-mount *source* survives on the host untouched, and
+recreation on ``:stable`` re-attaches the identical sources. Quarantine is a
+``docker rm``, not an incident. This module's job is to keep that invariant honest
+at the moment of the destructive step: it re-attaches the **entire** host-backed
+mount set verbatim and swaps **only** the image ``:edge → :stable`` (the §5.6
+rollback = repoint at the prior ``:stable`` digest).
+
+Separation of concerns — this module **plans and asserts only**. It performs no
+docker call itself (no ``stop`` / ``rm`` / ``run``): that is the wrapper
+``scripts/ci/quarantine-container.sh``, which runs ``docker inspect`` to feed this
+planner, then executes the plan it returns — keeping the logic in a unit-tested
+module, never in the shell (project rule). The live seam (mapping an aoe sandbox
+session to its container id, and the host→container stop path) is UNPROVEN against
+a real sandbox (Dev Spec TC-7 / §5.N#5, exercised by MV-04); the pure planner below
+is the story's canonical oracle (``tests/contained-workflow/test_quarantine.py``),
+and the end-to-end zero-loss proof is E2E-03 / MV-05.
+
+CLI::
+
+    # plan a quarantine from a `docker inspect <cid>` dump + the resolved :stable ref
+    docker inspect <cid> | python3 quarantine.py \\
+        --container-inspect - --stable-ref REPO@sha256:… --should-quarantine
+
+    # inspect just the ordered steps (human), or the full JSON plan for the wrapper
+    python3 quarantine.py --container-inspect insp.json --stable-ref … \\
+        --should-quarantine --format steps
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+
+# The profile label the dogfood/dev-mode ring stamps (Story 4.1 / #974); the
+# surgeon reads it to compute should_quarantine, and it is preserved verbatim onto
+# the recreated container so the rebooted session keeps its ring identity.
+PROFILE_LABEL_KEY = "oaw.profile"
+
+# docker mount kinds (from `docker inspect .Mounts[].Type`).
+BIND = "bind"
+VOLUME = "volume"
+TMPFS = "tmpfs"
+
+
+class QuarantineError(ValueError):
+    """A quarantine contract violation — most importantly, a rollback that could
+    NOT be proven lossless. Raised LOUD, never swallowed: the whole point of the
+    guard is to refuse a destructive ``rm`` it cannot make safe."""
+
+
+# --- mount model (the lossless-invariant primitives) --------------------------
+
+
+@dataclass(frozen=True)
+class Mount:
+    """One entry of a container's ``docker inspect .Mounts`` list.
+
+    ``kind`` is the docker mount type; the lossless invariant keys off it — a
+    ``bind`` is host-backed (its ``source`` is a host path that ``docker rm`` never
+    touches), whereas a ``volume`` is docker-managed (a ``/var/lib/docker/volumes``
+    path) and a ``tmpfs`` is in-memory. ``source.startswith('/')`` is true for a
+    volume too, so host-backedness MUST key off ``kind == 'bind'``, never the path."""
+
+    kind: str
+    source: str
+    target: str
+    rw: bool
+
+    @property
+    def host_backed(self) -> bool:
+        """A host-backed bind-mount: survives ``docker rm`` and is re-attachable by
+        its host source on recreate. The ONLY durable-state shape R-01 permits."""
+        return self.kind == BIND and self.source.startswith("/")
+
+    @property
+    def durable_risk(self) -> bool:
+        """Durable RW state a ``docker rm`` cannot preserve re-attachably: a writable
+        docker-managed ``volume`` (named or anonymous). It is NOT host-backed, so it
+        breaks R-01 and cannot be re-mounted by host source on recreate — a lossy
+        shape the planner must refuse. (A ``tmpfs`` is ephemeral by design; a ``ro``
+        mount carries no work; a ``bind`` is host-backed and safe.)"""
+        return self.rw and self.kind == VOLUME
+
+    def to_docker_volume(self) -> str:
+        """``docker run -v`` spec re-attaching this mount verbatim: ``src:tgt[:ro]``."""
+        suffix = "" if self.rw else ":ro"
+        return f"{self.source}:{self.target}{suffix}"
+
+
+def parse_mount(obj: object) -> Mount:
+    """Parse one ``docker inspect .Mounts[]`` element into a :class:`Mount`.
+
+    Tolerant of the two spellings docker emits: modern ``.Mounts`` entries carry
+    ``Type``/``Source``/``Destination``/``RW``; ``RW`` defaults to True when absent
+    (docker omits it for rw). A missing ``Type`` is treated as ``bind`` only when a
+    host ``Source`` is present, else ``volume`` (conservative — an unlabeled durable
+    mount is assumed non-host-backed so the lossless guard errs toward refusing)."""
+    if not isinstance(obj, dict):
+        raise QuarantineError(f"mount must be an object, got {type(obj).__name__}")
+    source = str(obj.get("Source", obj.get("source", "")) or "")
+    target = str(obj.get("Destination", obj.get("Target", obj.get("target", ""))) or "")
+    kind = str(obj.get("Type", obj.get("type", "")) or "").strip().lower()
+    if not kind:
+        kind = BIND if source.startswith("/") else VOLUME
+    rw_raw = obj.get("RW", obj.get("rw", True))
+    rw = bool(rw_raw) if isinstance(rw_raw, bool) else str(rw_raw).lower() != "false"
+    return Mount(kind=kind, source=source, target=target, rw=rw)
+
+
+@dataclass(frozen=True)
+class Container:
+    """The broken ``:edge`` container as seen from the host via ``docker inspect``."""
+
+    id: str
+    name: str
+    image: str
+    labels: dict[str, str] = field(default_factory=dict)
+    mounts: tuple[Mount, ...] = ()
+
+    @property
+    def profile(self) -> str:
+        """The container's ``oaw.profile`` ring label, or ``''`` if unlabeled."""
+        return str(self.labels.get(PROFILE_LABEL_KEY, "") or "")
+
+
+def parse_container(obj: object) -> Container:
+    """Parse a ``docker inspect <cid>`` dump into a :class:`Container`.
+
+    Accepts either the raw ``docker inspect`` **list** (takes the first element) or
+    a single container object. Reads ``.Id`` / ``.Name`` / ``.Config.Image`` /
+    ``.Config.Labels`` / ``.Mounts``. A dump with no container is a loud error —
+    the wrapper must not have inspected a live container, and quarantining nothing
+    would be a silent no-op the surgeon's fail-on-quarantine signal expects to act."""
+    if isinstance(obj, list):
+        if not obj:
+            raise QuarantineError("docker inspect returned an empty list — no such container")
+        obj = obj[0]
+    if not isinstance(obj, dict):
+        raise QuarantineError(f"container inspect must be an object, got {type(obj).__name__}")
+    config = obj.get("Config") if isinstance(obj.get("Config"), dict) else {}
+    labels = config.get("Labels") if isinstance(config.get("Labels"), dict) else {}
+    raw_mounts = obj.get("Mounts") if isinstance(obj.get("Mounts"), list) else []
+    name = str(obj.get("Name", "") or "").lstrip("/")
+    return Container(
+        id=str(obj.get("Id", obj.get("id", "")) or ""),
+        name=name,
+        image=str(config.get("Image", obj.get("Image", "")) or ""),
+        labels={str(k): str(v) for k, v in labels.items()},
+        mounts=tuple(parse_mount(m) for m in raw_mounts),
+    )
+
+
+# --- the lossless invariant (R-02 / R-01) -------------------------------------
+
+
+def assert_lossless(container: Container) -> tuple[Mount, ...]:
+    """Prove the quarantine will lose NO durable state, and return the host-backed
+    mounts the recreate must re-attach (R-02).
+
+    The proof (Dev Spec §5.1, R-01): every piece of durable RW state lives on a
+    host-backed bind-mount, which ``docker rm`` cannot touch. So the check is: does
+    the broken container hold any durable RW state that is **not** host-backed? Such
+    state is a docker-managed ``volume`` (:attr:`Mount.durable_risk`) — durable, but
+    not re-attachable by host source on recreate. If any exists, we **refuse** the
+    quarantine (a lossy ``rm``) rather than strand work.
+
+    Returns every host-backed bind-mount (rw *and* ro) — the full mount set the
+    recreate re-attaches verbatim, so the session comes back up on ``:stable``
+    identical but for the image."""
+    risky = [m for m in container.mounts if m.durable_risk]
+    if risky:
+        targets = ", ".join(m.target or "?" for m in risky)
+        raise QuarantineError(
+            f"R-02/R-01 VIOLATION: cannot quarantine {container.name or container.id!r} "
+            f"losslessly — it holds durable RW state on non-host-backed mount(s): "
+            f"[{targets}]. A `docker rm` would strand these (a docker-managed volume "
+            f"is not re-attachable by host source on recreate). The stateless-container "
+            f"invariant (R-01) requires ALL durable state on host-backed bind-mounts; "
+            f"refusing a lossy rm. Fix the container's mount manifest, then re-quarantine."
+        )
+    preserved = tuple(m for m in container.mounts if m.host_backed)
+    return preserved
+
+
+# --- the quarantine plan ------------------------------------------------------
+
+STEP_STOP = "stop"
+STEP_RM = "rm"
+STEP_RECREATE = "recreate"
+
+
+@dataclass(frozen=True)
+class QuarantinePlan:
+    """The ordered, verified quarantine: stop → rm → recreate-on-:stable, with the
+    proof (preserved host-backed mounts) that it is lossless."""
+
+    container_id: str
+    name: str
+    profile: str
+    broken_image: str  # the :edge ref quarantined — held from promotion (feeds R-07)
+    recreate_image: str  # the :stable ref recreated on — the §5.6 rollback target
+    preserved_mounts: tuple[Mount, ...]
+    labels: dict[str, str]
+
+    @property
+    def recreate_volume_args(self) -> tuple[str, ...]:
+        """``docker run -v`` specs re-attaching every host-backed mount verbatim."""
+        return tuple(m.to_docker_volume() for m in self.preserved_mounts)
+
+    @property
+    def steps(self) -> tuple[str, ...]:
+        """The ordered destructive-then-recreate actions, as human-readable lines.
+
+        The ``rm`` is deliberately WITHOUT ``-v``: even a stray (non-durable) volume
+        must not be destroyed by the quarantine, and host binds are never docker's to
+        remove — the destructive step touches ONLY the disposable writable layer."""
+        cid = self.container_id or self.name
+        n = len(self.preserved_mounts)
+        return (
+            f"{STEP_STOP}: docker stop {cid}  "
+            f"(halt the broken :edge session; transcript already host-backed)",
+            f"{STEP_RM}: docker rm {cid}  "
+            f"(remove the disposable RTE — NO -v; all {n} durable mount(s) are "
+            f"host-backed and survive)",
+            f"{STEP_RECREATE}: docker run --label {PROFILE_LABEL_KEY}={self.profile or 'unknown'} "
+            f"{' '.join('-v ' + v for v in self.recreate_volume_args)} {self.recreate_image}  "
+            f"(recreate on :stable, re-attaching the identical host sources — §5.6 rollback)",
+        )
+
+    def as_dict(self) -> dict:
+        return {
+            "container_id": self.container_id,
+            "name": self.name,
+            "profile": self.profile,
+            "broken_image": self.broken_image,
+            "recreate_image": self.recreate_image,
+            "recreate_volume_args": list(self.recreate_volume_args),
+            "preserved_mounts": [
+                {"source": m.source, "target": m.target, "mode": "rw" if m.rw else "ro"}
+                for m in self.preserved_mounts
+            ],
+            "labels": self.labels,
+            "steps": list(self.steps),
+        }
+
+    def quarantine_record(self) -> dict:
+        """The telemetry the promotion gate's ``quarantines`` condition reads (R-07):
+        a quarantine occurred, so the quarantined ``:edge`` digest is **held from
+        promotion**. The wrapper appends this to the quarantine ledger the gate
+        queries; a non-zero count fails the gate (``promotion_gate.py``)."""
+        return {
+            "event": "quarantine",
+            "container_id": self.container_id,
+            "name": self.name,
+            "profile": self.profile,
+            "held_digest": self.broken_image,
+            "recreated_on": self.recreate_image,
+            "durable_mounts_preserved": len(self.preserved_mounts),
+        }
+
+    def summary(self) -> str:
+        head = (
+            f"quarantine {self.name or self.container_id} "
+            f"({self.broken_image} -> :stable {self.recreate_image}): "
+            f"LOSSLESS — {len(self.preserved_mounts)} host-backed mount(s) preserved"
+        )
+        return head + "\n" + "\n".join(f"  {i + 1}. {s}" for i, s in enumerate(self.steps))
+
+
+def plan_quarantine(
+    *,
+    container: Container,
+    stable_ref: str,
+    should_quarantine: bool,
+) -> QuarantinePlan:
+    """Plan a lossless quarantine + rollback for a broken ``:edge`` container (R-17).
+
+    ``should_quarantine`` is the flight surgeon's authoritative verdict and the
+    **only** trigger: this refuses any container the surgeon did not flag (a healthy
+    container, or a dev-mode breakage the surgeon excluded per R-22). The planner
+    does **not** re-derive detection or the profile filter — that is the surgeon's
+    job, already done (Dev Spec §5.7 seam); it acts on the verdict and owns the
+    **mechanics + the lossless proof**.
+
+    Guards (each fail-loud):
+
+    * ``should_quarantine`` must be True — never quarantine an unflagged container.
+    * :func:`assert_lossless` — every durable RW mount is host-backed, or refuse.
+    * ``stable_ref`` must differ from the broken image — recreating on the same
+      broken ``:edge`` digest is not a rollback (it would re-break immediately).
+    """
+    if not should_quarantine:
+        raise QuarantineError(
+            f"refusing to quarantine {container.name or container.id!r}: the flight "
+            f"surgeon did not flag it (should_quarantine=False). Quarantine acts ONLY "
+            f"on the surgeon's verdict — a healthy container, or a dev-mode breakage "
+            f"excluded per R-22, is never quarantined."
+        )
+    stable = str(stable_ref or "").strip()
+    if not stable:
+        raise QuarantineError("stable_ref is required — the :stable rollback target to recreate on")
+
+    preserved = assert_lossless(container)
+
+    if stable == container.image.strip():
+        raise QuarantineError(
+            f"recreate target {stable!r} equals the broken image — a rollback must "
+            f"recreate on :stable, not the same broken :edge digest (it would re-break). "
+            f"Resolve :stable to its promoted digest first (never the quarantined one)."
+        )
+
+    return QuarantinePlan(
+        container_id=container.id,
+        name=container.name,
+        profile=container.profile,
+        broken_image=container.image.strip(),
+        recreate_image=stable,
+        preserved_mounts=preserved,
+        labels=dict(container.labels),
+    )
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def _load_inspect(path: str) -> object:
+    text = sys.stdin.read() if path == "-" else open(path, encoding="utf-8").read()
+    return json.loads(text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--container-inspect",
+        required=True,
+        metavar="FILE",
+        help="`docker inspect <cid>` JSON of the broken container ('-' for stdin)",
+    )
+    parser.add_argument(
+        "--stable-ref",
+        required=True,
+        help="the resolved :stable image ref to recreate on (the §5.6 rollback target)",
+    )
+    parser.add_argument(
+        "--should-quarantine",
+        action="store_true",
+        help="the flight surgeon's verdict — REQUIRED; without it the planner refuses "
+        "(quarantine acts only on the surgeon's should_quarantine)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "steps", "record"),
+        default="json",
+        help="stdout shape: full JSON plan (default), the ordered steps, or the "
+        "gate-facing quarantine record",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        container = parse_container(_load_inspect(args.container_inspect))
+        plan = plan_quarantine(
+            container=container,
+            stable_ref=args.stable_ref,
+            should_quarantine=args.should_quarantine,
+        )
+    except (QuarantineError, json.JSONDecodeError, OSError) as exc:
+        print(f"quarantine error: {exc}", file=sys.stderr)
+        return 2
+
+    print(plan.summary(), file=sys.stderr)
+    if args.format == "steps":
+        print("\n".join(plan.steps))
+    elif args.format == "record":
+        print(json.dumps(plan.quarantine_record()))
+    else:
+        print(json.dumps(plan.as_dict(), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contained-workflow/manual-verification.md
+++ b/docs/contained-workflow/manual-verification.md
@@ -13,7 +13,7 @@ own them and are all executed and recorded in the closing story (4.3, #976).
 | MV-02 | Live `~/.claude` not exposed under the full custom mount set | R-01, R-03 | Story 1.3+ |
 | MV-03 | Network egress reaches scream-hole / discord / github from inside | R-05 | later |
 | MV-04 | `aoe send` reaches into a running container (control-plane ingress) | R-15 | Story 3.1 (#970) |
-| MV-05 | A broken container quarantines and recreates on `:stable`, zero loss | R-02, R-17 | Story 3.2+ |
+| MV-05 | A broken container quarantines and recreates on `:stable`, zero loss | R-02, R-17 | Story 3.2 (#971) |
 | MV-06 | A wedged/OOM-killed `claude` still flushed its transcript | R-15 | Story 3.1 (#970) |
 | MV-07 | A secret added mid-session is usable with no container restart | R-13 | Story 1.5 (#965) |
 
@@ -433,4 +433,142 @@ aoe -p meful-test remove <session-id>
 
 | Date | Operator | Image digest / ID | pre-kill lines | post-kill lines | parseable? | surgeon verdict | PASS/FAIL |
 |------|----------|-------------------|----------------|-----------------|------------|-----------------|-----------|
+| _pending_ | _pending_ | _pending_ | | | | | Executed and recorded in closing story 4.3 (#976) |
+
+---
+
+## MV-05 — A broken container quarantines and recreates on `:stable`, zero loss `[R-02, R-17]`
+
+**Goal.** Prove the whole quarantine lifecycle end-to-end on a **real** container:
+a broken `:edge` dogfood container is detected by the flight surgeon, quarantined
+(stop → `docker rm` → recreate on `:stable`), and comes back with **zero durable
+work lost** — the lossless-rollback keystone (Dev Spec §4.6; R-02/R-17).
+
+**Why manual.** The lossless *mechanics* are unit-proven in the stock pytest lane
+(`tests/contained-workflow/test_quarantine.py`) — including the docker-gated
+`test_e2e03_real_rollback_preserves_on_disk_work`, which plants a real container
+with a host-backed bind holding work, runs the real stop/`rm`/recreate, and asserts
+the on-disk file survives. This procedure proves the same through the **real aoe
+sandbox session** an agent runs in and the **real surgeon → quarantine wrapper**
+trigger path: that `aoe` recreates the session on `:stable`, that host-backed
+memory/workspace survive the `docker rm`, and that the quarantined `:edge` digest is
+held from promotion. It needs a live aoe session + the `:edge`/`:stable` image pair,
+so it cannot run in the pytest lane.
+
+### Preconditions
+
+- **aoe 1.13.0**, **rootful docker** — as MV-01.
+- An `:edge` and a `:stable` image (distinct digests). For an isolated run, build
+  the image and tag two stand-ins:
+  `make -C containers/oakandwave-workflow build` then
+  `docker tag oakandwave-workflow:edge oaw-mv05:edge` and
+  `docker tag oakandwave-workflow:edge oaw-mv05:stable`.
+- An isolated aoe profile (as MV-01) so no fleet session is touched.
+- The flight surgeon (`scripts/flight-surgeon/surgeon.py`) and the quarantine
+  wrapper (`scripts/ci/quarantine-container.sh`) present.
+
+### Procedure
+
+1. **Launch a dogfood sandbox session on `:edge`** in the isolated profile, with a
+   host-backed workspace (the durable mount under test):
+
+   ```bash
+   mkdir -p /tmp/mv05-ws && cd /tmp/mv05-ws && git init -q
+   aoe -p meful-test add --sandbox --sandbox-image oaw-mv05:edge --launch /tmp/mv05-ws
+   ```
+
+2. **Do real work that lands on the host-backed mount** — write a durable artifact
+   from inside the session (this is the "work" that must survive):
+
+   ```bash
+   echo 'zero-work-lost' > /tmp/mv05-ws/durable-work.txt
+   ```
+
+   Confirm on the **host**: `cat /tmp/mv05-ws/durable-work.txt` → `zero-work-lost`.
+
+3. **Plant the break.** Wedge the agent so the surgeon classifies it broken — e.g.
+   drive it into a tool loop, or hard-kill `claude` inside the container while aoe
+   still reports `running` (as MV-06 step 3). The transcript stops progressing.
+
+4. **Confirm the surgeon flags it** (host-side, reading the host-backed transcript —
+   no container access):
+
+   ```bash
+   python3 scripts/flight-surgeon/surgeon.py --live \
+     --transcripts-root ~/.claude/projects --fail-on-quarantine ; echo "exit=$?"
+   ```
+
+   **EXPECT:** the container is reported `should_quarantine=true` and the exit is
+   `3`. A dogfood breakage must flag; a `dev-mode` one would not (R-22).
+
+5. **Note the container id** and **run the quarantine** on the surgeon's verdict:
+
+   ```bash
+   cid=$(docker ps --filter name=<session> --format '{{.ID}}')
+   CONTAINER_ID="$cid" SHOULD_QUARANTINE=true \
+     OAW_STABLE_RESOLVED_REF=oaw-mv05:stable \
+     scripts/ci/quarantine-container.sh
+   ```
+
+   The wrapper prints the lossless plan (`N host-backed mount(s) preserved`), then
+   stops + `docker rm`s the broken container and recreates on `:stable`. It appends
+   a quarantine record to `~/.oaw/quarantine/ledger.jsonl`.
+
+6. **Confirm zero work lost** on the **host** — the durable artifact survived the
+   `docker rm` + recreate:
+
+   ```bash
+   cat /tmp/mv05-ws/durable-work.txt   # expect: zero-work-lost
+   ```
+
+   **EXPECT:** `zero-work-lost` — unchanged. A missing/empty file is a **FAIL**
+   (R-02 violated — the rollback was not lossless).
+
+7. **Confirm the recreate is on `:stable`** and re-attached the host source:
+
+   ```bash
+   new=$(docker ps --filter name=<session> --format '{{.ID}}')
+   docker inspect --format '{{.Config.Image}}' "$new"      # expect: oaw-mv05:stable
+   docker inspect --format '{{json .Mounts}}' "$new"       # /tmp/mv05-ws still bind-mounted
+   ```
+
+8. **Confirm the bad `:edge` digest is held from promotion** — the ledger carries
+   the quarantine so the gate's zero-quarantines condition (R-07) trips:
+
+   ```bash
+   tail -1 ~/.oaw/quarantine/ledger.jsonl   # {"event":"quarantine","held_digest":"…edge…",…}
+   ```
+
+9. **Record** the result in the log below: date, operator, `:edge`/`:stable`
+   digests, the surgeon verdict, the step-6 file content, the step-7 image, and
+   PASS/FAIL.
+
+### Cleanup
+
+```bash
+aoe -p meful-test remove <session-id>
+docker rmi oaw-mv05:edge oaw-mv05:stable
+rm -rf /tmp/mv05-ws
+```
+
+### Failure handling
+
+- **Step 6 file missing/empty.** The durable state was not host-backed, or the
+  recreate did not re-attach the source. Inspect the broken container's mounts
+  before the run (`docker inspect --format '{{json .Mounts}}' <cid>`): a durable RW
+  `volume` (not a `bind`) is the R-01 violation the planner refuses — if the wrapper
+  *proceeded*, capture the plan JSON and open a bug against Story 3.2 (#971). If the
+  mount was a bind but the file is gone, capture the recreate's `-v` args.
+- **Step 4 does not flag.** Confirm the profile label is `dogfood` (a `dev-mode`
+  label excludes from quarantine by design, R-22) and that aoe still reports the
+  session `running`; a `stopped`/`error` session is a different (non-stall) path.
+- **`aoe`-side recreate.** The wrapper recreates via `docker run`; the fleet path
+  recreates the aoe **session** on `:stable` (`aoe add --sandbox --sandbox-image
+  oaw-mv05:stable`). If the host→container stop seam (MV-04) resolved to "no in-band
+  ingress", the wrapper's `docker stop` is the fallback — record which path was used.
+
+### Result log
+
+| Date | Operator | `:edge` / `:stable` digest | surgeon verdict | step-6 content | step-7 image | PASS/FAIL | Notes |
+|------|----------|----------------------------|-----------------|----------------|--------------|-----------|-------|
 | _pending_ | _pending_ | _pending_ | | | | | Executed and recorded in closing story 4.3 (#976) |

--- a/scripts/ci/quarantine-container.sh
+++ b/scripts/ci/quarantine-container.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# quarantine-container.sh — quarantine a broken :edge container + roll back to
+# :stable losslessly (Story 3.2 / #971, Dev Spec §4.6 / §5.7, R-02/R-17).
+#
+# The remediation the flight surgeon triggers: the surgeon (Story 3.1) DETECTS a
+# broken :edge container from the host and emits should_quarantine=true; this
+# wrapper ACTS on that verdict — stop → docker rm → recreate on :stable — while a
+# unit-tested planner proves the rollback loses no durable state BEFORE the
+# destructive rm runs.
+#
+# The DECISION + the lossless PROOF live in
+# containers/oakandwave-workflow/quarantine.py (it refuses a lossy rm: any durable
+# RW state not on a host-backed bind-mount is a fail-loud refusal). This wrapper
+# only INSPECTS the container, hands the planner the surgeon's verdict, and APPLIES
+# the plan (stop / rm-without-`-v` / recreate) — the logic stays in the tested
+# module, never in this shell (project rule).
+#
+# Lossless because the container filesystem is a disposable RTE and ALL durable
+# state is host-backed (R-01): docker rm destroys only the writable layer; every
+# host-backed bind-mount source survives on the host and the recreate re-attaches
+# the identical sources on :stable (§5.6 rollback = repoint at the :stable digest).
+#
+# Inputs (env):
+#   CONTAINER_ID        the broken :edge container to quarantine (required).
+#   SHOULD_QUARANTINE   the flight surgeon's verdict; MUST be "true" to proceed —
+#                       this wrapper never quarantines a container the surgeon did
+#                       not flag (a healthy one, or a dev-mode breakage excluded by
+#                       R-22). Default: unset ⇒ abort.
+#   STABLE_REF          the :stable moving tag to resolve, registry/image:stable
+#                       (default: derived from IMAGE_REPO + STABLE_TAG).
+#   IMAGE_REPO          registry/image for the fleet image
+#                       (default: ghcr.io/wave-engineering/oakandwave-workflow).
+#   STABLE_TAG          the moving tag to roll back to (default: stable).
+#   OAW_QUARANTINE_LEDGER   append the quarantine record here so the promotion gate's
+#                       zero-quarantines condition (R-07) can read it
+#                       (default: ~/.oaw/quarantine/ledger.jsonl).
+#   QUARANTINE_DRY_RUN  "true" ⇒ inspect + plan + print, do NOT stop/rm/recreate
+#                       (needs OAW_CONTAINER_INSPECT + OAW_STABLE_RESOLVED_REF so it
+#                       runs without docker — unit-testable).
+#
+# Injected resolution seams (used verbatim when set; else resolved via docker):
+#   OAW_STABLE_RESOLVED_REF   :stable's immutable digest (skips docker pull/inspect).
+#   OAW_CONTAINER_INSPECT     a file holding `docker inspect <cid>` JSON (skips the
+#                             live inspect — lets a test drive the whole plan path).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+QUARANTINE_PY="$REPO_DIR/containers/oakandwave-workflow/quarantine.py"
+
+CONTAINER_ID="${CONTAINER_ID:-}"
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/wave-engineering/oakandwave-workflow}"
+STABLE_TAG="${STABLE_TAG:-stable}"
+STABLE_REF="${STABLE_REF:-${IMAGE_REPO}:${STABLE_TAG}}"
+LEDGER="${OAW_QUARANTINE_LEDGER:-$HOME/.oaw/quarantine/ledger.jsonl}"
+DRY_RUN="${QUARANTINE_DRY_RUN:-false}"
+
+[[ -n "$CONTAINER_ID" ]] || {
+	echo "  [!] CONTAINER_ID is required (the broken :edge container to quarantine)" >&2
+	exit 1
+}
+
+# The surgeon's verdict is the ONLY trigger. Never quarantine a container the
+# surgeon did not flag — mirror the planner's own refusal, fail-loud, up front.
+if [[ "${SHOULD_QUARANTINE:-}" != "true" ]]; then
+	echo "  [!] SHOULD_QUARANTINE != true — refusing. Quarantine acts only on the" >&2
+	echo "      flight surgeon's should_quarantine verdict (Dev Spec §5.7)." >&2
+	exit 1
+fi
+
+# --- 1. Resolve :stable → the immutable rollback digest -----------------------
+stable_ref="${OAW_STABLE_RESOLVED_REF:-}"
+if [[ -z "$stable_ref" ]]; then
+	if [[ "$DRY_RUN" == "true" ]]; then
+		echo "  [!] QUARANTINE_DRY_RUN needs OAW_STABLE_RESOLVED_REF" >&2
+		exit 1
+	fi
+	command -v docker >/dev/null 2>&1 || {
+		echo "  [!] docker not found — needed to resolve $STABLE_REF" >&2
+		exit 1
+	}
+	echo "==> resolving $STABLE_REF (the :stable rollback target)"
+	docker pull "$STABLE_REF" >/dev/null
+	stable_ref="$(docker image inspect --format '{{index .RepoDigests 0}}' "$STABLE_REF")"
+fi
+
+# --- 2. Inspect the broken container ------------------------------------------
+inspect_src="${OAW_CONTAINER_INSPECT:-}"
+if [[ -z "$inspect_src" ]]; then
+	command -v docker >/dev/null 2>&1 || {
+		echo "  [!] docker not found — needed to inspect $CONTAINER_ID" >&2
+		exit 1
+	}
+	inspect_src="$(mktemp)"
+	trap 'rm -f "$inspect_src"' EXIT
+	docker inspect "$CONTAINER_ID" >"$inspect_src"
+fi
+
+# --- 3. Plan the quarantine (lossless proof runs HERE, before any rm) ----------
+# The planner refuses (non-zero exit) if the rollback cannot be proven lossless —
+# so a plan we can read back is itself the go-ahead for the destructive step.
+plan_json="$(python3 "$QUARANTINE_PY" \
+	--container-inspect "$inspect_src" \
+	--stable-ref "$stable_ref" \
+	--should-quarantine \
+	--format json)"
+
+read -r name profile recreate_image < <(
+	printf '%s' "$plan_json" | python3 -c \
+		'import json,sys; p=json.load(sys.stdin); print(p["name"] or p["container_id"], p["profile"] or "unknown", p["recreate_image"])'
+)
+# The -v args re-attaching every host-backed mount verbatim (newline-delimited).
+mapfile -t vol_args < <(
+	printf '%s' "$plan_json" | python3 -c \
+		'import json,sys; [print(v) for v in json.load(sys.stdin)["recreate_volume_args"]]'
+)
+
+echo "==> quarantine plan: $name (profile=$profile) -> recreate on $recreate_image"
+echo "    preserving ${#vol_args[@]} host-backed mount(s) — proven lossless"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+	echo "==> [dry-run] would: stop $CONTAINER_ID; docker rm $CONTAINER_ID; recreate on $recreate_image"
+	printf '%s\n' "$plan_json"
+	exit 0
+fi
+
+# --- 4. Apply: stop → rm (NO -v) → recreate on :stable ------------------------
+# rm is deliberately WITHOUT -v: the destructive step touches ONLY the disposable
+# writable layer; host binds are not docker's to remove and any stray volume is
+# left intact. Every durable mount is host-backed (proven in step 3), so this loses
+# nothing.
+echo "==> stopping $CONTAINER_ID"
+docker stop "$CONTAINER_ID" >/dev/null || true
+echo "==> removing $CONTAINER_ID (disposable RTE — host-backed state survives)"
+docker rm "$CONTAINER_ID" >/dev/null
+
+recreate=(docker run -d --label "oaw.profile=${profile}")
+[[ -n "$name" ]] && recreate+=(--name "$name")
+for v in "${vol_args[@]}"; do
+	[[ -n "$v" ]] && recreate+=(-v "$v")
+done
+recreate+=("$recreate_image")
+
+echo "==> recreating on :stable ($recreate_image), re-attaching the host sources"
+new_cid="$("${recreate[@]}")"
+echo "==> recreated as $new_cid — durable state intact (§5.6 lossless rollback)"
+
+# --- 5. Ledger the quarantine so the promotion gate holds the bad digest (R-07)
+mkdir -p "$(dirname "$LEDGER")"
+record="$(python3 "$QUARANTINE_PY" \
+	--container-inspect "$inspect_src" \
+	--stable-ref "$stable_ref" \
+	--should-quarantine \
+	--format record)"
+printf '%s\n' "$record" >>"$LEDGER"
+echo "==> ledgered quarantine -> $LEDGER (the quarantined :edge digest is held from promotion)"
+
+# The one line on stdout is the recreated container id.
+echo "$new_cid"

--- a/tests/contained-workflow/test_quarantine.py
+++ b/tests/contained-workflow/test_quarantine.py
@@ -1,0 +1,469 @@
+"""Oracle for Story 3.2 (#971) — quarantine + lossless rollback (E2E-03, R-02/R-17).
+
+The remediation half of the flight surgeon: Story 3.1 (test_surgeon.py) proves the
+probe DETECTS a broken ``:edge`` container and emits ``should_quarantine``; this
+module proves the ACTION on that verdict — stop → ``docker rm`` → recreate on
+``:stable`` — is **lossless**.
+
+The authoritative end-to-end proof is E2E-03 itself: plant a broken ``:edge``,
+confirm the surgeon detects it and the quarantine rolls back to ``:stable`` with
+durable state intact. The full lifecycle needs a real ``:edge`` + ``:stable`` image
+pair (mirrors test_throwaway_ci_ring.py / test_ownership.py), so it cannot run in
+the stock pytest lane. This module proves, **hermetically**, the properties that
+make the quarantine correct — and a docker-gated branch runs the real
+stop/rm/recreate and asserts on-disk durable state survives:
+
+* **AC1 [R-02, R-17]** — a planted broken ``:edge`` is quarantined and recreated on
+  ``:stable`` with **zero work lost**. The named story oracle
+  :func:`test_lossless_rollback_preserves_host_backed_work` proves the plan
+  re-attaches every host-backed mount verbatim and swaps only the image; the
+  docker-gated :func:`test_e2e03_real_rollback_preserves_on_disk_work` proves a real
+  ``docker rm`` + recreate leaves the host file intact.
+* The **lossless invariant is mechanical, not a hope**:
+  :func:`test_refuses_non_host_backed_durable_state` shows the planner **refuse** a
+  lossy ``rm`` red-first when durable RW state is not host-backed.
+* The **surgeon verdict is the only trigger**:
+  :func:`test_consumes_surgeon_should_quarantine_verdict` drives the real surgeon →
+  quarantine seam, and :func:`test_dev_mode_breakage_is_never_quarantined` proves a
+  dev-mode breakage (R-22) is refused.
+
+MV-05 (the manual zero-loss run on a real container + host) is documented in
+``docs/contained-workflow/manual-verification.md``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUAR_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+QUAR_PY = QUAR_DIR / "quarantine.py"
+SURGEON_DIR = REPO_ROOT / "scripts" / "flight-surgeon"
+WRAPPER = REPO_ROOT / "scripts" / "ci" / "quarantine-container.sh"
+
+# Path-style import (no PYTHONPATH dependency), mirroring test_surgeon.py.
+sys.path.insert(0, str(QUAR_DIR))
+sys.path.insert(0, str(SURGEON_DIR))
+import quarantine as q  # noqa: E402
+import surgeon as fs  # noqa: E402
+
+
+# --- fixtures -----------------------------------------------------------------
+
+
+def make_inspect(
+    *,
+    cid: str = "edge123",
+    name: str = "dogbox",
+    image: str = "ghcr.io/wave-engineering/oakandwave-workflow:edge",
+    profile: str = "dogfood",
+    mounts: list[dict] | None = None,
+) -> list[dict]:
+    """A ``docker inspect <cid>`` dump (list form) for a dogfood ``:edge`` container.
+
+    Default mounts model the real state taxonomy (§5.3): a host-backed rw memory
+    bind (durable work), a host-backed rw workspace bind, and a ro secrets bind.
+    All host-backed — so a ``docker rm`` loses nothing."""
+    if mounts is None:
+        mounts = [
+            {
+                "Type": "bind",
+                "Source": "/home/bakerb/.oaw/state/8/memory",
+                "Destination": "/home/ubuntu/.oaw/state/8/memory",
+                "RW": True,
+            },
+            {
+                "Type": "bind",
+                "Source": "/home/bakerb/work/dogbox",
+                "Destination": "/workspace",
+                "RW": True,
+            },
+            {
+                "Type": "bind",
+                "Source": "/home/bakerb/.secrets",
+                "Destination": "/home/ubuntu/.secrets",
+                "RW": False,
+            },
+        ]
+    return [
+        {
+            "Id": cid,
+            "Name": f"/{name}",
+            "Config": {"Image": image, "Labels": {"oaw.profile": profile}},
+            "Mounts": mounts,
+        }
+    ]
+
+
+STABLE = "ghcr.io/wave-engineering/oakandwave-workflow@sha256:" + "a" * 64
+
+
+def looping_transcript(n: int = 6) -> list[dict]:
+    """A transcript whose tail is the SAME tool action repeated ``n`` times — a
+    'no forward progress' loop the surgeon classifies broken while running."""
+    block = {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}
+    return [{"message": {"content": [dict(block)]}} for _ in range(n)]
+
+
+# --- AC1: lossless rollback (the named story oracle) --------------------------
+
+
+def test_lossless_rollback_preserves_host_backed_work() -> None:
+    """E2E-03 / AC1 [R-02, R-17]: a broken :edge is quarantined and recreated on
+    :stable with zero work lost.
+
+    The 'zero work lost' proof, mechanically: the plan re-attaches EVERY host-backed
+    mount (memory, workspace, secrets) verbatim — same source→target, same mode —
+    and swaps ONLY the image :edge → :stable. Since all durable state is host-backed
+    (R-01), the docker rm between stop and recreate cannot touch it."""
+    container = q.parse_container(make_inspect())
+    plan = q.plan_quarantine(container=container, stable_ref=STABLE, should_quarantine=True)
+
+    # Recreated on :stable — the rollback target, not the broken :edge.
+    assert plan.recreate_image == STABLE
+    assert plan.broken_image.endswith(":edge")
+
+    # Every host-backed mount is preserved verbatim (source:target[:ro]).
+    reattached = set(plan.recreate_volume_args)
+    assert "/home/bakerb/.oaw/state/8/memory:/home/ubuntu/.oaw/state/8/memory" in reattached
+    assert "/home/bakerb/work/dogbox:/workspace" in reattached
+    assert "/home/bakerb/.secrets:/home/ubuntu/.secrets:ro" in reattached
+    assert len(plan.preserved_mounts) == 3
+
+    # The bad :edge digest is held from promotion (feeds the gate's R-07 condition).
+    rec = plan.quarantine_record()
+    assert rec["event"] == "quarantine"
+    assert rec["held_digest"] == plan.broken_image
+    assert rec["recreated_on"] == STABLE
+    assert rec["durable_mounts_preserved"] == 3
+
+
+def test_rm_step_is_without_dash_v() -> None:
+    """The destructive step is ``docker rm`` WITHOUT ``-v``: it removes only the
+    disposable writable layer. ``-v`` would destroy anonymous volumes — belt-and-
+    suspenders even though the lossless guard already refuses durable volumes."""
+    container = q.parse_container(make_inspect())
+    plan = q.plan_quarantine(container=container, stable_ref=STABLE, should_quarantine=True)
+    rm_step = next(s for s in plan.steps if s.startswith("rm:"))
+    assert "docker rm " in rm_step
+    assert "docker rm -v" not in rm_step
+    assert "rm --volumes" not in rm_step
+
+
+def test_profile_label_preserved_on_recreate() -> None:
+    """The container's ring label is carried onto the recreate so the rebooted
+    session keeps its dogfood/dev-mode identity (feeds the surgeon's R-22 filter)."""
+    container = q.parse_container(make_inspect(profile="dogfood"))
+    plan = q.plan_quarantine(container=container, stable_ref=STABLE, should_quarantine=True)
+    assert plan.profile == "dogfood"
+    recreate_step = next(s for s in plan.steps if s.startswith("recreate:"))
+    assert "oaw.profile=dogfood" in recreate_step
+
+
+# --- the lossless invariant is mechanical (red-first refusals) ----------------
+
+
+def test_refuses_non_host_backed_durable_state() -> None:
+    """RED-FIRST [R-02/R-01]: durable RW state on a docker-managed volume (NOT
+    host-backed) means a ``docker rm`` would strand it — the planner REFUSES the
+    lossy rm rather than lose work. This is the guard that makes 'lossless' a
+    proof, not a hope."""
+    mounts = [
+        {"Type": "bind", "Source": "/home/bakerb/work", "Destination": "/workspace", "RW": True},
+        # A named docker volume holding RW state — durable but NOT host-backed.
+        {"Type": "volume", "Source": "/var/lib/docker/volumes/scratch/_data",
+         "Destination": "/data", "RW": True},
+    ]
+    container = q.parse_container(make_inspect(mounts=mounts))
+    with pytest.raises(q.QuarantineError, match="R-02/R-01 VIOLATION"):
+        q.plan_quarantine(container=container, stable_ref=STABLE, should_quarantine=True)
+
+
+def test_tmpfs_and_readonly_volume_are_not_a_loss_risk() -> None:
+    """Only durable RW state that isn't host-backed is a risk. A tmpfs (ephemeral by
+    design) and a RO volume (carries no work) are NOT — the quarantine proceeds."""
+    mounts = [
+        {"Type": "bind", "Source": "/home/bakerb/work", "Destination": "/workspace", "RW": True},
+        {"Type": "tmpfs", "Source": "", "Destination": "/tmp", "RW": True},
+        {"Type": "volume", "Source": "/var/lib/docker/volumes/ro/_data",
+         "Destination": "/ro", "RW": False},
+    ]
+    container = q.parse_container(make_inspect(mounts=mounts))
+    plan = q.plan_quarantine(container=container, stable_ref=STABLE, should_quarantine=True)
+    # Only the host-backed bind is re-attached; tmpfs/volume are dropped.
+    assert plan.recreate_volume_args == ("/home/bakerb/work:/workspace",)
+
+
+def test_refuses_unflagged_container() -> None:
+    """The surgeon's verdict is the ONLY trigger: a container the surgeon did not
+    flag (should_quarantine=False) is never quarantined."""
+    container = q.parse_container(make_inspect())
+    with pytest.raises(q.QuarantineError, match="did not flag"):
+        q.plan_quarantine(container=container, stable_ref=STABLE, should_quarantine=False)
+
+
+def test_refuses_recreate_on_the_same_broken_digest() -> None:
+    """A rollback recreates on :stable, never on the same broken :edge digest —
+    that would re-break immediately. Refused fail-loud."""
+    same = "ghcr.io/wave-engineering/oakandwave-workflow@sha256:" + "b" * 64
+    container = q.parse_container(make_inspect(image=same))
+    with pytest.raises(q.QuarantineError, match="equals the broken image"):
+        q.plan_quarantine(container=container, stable_ref=same, should_quarantine=True)
+
+
+def test_missing_stable_ref_is_loud() -> None:
+    container = q.parse_container(make_inspect())
+    with pytest.raises(q.QuarantineError, match="stable_ref is required"):
+        q.plan_quarantine(container=container, stable_ref="  ", should_quarantine=True)
+
+
+# --- parsing robustness -------------------------------------------------------
+
+
+def test_parses_docker_inspect_list_and_single_forms() -> None:
+    """Accepts both the raw ``docker inspect`` list and a single container object,
+    reading Id/Name/Config.Image/Labels/Mounts; the leading '/' on Name is stripped."""
+    as_list = q.parse_container(make_inspect(cid="c1", name="dogbox"))
+    as_single = q.parse_container(make_inspect(cid="c1", name="dogbox")[0])
+    assert as_list == as_single
+    assert as_list.id == "c1"
+    assert as_list.name == "dogbox"  # '/' stripped
+    assert as_list.profile == "dogfood"
+
+
+def test_empty_inspect_is_loud() -> None:
+    """An empty inspect (no such container) is a loud error, never a silent no-op —
+    the surgeon's fail-on-quarantine signal expects an action to have occurred."""
+    with pytest.raises(q.QuarantineError, match="no such container"):
+        q.parse_container([])
+
+
+def test_rw_defaults_true_when_docker_omits_it() -> None:
+    """docker omits ``RW`` for a rw mount; a bind with no RW key is rw (host-backed,
+    preserved), not misread as ro."""
+    m = q.parse_mount({"Type": "bind", "Source": "/h/x", "Destination": "/x"})
+    assert m.rw is True and m.host_backed is True
+
+
+def test_module_is_kit_independent() -> None:
+    """Like the surgeon (R-15), the planner runs host-side and imports ONLY the
+    standard library — a broken container's kit can never shape the rollback plan."""
+    tree = ast.parse(QUAR_PY.read_text())
+    stdlib = {
+        "argparse", "json", "sys", "dataclasses", "__future__",
+        "os", "pathlib", "typing", "collections", "re",
+    }
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imported.add(node.module.split(".")[0])
+    assert imported <= stdlib, f"non-stdlib imports: {imported - stdlib}"
+
+
+# --- the surgeon -> quarantine seam (real integration) ------------------------
+
+
+def test_consumes_surgeon_should_quarantine_verdict() -> None:
+    """The seam end-to-end: the REAL surgeon classifies a running+looping dogfood
+    container broken → should_quarantine=True → the quarantine plans the rollback.
+    Detection (3.1) and action (3.2) are wired through the same verdict."""
+    verdict = fs.assess(
+        container_id="edge123",
+        title="dogbox",
+        status="running",
+        profile="dogfood",
+        entries=looping_transcript(),
+    )
+    assert verdict.should_quarantine is True
+
+    container = q.parse_container(make_inspect(cid="edge123"))
+    plan = q.plan_quarantine(
+        container=container, stable_ref=STABLE, should_quarantine=verdict.should_quarantine
+    )
+    assert plan.recreate_image == STABLE
+    assert plan.container_id == "edge123"
+
+
+def test_dev_mode_breakage_is_never_quarantined() -> None:
+    """[R-22] via the real surgeon: a dev-mode container that is BROKEN (running +
+    looping) is classified broken but should_quarantine=False — and the quarantine
+    then REFUSES it. A dev-mode breakage never trips the destructive rollback."""
+    verdict = fs.assess(
+        container_id="dev1",
+        title="devbox",
+        status="running",
+        profile="dev-mode",
+        entries=looping_transcript(),
+    )
+    assert verdict.health.broken is True
+    assert verdict.should_quarantine is False
+
+    container = q.parse_container(make_inspect(cid="dev1", profile="dev-mode"))
+    with pytest.raises(q.QuarantineError, match="did not flag"):
+        q.plan_quarantine(
+            container=container, stable_ref=STABLE, should_quarantine=verdict.should_quarantine
+        )
+
+
+# --- the shell wrapper's plumbing (hermetic, via dry-run + injected seams) ----
+
+
+def test_wrapper_dry_run_emits_the_plan_without_docker() -> None:
+    """The wrapper wires to the planner: with QUARANTINE_DRY_RUN + the injected
+    inspect/stable seams it resolves the full plan and would stop/rm/recreate — with
+    NO docker call. Proves the shell plumbing hermetically (the real stop/rm/recreate
+    is the docker-gated test below)."""
+    if not os.access(WRAPPER, os.X_OK):
+        pytest.skip("wrapper not executable")
+    inspect_file = QUAR_DIR / ".pytest-inspect.json"  # written+removed in-test
+    try:
+        inspect_file.write_text(json.dumps(make_inspect()))
+        env = dict(os.environ)
+        env.update(
+            CONTAINER_ID="edge123",
+            SHOULD_QUARANTINE="true",
+            QUARANTINE_DRY_RUN="true",
+            OAW_CONTAINER_INSPECT=str(inspect_file),
+            OAW_STABLE_RESOLVED_REF=STABLE,
+        )
+        proc = subprocess.run(
+            ["bash", str(WRAPPER)], capture_output=True, text=True, env=env, timeout=60
+        )
+    finally:
+        inspect_file.unlink(missing_ok=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "[dry-run]" in proc.stdout
+    plan = json.loads(proc.stdout[proc.stdout.index("{"):])
+    assert plan["recreate_image"] == STABLE
+    assert "/home/bakerb/work/dogbox:/workspace" in plan["recreate_volume_args"]
+
+
+def test_wrapper_refuses_without_surgeon_verdict() -> None:
+    """The wrapper mirrors the planner's refusal up front: no SHOULD_QUARANTINE=true
+    ⇒ abort, never quarantine a container the surgeon did not flag."""
+    if not os.access(WRAPPER, os.X_OK):
+        pytest.skip("wrapper not executable")
+    env = dict(os.environ)
+    env.update(CONTAINER_ID="edge123", QUARANTINE_DRY_RUN="true", OAW_STABLE_RESOLVED_REF=STABLE)
+    env.pop("SHOULD_QUARANTINE", None)
+    proc = subprocess.run(
+        ["bash", str(WRAPPER)], capture_output=True, text=True, env=env, timeout=60
+    )
+    assert proc.returncode != 0
+    assert "SHOULD_QUARANTINE" in proc.stderr
+
+
+# --- E2E-03 docker-gated: the REAL zero-loss mechanic (self-skips) ------------
+
+
+def _skip_or_fail(msg: str, require: bool) -> None:
+    if require:
+        pytest.fail(msg + " (OAKANDWAVE_REQUIRE_IMAGE set)")
+    pytest.skip(msg)
+
+
+def _pick_local_image(docker: str) -> str | None:
+    """The smallest already-present local image to stand in for :edge/:stable — we
+    never PULL (mirrors test_ownership.py: absence self-skips, not a network fetch).
+    ``sleep`` (used to keep the container up) is universal across these bases."""
+    for ref in (
+        os.environ.get("OAKANDWAVE_IMAGE", ""),
+        "oakandwave-workflow:edge",
+        "busybox:latest",
+        "busybox",
+        "alpine:latest",
+        "alpine",
+    ):
+        if ref and subprocess.run(
+            [docker, "image", "inspect", ref], capture_output=True
+        ).returncode == 0:
+            return ref
+    return None
+
+
+def test_e2e03_real_rollback_preserves_on_disk_work(tmp_path: Path) -> None:
+    """E2E-03 [R-02, R-17]: a REAL container with a host-backed bind holding work is
+    quarantined (stop → docker rm → recreate on a distinct :stable image) and the
+    on-disk work SURVIVES — the concrete zero-loss proof. Self-skips without docker
+    or a local image; OAKANDWAVE_REQUIRE_IMAGE makes absence a hard failure (CI)."""
+    docker = shutil.which("docker")
+    require = bool(os.environ.get("OAKANDWAVE_REQUIRE_IMAGE"))
+    if docker is None:
+        _skip_or_fail("docker binary not found on PATH", require)
+    base = _pick_local_image(docker)
+    if base is None:
+        _skip_or_fail("no local image to stand in for :edge/:stable", require)
+
+    # Distinct :edge / :stable tags off the base so broken_image != recreate target.
+    tag = f"oaw-quarantine-test-{uuid.uuid4().hex[:8]}"
+    edge_ref, stable_ref = f"{tag}:edge", f"{tag}:stable"
+    work = tmp_path / "memory"
+    work.mkdir()
+    (work / "durable-work.txt").write_text("zero-work-lost")
+    os.chmod(tmp_path, 0o777)
+    os.chmod(work, 0o777)
+
+    name = f"quar-{uuid.uuid4().hex[:8]}"
+    created: list[str] = []
+    try:
+        for ref in (edge_ref, stable_ref):
+            assert subprocess.run(
+                [docker, "tag", base, ref], capture_output=True
+            ).returncode == 0, f"could not tag {base} -> {ref}"
+
+        # Plant the "broken :edge": a container with the work bind-mounted host-backed.
+        run = subprocess.run(
+            [docker, "run", "-d", "--name", name, "--label", "oaw.profile=dogfood",
+             "-v", f"{work}:/work", edge_ref, "sleep", "300"],
+            capture_output=True, text=True, timeout=120,
+        )
+        assert run.returncode == 0, run.stderr
+        created.append(name)
+        edge_cid = run.stdout.strip()
+
+        # Inspect → plan (the lossless proof runs here, before any rm).
+        insp = subprocess.run(
+            [docker, "inspect", edge_cid], capture_output=True, text=True, timeout=60
+        )
+        assert insp.returncode == 0, insp.stderr
+        container = q.parse_container(json.loads(insp.stdout))
+        plan = q.plan_quarantine(
+            container=container, stable_ref=stable_ref, should_quarantine=True
+        )
+        assert f"{work}:/work" in plan.recreate_volume_args
+
+        # Apply the quarantine: stop → rm (NO -v) → recreate on :stable.
+        subprocess.run([docker, "stop", edge_cid], capture_output=True, timeout=60)
+        subprocess.run([docker, "rm", edge_cid], capture_output=True, timeout=60, check=True)
+        recreate = [docker, "run", "-d", "--name", name, "--label", f"oaw.profile={plan.profile}"]
+        for v in plan.recreate_volume_args:
+            recreate += ["-v", v]
+        recreate += [stable_ref, "sleep", "300"]
+        rerun = subprocess.run(recreate, capture_output=True, text=True, timeout=120)
+        assert rerun.returncode == 0, rerun.stderr
+        new_cid = rerun.stdout.strip()
+
+        # Zero work lost: the host-backed file survived the rm + recreate untouched.
+        assert (work / "durable-work.txt").read_text() == "zero-work-lost"
+        # The new container runs on :stable and re-attached the same host source.
+        img = subprocess.run(
+            [docker, "inspect", "--format", "{{.Config.Image}}", new_cid],
+            capture_output=True, text=True, timeout=60,
+        ).stdout.strip()
+        assert img == stable_ref
+    finally:
+        for cid in (name,):
+            subprocess.run([docker, "rm", "-f", cid], capture_output=True)
+        for ref in (edge_ref, stable_ref):
+            subprocess.run([docker, "rmi", ref], capture_output=True)


### PR DESCRIPTION
## Summary
Flight #971 (P3W1) — the remediation half of the flight surgeon (#970, already in kahuna/959-P3W1). Consumes the surgeon's `should_quarantine` verdict and acts: stop -> docker rm (without -v) -> recreate on `:stable`, with a unit-tested planner proving the rollback loses no durable state before the destructive rm.

## Changes
- `containers/oakandwave-workflow/quarantine.py`: stdlib-only pure planner + the lossless invariant (`assert_lossless` fails loud on lossy rm).
- `scripts/ci/quarantine-container.sh`: wrapper (inspect -> plan -> stop/rm/recreate), ledgers the quarantine so the promotion gate holds the bad `:edge` digest (R-07); `QUARANTINE_DRY_RUN` + injected seams keep it docker-free testable.
- `tests/contained-workflow/test_quarantine.py`: E2E-03 oracle — hermetic property tests plus the real surgeon->quarantine seam and a docker-gated real stop/rm/recreate.
- `docs/contained-workflow/manual-verification.md`: MV-05 procedure + row.

## Cross-flight seam (PRIME reconcile)
Verified the consumer seam against the provider as merged in base: `fs.assess(*, container_id, title, status, profile, entries)` returns `Assessment.should_quarantine: bool` and `.health.broken` — exactly what this flight consumes. No interface break. commutativity_verify (single-target, base_ref=kahuna/959-P3W1): STRONG.

## Linked Issues
Closes #971

## Test Plan
Full suite run at reconcile (dod_run_test_suite) after merge into kahuna/959-P3W1.