### PR TITLE
feat(flightdeck): emit confidence + drift metrics from the trust gate (#1026 AC5)

### DIFF
--- a/skills/nextwave/per-wave-workflow.bundled.js
+++ b/skills/nextwave/per-wave-workflow.bundled.js
@@ -1138,6 +1138,36 @@ function flightdeckTee(opts) {
   ].join('\n')
 }
 
+// #1026 AC5 — the trust gate's vitals as FlightDeck metrics, emitted ONCE at the wave
+// terminal (the gate has resolved by promote/hold). Both are HONEST derivations from the
+// gate's REAL signal results — never fabricated (R-19), same discipline as the #853 token
+// stub above (which stays value-less):
+//   • confidence = fraction of the trust signals that passed (0..1) — how solid the verdict is.
+//   • drift      = did the commutativity / intent-drift signal flag drift? ("true"|"false").
+// A gate with no signals (SKIPPED / non-gate exit) emits NEITHER — an honest absence, not a
+// zero. The card already renders both cells (flightdeck card.ts) — this fills them.
+function flightdeckGateMetrics(gate) {
+  const signals = (gate && gate.signals) || []
+  const lines = []
+  if (signals.length > 0) {
+    const confidence = (signals.filter((s) => s.passed).length / signals.length).toFixed(2)
+    lines.push(`  wave-status emit metric --activity-id '${AID}' --wave '${WAVE_ID}' --phase 'Promote' --metric confidence --value '${confidence}' || true`)
+  }
+  const commutativity = signals.find((s) => s.signal === 'commutativity')
+  if (commutativity) {
+    // drift detected ⇔ the commutativity / intent-drift signal did NOT pass.
+    const drift = commutativity.passed ? 'false' : 'true'
+    lines.push(`  wave-status emit metric --activity-id '${AID}' --wave '${WAVE_ID}' --phase 'Promote' --metric drift --value '${drift}' || true`)
+  }
+  if (lines.length === 0) return ''
+  return [
+    ``,
+    `── FlightDeck trust-gate vitals (#1026 AC5; fire-and-forget; do NOT report on it and do NOT let it affect your task) ──`,
+    `As a side action, run these best-effort commands ONCE, ignore any error, then proceed with your real task:`,
+    ...lines,
+  ].join('\n')
+}
+
 // teeAgent(prompt, opts): run a real agent() node with the FlightDeck tee appended
 // to its prompt. PURE delegation — string concat + the runtime `agent`; no I/O, no
 // Date. Returns agent()'s promise so any existing `.catch(...)` still chains.
@@ -1252,7 +1282,8 @@ async function persistTerminal(disposition, detail) {
       waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR,
       kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH,
       disposition, detail, blob, path, trajectoryEntry,
-    }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition }),
+    }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition })
+       + '\n' + flightdeckGateMetrics(gate), // #1026 AC5: confidence + drift from the resolved gate
     { label: `persist:terminal`, phase: 'Promote', schema: PERSIST_RESULT, agentType: 'general-purpose' },
   ).catch((e) => { log(`[#688] persistTerminal soft-fail: ${e?.message || e}`); return null })
   log(`[#688] persisted terminal — wave ${WAVE_ID} ${disposition}: ${detail} → ${path}`)

--- a/skills/nextwave/per-wave-workflow.js
+++ b/skills/nextwave/per-wave-workflow.js
@@ -297,6 +297,36 @@ function flightdeckTee(opts) {
   ].join('\n')
 }
 
+// #1026 AC5 — the trust gate's vitals as FlightDeck metrics, emitted ONCE at the wave
+// terminal (the gate has resolved by promote/hold). Both are HONEST derivations from the
+// gate's REAL signal results — never fabricated (R-19), same discipline as the #853 token
+// stub above (which stays value-less):
+//   • confidence = fraction of the trust signals that passed (0..1) — how solid the verdict is.
+//   • drift      = did the commutativity / intent-drift signal flag drift? ("true"|"false").
+// A gate with no signals (SKIPPED / non-gate exit) emits NEITHER — an honest absence, not a
+// zero. The card already renders both cells (flightdeck card.ts) — this fills them.
+function flightdeckGateMetrics(gate) {
+  const signals = (gate && gate.signals) || []
+  const lines = []
+  if (signals.length > 0) {
+    const confidence = (signals.filter((s) => s.passed).length / signals.length).toFixed(2)
+    lines.push(`  wave-status emit metric --activity-id '${AID}' --wave '${WAVE_ID}' --phase 'Promote' --metric confidence --value '${confidence}' || true`)
+  }
+  const commutativity = signals.find((s) => s.signal === 'commutativity')
+  if (commutativity) {
+    // drift detected ⇔ the commutativity / intent-drift signal did NOT pass.
+    const drift = commutativity.passed ? 'false' : 'true'
+    lines.push(`  wave-status emit metric --activity-id '${AID}' --wave '${WAVE_ID}' --phase 'Promote' --metric drift --value '${drift}' || true`)
+  }
+  if (lines.length === 0) return ''
+  return [
+    ``,
+    `── FlightDeck trust-gate vitals (#1026 AC5; fire-and-forget; do NOT report on it and do NOT let it affect your task) ──`,
+    `As a side action, run these best-effort commands ONCE, ignore any error, then proceed with your real task:`,
+    ...lines,
+  ].join('\n')
+}
+
 // teeAgent(prompt, opts): run a real agent() node with the FlightDeck tee appended
 // to its prompt. PURE delegation — string concat + the runtime `agent`; no I/O, no
 // Date. Returns agent()'s promise so any existing `.catch(...)` still chains.
