### PR TITLE
fix(flightdeck): driver owns the campaign card, keyed on the plan id (#1026 incr 3)

### DIFF
--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -167,6 +167,30 @@ legacy `/wavemachine` pre-flight; see that skill for the detailed rationale.)
 
 ## Launch sequence (before the loop)
 
+**First — pin the FlightDeck campaign card (#1026).** BEFORE any `wave-status` emit,
+`export FLIGHTDECK_ACTIVITY_ID=<plan_id>` (the Plan tracking-issue number this campaign
+runs) in the loop's shell. Every main-session emit — the state mutators (steps 1/§ below)
+AND the per-wave tee, which keys on the same id — then lands on ONE card, keyed
+deterministically on the plan, never the repo path (the driver owns the campaign card:
+`wave-status init` runs in the sdlc-server MCP process whose env the driver cannot pin, so
+the card can only be keyed here). Then emit its vitals ONCE (idempotent on resume — it just
+refreshes the card):
+
+```bash
+dev_name="$(jq -r '.dev_name // empty' .claude/agent-identity.json 2>/dev/null)"
+wave-status emit activity_start \
+  --activity-id "$FLIGHTDECK_ACTIVITY_ID" --activity-type campaign \
+  ${dev_name:+--agent "$dev_name"} \
+  --detail "{\"planTotal\": <total waves in the approved plan>}" \
+  --label "<project>" || true
+```
+(Omit `--agent` when the Dev-Name is absent — `${dev_name:+…}` — so the card falls back to
+the project label rather than rendering an empty title; quote `<project>` in case it has spaces.)
+
+`<total waves…>` (the wave denominator) and `<project>` (the fallback title) come from
+`wave_show`/the plan. `--agent` is the Dev-Name (card title). The per-wave `promoted` step
+then accrues the numerator (`per-wave-workflow.js`, #1026 incr 2).
+
 1. Set the `wavemachine_active` flag (`wave-status wavemachine-start --launcher main`).
    Unset it on EVERY exit path (`wave-status wavemachine-stop`) — treat as a `finally`.
 2. Regenerate + open the status panel (`generate-status-panel` then `xdg-open`).

--- a/src/wave_status/state.py
+++ b/src/wave_status/state.py
@@ -655,19 +655,13 @@ def init_state(plan_data: dict, root: Path, *, force: bool = False) -> None:
     # --- flights.json (empty initially) ---
     save_json(d / "flights.json", {"flights": {}})
 
-    # FlightDeck campaign card (#1026): tag this as a `campaign` activity (not a
-    # session) and carry the wave DENOMINATOR (`planTotal`) so the card can render
-    # "completed/planTotal" instead of "0/?". The Dev-Name (title) is resolved from
-    # the identity file by emit_state_event; the numerator accrues from per-wave
-    # `promoted` steps. `label` stays the project — the card's fallback title.
-    _emit_event(
-        root,
-        "activity_start",
-        wave=first_wave,
-        label=plan_data.get("project"),
-        activity_type="campaign",
-        detail={"planTotal": len(wave_ids)},
-    )
+    # A bare activity_start marks the plan's creation. The FlightDeck CAMPAIGN card
+    # (Dev-Name title, planTotal denominator, campaign type) is emitted by the
+    # wavemachine DRIVER keyed on <plan_id> — see skills/wavemachine (#1026). The
+    # driver owns the campaign card so it is keyed deterministically on the plan id
+    # rather than the repo path: init runs via the sdlc-server MCP process, whose env
+    # the driver cannot pin, so it could never be re-keyed here from the driver's shell.
+    _emit_event(root, "activity_start", wave=first_wave, label=plan_data.get("project"))
 
 
 def extend_state(plan_data: dict, root: Path) -> None:

--- a/tests/test_state_emit_integration.py
+++ b/tests/test_state_emit_integration.py
@@ -72,22 +72,11 @@ class TestOneEventPerMutation:
         state.init_state(sample_plan, temp_git_repo)
         ev = _one("activity_start")
         assert ev["wave"] == "wave-1"
-        # FlightDeck campaign card (#1026): tagged a `campaign` (not a session), and
-        # carries the wave DENOMINATOR so the card renders completed/planTotal, not "0/?".
-        assert ev["activityType"] == "campaign"
-        assert ev["detail"]["planTotal"] == 3  # sample_plan has wave-1/2/3
-
-    def test_init_state_activity_start_carries_dev_name(self, temp_git_repo, sample_plan):
-        # #1026: the card title is the Dev-Name from the identity file (the render
-        # falls back to the project label when it is absent).
-        cl = temp_git_repo / ".claude"
-        cl.mkdir(exist_ok=True)
-        (cl / "agent-identity.json").write_text(
-            json.dumps({"dev_name": "dangling-pointer", "dev_team": "bs"}), encoding="utf-8"
-        )
-        state.init_state(sample_plan, temp_git_repo)
-        ev = _one("activity_start")
-        assert ev["agent"] == "dangling-pointer"
+        # #1026: init emits a BARE activity_start — the FlightDeck campaign vitals
+        # (dev-name title, planTotal denominator, campaign type) are emitted by the
+        # wavemachine DRIVER keyed on <plan_id>, not here (see skills/wavemachine).
+        assert "activityType" not in ev
+        assert "detail" not in ev
 
     def test_planning_phase(self, inited):
         state.planning(inited)

--- a/tests/test_wavemachine_skill.py
+++ b/tests/test_wavemachine_skill.py
@@ -759,3 +759,23 @@ class TestAC2_ExhaustiveLegalExits:
         assert "WAVE_AXIOMS.md" in head, (
             "Top-of-file `## Axioms` block must reference WAVE_AXIOMS.md."
         )
+
+
+class TestFlightdeckCampaignCard:
+    """#1026: the driver owns the FlightDeck campaign card — the launch sequence pins
+    the activity id to the plan and emits the card's vitals (so it's keyed
+    deterministically on the plan, not the repo path)."""
+
+    def test_launch_pins_activity_id_to_plan(self, skill_text: str) -> None:
+        launch = _bootstrap(skill_text)  # the "Launch sequence" section
+        assert "export FLIGHTDECK_ACTIVITY_ID=" in launch, (
+            "Launch sequence must pin FLIGHTDECK_ACTIVITY_ID to the plan id so the "
+            "campaign card keys on the plan, not the repo path (#1026)."
+        )
+
+    def test_launch_emits_campaign_activity_start_vitals(self, skill_text: str) -> None:
+        launch = _bootstrap(skill_text)
+        assert "wave-status emit activity_start" in launch
+        assert "--activity-type campaign" in launch
+        assert "planTotal" in launch  # the wave denominator
+        assert "dev_name" in launch  # the Dev-Name (card title)


### PR DESCRIPTION
## Summary

Increment 3 of #1026 — make the FlightDeck campaign card deterministic. It was keyed on the repo path (workspace-scoped, over-grouping across campaigns); it now keys on the plan id, owned by the wavemachine **driver**. This is the keystone that lands the whole campaign — vitals + mutators + tee + numerator — on one card.

## Changes

- **`skills/wavemachine/SKILL.md`** — the launch sequence `export FLIGHTDECK_ACTIVITY_ID=<plan_id>` before any `wave-status` emit (so the state mutators AND the per-wave tee, which already keys on the same `PLAN_ID` from incr 2, land on one card), then emits the card's vitals once: `activity_start --activity-type campaign --agent <dev-name> --detail planTotal --label <project>`. `--agent` is omitted when the Dev-Name is absent (falls back to the project label); `--label` quoted.
- **`src/wave_status/state.py`** — `init_state`'s `activity_start` reverted to a **bare** emit. The campaign vitals can only be keyed by the driver: init runs in the sdlc-server MCP process whose env the driver cannot pin. (`resolve_agent` in `emit.py` is unchanged — still used by `emit_state_event` for mutator-event attribution.)
- Tests: reverted the incr-1 init-vitals assertions; added `TestFlightdeckCampaignCard` guarding the driver contract.

## Linked Issues

Part of #1026 (follow-on: `confidence`/`drift` metrics; terminal/eviction event; flightdeck-app render + Swarm redeploy).

## Test Plan

- `validate.sh` 207/0; full pytest 1893 passed; wavemachine/state/emit suites green; `TestFlightdeckCampaignCard` 2/2.
- Code-review: no critical/important. Verified the prose emit is CLI/shell-correct (flags map to argparse; `--wave`-absent validates since the schema requires only kind/activityId/ts; separate activity ids so no collision/double-count with init's bare card). 2 below-threshold minors (empty-agent → omit; quoted label) fixed.