### PR TITLE
fix(oakandwave-image): whitelist the check-deps build gate

### DIFF
--- a/containers/oakandwave-workflow/Dockerfile
+++ b/containers/oakandwave-workflow/Dockerfile
@@ -142,13 +142,16 @@ WORKDIR ${KIT_SRC}
 # under --no-mcps — the remainder are runtime-only items check-deps can never see
 # at build time: the secret tokens (slack-bot-token, discord-bot-token; never
 # baked — R-12, provided at runtime via the ro ~/.secrets mount) and any
-# host-specific hook path in settings.template.json. The tolerance greps the
-# check-deps SUMMARY sentinel, which fires on ANY missing-dep count — it does not
-# distinguish which deps, so today's expected-missing items (the two secrets + the
-# host hook) are tolerated alongside anything else check-deps would report
-# (tightening to a per-dep whitelist tracked in #1016). The real guarantees: a
-# genuine install error aborts under set -euo pipefail BEFORE check-deps (sentinel
-# absent → build fails), and the positive assertions below cover the kit AND all
+# host-specific hook path in settings.template.json. The tolerance FIRST greps the
+# check-deps SUMMARY sentinel (a non-zero rc that ISN'T the advisory is a genuine
+# install error → build fails), THEN pipes the advisory through
+# `assert-only-expected-deps-missing.sh`, which fails the build if ANY missing dep
+# is outside the expected-missing whitelist (the two secret tokens + the runtime-
+# installed wtf-server hook). So a real regression — gh/jq/python3/curl/git going
+# missing — can no longer hide behind the content-agnostic sentinel (#1016). The
+# real guarantees: a genuine install error aborts under set -euo pipefail BEFORE
+# check-deps (sentinel absent → build fails), the whitelist gate rejects any
+# unexpected missing dep, and the positive assertions below cover the kit AND all
 # five MCP servers.
 #
 # Pre-create ~/.claude.json ({} is augmented in place): the two jq-registering
@@ -164,6 +167,7 @@ RUN set +e; \
 	if [ "$rc" -ne 0 ]; then \
 		printf '%s\n' "$out" | grep -q "required dependency/dependencies missing" \
 			|| { echo "install failed (not the dependency advisory) — rc=$rc"; exit "$rc"; }; \
+		printf '%s\n' "$out" | ./scripts/ci/assert-only-expected-deps-missing.sh; \
 	fi; \
 	test -d "$HOME/.claude/skills"; \
 	test -n "$(find "$HOME/.claude/skills" -name SKILL.md -print -quit)"; \

