### PR TITLE
chore(contained-workflow): container profiles + gate-side label filter (#974)

### DIFF
--- a/containers/oakandwave-workflow/profiles.py
+++ b/containers/oakandwave-workflow/profiles.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Container profiles + label filtering — Story 4.1 (#974), Plan #959, Dev Spec §5.9.
+
+This module is the **canonical owner** of the two container profiles and the
+``oaw.profile`` label the rest of the contained-workflow reads (R-21/R-22):
+
+* **dogfood** — overlay OFF, **image-only**. The candidate ring: its runs feed the
+  soak clock and its breakages trip quarantine. It is what the promotion gate
+  measures. Labeled ``oaw.profile=dogfood``.
+* **dev-mode** — the **skills overlay is ON** (a bind-mount of the developer's
+  working-copy skills over the image's baked skills, so a skill edit is testable
+  live without a rebuild — the R-06 non-promotable exception). Labeled
+  ``oaw.profile=dev-mode`` and marked **non-candidate**: dev-mode runs and
+  breakages are **excluded from promotion telemetry** — they never accrue soak and
+  never trip quarantine.
+
+Requirements this module is the guard for:
+
+* **R-21** — the system provides two profiles: dev-mode (skills overlay ON, labeled
+  non-candidate) and dogfood (overlay OFF, image-only, feeds the gate). Realised as
+  the :data:`PROFILES` registry: each :class:`Profile` fixes its label, whether the
+  skills overlay is ON, and whether it is a candidate; :func:`launch_spec` renders
+  the concrete launch (the ``oaw.profile`` label + — for dev-mode only — the skills
+  overlay ``-v`` mount that makes "overlay ON" a real bind, not a flag).
+* **R-22** — the health probe **and the promotion gate** filter on the profile
+  label; dev-mode runs and breakages do not count toward soak or trip quarantine.
+  The **probe** half is the flight surgeon (``scripts/flight-surgeon/surgeon.py``,
+  Story 3.1), which already excludes dev-mode from ``should_quarantine``. This
+  module is the **gate** half: :func:`filter_candidate_records` drops every
+  non-candidate (dev-mode) telemetry record, and :func:`aggregate_gate_signals`
+  folds the *filtered* soak/quarantine ledgers into the exact
+  ``SOAK_HOURS`` / ``QUARANTINE_COUNT`` signals ``promotion_gate.py`` consumes — so
+  a dev-mode session can never inflate soak nor a dev-mode breakage fail the gate.
+
+Design — **fail-safe toward measuring the candidate** (assertion-liveness, D7):
+
+* Candidacy is the *default*: only an **explicit** dev-mode label excludes a record
+  from the gate (:func:`is_candidate`). An unlabeled / unknown-profile record stays
+  a candidate, so a real dogfood run can never silently escape the soak/quarantine
+  accounting merely by lacking a label. This mirrors the surgeon's
+  ``quarantine_eligible`` on the probe side — the two halves agree by construction.
+
+Why the label logic is duplicated with the surgeon (and that is correct): the
+surgeon imports **only the standard library** so a broken container's kit can never
+shape its verdict (R-15). It therefore cannot import this module. The small
+normalize/alias table is intentionally re-stated there; **this module is the
+canonical definition of record**, and the two are kept in lock-step by
+``tests/contained-workflow/test_profiles.py`` (which asserts the alias sets match).
+
+CLI — the gate-signal emitter plugs straight into ``promote-oakandwave-image.sh``'s
+``GATE_SIGNALS_CMD`` seam::
+
+    python3 profiles.py --emit gate-signals \\
+        --soak-ledger ~/.oaw/soak/ledger.jsonl \\
+        --quarantine-ledger ~/.oaw/quarantine/ledger.jsonl
+    # -> SOAK_HOURS=<candidate soak sum>
+    #    QUARANTINE_COUNT=<candidate quarantine count>
+
+    python3 profiles.py --emit launch --profile dev-mode
+    # -> the docker/aoe launch args: the oaw.profile label + the skills overlay -v
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# The docker label key that stamps a container's ring. Identical to
+# ``quarantine.py``'s ``PROFILE_LABEL_KEY`` (the recreate preserves it verbatim)
+# and to the label the surgeon reads — the one string all three agree on (R-22).
+PROFILE_LABEL_KEY = "oaw.profile"
+
+# The path the kit bakes skills to inside the image (Dockerfile: USER ubuntu,
+# HOME=/home/ubuntu, ``./install`` lands skills under $HOME/.claude/skills). The
+# dev-mode overlay binds the developer's working skills over exactly this path.
+IMAGE_SKILLS_TARGET = "/home/ubuntu/.claude/skills"
+
+# The default host source for the dev-mode skills overlay, in the same
+# ``~/.oaw/overlay/<major>/`` family as the user-overlay mounts (30-user-overlay).
+# ``<major>`` is substituted at render time; overridable via the CLI so a developer
+# can point the overlay at their live working tree.
+DEFAULT_SKILLS_OVERLAY_SOURCE = "~/.oaw/overlay/<major>/skills"
+
+
+@dataclass(frozen=True)
+class Profile:
+    """One container profile (R-21).
+
+    ``label`` is the ``oaw.profile`` value stamped on the container and read back by
+    the surgeon and the gate filter. ``skills_overlay`` is True iff the dev-mode
+    skills overlay is bound (overlay ON). ``candidate`` is True iff the profile
+    feeds the promotion telemetry — dogfood is a candidate; dev-mode is **not**, so
+    it is excluded from soak and quarantine (R-22)."""
+
+    name: str
+    label: str
+    skills_overlay: bool
+    candidate: bool
+    aliases: frozenset[str] = field(default_factory=frozenset)
+
+
+# --- the two profiles (R-21) --------------------------------------------------
+
+DOGFOOD = Profile(
+    name="dogfood",
+    label="dogfood",
+    skills_overlay=False,  # image-only — nothing bound over the baked skills
+    candidate=True,  # feeds the gate: its runs accrue soak, its breakages quarantine
+    aliases=frozenset({"dogfood", "dogfood-ring", "candidate"}),
+)
+
+DEV_MODE = Profile(
+    name="dev-mode",
+    label="dev-mode",
+    skills_overlay=True,  # the working-copy skills overlay is bound (R-06 exception)
+    candidate=False,  # non-candidate — excluded from promotion telemetry (R-22)
+    aliases=frozenset({"dev-mode", "dev_mode", "devmode", "dev"}),
+)
+
+# Registry, keyed by canonical name. Exactly two profiles exist (R-21).
+PROFILES: dict[str, Profile] = {DOGFOOD.name: DOGFOOD, DEV_MODE.name: DEV_MODE}
+
+
+class ProfileError(ValueError):
+    """A profile contract violation. Raised LOUD, never swallowed."""
+
+
+def normalize_profile(value: object) -> str:
+    """Normalize a raw label value to a canonical profile name, or ``unknown``.
+
+    Only an explicit dev-mode / dogfood marker (via each profile's alias set)
+    resolves; anything else is ``unknown``. ``unknown`` is treated as a **candidate**
+    (see :func:`is_candidate`) so a mislabeled dogfood container is never silently
+    dropped from the gate."""
+    if not isinstance(value, str):
+        return "unknown"
+    v = value.strip().lower()
+    for prof in PROFILES.values():
+        if v in prof.aliases:
+            return prof.name
+    return "unknown"
+
+
+def get_profile(name: object) -> Profile:
+    """Resolve ``name`` to its canonical :class:`Profile`, else raise.
+
+    Accepts any alias (via :func:`normalize_profile`). An unknown/unresolvable value
+    is a loud error — a launch must name one of the two real profiles; there is no
+    implicit default (a silent default is exactly the mislabel R-22 guards against)."""
+    canonical = normalize_profile(name)
+    if canonical not in PROFILES:
+        raise ProfileError(
+            f"unknown profile {name!r} — must be one of {sorted(PROFILES)} "
+            f"(or a recognised alias); there is no implicit default"
+        )
+    return PROFILES[canonical]
+
+
+def is_candidate(value: object) -> bool:
+    """True iff a record/container with this profile label **counts** toward the
+    gate (R-22). dev-mode is the only non-candidate; unknown/unlabeled defaults to
+    candidate — fail-safe toward measuring, never toward silently excluding."""
+    canonical = normalize_profile(value)
+    prof = PROFILES.get(canonical)
+    return prof.candidate if prof is not None else True
+
+
+def skills_overlay_on(value: object) -> bool:
+    """True iff the named profile binds the skills overlay (R-21). Only dev-mode
+    does; an unknown profile is treated as overlay-OFF (image-only) — the safe,
+    promotable shape."""
+    canonical = normalize_profile(value)
+    prof = PROFILES.get(canonical)
+    return bool(prof.skills_overlay) if prof is not None else False
+
+
+# --- launch spec: the label + the (dev-mode-only) skills overlay (R-21) -------
+
+
+def skills_overlay_mount(
+    profile: object,
+    *,
+    major: int | str,
+    source: str = DEFAULT_SKILLS_OVERLAY_SOURCE,
+    mode: str = "rw",
+) -> str | None:
+    """The ``docker run -v`` spec binding the dev-mode skills overlay, or ``None``.
+
+    Returns ``None`` for any overlay-OFF profile (dogfood, unknown) — image-only, so
+    nothing is bound and the baked skills stand. For dev-mode, returns
+    ``<host-source>:<image-skills-target>[:mode]`` with ``<major>`` substituted, so
+    the developer's working skills shadow the baked ones (overlay ON, R-21). This is
+    the R-06 non-promotable exception — the overlay is *why* dev-mode is a
+    non-candidate."""
+    if not skills_overlay_on(profile):
+        return None
+    src = str(source).replace("<major>", str(major))
+    suffix = "" if mode == "rw" else f":{mode}"
+    return f"{src}:{IMAGE_SKILLS_TARGET}{suffix}"
+
+
+def launch_spec(
+    profile: object,
+    *,
+    major: int | str,
+    skills_overlay_source: str = DEFAULT_SKILLS_OVERLAY_SOURCE,
+) -> list[str]:
+    """Render the concrete launch args for a profile (R-21).
+
+    Always stamps ``--label oaw.profile=<label>`` (the string the surgeon and the
+    gate filter both read). For dev-mode it additionally appends ``-v <overlay>`` so
+    the skills overlay is a **real bind**, not merely a flag — "overlay ON" is
+    enforced by the mount, "overlay OFF" by its absence. The wrapper that launches
+    the container (or the aoe profile) consumes these args verbatim."""
+    prof = get_profile(profile)
+    args = ["--label", f"{PROFILE_LABEL_KEY}={prof.label}"]
+    mount = skills_overlay_mount(prof.name, major=major, source=skills_overlay_source)
+    if mount is not None:
+        args += ["-v", mount]
+    return args
+
+
+# --- the gate-side telemetry filter (R-22, the gate half) ---------------------
+
+
+def _record_profile(record: object) -> object:
+    """Extract the ``profile`` field from a telemetry record (quarantine ledger
+    entries carry it via ``quarantine.py``'s ``quarantine_record()``; soak records
+    carry it per session). A record with no ``profile`` key yields ``None`` — which
+    :func:`is_candidate` treats as a candidate, so an unlabeled record is *kept*
+    (counted), never silently dropped."""
+    if isinstance(record, dict):
+        return record.get("profile")
+    return None
+
+
+def filter_candidate_records(records: list[dict]) -> list[dict]:
+    """Drop every **non-candidate** (dev-mode) telemetry record (R-22).
+
+    This is the gate-side profile filter: given raw telemetry (soak sessions or
+    quarantine events, each tagged with its ``profile``), keep only the records that
+    count toward promotion. dev-mode records are removed so they can neither inflate
+    soak nor trip the zero-quarantines condition. Unlabeled/unknown records are
+    **kept** (candidate by default) — fail-safe toward measuring the candidate."""
+    return [r for r in records if isinstance(r, dict) and is_candidate(_record_profile(r))]
+
+
+def _soak_hours_of(record: dict) -> float:
+    """Accrued soak hours for one candidate soak record: ``hours`` if present, else
+    ``seconds``/3600. A record with neither contributes 0 (it carries no measurable
+    soak) rather than crashing the aggregation."""
+    if "hours" in record:
+        try:
+            return float(record["hours"])
+        except (TypeError, ValueError):
+            return 0.0
+    if "seconds" in record:
+        try:
+            return float(record["seconds"]) / 3600.0
+        except (TypeError, ValueError):
+            return 0.0
+    return 0.0
+
+
+def aggregate_gate_signals(
+    *,
+    soak_records: list[dict],
+    quarantine_records: list[dict],
+) -> dict[str, float | int]:
+    """Fold the **profile-filtered** ledgers into the gate's soak/quarantine signals.
+
+    Both ledgers are passed through :func:`filter_candidate_records` first, so
+    dev-mode never contributes (R-22):
+
+    * ``soak_hours`` — the sum of :func:`_soak_hours_of` over the candidate soak
+      records (dev-mode soak excluded).
+    * ``quarantine_count`` — the count of candidate ``event == "quarantine"`` records
+      (a dev-mode breakage, even if one leaked into the ledger, does not count).
+
+    The returned dict is exactly the two signals ``promotion_gate.py`` reads as
+    ``--soak-hours`` / ``--quarantines``; :func:`gate_signals_kv` renders them for
+    the wrapper's ``GATE_SIGNALS_CMD`` seam."""
+    candidate_soak = filter_candidate_records(soak_records)
+    candidate_quarantines = filter_candidate_records(quarantine_records)
+    soak_hours = sum(_soak_hours_of(r) for r in candidate_soak)
+    quarantine_count = sum(
+        1 for r in candidate_quarantines if str(r.get("event", "quarantine")) == "quarantine"
+    )
+    return {"soak_hours": soak_hours, "quarantine_count": quarantine_count}
+
+
+def gate_signals_kv(signals: dict[str, float | int]) -> str:
+    """Render aggregated signals as the ``KEY=VALUE`` lines the promote wrapper's
+    ``GATE_SIGNALS_CMD`` seam sources (``SOAK_HOURS`` / ``QUARANTINE_COUNT``). Soak
+    hours print with no trailing ``.0`` when whole, matching the gate's ``%g``."""
+    soak = signals["soak_hours"]
+    soak_str = f"{soak:g}" if isinstance(soak, float) else str(soak)
+    return f"SOAK_HOURS={soak_str}\nQUARANTINE_COUNT={int(signals['quarantine_count'])}"
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def _read_ledger(path: str | None) -> list[dict]:
+    """Read a ``.jsonl`` telemetry ledger (one JSON object per line) into a list.
+
+    A missing path or ``None`` yields ``[]`` (no telemetry ⇒ no candidate soak /
+    zero counted quarantines — the gate's own fail-closed logic then handles the
+    empty-soak case as RED). Blank and malformed lines are skipped."""
+    if not path:
+        return []
+    p = Path(path).expanduser()
+    if not p.is_file():
+        return []
+    out: list[dict] = []
+    with p.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                out.append(obj)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--emit",
+        choices=("gate-signals", "launch"),
+        required=True,
+        help="gate-signals: profile-filtered SOAK_HOURS/QUARANTINE_COUNT KV for the "
+        "promote wrapper's GATE_SIGNALS_CMD seam. launch: a profile's docker/aoe args.",
+    )
+    parser.add_argument("--soak-ledger", default=None, help="path to the soak .jsonl ledger")
+    parser.add_argument(
+        "--quarantine-ledger", default=None, help="path to the quarantine .jsonl ledger"
+    )
+    parser.add_argument(
+        "--profile", default=None, help="profile name for --emit launch (dev-mode|dogfood)"
+    )
+    parser.add_argument(
+        "--major", default="1", help="the state/image major for <major> substitution"
+    )
+    parser.add_argument(
+        "--skills-overlay-source",
+        default=DEFAULT_SKILLS_OVERLAY_SOURCE,
+        help="host source for the dev-mode skills overlay (--emit launch)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.emit == "gate-signals":
+        signals = aggregate_gate_signals(
+            soak_records=_read_ledger(args.soak_ledger),
+            quarantine_records=_read_ledger(args.quarantine_ledger),
+        )
+        print(gate_signals_kv(signals))
+        return 0
+
+    # --emit launch
+    if not args.profile:
+        print("--profile is required for --emit launch", file=sys.stderr)
+        return 2
+    try:
+        args_out = launch_spec(
+            args.profile, major=args.major, skills_overlay_source=args.skills_overlay_source
+        )
+    except ProfileError as exc:
+        print(f"profile error: {exc}", file=sys.stderr)
+        return 2
+    print(" ".join(args_out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -63,6 +63,32 @@ flowchart TB
 | CI build/push + throwaway-CI ring | Builds, signs, SBOMs, pushes by digest; smokes install-from-zero | 2.1/2.2 |
 | Promotion gate | Mechanical conjunction over FlightDeck + CI; retags the tested digest | 2.3 |
 | Flight surgeon | Host-side probe reading the host-backed transcript; quarantine + rollback | 3.1/3.2 |
+| Container profiles (`profiles.py`) | The two rings + the `oaw.profile` label; the gate-side telemetry filter | 4.1 (#974) |
+
+### 2.1 Container profiles (Story 4.1, R-21/R-22)
+
+The candidate runs in one of **two profiles**, distinguished by the `oaw.profile`
+docker label the surgeon and the promotion gate both read:
+
+| Profile | Skills overlay | `oaw.profile` | Candidate? | Role |
+|---------|----------------|---------------|------------|------|
+| **dogfood** | OFF — image-only | `dogfood` | yes | The real dogfood ring: its runs accrue soak and its breakages trip quarantine — it is what the gate measures. |
+| **dev-mode** | ON — the developer's working skills bind over the baked skills (the R-06 non-promotable exception) | `dev-mode` | **no** | Skill iteration without a rebuild. **Excluded from promotion telemetry** — dev-mode runs/breakages never count toward soak nor trip quarantine. |
+
+`containers/oakandwave-workflow/profiles.py` is the canonical owner of the label
+and the candidacy rule. It renders each profile's launch (`launch_spec` — the
+`oaw.profile` label plus, for dev-mode only, the skills-overlay `-v` bind, so
+"overlay ON" is a real mount and "overlay OFF" its absence), and provides the
+**gate-side filter** (`aggregate_gate_signals`) that folds the soak/quarantine
+ledgers into `SOAK_HOURS` / `QUARANTINE_COUNT` with every dev-mode record dropped.
+The **probe half** of the same filter lives in the flight surgeon
+(`scripts/flight-surgeon/surgeon.py`), which excludes dev-mode from
+`should_quarantine`; the surgeon re-states the alias table rather than importing
+`profiles.py` because it must depend on only the standard library (R-15), and a
+lock-step test keeps the two in agreement. The promote wrapper
+(`scripts/ci/promote-oakandwave-image.sh`) defaults its `GATE_SIGNALS_CMD` to this
+filter when `OAW_SOAK_LEDGER` / `OAW_QUARANTINE_LEDGER` are supplied — so the gate
+filters on the label end-to-end.
 
 ## 3. The mount manifest (Story 1.3, this story)
 

--- a/scripts/ci/promote-oakandwave-image.sh
+++ b/scripts/ci/promote-oakandwave-image.sh
@@ -34,6 +34,15 @@
 #                       false ⇒ no promotion even when the gate is green).
 #   GATE_SIGNALS_CMD    optional command emitting `KEY=VALUE` lines (a FlightDeck
 #                       query seam); its output is sourced before reading signals.
+#   OAW_SOAK_LEDGER     optional path to the soak `.jsonl` ledger. When set (and
+#   OAW_QUARANTINE_LEDGER  GATE_SIGNALS_CMD is unset), the gate's SOAK_HOURS /
+#                       QUARANTINE_COUNT are computed from these ledgers through the
+#                       PROFILE FILTER (containers/oakandwave-workflow/profiles.py):
+#                       dev-mode runs and breakages are excluded, so they never
+#                       accrue soak nor trip the zero-quarantines condition (R-22 —
+#                       the gate half of the profile filter; the surgeon is the
+#                       probe half). This is how "the gate filters on the label" is
+#                       wired end-to-end, not merely available as a library.
 #   THROWAWAY_CI_PASSED E2E-01 smoke result for DIGEST_REF (true/false).
 #   THROWAWAY_CI_DIGEST the digest E2E-01 tested (defaults to DIGEST_REF; the gate
 #                       still requires it to equal the promotion target — R-23).
@@ -51,6 +60,21 @@ REPO_DIR="$(cd "$HERE/../.." && pwd)"
 GATE_PY="$REPO_DIR/containers/oakandwave-workflow/promotion_gate.py"
 
 : "${DIGEST_REF:?DIGEST_REF must be set (registry/image@sha256:...)}"
+
+PROFILES_PY="$REPO_DIR/containers/oakandwave-workflow/profiles.py"
+
+# --- Profile-filtered telemetry: the gate half of R-22 ------------------------
+# When soak/quarantine ledgers are supplied and no explicit GATE_SIGNALS_CMD is
+# set, default the signal seam to the profile filter: profiles.py folds the
+# ledgers into SOAK_HOURS / QUARANTINE_COUNT while EXCLUDING dev-mode records, so
+# a dev-mode session cannot inflate soak and a dev-mode breakage cannot fail the
+# gate (R-22). Explicitly-set GATE_SIGNALS_CMD wins (an operator can still inject
+# a live FlightDeck query).
+if [[ -z "${GATE_SIGNALS_CMD:-}" && (-n "${OAW_SOAK_LEDGER:-}" || -n "${OAW_QUARANTINE_LEDGER:-}") ]]; then
+	GATE_SIGNALS_CMD="python3 $(printf '%q' "$PROFILES_PY") --emit gate-signals"
+	[[ -n "${OAW_SOAK_LEDGER:-}" ]] && GATE_SIGNALS_CMD+=" --soak-ledger $(printf '%q' "$OAW_SOAK_LEDGER")"
+	[[ -n "${OAW_QUARANTINE_LEDGER:-}" ]] && GATE_SIGNALS_CMD+=" --quarantine-ledger $(printf '%q' "$OAW_QUARANTINE_LEDGER")"
+fi
 
 # --- Optional FlightDeck-query seam: populate signal env from its KV output ---
 if [[ -n "${GATE_SIGNALS_CMD:-}" ]]; then

--- a/tests/contained-workflow/test_profiles.py
+++ b/tests/contained-workflow/test_profiles.py
@@ -1,0 +1,242 @@
+"""Oracle for Story 4.1 (#974) — dev-mode vs dogfood profiles + label filtering.
+
+Two acceptance criteria, both proved here as *pure* unit oracles (no docker, no
+aoe, no registry) so they run for real in the stock ``pytest tests/`` lane:
+
+* **AC1 [R-21]** — two profiles exist; dev-mode has the skills overlay ON and is
+  labeled non-candidate; dogfood is overlay-OFF/image-only and feeds the gate.
+  Proved by :func:`test_two_profiles_exist`, :func:`test_dev_mode_overlay_on`,
+  :func:`test_dogfood_overlay_off_image_only`, and :func:`test_launch_spec_labels`.
+* **AC2 [R-22]** — the gate filters on the label; dev-mode runs/breakages don't
+  count toward soak or trip quarantine. The named story oracle,
+  :func:`test_profile_filter`, drives mixed soak + quarantine ledgers and asserts
+  every dev-mode record is excluded from the aggregated gate signals.
+
+Plus a lock-step guard (:func:`test_alias_sets_match_surgeon`) proving this module
+— the canonical owner of the profile label — and the deliberately kit-independent
+surgeon (which cannot import it, R-15) agree on the dev-mode/dogfood alias sets.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+PROFILES_PY = CONTAINER_DIR / "profiles.py"
+SURGEON_DIR = REPO_ROOT / "scripts" / "flight-surgeon"
+
+# Path-style import (no PYTHONPATH dependency), mirroring test_gate.py.
+sys.path.insert(0, str(CONTAINER_DIR))
+import profiles as pf  # noqa: E402
+
+
+# --- AC1 [R-21] — two profiles exist, with the right overlay/label/candidacy ---
+
+
+def test_two_profiles_exist():
+    """Exactly two profiles: dogfood and dev-mode (R-21)."""
+    assert set(pf.PROFILES) == {"dogfood", "dev-mode"}
+    assert pf.get_profile("dogfood") is pf.DOGFOOD
+    assert pf.get_profile("dev-mode") is pf.DEV_MODE
+
+
+def test_dev_mode_overlay_on():
+    """dev-mode: skills overlay ON, labeled non-candidate (R-21)."""
+    assert pf.DEV_MODE.skills_overlay is True
+    assert pf.DEV_MODE.candidate is False
+    assert pf.DEV_MODE.label == "dev-mode"
+    assert pf.skills_overlay_on("dev-mode") is True
+    assert pf.is_candidate("dev-mode") is False
+
+
+def test_dogfood_overlay_off_image_only():
+    """dogfood: overlay OFF (image-only), candidate — feeds the gate (R-21)."""
+    assert pf.DOGFOOD.skills_overlay is False
+    assert pf.DOGFOOD.candidate is True
+    assert pf.DOGFOOD.label == "dogfood"
+    assert pf.skills_overlay_on("dogfood") is False
+    assert pf.is_candidate("dogfood") is True
+
+
+def test_launch_spec_labels_and_overlay():
+    """The launch spec stamps oaw.profile and binds the overlay ONLY for dev-mode.
+
+    "overlay ON" must be a real ``-v`` bind over the baked skills, not a mere flag;
+    "overlay OFF" must be the absence of that bind (image-only) — R-21."""
+    dog = pf.launch_spec("dogfood", major=1)
+    assert dog == ["--label", "oaw.profile=dogfood"]
+    assert "-v" not in dog  # image-only
+
+    dev = pf.launch_spec("dev-mode", major=1)
+    assert dev[:2] == ["--label", "oaw.profile=dev-mode"]
+    assert "-v" in dev
+    mount = dev[dev.index("-v") + 1]
+    # binds a host skills source over the image's baked skills path
+    assert mount.endswith(":" + pf.IMAGE_SKILLS_TARGET)
+    assert "<major>" not in mount  # <major> substituted
+
+
+def test_overlay_mount_major_substitution():
+    """The overlay source substitutes <major>; dogfood binds nothing."""
+    assert pf.skills_overlay_mount("dogfood", major=2) is None
+    m = pf.skills_overlay_mount("dev-mode", major=2)
+    assert m is not None and "/2/" in m and "<major>" not in m
+
+
+def test_unknown_profile_rejected_by_get():
+    """A launch must name a real profile — no implicit default (R-22 mislabel guard)."""
+    with pytest.raises(pf.ProfileError):
+        pf.get_profile("candidate-ish-typo")
+
+
+def test_aliases_resolve():
+    """Common aliases resolve to their canonical profile."""
+    assert pf.normalize_profile("dev_mode") == "dev-mode"
+    assert pf.normalize_profile("devmode") == "dev-mode"
+    assert pf.normalize_profile("DEV") == "dev-mode"
+    assert pf.normalize_profile("candidate") == "dogfood"
+    assert pf.normalize_profile("nonsense") == "unknown"
+    assert pf.normalize_profile(None) == "unknown"
+
+
+# --- AC2 [R-22] — the gate filters on the label -------------------------------
+
+
+def test_profile_filter():
+    """dev-mode telemetry is excluded from the aggregated soak/quarantine signals.
+
+    The named story oracle. A mixed ledger of dogfood + dev-mode soak sessions and
+    quarantine events must fold into gate signals that count **only** the dogfood
+    (candidate) records — a dev-mode session cannot inflate soak, and a dev-mode
+    breakage cannot trip the zero-quarantines condition (R-22)."""
+    soak = [
+        {"profile": "dogfood", "hours": 20},
+        {"profile": "dogfood", "hours": 10},
+        {"profile": "dev-mode", "hours": 500},  # must NOT count toward soak
+        {"profile": "dev_mode", "seconds": 3600},  # alias — also excluded
+    ]
+    quarantines = [
+        {"event": "quarantine", "profile": "dogfood", "held_digest": "repo@sha256:a"},
+        {"event": "quarantine", "profile": "dev-mode", "held_digest": "repo@sha256:b"},
+    ]
+
+    signals = pf.aggregate_gate_signals(soak_records=soak, quarantine_records=quarantines)
+
+    # only the two dogfood soak records (20 + 10) count — the 500h+1h dev-mode soak
+    # is excluded.
+    assert signals["soak_hours"] == 30
+    # only the one dogfood quarantine counts — the dev-mode breakage is excluded.
+    assert signals["quarantine_count"] == 1
+
+
+def test_filter_keeps_unlabeled_as_candidate():
+    """Fail-safe: an unlabeled/unknown record is KEPT (candidate) — a real dogfood
+    run cannot escape the soak/quarantine accounting merely by lacking a label."""
+    records = [
+        {"hours": 5},  # no profile key
+        {"profile": "unknown", "hours": 7},
+        {"profile": "dev-mode", "hours": 99},
+    ]
+    kept = pf.filter_candidate_records(records)
+    assert {r.get("profile") for r in kept} == {None, "unknown"}
+    assert len(kept) == 2
+
+
+def test_dev_mode_only_ledger_yields_zero_soak():
+    """A ledger with ONLY dev-mode soak accrues zero candidate soak — the gate then
+    reads soak RED on its own (dev-mode can never satisfy the soak condition)."""
+    signals = pf.aggregate_gate_signals(
+        soak_records=[{"profile": "dev-mode", "hours": 1000}],
+        quarantine_records=[],
+    )
+    assert signals["soak_hours"] == 0
+    assert signals["quarantine_count"] == 0
+
+
+def test_gate_signals_kv_shape():
+    """The KV render is exactly the SOAK_HOURS / QUARANTINE_COUNT keys the promote
+    wrapper's GATE_SIGNALS_CMD seam sources into the gate."""
+    kv = pf.gate_signals_kv({"soak_hours": 30.0, "quarantine_count": 1})
+    assert "SOAK_HOURS=30" in kv
+    assert "QUARANTINE_COUNT=1" in kv
+    # whole soak hours print without a trailing .0 (matches the gate's %g)
+    assert "SOAK_HOURS=30.0" not in kv
+
+
+# --- lock-step guard: this module and the surgeon agree on the aliases --------
+
+
+def test_alias_sets_match_surgeon():
+    """This module owns the profile label; the surgeon re-states the alias table
+    because it must import only stdlib (R-15) and so cannot import this module. The
+    two MUST agree, or a container labeled dev-mode by the launch spec could be read
+    as a candidate by the probe (or vice-versa). Assert lock-step."""
+    sys.path.insert(0, str(SURGEON_DIR))
+    import surgeon as fs  # noqa: E402
+
+    assert pf.DEV_MODE.aliases == fs._DEV_MODE_ALIASES
+    assert pf.DOGFOOD.aliases == fs._DOGFOOD_ALIASES
+    # and the label key itself is the one string all three components share
+    import quarantine as q  # noqa: E402  (colocated in CONTAINER_DIR, already on path)
+
+    assert pf.PROFILE_LABEL_KEY == q.PROFILE_LABEL_KEY == "oaw.profile"
+
+
+# --- CLI wiring (the gate-signals emitter feeds the promote wrapper) ----------
+
+
+def test_cli_gate_signals(tmp_path):
+    """The --emit gate-signals CLI reads the ledgers, applies the profile filter,
+    and prints the KV the wrapper's GATE_SIGNALS_CMD seam expects."""
+    soak = tmp_path / "soak.jsonl"
+    soak.write_text(
+        '{"profile":"dogfood","hours":24}\n{"profile":"dev-mode","hours":99}\n',
+        encoding="utf-8",
+    )
+    quar = tmp_path / "quar.jsonl"
+    quar.write_text(
+        '{"event":"quarantine","profile":"dev-mode","held_digest":"r@sha256:a"}\n',
+        encoding="utf-8",
+    )
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(PROFILES_PY),
+            "--emit",
+            "gate-signals",
+            "--soak-ledger",
+            str(soak),
+            "--quarantine-ledger",
+            str(quar),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "SOAK_HOURS=24" in out
+    assert "QUARANTINE_COUNT=0" in out  # the dev-mode quarantine excluded
+
+
+def test_cli_launch_emit():
+    """The --emit launch CLI renders a profile's docker/aoe args."""
+    dev = subprocess.run(
+        [sys.executable, str(PROFILES_PY), "--emit", "launch", "--profile", "dev-mode", "--major", "1"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert "--label oaw.profile=dev-mode" in dev
+    assert "-v" in dev
+
+    dog = subprocess.run(
+        [sys.executable, str(PROFILES_PY), "--emit", "launch", "--profile", "dogfood"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert dog == "--label oaw.profile=dogfood"


### PR DESCRIPTION
## Summary
Flight #974 for wave P4W1 (Plan #959, contained-workflow). Adds the container-profiles module that owns the `oaw.profile` label and the dogfood/dev-mode candidacy rule, and wires the promotion gate's telemetry filter to it (R-21/R-22, Story 4.1).

## Changes
- `containers/oakandwave-workflow/profiles.py` — canonical owner of the `oaw.profile` label + candidacy rule; renders each profile's `launch_spec` (dev-mode adds the skills-overlay bind) and provides the gate-side `aggregate_gate_signals` filter that folds soak/quarantine ledgers while dropping dev-mode records.
- `scripts/ci/promote-oakandwave-image.sh` — defaults `GATE_SIGNALS_CMD` to `profiles.py --emit gate-signals` when soak/quarantine ledgers are supplied, so the gate filters on the label end-to-end.
- `docs/contained-workflow/architecture.md` — documents the two-profile ring and the gate/probe filter split.
- `tests/contained-workflow/test_profiles.py` — 14 tests covering label/candidacy/launch-spec/gate-signals.

## Linked Issues
Closes #974

## Test Plan
- `./scripts/ci/validate.sh` → 200 passed, 0 failed
- `pytest tests/contained-workflow/test_profiles.py` → 14 passed
- commutativity_verify (single-target, base kahuna/959-P4W1) → ORACLE_REQUIRED (by-design infra-file signal for the CI-script edit; purely additive diff, oracle HOLD by PRIME reconcile)
- Full `pytest tests/` run in progress at reconcile time.