### PR TITLE
fix(ci): move SBOM attestation off public rekor to an RFC3161 TSA

### DIFF
--- a/.github/workflows/oakandwave-workflow-image.yml
+++ b/.github/workflows/oakandwave-workflow-image.yml
@@ -57,6 +57,13 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
+        with:
+          # Pinned to cosign v2.x: the SBOM attestation skips the public rekor
+          # tlog (its predicate exceeds rekor's body ceiling for this ~10 GB
+          # image, failing every run — #995) and uses an RFC3161 TSA instead.
+          # cosign v3 dropped the --tlog-upload lever for the declarative
+          # signing-config model; migrating to that is a follow-up.
+          cosign-release: 'v2.6.4'
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0
@@ -96,6 +103,13 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
+        with:
+          # Pinned to cosign v2.x: the SBOM attestation skips the public rekor
+          # tlog (its predicate exceeds rekor's body ceiling for this ~10 GB
+          # image, failing every run — #995) and uses an RFC3161 TSA instead.
+          # cosign v3 dropped the --tlog-upload lever for the declarative
+          # signing-config model; migrating to that is a follow-up.
+          cosign-release: 'v2.6.4'
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/scripts/ci/sign-oakandwave-image.sh
+++ b/scripts/ci/sign-oakandwave-image.sh
@@ -7,15 +7,22 @@
 # verifies (Story 2.2, E2E-01) attest the exact bytes that were built and will be
 # promoted (R-23).
 #
-# Keyless (Fulcio/Rekor) signing: no long-lived key material. In GitHub Actions
-# this consumes the workflow's OIDC token (permissions: id-token: write). cosign
-# and syft are installed by the workflow via their `uses:` installer actions; this
-# script only orchestrates them, keeping the CI/CD YAML free of procedural logic.
+# Keyless (Fulcio) signing: no long-lived key material. In GitHub Actions this
+# consumes the workflow's OIDC token (permissions: id-token: write). The image
+# SIGNATURE goes to the public rekor tlog (small, publicly auditable); the syft
+# SBOM ATTESTATION is bound to an RFC3161 TSA timestamp and kept OFF the public
+# tlog (its predicate exceeds rekor's body limit for a ~10 GB image — #995).
+# cosign and syft are installed by the workflow via their `uses:` installer
+# actions (cosign pinned to v2.x — see the workflow — because v3 dropped the
+# --tlog-upload lever); this script only orchestrates them, keeping the CI/CD
+# YAML free of procedural logic.
 #
 # Inputs (env):
-#   DIGEST_REF   the immutable pin `registry/image@sha256:…` to sign + SBOM
-#                (required; build-oakandwave-image.sh emits it as `digest_ref=`).
-#   COSIGN_YES   passed through as `cosign --yes` (default: true — non-interactive CI).
+#   DIGEST_REF       the immutable pin `registry/image@sha256:…` to sign + SBOM
+#                    (required; build-oakandwave-image.sh emits it as `digest_ref=`).
+#   COSIGN_YES       passed through as `cosign --yes` (default: true — non-interactive CI).
+#   TSA_SERVER_URL   RFC3161 TSA endpoint for the SBOM attestation timestamp
+#                    (default: https://timestamp.sigstore.dev/api/v1/timestamp).
 
 set -euo pipefail
 
@@ -48,10 +55,21 @@ trap 'rm -f "$sbom_file"' EXIT
 echo "==> syft SBOM (spdx-json) for $DIGEST_REF"
 syft "$DIGEST_REF" -o spdx-json="$sbom_file"
 
-echo "==> cosign attest SBOM -> $DIGEST_REF"
+# The SBOM predicate for this ~10 GB image exceeds rekor.sigstore.dev's request
+# body ceiling, so uploading it to the PUBLIC transparency log fails on every run
+# (#995 — the image workflow had never gone green). R-24 requires the SBOM be
+# attached to the digest and verifiable by the ring — NOT that it live in the
+# public tlog — so skip rekor (--tlog-upload=false) and bind a trusted RFC3161
+# timestamp from Sigstore's public TSA instead. The signature above stays in
+# rekor (small, publicly transparent); only the bulky SBOM attestation moves off
+# it. The ring's verify-attestation matches: --insecure-ignore-tlog +
+# --use-signed-timestamps against the TSA cert chain.
+echo "==> cosign attest SBOM -> $DIGEST_REF (TSA-timestamped, off the public rekor tlog)"
 cosign attest "${cosign_yes[@]}" \
 	--predicate "$sbom_file" \
 	--type spdxjson \
+	--tlog-upload=false \
+	--timestamp-server-url="${TSA_SERVER_URL:-https://timestamp.sigstore.dev/api/v1/timestamp}" \
 	"$DIGEST_REF"
 
-echo "==> signature + SBOM attached to $DIGEST_REF"
+echo "==> signature (rekor) + SBOM (TSA) attached to $DIGEST_REF"

--- a/scripts/ci/throwaway-ci-ring.sh
+++ b/scripts/ci/throwaway-ci-ring.sh
@@ -63,7 +63,7 @@ oidc_issuer="${COSIGN_OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
 smoke_suite="${SMOKE_SUITE:-$REPO_DIR/tests/contained-workflow/test_image.py}"
 
 # --- Required tooling ---------------------------------------------------------