--- a/scripts/ci/assert-only-expected-deps-missing.sh
+++ b/scripts/ci/assert-only-expected-deps-missing.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# assert-only-expected-deps-missing.sh — tighten the oakandwave-workflow image's
+# check-deps tolerance (#1016).
+#
+# The image build tolerates check-deps' missing-dependency advisory because a few
+# items are legitimately absent at BUILD time and only materialize at runtime:
+#   - the two secret tokens (slack-bot-token, discord-bot-token) — never baked
+#     (R-12), mounted read-only at runtime;
+#   - the wtf-server PostToolUse hook — installed into the user's home at runtime.
+# The old tolerance grepped only the SUMMARY sentinel ("required
+# dependency/dependencies missing"), which fires on ANY missing count — it could
+# not distinguish those expected gaps from a real regression (e.g. gh / jq /
+# python3 / curl / glab going missing). This reads the install + check-deps output
+# and FAILS unless EVERY missing required dependency is a whitelisted expected gap.
+#
+# Two independent guards, because check-deps reports missing deps two ways:
+#   1. Per-item: each missing REQUIRED dep prints "  [!] <item> — NOT FOUND …"
+#      (check-deps.sh _check_hook_scripts/_check_manifest_deps/_check_commands/
+#      _check_secrets). Any such line NOT matching the whitelist → fail.
+#   2. Count cross-check: check-deps prints "<N> required dependency/dependencies
+#      missing." If N exceeds the number of "[!] … NOT FOUND" lines we saw, some
+#      missing deps produced NO such line and are UNACCOUNTED — the canonical case
+#      is jq itself missing: check-deps' jq-guarded scans bail early (printing a
+#      lowercase "jq not found", not "NOT FOUND") yet still count as missing. We
+#      refuse to tolerate what we cannot see.
+#
+# Input:  the combined install + check-deps output on stdin.
+# Exit:   0 if every missing REQUIRED dep is whitelisted AND fully accounted for;
+#         1 (loud) otherwise.
+set -euo pipefail
+
+# Substrings identifying the legitimately-expected-missing items at build time.
+# Keep in sync with R-12 (secrets, runtime-mounted) and the runtime-installed
+# wtf-server hook. The wtf entry matches by basename so it holds regardless of the
+# home prefix ($HOME differs per user / container uid).
+EXPECTED_MISSING=(
+	'slack-bot-token'
+	'discord-bot-token'
+	'wtf-post-tool-use.sh'
+)
+
+input="$(cat)"
+
+unexpected=0
+not_found_count=0
+while IFS= read -r line; do
+	# Only the check-deps missing-REQUIRED-dep marker: "  [!] … NOT FOUND …".
+	# Anchoring on "[!]" (not a bare "NOT FOUND") avoids a benign upstream
+	# "NOT FOUND" elsewhere in the install stream tripping the gate.
+	[[ "$line" == *"[!]"*"NOT FOUND"* ]] || continue
+	not_found_count=$((not_found_count + 1))
+	for pat in "${EXPECTED_MISSING[@]}"; do
+		[[ "$line" == *"$pat"* ]] && continue 2
+	done
+	echo "UNEXPECTED missing dependency (outside the image-build whitelist): ${line}" >&2
+	unexpected=1
+done <<<"$input"
+
+# Count cross-check: reconcile the SUMMARY count with what we could actually see.
+summary_count="$(printf '%s\n' "$input" | grep -oE '[0-9]+ required dependency/dependencies missing' | grep -oE '^[0-9]+' | tail -1 || true)"
+if [[ -n "$summary_count" && "$summary_count" -gt "$not_found_count" ]]; then
+	echo "check-deps reported ${summary_count} missing dependency/dependencies but only ${not_found_count} appeared as '[!] … NOT FOUND' — $((summary_count - not_found_count)) unaccounted (e.g. jq itself missing bails check-deps' guarded scans before they can report)." >&2
+	unexpected=1
+fi
+
+if [[ "$unexpected" -ne 0 ]]; then
+	echo "check-deps reported a missing dependency outside the expected-missing set — failing the build (#1016)." >&2
+	exit 1
+fi
+
+echo "check-deps advisory: only expected-missing items (secrets + wtf hook), fully accounted — tolerated."