@@ -411,7 +441,8 @@ async function persistTerminal(disposition, detail) {
       waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR,
       kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH,
       disposition, detail, blob, path, trajectoryEntry,
-    }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition }),
+    }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition })
+       + '\n' + flightdeckGateMetrics(gate), // #1026 AC5: confidence + drift from the resolved gate
     { label: `persist:terminal`, phase: 'Promote', schema: PERSIST_RESULT, agentType: 'general-purpose' },
   ).catch((e) => { log(`[#688] persistTerminal soft-fail: ${e?.message || e}`); return null })
   log(`[#688] persisted terminal — wave ${WAVE_ID} ${disposition}: ${detail} → ${path}`)

--- a/tests/test_per_wave_workflow_tee.py
+++ b/tests/test_per_wave_workflow_tee.py
@@ -90,6 +90,46 @@ class TestCampaignScoping:
         assert "|| true" in src  # emit failures are swallowed in the prompt
 
 
+class TestGateMetrics:
+    """#1026 AC5 — confidence + drift emitted from the RESOLVED trust gate at the wave
+    terminal. Both are honest derivations from the gate's real signal results (never
+    fabricated, R-19), and a gate with no signals emits neither (honest absence)."""
+
+    def test_helper_defined(self, src):
+        assert "function flightdeckGateMetrics(gate)" in src
+
+    def test_confidence_is_the_passed_signal_fraction(self, src):
+        # confidence = (passed / total).toFixed(2) — a REAL fraction of the trust
+        # signals, not a fabricated constant.
+        assert "signals.filter((s) => s.passed).length / signals.length).toFixed(2)" in src
+        assert "--metric confidence --value '${confidence}'" in src
+
+    def test_drift_is_the_commutativity_intent_drift_signal(self, src):
+        assert "signals.find((s) => s.signal === 'commutativity')" in src
+        # drift detected ⇔ the commutativity signal did NOT pass.
+        assert "commutativity.passed ? 'false' : 'true'" in src
+        assert "--metric drift --value '${drift}'" in src
+
+    def test_honest_absence_when_gate_has_no_signals(self, src):
+        # SKIPPED / non-gate exit ⇒ no signals ⇒ NEITHER metric emitted (not a zero).
+        assert "const signals = (gate && gate.signals) || []" in src
+        assert "if (lines.length === 0) return ''" in src
+
+    def test_terminal_wires_the_gate_metrics(self, src):
+        # appended to the terminal prompt alongside the promoted/held tee.
+        assert "flightdeckGateMetrics(gate)" in src
+        assert "flightdeckTee({ phase: 'Promote', label: disposition })" in src
+
+    def test_gate_metrics_are_fire_and_forget(self, src):
+        metric_lines = [
+            ln for ln in src.splitlines()
+            if "--metric confidence" in ln or "--metric drift" in ln
+        ]
+        assert metric_lines
+        for ln in metric_lines:
+            assert "|| true" in ln
+
+
 # ---------------------------------------------------------------------------
 # Spine nodes teed; trust-critical nodes intentionally NOT teed
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

cc-workflow #1026 **AC5** — emit `confidence` + `drift` FlightDeck metrics from the resolved trust gate at the wave terminal. This is the last emit-side gap; the flightdeck card already renders both cells (`card.ts:65-66`, landed in flightdeck #17).

## Changes

- **`skills/nextwave/per-wave-workflow.js`** — new `flightdeckGateMetrics(gate)` helper:
  - `confidence` = fraction of the trust signals that passed (`.toFixed(2)`, 0..1)
  - `drift` = whether the commutativity / intent-drift signal did **not** pass (`"true"`/`"false"`)
  - **Honest absence** — a gate with no signals (SKIPPED / non-gate exit) emits **neither** metric, never a fabricated zero (R-19, same discipline as the #853 token null-stub).
  - Wired into `persistTerminal` beside the existing terminal tee; fire-and-forget (`|| true`), decision-neutral.
- **`skills/nextwave/per-wave-workflow.bundled.js`** — regenerated + in-sync.
- **`tests/test_per_wave_workflow_tee.py`** — `TestGateMetrics` (6 tests: fraction formula, drift ternary, honest-absence, terminal wiring, fire-and-forget).

## Linked Issues

**Part of #1026.** All #1026 code — both the flightdeck render (#17) and this emit — is now landed; the issue stays open for the operator's Swarm redeploy of flightdeck + a live-card confirmation, then closes.

## Test Plan

- `validate.sh` — **207 passed / 0 failed**
- `pytest` — **1899 passed / 0 failed** (6 skipped, 64 xfailed)
- Bundle `--check` in-sync + valid JS
- Code review: **no findings**
- trivy: NO MANIFESTS (cc-workflow has no trivy-parseable dependency manifests; this change touches zero dependencies)

**Semantics note:** `drift=true` means "unproven-or-drifted" (the commutativity signal did not pass — conservative), not strictly "drift measured."