-for tool in docker cosign python3; do
+for tool in docker cosign python3 curl; do
 	command -v "$tool" >/dev/null 2>&1 || {
 		echo "  [!] $tool not found on PATH — the ring needs it" >&2
 		exit 1
@@ -89,12 +89,25 @@ cosign verify \
 	"$DIGEST_REF" >/dev/null
 
 # --- 2. syft SBOM (R-24) — SPDX attestation bound to the digest ---------------
-echo "[ring] verify-sbom (cosign attestation, spdxjson)"
+# The attestation is TSA-timestamped and deliberately NOT in the public rekor
+# tlog: the SBOM predicate for this ~10 GB image exceeds rekor's body limit, so
+# the producer skips it (#995). Verify the RFC3161 timestamp against Sigstore's
+# public TSA cert chain (fetched below) and skip the tlog check; the identity
+# binding (cert-identity + OIDC issuer) is unchanged, so this is still an
+# identity-bound verification, just timestamp-anchored instead of tlog-anchored.
+echo "[ring] verify-sbom (cosign attestation, spdxjson — TSA-timestamped)"
+tsa_certchain_url="${TSA_CERTCHAIN_URL:-https://timestamp.sigstore.dev/api/v1/timestamp/certchain}"
+tsa_chain="$(mktemp -t sigstore-tsa-chain.XXXXXX.pem)"
+curl -fsSL "$tsa_certchain_url" -o "$tsa_chain"
 cosign verify-attestation \
 	--type spdxjson \
 	--certificate-identity-regexp "$cert_identity_regexp" \
 	--certificate-oidc-issuer "$oidc_issuer" \
+	--insecure-ignore-tlog=true \
+	--use-signed-timestamps=true \
+	--timestamp-certificate-chain "$tsa_chain" \
 	"$DIGEST_REF" >/dev/null
+rm -f "$tsa_chain"
 
 # --- 3. registry permissions + install-from-zero (R-24) -----------------------
 # A successful pull from a clean local store proves the candidate is

--- a/tests/contained-workflow/test_throwaway_ci_ring.py
+++ b/tests/contained-workflow/test_throwaway_ci_ring.py
@@ -185,7 +185,7 @@ def test_ring_against_live_digest() -> None:
     digest = os.environ.get("OAKANDWAVE_RING_DIGEST")
     if not digest:
         pytest.skip("set OAKANDWAVE_RING_DIGEST to a live signed digest to run E2E-01")
-    for tool in ("docker", "cosign", "python3"):
+    for tool in ("docker", "cosign", "python3", "curl"):
         if shutil.which(tool) is None:
             pytest.fail(f"OAKANDWAVE_RING_DIGEST set but {tool} not on PATH")
 


### PR DESCRIPTION
## Summary

The `oakandwave-workflow image` workflow has **never passed** — 10+ consecutive failures on `main`. `cosign attest` of the syft SBOM for the ~10 GB image exceeds `rekor.sigstore.dev`'s request-body ceiling and fails on every run (the small image signature succeeds). Because `build` fails, the `smoke` job — the post-merge `test_image.py` verification — has been silently skipped every time.

R-24 requires the SBOM be **attached to the digest and verified by the throwaway-CI ring**, not that it live in the public transparency log. So the SBOM attestation moves off the public rekor tlog onto a trusted RFC3161 timestamp. (BJ approved dropping public tlog transparency for the SBOM specifically.)

## Changes

- **`.github/workflows/oakandwave-workflow-image.yml`** — pin cosign to **v2.6.4** in both `sigstore/cosign-installer@v3` steps. cosign v3 dropped the `--tlog-upload` lever for a declarative signing-config model; the v2 flow is documented and testable. Migrating to the v3 signing-config is a follow-up.
- **`scripts/ci/sign-oakandwave-image.sh`** — SBOM `cosign attest` now uses `--tlog-upload=false --timestamp-server-url=<Sigstore public TSA>`: skips the oversized rekor upload, binds a trusted timestamp. The image **signature** is unchanged (still on rekor, publicly auditable).
- **`scripts/ci/throwaway-ci-ring.sh`** — `verify-attestation` verifies with `--insecure-ignore-tlog --use-signed-timestamps` against the fetched Sigstore TSA cert chain; `curl` added to required tools. Identity binding unchanged on both verify calls.
- **`tests/contained-workflow/test_throwaway_ci_ring.py`** — the real-run tool precheck includes `curl`.

## Linked Issues

Closes #995

## Test Plan

- shellcheck + shfmt clean; TSA endpoint + certchain URL reachable (returns PEM).
- Affected tests (`test_throwaway_ci_ring`, `test_provenance`) 15 passed / 1 skipped; `validate.sh` 204/0; full pytest 1880 passed, exit 0.
- code-review: no critical/important; verified per-artifact sign/verify symmetry, exact v2.6.4 flag spellings, boolean `=` form, predicate-type match.
- **Keyless flow can't be tested locally** (needs GitHub OIDC) — proven by the post-merge `oakandwave-workflow image` run on `main` (build → sign → SBOM-attest → ring verify). Main's image workflow is already red on every commit, so this can only fix it or leave it as-is. If red post-merge, fix-forward.