--- a/tests/regression/test_check_deps_whitelist.sh
+++ b/tests/regression/test_check_deps_whitelist.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# test_check_deps_whitelist.sh — #1016: the oakandwave-workflow image build gate.
+#
+# Picked up by scripts/ci/validate.sh's "Regression tests" loop (tests/regression/*.sh).
+#
+# The image build tolerates check-deps' expected-missing items (the two secret
+# tokens + the runtime-installed wtf-server hook) but must FAIL on any OTHER
+# missing required dependency. Two failure shapes are covered:
+#   - a normal missing dep prints "  [!] <item> — NOT FOUND …" (e.g. gh);
+#   - jq itself missing bails check-deps' jq-guarded scans early: NO "NOT FOUND"
+#     line, but the SUMMARY count is still nonzero (the count cross-check catches it).
+# The gate is invoked exactly as the Dockerfile invokes it — directly (./…), NOT
+# via `bash …` — so this also guards the script's executable bit.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GATE="$REPO_DIR/scripts/ci/assert-only-expected-deps-missing.sh"
+
+pass=0
+fail=0
+check() { # <description> <expected-rc> <actual-rc>
+	if [[ "$2" -eq "$3" ]]; then
+		echo "  [PASS] $1"
+		pass=$((pass + 1))
+	else
+		echo "  [FAIL] $1 (expected rc=$2, got rc=$3)"
+		fail=$((fail + 1))
+	fi
+}
+
+# The exact expected-missing set from a real container build (#1014 build log):
+# the wtf hook + the two secret tokens — 3 missing, all whitelisted.
+expected_only='  [✓] gh (/usr/bin/gh)
+  [!] hook: /home/ubuntu/.local/share/wtf-server/hooks/wtf-post-tool-use.sh — NOT FOUND
+  [!]   Referenced in settings.template.json hooks
+  [!] slack-bot-token — NOT FOUND (/home/ubuntu/secrets/slack-bot-token)
+  [!] discord-bot-token — NOT FOUND (/home/ubuntu/secrets/discord-bot-token)
+3 required dependency/dependencies missing.'
+
+# An UNEXPECTED regression: gh has gone missing (4 missing, one not whitelisted).
+with_unexpected='  [!] hook: /home/ubuntu/.local/share/wtf-server/hooks/wtf-post-tool-use.sh — NOT FOUND
+  [!] slack-bot-token — NOT FOUND (/home/ubuntu/secrets/slack-bot-token)
+  [!] discord-bot-token — NOT FOUND (/home/ubuntu/secrets/discord-bot-token)
+  [!] gh — NOT FOUND (needed for: GitHub CLI)
+4 required dependency/dependencies missing.'
+
+# A clean build: nothing missing.
+none_missing='  [✓] gh (/usr/bin/gh)
+  [✓] jq (/usr/bin/jq)
+All required dependencies present.'
+
+# jq itself missing: check-deps' jq-guarded scans bail early, so NO "NOT FOUND"
+# line is emitted, but the summary count is still nonzero. The count cross-check
+# must catch this (the exact regression class #1016 targets).
+jq_missing='  [!] jq not found — cannot scan settings.template.json hooks
+  [!] jq not found — cannot read deps.json
+2 required dependency/dependencies missing.'
+
+rc=0
+printf '%s\n' "$expected_only" | "$GATE" >/dev/null 2>&1 || rc=$?
+check "tolerates ONLY the expected-missing items (secrets + wtf hook)" 0 "$rc"
+
+rc=0
+printf '%s\n' "$with_unexpected" | "$GATE" >/dev/null 2>&1 || rc=$?
+check "FAILS when an unexpected dep (gh) is missing" 1 "$rc"
+
+rc=0
+printf '%s\n' "$none_missing" | "$GATE" >/dev/null 2>&1 || rc=$?
+check "passes when nothing is missing" 0 "$rc"
+
+rc=0
+printf '%s\n' "$jq_missing" | "$GATE" >/dev/null 2>&1 || rc=$?
+check "FAILS on a jq regression (count > NOT-FOUND lines, no NOT FOUND emitted)" 1 "$rc"
+
+# The wtf hook whitelist is by basename — must hold for any home prefix.
+rc=0
+printf '%s\n' '  [!] hook: /home/bakerb/.local/share/wtf-server/hooks/wtf-post-tool-use.sh — NOT FOUND
+1 required dependency/dependencies missing.' | "$GATE" >/dev/null 2>&1 || rc=$?
+check "wtf-hook whitelist holds regardless of home prefix" 0 "$rc"
+
+echo "  ${pass} passed, ${fail} failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary

The oakandwave-workflow Dockerfile tolerated check-deps advisories by grepping a content-agnostic SUMMARY sentinel, which could not distinguish the expected-missing items (two secret tokens + the runtime-installed wtf-server hook) from a real regression (gh/jq/python3/curl/glab going missing).

## Changes

- **`scripts/ci/assert-only-expected-deps-missing.sh`** (new) — reads the install + check-deps output; fails if any missing REQUIRED dep is outside the whitelist, **plus a count cross-check**: check-deps prints `<N> … missing`, and if N exceeds the number of `[!] … NOT FOUND` lines, some deps are unaccounted (the canonical case: **jq itself missing** bails check-deps' jq-guarded scans early, emitting no `NOT FOUND` line). The filter anchors on the `[!]` marker to avoid stray `NOT FOUND` false-positives.
- **`containers/oakandwave-workflow/Dockerfile`** — pipe the install advisory through the gate after the sentinel check; comment updated.
- **`tests/regression/test_check_deps_whitelist.sh`** (new) — invokes the gate exactly as the Dockerfile does (directly, guarding the exec bit); 5/5 including the jq-regression case.

## Linked Issues

Closes #1016

## Test Plan

- Regression test 5/5 (expected-only pass; unexpected `gh` fail; nothing-missing pass; **jq-regression fail**; wtf-hook prefix-agnostic). Whitelist validated against a real container build's actual advisory. shellcheck + shfmt clean; script committed 100755. Real `make ci` build green (gate tolerated the legit 3-expected-missing, oracle passed).
- Code-review found 2 important issues (jq blind-spot; test/exec-bit mismatch) — **both fixed** in this branch. Note: git-in-`deps.json` (so a git regression is *checked*) is a separable follow-up; the issue names gh/python3/curl, all already guarded.