### PR TITLE
fix(config): use a ~/-relative wtf-server hook path in settings.template.json

### DIFF
--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/bakerb/.local/share/wtf-server/hooks/wtf-post-tool-use.sh"
+            "command": "~/.local/share/wtf-server/hooks/wtf-post-tool-use.sh"
           }
         ]
       },

--- a/tests/test_settings_template_no_hardcoded_paths.py
+++ b/tests/test_settings_template_no_hardcoded_paths.py
@@ -1,0 +1,30 @@
+"""Guard: config/settings.template.json must not hardcode a developer-home path.
+
+Regression test for #1015 — a `/home/bakerb/.local/share/wtf-server/hooks/…`
+wtf-server hook path was baked into the COMMITTED template, breaking for every
+other user/install (the path does not exist) and leaking in the oakandwave-
+workflow image. Hook command paths must be portable: `~/`-relative (Claude Code
+expands `~` to $HOME at hook-exec time) or $CLAUDE_PROJECT_DIR-relative — never
+an absolute `/home/<user>/…`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO_ROOT / "config" / "settings.template.json"
+
+# Any absolute path rooted at a specific user's home directory.
+_ABS_HOME = re.compile(r"/home/[^/\s\"]+/")
+
+
+def test_settings_template_has_no_hardcoded_home_paths() -> None:
+    text = TEMPLATE.read_text()
+    matches = sorted(set(_ABS_HOME.findall(text)))
+    assert not matches, (
+        "config/settings.template.json must not hardcode an absolute "
+        "/home/<user>/ path — use a ~/ path, which expands to $HOME at "
+        f"hook-exec time. Offending prefixes: {matches}"
+    )


### PR DESCRIPTION
## Summary

`config/settings.template.json:59` hardcoded `/home/bakerb/.local/share/wtf-server/hooks/wtf-post-tool-use.sh` — a developer-home path baked into the committed template, breaking for every other user/install and leaking into the oakandwave-workflow image.

## Changes

- Change the wtf-server PostToolUse hook command to `~/.local/share/wtf-server/hooks/wtf-post-tool-use.sh`. `~` expands to `$HOME` at hook-exec time (`install:634`; every sibling hook in the file already uses `~/`). This is simpler and more consistent than the `{{HOME}}`+sed marker the issue suggested — that pattern exists for logrotate configs in `/etc/`, where `~` is *not* shell-expanded; hook `command` strings are.
- Add `tests/test_settings_template_no_hardcoded_paths.py` — regression guard asserting no absolute `/home/<user>/` path in the template.

## Linked Issues

Closes #1015

## Test Plan

- `jq empty` valid; no hardcoded home paths remain; guard test passes and its regex is proven to catch the old bad path. Code-review confirmed `~` expansion and the tilde-over-marker decision; no findings.