### PR TITLE
fix(flightdeck): emit campaign identity + wave denominator to the card (#1026 incr 1)

### DIFF
--- a/src/wave_status/events/emit.py
+++ b/src/wave_status/events/emit.py
@@ -31,6 +31,7 @@ DI-seams (env vars):
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import threading
@@ -106,6 +107,45 @@ def activity_id_for_root(root: object) -> str:
         return name or "unknown"
     except Exception:
         return "unknown"
+
+
+def _dev_name_from(path: Path) -> str | None:
+    """Read ``dev_name`` from a JSON identity file, or ``None``. Never raises
+    (missing file, malformed JSON, non-dict, and empty name all yield ``None``)."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        name = data.get("dev_name")
+        return name if isinstance(name, str) and name else None
+    except Exception:
+        return None
+
+
+def resolve_agent(root: object) -> str | None:
+    """Resolve the emitting agent's Dev-Name for the FlightDeck card title (#1026).
+
+    Resolution order, mirroring ``scripts/flightdeck-session-emit.sh`` and the
+    CLAUDE.md identity rule:
+
+    1. ``FLIGHTDECK_AGENT`` env (an operator/driver can pin it);
+    2. the canonical ``<root>/.claude/agent-identity.json`` ``dev_name``;
+    3. the legacy ``/tmp/claude-agent-<md5(root)>.json`` ``dev_name`` — the
+       transition-window fallback while the fleet cycles off the /tmp scheme.
+
+    Returns ``None`` when none resolve, so the card render falls back to the
+    project label rather than showing a hostname. Never raises.
+    """
+    env = os.environ.get("FLIGHTDECK_AGENT")
+    if env:
+        return env
+    root_s = str(root)
+    name = _dev_name_from(Path(root_s) / ".claude" / "agent-identity.json")
+    if name:
+        return name
+    try:
+        digest = hashlib.md5(root_s.encode("utf-8")).hexdigest()  # noqa: S324 (non-crypto keying)
+    except Exception:
+        return None
+    return _dev_name_from(Path("/tmp") / f"claude-agent-{digest}.json")
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +347,7 @@ def emit_state_event(root: object, kind: str, **fields: object) -> dict | None:
         return emit(
             kind,
             activity_id=activity_id_for_root(root),
-            agent=os.environ.get("FLIGHTDECK_AGENT"),
+            agent=resolve_agent(root),
             log_ref=os.environ.get("FLIGHTDECK_LOG_REF"),
             **fields,
         )

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -655,7 +655,19 @@ def init_state(plan_data: dict, root: Path, *, force: bool = False) -> None:
     # --- flights.json (empty initially) ---
     save_json(d / "flights.json", {"flights": {}})
 
-    _emit_event(root, "activity_start", wave=first_wave, label=plan_data.get("project"))
+    # FlightDeck campaign card (#1026): tag this as a `campaign` activity (not a
+    # session) and carry the wave DENOMINATOR (`planTotal`) so the card can render
+    # "completed/planTotal" instead of "0/?". The Dev-Name (title) is resolved from
+    # the identity file by emit_state_event; the numerator accrues from per-wave
+    # `promoted` steps. `label` stays the project — the card's fallback title.
+    _emit_event(
+        root,
+        "activity_start",
+        wave=first_wave,
+        label=plan_data.get("project"),
+        activity_type="campaign",
+        detail={"planTotal": len(wave_ids)},
+    )
 
 
 def extend_state(plan_data: dict, root: Path) -> None:

--- a/tests/test_events_emit.py
+++ b/tests/test_events_emit.py
@@ -280,3 +280,75 @@ class TestEmitCli:
         )
         assert r.returncode == 0  # fire-and-forget: never fail the caller
         assert not ep.exists() or ep.read_text() == ""
+
+
+class TestResolveAgent:
+    """resolve_agent() — the FlightDeck card's Dev-Name title source (#1026)."""
+
+    def test_env_wins(self, monkeypatch):
+        from wave_status.events.emit import resolve_agent
+
+        monkeypatch.setenv("FLIGHTDECK_AGENT", "babelfish")
+        assert resolve_agent("/any/root") == "babelfish"
+
+    def test_reads_dev_name_from_identity(self, tmp_path, monkeypatch):
+        from wave_status.events.emit import resolve_agent
+
+        monkeypatch.delenv("FLIGHTDECK_AGENT", raising=False)
+        cl = tmp_path / ".claude"
+        cl.mkdir()
+        (cl / "agent-identity.json").write_text(
+            json.dumps({"dev_name": "dangling-pointer", "dev_team": "bs"}), encoding="utf-8"
+        )
+        assert resolve_agent(tmp_path) == "dangling-pointer"
+
+    def test_missing_identity_returns_none(self, tmp_path, monkeypatch):
+        from wave_status.events.emit import resolve_agent
+
+        monkeypatch.delenv("FLIGHTDECK_AGENT", raising=False)
+        assert resolve_agent(tmp_path / "no-such") is None
+
+    def test_env_beats_present_identity_file(self, tmp_path, monkeypatch):
+        from wave_status.events.emit import resolve_agent
+
+        cl = tmp_path / ".claude"
+        cl.mkdir()
+        (cl / "agent-identity.json").write_text(json.dumps({"dev_name": "from-file"}), encoding="utf-8")
+        monkeypatch.setenv("FLIGHTDECK_AGENT", "from-env")
+        assert resolve_agent(tmp_path) == "from-env"
+
+    def test_malformed_or_nondict_json_returns_none(self, tmp_path, monkeypatch):
+        from wave_status.events.emit import resolve_agent
+
+        monkeypatch.delenv("FLIGHTDECK_AGENT", raising=False)
+        cl = tmp_path / ".claude"
+        cl.mkdir()
+        (cl / "agent-identity.json").write_text("not json {", encoding="utf-8")
+        assert resolve_agent(tmp_path) is None
+        (cl / "agent-identity.json").write_text('["a","list"]', encoding="utf-8")
+        assert resolve_agent(tmp_path) is None
+
+    def test_empty_dev_name_returns_none(self, tmp_path, monkeypatch):
+        from wave_status.events.emit import resolve_agent
+
+        monkeypatch.delenv("FLIGHTDECK_AGENT", raising=False)
+        cl = tmp_path / ".claude"
+        cl.mkdir()
+        (cl / "agent-identity.json").write_text(json.dumps({"dev_name": ""}), encoding="utf-8")
+        assert resolve_agent(tmp_path) is None
+
+    def test_legacy_tmp_fallback(self, tmp_path, monkeypatch):
+        # #1026: transition-window fallback to /tmp/claude-agent-<md5(root)>.json
+        # when the canonical file is absent (mirrors flightdeck-session-emit.sh).
+        import hashlib
+
+        from wave_status.events.emit import resolve_agent
+
+        monkeypatch.delenv("FLIGHTDECK_AGENT", raising=False)
+        digest = hashlib.md5(str(tmp_path).encode("utf-8")).hexdigest()
+        legacy = Path("/tmp") / f"claude-agent-{digest}.json"
+        legacy.write_text(json.dumps({"dev_name": "legacy-name"}), encoding="utf-8")
+        try:
+            assert resolve_agent(tmp_path) == "legacy-name"  # no canonical file → uses /tmp
+        finally:
+            legacy.unlink(missing_ok=True)

--- a/tests/test_state_emit_integration.py
+++ b/tests/test_state_emit_integration.py
@@ -72,6 +72,22 @@ class TestOneEventPerMutation:
         state.init_state(sample_plan, temp_git_repo)
         ev = _one("activity_start")
         assert ev["wave"] == "wave-1"
+        # FlightDeck campaign card (#1026): tagged a `campaign` (not a session), and
+        # carries the wave DENOMINATOR so the card renders completed/planTotal, not "0/?".
+        assert ev["activityType"] == "campaign"
+        assert ev["detail"]["planTotal"] == 3  # sample_plan has wave-1/2/3
+
+    def test_init_state_activity_start_carries_dev_name(self, temp_git_repo, sample_plan):
+        # #1026: the card title is the Dev-Name from the identity file (the render
+        # falls back to the project label when it is absent).
+        cl = temp_git_repo / ".claude"
+        cl.mkdir(exist_ok=True)
+        (cl / "agent-identity.json").write_text(
+            json.dumps({"dev_name": "dangling-pointer", "dev_team": "bs"}), encoding="utf-8"
+        )
+        state.init_state(sample_plan, temp_git_repo)
+        ev = _one("activity_start")
+        assert ev["agent"] == "dangling-pointer"
 
     def test_planning_phase(self, inited):
         state.planning(inited)


### PR DESCRIPTION
## Summary

Increment 1 of #1026 — the FlightDeck campaign card shows every field wrong because the emit **starves** the (already-capable) flightdeck fold. This lands the emit-side campaign **identity** + wave **denominator**. It does **not** close #1026.

## Changes

- **`src/wave_status/events/emit.py`** — `resolve_agent(root)`: resolves the Dev-Name for the card title. `$FLIGHTDECK_AGENT` (env override) → `<root>/.claude/agent-identity.json` `dev_name` → legacy `/tmp/claude-agent-<md5(root)>.json` (fleet-transition fallback, mirroring `flightdeck-session-emit.sh`) → `None` (render falls back to project label). `emit_state_event` now uses it instead of a bare `os.environ.get`.
- **`src/wave_status/state.py`** — the campaign `activity_start` now carries `activity_type="campaign"` + `detail={"planTotal": len(wave_ids)}` (the wave denominator the fold reads from `activity_start.detail.planTotal`).
- **Tests** — `resolve_agent` (env-wins, canonical, legacy `/tmp`, malformed/non-dict JSON, empty-name, missing) + `init_state` activity_start vitals + dev-name.

## Linked Issues

Part of #1026 (does not close it — follow-on increments remain: per-wave tee campaign-scoping + `promoted` numerator, confidence/drift metrics, terminal/eviction, and the flightdeck-app render for title=agent + machine-time + your Swarm redeploy).

## Test Plan

- Verified the emitted JSON keys (`agent`, `activityType`, `detail.planTotal`) match what `flightdeck/src/fold.ts` reads.
- `validate.sh` 207/0; full pytest 1886 passed; post-review-fix broader emit/state re-run 468/0.
- Code-review: ship-able; the one important finding (dropped legacy identity fallback) fixed + hardening tests added.

Visible impact of this increment alone: the **denominator** populates (`0/N`) and the card is tagged a campaign; the **title→Dev-Name** also needs the flightdeck-app render change (a later increment).