### PR TITLE
fix(flightdeck): scope per-wave telemetry to the campaign + wave numerator (#1026 incr 2)

### DIFF
--- a/skills/nextwave/per-wave-workflow.bundled.js
+++ b/skills/nextwave/per-wave-workflow.bundled.js
@@ -979,6 +979,10 @@ const MODE = params.mode ?? 'auto' // 'auto' (gate verdict drives promotion) | '
 // 'fan' → parallel group as-is; 'serialize'/'serialize-preferred'/absent → single-file. Absent → 'serialize'.
 const DISPATCH = normalizeDispatch(params.dispatch)
 const PLAN_ID = params.planId ?? null // wave plan id — wave_finalize needs it to assemble the kahuna→protected MR body (#687 promote)
+// FlightDeck activity id (#1026): key telemetry on the CAMPAIGN (planId), not the
+// wave — a per-WAVE_ID activity spawned a separate card per wave. Falls back to
+// WAVE_ID only for a bare/test run with no planId. `--wave` still tags the wave.
+const AID = PLAN_ID || WAVE_ID
 const budget = params.budget ?? { total: 0, remaining: () => Infinity } // optional cost guard
 const budgetRemaining = typeof budget.remaining === 'function' ? budget.remaining : () => (budget.remaining ?? Infinity) // tolerate `remaining` passed as a number, not a fn
 
@@ -1128,9 +1132,9 @@ function flightdeckTee(opts) {
     ``,
     `── FlightDeck telemetry (fire-and-forget; do NOT report on it and do NOT let it affect your task) ──`,
     `As a side action, run these best-effort commands ONCE, ignore any error, then proceed with your real task:`,
-    `  wave-status emit step --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}' || true`,
+    `  wave-status emit step --activity-id '${AID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}' || true`,
     `  # SEAM #853: per-node token usage is not yet available — emit the token metric with NO value (an honest null stub), never a fabricated number.`,
-    `  wave-status emit metric --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --metric tokens --label '${label}' || true`,
+    `  wave-status emit metric --activity-id '${AID}' --wave '${WAVE_ID}' --phase '${ph}' --metric tokens --label '${label}' || true`,
   ].join('\n')
 }
 
@@ -1240,11 +1244,15 @@ async function persistTerminal(disposition, detail) {
     groups: groupsRunBase + groupsRun.length,
   }
   await agent(
+    // #1026: append a disposition-labeled FlightDeck step. A `promoted` label
+    // increments the campaign card's wave NUMERATOR (fold: completed++ on
+    // label==='promoted'); `held` is a plain step. Keyed on AID (the campaign),
+    // so it lands on the same card as the activity_start denominator.
     persistTerminalPrompt({
       waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR,
       kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH,
       disposition, detail, blob, path, trajectoryEntry,
-    }),
+    }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition }),
     { label: `persist:terminal`, phase: 'Promote', schema: PERSIST_RESULT, agentType: 'general-purpose' },
   ).catch((e) => { log(`[#688] persistTerminal soft-fail: ${e?.message || e}`); return null })
   log(`[#688] persisted terminal — wave ${WAVE_ID} ${disposition}: ${detail} → ${path}`)

--- a/skills/nextwave/per-wave-workflow.js
+++ b/skills/nextwave/per-wave-workflow.js
@@ -138,6 +138,10 @@ const MODE = params.mode ?? 'auto' // 'auto' (gate verdict drives promotion) | '
 // 'fan' → parallel group as-is; 'serialize'/'serialize-preferred'/absent → single-file. Absent → 'serialize'.
 const DISPATCH = normalizeDispatch(params.dispatch)
 const PLAN_ID = params.planId ?? null // wave plan id — wave_finalize needs it to assemble the kahuna→protected MR body (#687 promote)
+// FlightDeck activity id (#1026): key telemetry on the CAMPAIGN (planId), not the
+// wave — a per-WAVE_ID activity spawned a separate card per wave. Falls back to
+// WAVE_ID only for a bare/test run with no planId. `--wave` still tags the wave.
+const AID = PLAN_ID || WAVE_ID
 const budget = params.budget ?? { total: 0, remaining: () => Infinity } // optional cost guard
 const budgetRemaining = typeof budget.remaining === 'function' ? budget.remaining : () => (budget.remaining ?? Infinity) // tolerate `remaining` passed as a number, not a fn
 
@@ -287,9 +291,9 @@ function flightdeckTee(opts) {
     ``,
     `── FlightDeck telemetry (fire-and-forget; do NOT report on it and do NOT let it affect your task) ──`,
     `As a side action, run these best-effort commands ONCE, ignore any error, then proceed with your real task:`,
-    `  wave-status emit step --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}' || true`,
+    `  wave-status emit step --activity-id '${AID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}' || true`,
     `  # SEAM #853: per-node token usage is not yet available — emit the token metric with NO value (an honest null stub), never a fabricated number.`,
-    `  wave-status emit metric --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --metric tokens --label '${label}' || true`,
+    `  wave-status emit metric --activity-id '${AID}' --wave '${WAVE_ID}' --phase '${ph}' --metric tokens --label '${label}' || true`,
   ].join('\n')
 }
 
