### PR TITLE
feat(contained-workflow): dogfood cutover + soak accrual + E2E-02 cycle (#975)

### DIFF
--- a/containers/oakandwave-workflow/soak_ledger.py
+++ b/containers/oakandwave-workflow/soak_ledger.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Dogfood soak accrual — Story 4.2 (#975), Plan #959, Dev Spec §4.3 / §5.6 (R-07).
+
+The FlightDeck soak **writer**. Prior waves built everything that *reads* soak —
+the promotion gate's soak condition (``promotion_gate.py``) and the profile-filtered
+roll-up (``profiles.aggregate_gate_signals``) — but nothing *wrote* it. The gate's
+soak condition could therefore never go green from real dogfood work, because no
+code path turned clean dogfood work into soak records. This module is that missing
+writer: it turns a dogfood container's **clean work span** into a soak record and
+appends it to the FlightDeck soak ledger (``~/.oaw/soak/ledger.jsonl``) that the
+gate consumes through the profile filter.
+
+The record shape is exactly what ``profiles.aggregate_gate_signals`` folds:
+``{"event": "soak", "profile": <label>, "hours": <float>, ...}`` — so a record
+written here flows, unchanged, into the ``--soak-hours`` signal
+``promote-oakandwave-image.sh`` feeds the gate. This closes the FlightDeck loop:
+**surgeon watches → clean spans accrue here → gate reads the filtered soak** (§4.3:
+"the flight surgeon watches each container; clean work accrues soak in FlightDeck").
+
+Requirements this module is the writer for:
+
+* **R-07** — soak is one of the four mechanical promotion conditions. This is the
+  only code that produces the soak signal, so "the gate is mechanical" extends to
+  "soak is measured, never asserted": a record is written only for a real, clean,
+  candidate work span.
+* **R-21 / R-22** — accrual filters on the profile label. A **dev-mode** session
+  never accrues soak (:func:`accrue_record` returns ``None`` for it), reusing
+  ``profiles.is_candidate`` as the single source of truth for "what counts" — so
+  the writer and the gate-side filter can never disagree about candidacy.
+
+Design — **soak is earned, never granted** (assertion-liveness, D7):
+
+* A record is emitted **only** for a candidate profile (dev-mode excluded, R-22),
+  **only** for clean work (``broken`` sessions accrue nothing — §4.3 "*clean* work
+  accrues soak"; a stalled/looping/quarantined session's dirty span is not soak),
+  and **only** for a strictly-positive span.
+* Accrual is **watermarked per session**: :func:`accrue` reads the last ``until``
+  already recorded for a session and counts only the *new* clean time since then, so
+  running the accrual pass repeatedly (a cron, a soak loop) can never double-count a
+  span. Idempotent by construction — re-running with no new activity writes nothing.
+* Every exclusion is a *returned reason*, never a silent drop: :func:`accrue`
+  reports what it wrote AND what it skipped and why, so a dogfood session that fails
+  to accrue is visible, not mysteriously stuck at zero soak.
+
+CLI::
+
+    # accrue from an observations manifest (the surgeon's shape + a clean span)
+    python3 soak_ledger.py --observations obs.json --ledger ~/.oaw/soak/ledger.jsonl
+
+Prints a human summary (written / skipped, with reasons) on stderr and the JSON of
+the appended records on stdout; exits 0 normally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# profiles.py is the canonical owner of the profile label + candidacy (R-21/R-22).
+# soak_ledger is a candidate-telemetry writer and CAN import it (unlike the
+# deliberately kit-independent surgeon, R-15) — so "what counts as a candidate" has
+# exactly one definition, shared by the writer here and the gate-side filter.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import profiles as pf  # noqa: E402
+
+# The default FlightDeck soak ledger — the same path profiles.py's CLI documents
+# and promote-oakandwave-image.sh reads via OAW_SOAK_LEDGER. One JSON object/line.
+DEFAULT_LEDGER = "~/.oaw/soak/ledger.jsonl"
+
+SOAK_EVENT = "soak"
+
+
+class SoakError(ValueError):
+    """A soak-accrual contract violation. Raised LOUD, never swallowed."""
+
+
+def parse_ts(value: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp to an aware UTC datetime, or ``None``.
+
+    Tolerates a trailing ``Z`` and naive stamps (assumed UTC). A malformed/absent
+    stamp is ``None`` — never an exception (a soak pass must degrade a bad record,
+    not crash the accrual)."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def clamped_window(
+    active_since: object,
+    active_until: object,
+    *,
+    watermark: datetime | None = None,
+) -> tuple[datetime | None, datetime | None, float]:
+    """The watermark-clamped accrual window: ``(effective_start, end, hours)``.
+
+    The single clamp primitive both :func:`soak_hours` and :func:`accrue_record` use,
+    so the counted hours and the audit ``since`` can never describe different windows.
+    ``effective_start`` is ``max(active_since, watermark)`` — a watermark (the last
+    ``until`` already recorded for this session) makes a re-run count only the *new*
+    time since the prior accrual, never re-counting a recorded span. An unparseable
+    or non-positive span yields ``hours == 0.0`` (nothing to accrue), never negative."""
+    start = parse_ts(active_since)
+    end = parse_ts(active_until)
+    if start is None or end is None:
+        return start, end, 0.0
+    effective_start = watermark if (watermark is not None and watermark > start) else start
+    delta = (end - effective_start).total_seconds()
+    return effective_start, end, (delta / 3600.0 if delta > 0 else 0.0)
+
+
+def soak_hours(
+    active_since: object,
+    active_until: object,
+    *,
+    watermark: datetime | None = None,
+) -> float:
+    """The clean-work hours to accrue for one span, watermark-clamped (see
+    :func:`clamped_window`). A convenience for a caller that wants only the hours."""
+    return clamped_window(active_since, active_until, watermark=watermark)[2]
+
+
+@dataclass(frozen=True)
+class AccrualResult:
+    """One session's accrual outcome: the record written (or ``None``), and why."""
+
+    session: str
+    profile: str
+    record: dict | None
+    reason: str
+
+    @property
+    def accrued(self) -> bool:
+        return self.record is not None
+
+
+def accrue_record(
+    *,
+    session: str,
+    profile: object,
+    active_since: object,
+    active_until: object,
+    watermark: datetime | None = None,
+    broken: bool = False,
+) -> AccrualResult:
+    """Build the soak record for one dogfood session, or explain the exclusion.
+
+    Emits a record **iff** (in this order):
+
+    1. the profile is a **candidate** — dev-mode is excluded (R-22); an
+       unlabeled/unknown profile is a candidate (fail-safe toward measuring, mirrors
+       ``profiles.is_candidate`` and the surgeon's ``quarantine_eligible``);
+    2. the work is **clean** — a ``broken`` (stalled / looping / quarantined) session
+       accrues nothing (§4.3: *clean* work accrues soak); and
+    3. the watermark-clamped span is **strictly positive**.
+
+    Any failing gate returns ``record=None`` with a human ``reason`` — never a silent
+    zero. The record carries ``profile`` + ``hours`` (what the gate reads) plus the
+    ``session`` and ``since``/``until`` bounds (audit + the next pass's watermark)."""
+    prof = pf.normalize_profile(profile)
+    if not pf.is_candidate(profile):
+        return AccrualResult(session, prof, None, f"profile={prof}: dev-mode is non-candidate — no soak (R-22)")
+    if broken:
+        return AccrualResult(session, prof, None, "session is broken/quarantined — clean work only accrues soak (§4.3)")
+    effective_start, end, hours = clamped_window(active_since, active_until, watermark=watermark)
+    if effective_start is None or end is None:
+        return AccrualResult(session, prof, None, "unparseable active span — no soak to accrue")
+    if hours <= 0:
+        wm = f" since watermark {watermark.isoformat()}" if watermark is not None else ""
+        return AccrualResult(session, prof, None, f"no new clean span to accrue{wm}")
+    record = {
+        "event": SOAK_EVENT,
+        "profile": prof,
+        "session": str(session),
+        "since": effective_start.isoformat(),
+        "until": end.isoformat(),
+        "hours": hours,
+    }
+    return AccrualResult(session, prof, record, f"accrued {hours:g}h of clean {prof} soak")
+
+
+def read_ledger(path: object) -> list[dict]:
+    """Read the soak ``.jsonl`` ledger into a list of records. Missing ⇒ ``[]``;
+    blank and malformed lines are skipped (a partially-written tail must not crash
+    the accrual)."""
+    p = Path(str(path)).expanduser()
+    if not p.is_file():
+        return []
+    out: list[dict] = []
+    with p.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                out.append(obj)
+    return out
+
+
+def session_watermarks(records: list[dict]) -> dict[str, datetime]:
+    """The latest recorded ``until`` per session across existing soak records.
+
+    This is the per-session watermark the next accrual clamps against, so a repeated
+    pass counts only new clean time. Only ``event == "soak"`` records with a
+    parseable ``until`` contribute; anything else is ignored."""
+    marks: dict[str, datetime] = {}
+    for r in records:
+        if str(r.get("event", SOAK_EVENT)) != SOAK_EVENT:
+            continue
+        session = r.get("session")
+        until = parse_ts(r.get("until"))
+        if not isinstance(session, str) or until is None:
+            continue
+        if session not in marks or until > marks[session]:
+            marks[session] = until
+    return marks
+
+
+def append_record(path: object, record: dict) -> None:
+    """Append one soak record as a JSON line, creating the ledger + parents if
+    absent. The ledger is host-backed (durable) so soak survives a container
+    ``docker rm`` — the stateless-container invariant (R-01) applies to soak too."""
+    p = Path(str(path)).expanduser()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n")
+
+
+def aggregate_or_zero(ledger_path: object = DEFAULT_LEDGER) -> float:
+    """The current candidate soak total (hours) in the ledger, or ``0.0`` if empty.
+
+    Reads the ledger back through the **same profile filter the gate uses**
+    (``profiles.aggregate_gate_signals``), so "how much soak have we accrued" answers
+    with exactly the number the promotion gate will see — dev-mode already excluded
+    (R-22). A convenience for the cutover/operator and the soak loop's progress check;
+    the gate itself sources this through ``promote-oakandwave-image.sh``'s
+    ``OAW_SOAK_LEDGER`` seam, not this helper."""
+    signals = pf.aggregate_gate_signals(
+        soak_records=read_ledger(ledger_path), quarantine_records=[]
+    )
+    return float(signals["soak_hours"])
+
+
+def accrue(
+    *,
+    observations: list[dict],
+    ledger_path: object = DEFAULT_LEDGER,
+    now: datetime | None = None,
+) -> list[AccrualResult]:
+    """Accrue soak for a batch of dogfood session observations (the top-level pass).
+
+    Each observation: ``session``, ``profile``, ``active_since`` and an
+    ``active_until`` (defaulting to ``now`` for a still-running session), and an
+    optional ``broken`` flag (a surgeon verdict). Reads the existing ledger once for
+    per-session watermarks, builds each session's record (skipping dev-mode, broken,
+    and empty spans with a reason), and appends the survivors. Returns every
+    :class:`AccrualResult` — written and skipped alike — so nothing is a silent drop.
+    """
+    now = now or datetime.now(timezone.utc)
+    watermarks = session_watermarks(read_ledger(ledger_path))
+    results: list[AccrualResult] = []
+    for obs in observations:
+        if not isinstance(obs, dict):
+            raise SoakError(f"observation must be an object, got {type(obs).__name__}")
+        session = str(obs.get("session", obs.get("container_id", obs.get("id", "?"))))
+        result = accrue_record(
+            session=session,
+            profile=obs.get("profile"),
+            active_since=obs.get("active_since"),
+            active_until=obs.get("active_until", now),
+            watermark=watermarks.get(session),
+            broken=bool(obs.get("broken", False)),
+        )
+        if result.record is not None:
+            append_record(ledger_path, result.record)
+        results.append(result)
+    return results
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def _load_observations(path: str) -> list[dict]:
+    text = sys.stdin.read() if path == "-" else Path(path).expanduser().read_text()
+    data = json.loads(text)
+    if isinstance(data, dict) and isinstance(data.get("observations"), list):
+        data = data["observations"]
+    if not isinstance(data, list):
+        raise SoakError("observations must be a JSON list (or {observations: [...]})")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--observations",
+        metavar="FILE",
+        required=True,
+        help="JSON manifest of dogfood session observations ('-' for stdin)",
+    )
+    parser.add_argument(
+        "--ledger",
+        default=DEFAULT_LEDGER,
+        help=f"soak .jsonl ledger to append to (default {DEFAULT_LEDGER})",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        observations = _load_observations(args.observations)
+        results = accrue(observations=observations, ledger_path=args.ledger)
+    except (SoakError, OSError, json.JSONDecodeError) as exc:
+        print(f"soak-accrual error: {exc}", file=sys.stderr)
+        return 2
+
+    written = [r for r in results if r.accrued]
+    total = sum(r.record["hours"] for r in written)  # type: ignore[index]
+    print("soak accrual:", file=sys.stderr)
+    for r in results:
+        mark = "SOAK" if r.accrued else "skip"
+        print(f"  [{mark}] {r.session} ({r.profile}) — {r.reason}", file=sys.stderr)
+    print(
+        f"  => {len(written)} record(s) written to {args.ledger}, {total:g}h candidate soak accrued",
+        file=sys.stderr,
+    )
+    print(json.dumps([r.record for r in written], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/dogfood-cutover.sh
+++ b/scripts/ci/dogfood-cutover.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# dogfood-cutover.sh — cut the OaW dev team onto :edge in the dogfood profile with
+# the flight surgeon watching (Story 4.2 / #975, Dev Spec §4.3, R-21/R-22/R-07).
+#
+# This is the mechanical entrypoint for the dogfood cutover (§4.3): launch each
+# target workspace as a dogfood-profile container on :edge, and start the flight
+# surgeon watching them so clean work accrues soak (soak_ledger.py) and a broken
+# candidate is caught (surgeon.py). The three pieces it composes are already
+# unit-proven; this wrapper only *plans* and — under an explicit operator apply —
+# *applies* the launches.
+#
+# The DECISIONS live in tested modules, never in this shell (project rule):
+#   * the dogfood launch args (the oaw.profile=dogfood label, overlay OFF)  —
+#     containers/oakandwave-workflow/profiles.py --emit launch --profile dogfood
+#   * the health verdict the surgeon acts on                                —
+#     scripts/flight-surgeon/surgeon.py
+#   * clean-span → soak record                                              —
+#     containers/oakandwave-workflow/soak_ledger.py
+#
+# SAFETY — plan-by-default (this cuts LIVE fleet agents onto a candidate image, so
+# it must never launch anything as a side effect of being run):
+#   The script DEFAULTS TO A DRY-RUN PLAN — it prints the exact `aoe add` line per
+#   workspace and the surgeon watch command, and launches NOTHING. Real launches
+#   happen ONLY when DOGFOOD_CUTOVER_APPLY=true AND aoe/docker are present — the
+#   operator's deliberate, per-cutover go (mirrors PROMOTE_DRY_RUN / ADOPT_DRY_RUN
+#   in the sibling wrappers). A red config (missing image, no workspaces) fails
+#   loud; it never silently no-ops into a false "cutover done".
+#
+# Inputs (env):
+#   EDGE_REF            the candidate image the dogfood ring runs (default
+#                       ghcr.io/wave-engineering/oakandwave-workflow:edge).
+#   CUTOVER_WORKSPACES  whitespace/newline-separated workspace paths to cut over
+#                       (required — the OaW dev team's working trees).
+#   OAW_MAJOR           the kit major for the dogfood profile's <major> mounts
+#                       (default 1).
+#   SOAK_LEDGER         the FlightDeck soak ledger the surgeon/accrual write
+#                       (default ~/.oaw/soak/ledger.jsonl) — the gate reads this.
+#   SURGEON_TRANSCRIPTS_ROOT  root the surgeon resolves host-backed transcripts
+#                       under (default ~/.claude/projects).
+#   DOGFOOD_CUTOVER_APPLY  "true" ⇒ actually launch (operator go); default false ⇒
+#                       plan only, launch nothing.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+PROFILES_PY="$REPO_DIR/containers/oakandwave-workflow/profiles.py"
+SURGEON_PY="$REPO_DIR/scripts/flight-surgeon/surgeon.py"
+
+EDGE_REF="${EDGE_REF:-ghcr.io/wave-engineering/oakandwave-workflow:edge}"
+OAW_MAJOR="${OAW_MAJOR:-1}"
+SOAK_LEDGER="${SOAK_LEDGER:-$HOME/.oaw/soak/ledger.jsonl}"
+SURGEON_TRANSCRIPTS_ROOT="${SURGEON_TRANSCRIPTS_ROOT:-$HOME/.claude/projects}"
+APPLY="${DOGFOOD_CUTOVER_APPLY:-false}"
+
+# --- Fail-closed on a red config ----------------------------------------------
+: "${CUTOVER_WORKSPACES:?CUTOVER_WORKSPACES must list the OaW workspace paths to cut over}"
+
+# The dogfood launch args (label + overlay-OFF) from the tested profile module —
+# NEVER hand-spelled here, so "dogfood is image-only" stays a property of profiles.py.
+dogfood_args="$(python3 "$PROFILES_PY" --emit launch --profile dogfood --major "$OAW_MAJOR")"
+
+echo "==> dogfood cutover onto $EDGE_REF (major $OAW_MAJOR)"
+echo "    dogfood launch args (from profiles.py): $dogfood_args"
+
+# --- Plan the per-workspace launches ------------------------------------------
+# Each workspace becomes one dogfood-profile sandbox on :edge. `aoe add --sandbox`
+# is the one-container-per-session seam (TC-1); the profile args stamp
+# oaw.profile=dogfood so the surgeon and the gate both filter on it (R-22).
+launched=0
+for ws in $CUTOVER_WORKSPACES; do
+	launch_cmd=(aoe add --sandbox --sandbox-image "$EDGE_REF")
+	# shellcheck disable=SC2206 # intentional word-split: profiles.py emits shell args
+	launch_cmd+=($dogfood_args "$ws")
+	echo "==> [$ws] ${launch_cmd[*]}"
+	if [[ "$APPLY" == "true" ]]; then
+		command -v aoe >/dev/null 2>&1 || {
+			echo "  [!] DOGFOOD_CUTOVER_APPLY=true but aoe not on PATH — cannot launch" >&2
+			exit 1
+		}
+		"${launch_cmd[@]}"
+		launched=$((launched + 1))
+	fi
+done
+
+# --- Start the surgeon watching the dogfood ring ------------------------------
+# The surgeon reads each :edge container's host-backed transcript (fate-independent,
+# R-15), filters on the profile label (dev-mode excluded, R-22), and fails non-zero
+# on a quarantine-eligible break so a cron/watcher can trigger quarantine.
+surgeon_cmd=(
+	python3 "$SURGEON_PY" --live
+	--transcripts-root "$SURGEON_TRANSCRIPTS_ROOT"
+	--fail-on-quarantine
+)
+echo "==> flight surgeon watch command: ${surgeon_cmd[*]}"
+echo "    soak ledger (clean work accrues here; the gate reads it): $SOAK_LEDGER"
+
+if [[ "$APPLY" != "true" ]]; then
+	echo "==> [plan] DOGFOOD_CUTOVER_APPLY!=true — planned $(echo "$CUTOVER_WORKSPACES" | wc -w) launch(es), launched 0, started no surgeon."
+	echo "    Re-run with DOGFOOD_CUTOVER_APPLY=true (operator go) to cut over for real."
+	exit 0
+fi
+
+echo "==> apply: launched $launched dogfood container(s); starting the surgeon watch"
+exec "${surgeon_cmd[@]}"

--- a/tests/contained-workflow/test_promotion_cycle.py
+++ b/tests/contained-workflow/test_promotion_cycle.py
@@ -1,0 +1,305 @@
+"""Oracle for Story 4.2 (#975) — dogfood cutover + soak → the E2E-02 promotion cycle.
+
+E2E-02 (Dev Spec §6.3): *soak → mechanical gate green → retag the tested digest
+:edge → :stable → rolling per-agent adoption* `[R-07, R-08]`. The authoritative
+end-to-end proof needs a real registry retag + live containers, so — exactly like
+test_throwaway_ci_ring.py (E2E-01) — the whole cycle against a live digest is a
+skip-gated branch (:func:`test_full_lifecycle_against_live_registry`). What runs
+in the stock ``pytest tests/`` lane is the **full lifecycle exercised hermetically**
+by composing the real, unit-proven modules of every prior wave into one chain:
+
+    soak_ledger.accrue            (Story 4.2 — the FlightDeck soak WRITER, new here)
+      → profiles.aggregate_gate_signals   (Story 4.1 — the profile filter, R-22)
+      → promotion_gate.evaluate_gate/promote  (Story 2.3 — mechanical gate, R-07)
+      → adoption.decide_adoption / plan_recreate  (Story 2.4 — rolling adopt, R-08)
+
+The story's two acceptance criteria, both proved below:
+
+* **AC1 [R-21]** — the OaW team works on :edge in the dogfood profile with the
+  surgeon active. Proved by :func:`test_cutover_plans_dogfood_ring_and_surgeon`
+  (the cutover script stamps oaw.profile=dogfood and wires the surgeon) and by the
+  soak-accrual filter proving dev-mode never accrues (:func:`test_soak_excludes_dev_mode`).
+* **AC2 [R-07, R-08]** — soak telemetry accrues in FlightDeck AND a promotion cycle
+  completes end-to-end. Proved by :func:`test_full_promotion_cycle_end_to_end`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_DIR = REPO_ROOT / "containers" / "oakandwave-workflow"
+CUTOVER_SCRIPT = REPO_ROOT / "scripts" / "ci" / "dogfood-cutover.sh"
+
+# Path-style import (no PYTHONPATH dependency), mirroring test_profiles.py.
+sys.path.insert(0, str(CONTAINER_DIR))
+import adoption as ad  # noqa: E402
+import profiles as pf  # noqa: E402
+import promotion_gate as pg  # noqa: E402
+import soak_ledger as sl  # noqa: E402
+
+# A stable content-addressed digest to promote through the whole cycle (R-23: the
+# digest tested is the digest promoted is the digest the fleet adopts).
+DIGEST = "ghcr.io/wave-engineering/oakandwave-workflow@sha256:" + "a" * 64
+
+
+def _obs(session, profile, hours, *, broken=False, start=None):
+    """A dogfood session observation: a clean `hours`-long span ending `start`+hours."""
+    start = start or datetime(2026, 7, 22, tzinfo=timezone.utc)
+    return {
+        "session": session,
+        "profile": profile,
+        "active_since": start.isoformat(),
+        "active_until": (start + timedelta(hours=hours)).isoformat(),
+        "broken": broken,
+    }
+
+
+# --- AC2 [R-07, R-08] — the full promotion cycle, end to end ------------------
+
+
+def test_full_promotion_cycle_end_to_end(tmp_path):
+    """soak accrues → gate green → retag :edge→:stable → rolling adoption (E2E-02).
+
+    Every stage is the REAL module; the chain is the story's whole point — the pieces
+    each prior wave unit-proved actually compose into a promotion cycle.
+    """
+    ledger = tmp_path / "soak" / "ledger.jsonl"
+
+    # 1. SOAK ACCRUES (the new FlightDeck writer). Two clean dogfood sessions total
+    #    30h; a dev-mode session and a broken dogfood session are BOTH excluded.
+    results = sl.accrue(
+        observations=[
+            _obs("agent-a", "dogfood", 20),
+            _obs("agent-b", "dogfood", 10),
+            _obs("agent-c", "dev-mode", 500),  # non-candidate — must not accrue (R-22)
+            _obs("agent-d", "dogfood", 99, broken=True),  # dirty — must not accrue (§4.3)
+        ],
+        ledger_path=ledger,
+    )
+    written = {r.session for r in results if r.accrued}
+    assert written == {"agent-a", "agent-b"}, "only clean dogfood work accrues soak"
+
+    # 2. THE PROFILE FILTER folds the FlightDeck ledger into the gate's soak signal —
+    #    the gate reads exactly what soak_ledger wrote (30h), dev-mode already gone.
+    signals = pf.aggregate_gate_signals(
+        soak_records=sl.read_ledger(ledger),
+        quarantine_records=[],
+    )
+    assert signals["soak_hours"] == 30
+    assert signals["quarantine_count"] == 0
+
+    # 3. THE MECHANICAL GATE goes green on the real signals and promotes the EXACT
+    #    tested digest — no rebuild, and the ACK only confirms an already-green gate.
+    report = pg.evaluate_gate(
+        target_digest=DIGEST,
+        ci_passed=True,
+        ci_digest=DIGEST,
+        soak_hours=signals["soak_hours"],
+        soak_required_hours=24.0,
+        quarantine_count=signals["quarantine_count"],
+        open_sev1_count=0,
+    )
+    assert report.green, report.summary()
+    promoted = pg.promote(report, operator_ack=True)
+    assert promoted == DIGEST, "the digest promoted is the digest soak+CI tested (R-23)"
+
+    # 4. ROLLING ADOPTION. :stable now points at the promoted digest (version 1.5.0);
+    #    a fleet agent on 1.4.0 adopts it at ITS OWN container-recreate — the launch
+    #    ref is the promoted digest, closing the tested→promoted→adopted chain.
+    plan = ad.plan_recreate(
+        current_ref="ghcr.io/wave-engineering/oakandwave-workflow@sha256:" + "b" * 64,
+        current_version="1.4.0",
+        target_ref=promoted,
+        target_version="1.5.0",
+    )
+    assert plan.action == ad.ADOPT
+    assert plan.launch_ref == promoted, "the agent adopts the exact promoted digest"
+
+
+def test_gate_red_when_soak_unmet_blocks_the_cycle(tmp_path):
+    """Under-soaked dogfood work cannot promote — even with the operator ACK (R-07).
+
+    The 4.2-lens red-first assertion: if the accrued soak is below the requirement,
+    the mechanical gate is RED and promotion refuses; the ACK never substitutes.
+    """
+    ledger = tmp_path / "ledger.jsonl"
+    sl.accrue(observations=[_obs("agent-a", "dogfood", 5)], ledger_path=ledger)  # 5h << 24h
+    signals = pf.aggregate_gate_signals(soak_records=sl.read_ledger(ledger), quarantine_records=[])
+
+    report = pg.evaluate_gate(
+        target_digest=DIGEST,
+        ci_passed=True,
+        ci_digest=DIGEST,
+        soak_hours=signals["soak_hours"],
+        soak_required_hours=24.0,
+        quarantine_count=0,
+        open_sev1_count=0,
+    )
+    assert not report.green
+    with pytest.raises(pg.GateError):
+        pg.promote(report, operator_ack=True)  # ACK cannot rescue a red soak condition
+
+
+# --- Soak accrual (the new FlightDeck writer) — R-21/R-22 + §4.3 --------------
+
+
+def test_soak_excludes_dev_mode(tmp_path):
+    """A dev-mode session accrues NO soak record (R-22) — its span never reaches the
+    ledger the gate reads, so a dev-mode session can never inflate soak."""
+    ledger = tmp_path / "ledger.jsonl"
+    results = sl.accrue(observations=[_obs("dev", "dev-mode", 100)], ledger_path=ledger)
+    assert not any(r.accrued for r in results)
+    assert not ledger.exists() or sl.read_ledger(ledger) == []
+    assert "dev-mode is non-candidate" in results[0].reason
+
+
+def test_soak_excludes_broken_session(tmp_path):
+    """A broken/quarantined dogfood session accrues nothing — *clean* work only
+    accrues soak (§4.3). The dirty span is not soak."""
+    ledger = tmp_path / "ledger.jsonl"
+    results = sl.accrue(
+        observations=[_obs("stalled", "dogfood", 30, broken=True)], ledger_path=ledger
+    )
+    assert not any(r.accrued for r in results)
+    assert "broken/quarantined" in results[0].reason
+
+
+def test_unlabeled_session_accrues_as_candidate(tmp_path):
+    """An unlabeled/unknown-profile session accrues (candidate by default) — fail-safe
+    toward measuring, mirroring profiles.is_candidate and the surgeon's eligibility."""
+    ledger = tmp_path / "ledger.jsonl"
+    results = sl.accrue(observations=[_obs("mystery", "somethingelse", 12)], ledger_path=ledger)
+    assert results[0].accrued
+    assert sl.aggregate_or_zero(ledger) == 12
+
+
+def test_soak_accrual_is_watermarked_idempotent(tmp_path):
+    """Re-running the accrual pass over the SAME span writes nothing the second time,
+    and a later span accrues only the new delta — no double-counting."""
+    ledger = tmp_path / "ledger.jsonl"
+    start = datetime(2026, 7, 22, tzinfo=timezone.utc)
+
+    first = sl.accrue(observations=[_obs("a", "dogfood", 10, start=start)], ledger_path=ledger)
+    assert first[0].accrued and sl.aggregate_or_zero(ledger) == 10
+
+    # Same span again → the watermark (until = start+10h) suppresses a duplicate.
+    again = sl.accrue(observations=[_obs("a", "dogfood", 10, start=start)], ledger_path=ledger)
+    assert not again[0].accrued
+    assert sl.aggregate_or_zero(ledger) == 10, "re-accruing the same span must not double-count"
+
+    # A later window (start → start+15h) accrues only the NEW 5h beyond the watermark.
+    later = {
+        "session": "a",
+        "profile": "dogfood",
+        "active_since": start.isoformat(),
+        "active_until": (start + timedelta(hours=15)).isoformat(),
+    }
+    grew = sl.accrue(observations=[later], ledger_path=ledger)
+    assert grew[0].accrued
+    assert grew[0].record["hours"] == pytest.approx(5.0)
+    assert sl.aggregate_or_zero(ledger) == pytest.approx(15.0)
+
+
+def test_soak_record_shape_matches_gate_reader(tmp_path):
+    """A written soak record is exactly what profiles._soak_hours_of reads — the
+    writer and the gate-side reader agree on the record contract by construction."""
+    ledger = tmp_path / "ledger.jsonl"
+    sl.accrue(observations=[_obs("a", "dogfood", 7)], ledger_path=ledger)
+    (record,) = sl.read_ledger(ledger)
+    assert record["event"] == "soak"
+    assert record["profile"] == "dogfood"
+    assert record["hours"] == 7
+    # The exact function the gate uses to read a soak record must agree.
+    assert pf._soak_hours_of(record) == 7
+
+
+# --- AC1 [R-21] — the cutover: dogfood ring + surgeon, plan-by-default --------
+
+
+def _run_cutover(env_overrides):
+    env = dict(os.environ)
+    for k in ("CUTOVER_WORKSPACES", "DOGFOOD_CUTOVER_APPLY", "EDGE_REF", "OAW_MAJOR"):
+        env.pop(k, None)
+    env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(CUTOVER_SCRIPT)], capture_output=True, text=True, env=env, timeout=60
+    )
+
+
+def test_cutover_script_is_executable():
+    """The cutover is invoked directly (./scripts/ci/dogfood-cutover.sh), so +x."""
+    assert CUTOVER_SCRIPT.exists(), f"cutover script missing: {CUTOVER_SCRIPT}"
+    assert os.access(CUTOVER_SCRIPT, os.X_OK), "cutover script must be executable"
+
+
+def test_cutover_plans_dogfood_ring_and_surgeon(tmp_path):
+    """Plan mode stamps oaw.profile=dogfood, wires the surgeon, and launches NOTHING.
+
+    AC1: the OaW team works on :edge in the dogfood profile with the surgeon active.
+    Plan-by-default proves the composition (dogfood label + surgeon watch) with no
+    aoe/docker — a real cutover is the operator's explicit DOGFOOD_CUTOVER_APPLY go.
+    """
+    proc = _run_cutover(
+        {
+            "CUTOVER_WORKSPACES": "/work/agent-a /work/agent-b",
+            "EDGE_REF": "ghcr.io/wave-engineering/oakandwave-workflow:edge",
+        }
+    )
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    # dogfood profile label (from profiles.py, not hand-spelled) — R-21.
+    assert "oaw.profile=dogfood" in out, "cutover must stamp the dogfood profile label"
+    # the surgeon is wired to watch, filtering on the label + failing on quarantine.
+    assert "surgeon.py" in out and "--fail-on-quarantine" in out
+    # :edge, per-workspace launches planned…
+    assert out.count("aoe add --sandbox") >= 2, "one dogfood sandbox planned per workspace"
+    # …but NOTHING launched (plan-by-default — this cuts LIVE fleet agents over).
+    assert "launched 0" in out and "plan" in out.lower()
+
+
+def test_cutover_fails_closed_without_workspaces():
+    """No CUTOVER_WORKSPACES ⇒ fail loud, never a silent no-op 'cutover done'."""
+    proc = _run_cutover({})
+    assert proc.returncode != 0
+    assert "CUTOVER_WORKSPACES" in (proc.stdout + proc.stderr)
+
+
+# --- Real-registry branch (skip-gated, mirrors test_throwaway_ci_ring.py) -----
+
+
+def test_full_lifecycle_against_live_registry():
+    """Run the whole promotion cycle against a real signed digest when provided.
+
+    Set OAKANDWAVE_CYCLE_DIGEST to a pushed+signed :edge digest (and be logged in to
+    ghcr) to exercise E2E-02 for real: promote (retag :edge→:stable) + adopt. Absent
+    that, this skips — the stock lane has no registry artifact to retag.
+    """
+    digest = os.environ.get("OAKANDWAVE_CYCLE_DIGEST")
+    if not digest:
+        pytest.skip("set OAKANDWAVE_CYCLE_DIGEST to a live signed :edge digest to run E2E-02")
+
+    promote = REPO_ROOT / "scripts" / "ci" / "promote-oakandwave-image.sh"
+    env = dict(os.environ)
+    env.update(
+        DIGEST_REF=digest,
+        THROWAWAY_CI_PASSED="true",
+        SOAK_HOURS="48",
+        SOAK_REQUIRED_HOURS="24",
+        QUARANTINE_COUNT="0",
+        OPEN_SEV1_COUNT="0",
+        OPERATOR_ACK="true",
+        PROMOTE_DRY_RUN="true",  # evaluate the gate + print the retag; do not push
+    )
+    proc = subprocess.run(
+        ["bash", str(promote)], capture_output=True, text=True, env=env, timeout=120
+    )
+    assert proc.returncode == 0, f"promotion cycle failed:\n{proc.stdout}\n{proc.stderr}"
+    assert digest in (proc.stdout + proc.stderr)


### PR DESCRIPTION
## Summary
Wave P4W2 flight integration for issue #975 into the `kahuna/959-P4W2` sandbox. Adds the FlightDeck soak **writer** (`soak_ledger.py`) that closes the promotion loop — clean dogfood work spans now accrue soak that the mechanical promotion gate reads through the profile filter — plus the dogfood-cutover CI script and the E2E-02 promotion-cycle test.

## Changes
- `containers/oakandwave-workflow/soak_ledger.py` — soak accrual writer (R-07, R-21/R-22); watermarked per session (idempotent), candidate-profile only (dev-mode excluded), clean-span only.
- `scripts/ci/dogfood-cutover.sh` — dogfood cutover script.
- `tests/contained-workflow/test_promotion_cycle.py` — E2E-02 promotion-cycle coverage.

## Linked Issues
Closes #975

## Test Plan
- `commutativity_verify` single-target (base `kahuna/959-P4W2`): STRONG.
- `./scripts/ci/validate.sh`: 202 passed, 0 failed.
- `./scripts/ci/test.sh` (full pytest): 1861 passed, 6 skipped, 64 xfailed, 2 xpassed, 0 failed.
- Interface deps (`profiles.is_candidate` / `aggregate_gate_signals`, `adoption`, `promotion_gate`) confirmed present in base — no interface break.