### PR TITLE
chore(deps): declare git in deps.json so check-deps guards it

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -14,6 +14,7 @@
   "commands": [
     { "name": "curl",       "required_by": "MCP install scripts" },
     { "name": "jq",         "required_by": "settings.json merge, MCP install" },
+    { "name": "git",        "required_by": "issue/branch/PR workflow, kit install" },
     { "name": "bun",        "required_by": "MCP server builds" },
     { "name": "gh",         "required_by": "GitHub CLI (issues, PRs, releases)" },
     { "name": "glab",       "required_by": "GitLab CLI (issues, MRs)" },


### PR DESCRIPTION
## Summary

`deps.json` `commands` declared curl/jq/bun/gh/glab/python3/shellcheck/… but not `git`, so `check-deps.sh` never verified it and a base-image regression that dropped git would be invisible to the oakandwave-workflow image's check-deps gate (#1016). This declares git so the gate covers it.

## Changes

- Add `{ "name": "git", "required_by": "issue/branch/PR workflow, kit install" }` to `deps.json` `commands`.

## Linked Issues

Closes #1024

## Test Plan

- git verified present in the built image (`/usr/bin/git` 2.53.0), so the addition introduces no new missing dep.
- Real `make ci` build **green**: check-deps reports `[✓] git`, the advisory is unchanged (2 secrets — the wtf hook resolves post-#1015), #1016's gate `fully accounted — tolerated`, oracle 4/4.
- `validate.sh` 207/0; `deps.json` valid JSON.
- Follow-up from the #1016 code review (out of #1016's stated scope).