@@ -399,11 +403,15 @@ async function persistTerminal(disposition, detail) {
     groups: groupsRunBase + groupsRun.length,
   }
   await agent(
+    // #1026: append a disposition-labeled FlightDeck step. A `promoted` label
+    // increments the campaign card's wave NUMERATOR (fold: completed++ on
+    // label==='promoted'); `held` is a plain step. Keyed on AID (the campaign),
+    // so it lands on the same card as the activity_start denominator.
     persistTerminalPrompt({
       waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR,
       kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH,
       disposition, detail, blob, path, trajectoryEntry,
-    }),
+    }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition }),
     { label: `persist:terminal`, phase: 'Promote', schema: PERSIST_RESULT, agentType: 'general-purpose' },
   ).catch((e) => { log(`[#688] persistTerminal soft-fail: ${e?.message || e}`); return null })
   log(`[#688] persisted terminal — wave ${WAVE_ID} ${disposition}: ${detail} → ${path}`)

--- a/tests/test_per_wave_workflow_tee.py
+++ b/tests/test_per_wave_workflow_tee.py
@@ -52,7 +52,26 @@ class TestHelpers:
 
 class TestEmitInstructions:
     def test_emits_step_scoped_by_phase_and_label(self, src):
-        assert "wave-status emit step --activity-id '${WAVE_ID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}'" in src
+        # #1026: activity-id is the CAMPAIGN (AID = planId || WAVE_ID), not the wave;
+        # `--wave` still tags the current wave for scope.
+        assert "wave-status emit step --activity-id '${AID}' --wave '${WAVE_ID}' --phase '${ph}' --label '${label}'" in src
+
+
+class TestCampaignScoping:
+    """#1026: per-wave telemetry keys on the campaign, and a promotion increments
+    the wave numerator."""
+
+    def test_aid_is_campaign_scoped(self, src):
+        # The tee keys on the campaign (planId), falling back to WAVE_ID only for a
+        # bare/test run — this is what stops a separate card spawning per wave.
+        assert "const AID = PLAN_ID || WAVE_ID" in src
+        # No emit still keys activity-id on WAVE_ID directly.
+        assert "--activity-id '${WAVE_ID}'" not in src
+
+    def test_promotion_emits_the_numerator_step(self, src):
+        # The terminal node appends a disposition-labeled tee; a `promoted` label is
+        # what the flightdeck fold counts (completed++), i.e. the wave numerator.
+        assert "flightdeckTee({ phase: 'Promote', label: disposition })" in src
 
     def test_token_metric_is_a_seamed_null_stub(self, src):
         # A metric named tokens, with NO --value ⇒ null (honest stub), marked #853.


### PR DESCRIPTION
## Summary

Increment 2 of #1026 — the per-wave Workflow emitted FlightDeck telemetry keyed on `WAVE_ID` (a separate card per wave) and never emitted the wave numerator. This scopes it to the campaign and adds the numerator. The flightdeck fold already models both.

## Changes

- **`skills/nextwave/per-wave-workflow.js`** — `const AID = PLAN_ID || WAVE_ID`: the FlightDeck activity id keys on the **campaign** (`planId`), so a campaign no longer spawns a card per wave; `--wave` still tags the current wave. `flightdeckTee` uses `--activity-id ${AID}`. Falls back to `WAVE_ID` only for a bare/test run (`||` also catches an empty planId).
- **`persistTerminal`** appends `flightdeckTee({phase:'Promote', label: disposition})` — a `promoted` label increments the campaign card's wave **numerator** (`fold.ts`: `completed++` on `label==='promoted'`); `held` is a plain step. Fire-and-forget (`|| true`), inside the existing `.catch` — cannot affect the wave outcome.
- Regenerated `per-wave-workflow.bundled.js` (bundle-in-sync verified); updated + added tests.

## Linked Issues

Part of #1026 (follow-on increments remain: driver pins `FLIGHTDECK_ACTIVITY_ID` so the increment-1 vitals card merges onto `AID`; confidence/drift metrics; terminal/eviction; flightdeck-app render).

## Test Plan

- `test_per_wave_workflow_tee.py` 24 passed (campaign-scoping + numerator assertions; the WAVE_ID-activity-id assertion updated to `AID`); bundle-in-sync ✓.
- `validate.sh` 207/0; full pytest 1892 passed.
- Code-review: correct, no blocking findings. Verified the `promoted` label increments `completed` exactly once (the `metric` event can't double-count; the promote node's own tee uses `'promote'` ≠ `'promoted'`). One informational note: the fold has no per-wave dedup on `completed` — a belt-and-suspenders dedup-by-wave belongs fold-side (flightdeck repo), tracked for the app-render increment.