### PR TITLE
fix(ci): normalize the oakandwave image path to lowercase + guard (#1031)

### DIFF
--- a/.github/workflows/oakandwave-workflow-image.yml
+++ b/.github/workflows/oakandwave-workflow-image.yml
@@ -33,7 +33,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      IMAGE: ghcr.io/${{ github.repository_owner }}/oakandwave-workflow
+      # GHCR path MUST be lowercase — the org login "Wave-Engineering" carries capitals,
+      # and `${{ github.repository_owner }}` would interpolate them into the image path
+      # (the Docker client + GHCR reject uppercase repo names). Hardcoded lowercase here,
+      # matching flightdeck and the sibling scripts; scripts/ci/lowercase-image-guard.sh
+      # fails CI if a capitalized (or raw repository_owner) image ref is ever reintroduced.
+      IMAGE: ghcr.io/wave-engineering/oakandwave-workflow
       TAG: edge
     # Expose the pushed digest so the throwaway-CI ring (smoke) pulls the exact
     # bytes this job built + signed — the digest tested is the digest promoted

--- a/scripts/ci/lowercase-image-guard.sh
+++ b/scripts/ci/lowercase-image-guard.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# lowercase-image-guard.sh — fail CI if any container image path is not lowercase (#1031).
+#
+# GHCR and the Docker client reject uppercase repo names. Our org login
+# "Wave-Engineering" carries capitals, so a raw ${{ github.repository_owner }} or a
+# hand-typed capitalized path is a latent pull/auth trap. This guard turns "every
+# published image path is lowercase" into a tested invariant, not a convention.
+#
+# Two failure classes, over the CI/deploy files that DECLARE image refs:
+#   1. an uppercase char inside a registry path   (ghcr.io/Wave-Engineering/...)
+#   2. a raw owner interpolation in an image ref  (ghcr.io/${{ github.repository_owner }}/...)
+#      — the capital-generator, even when a downstream ${VAR,,} currently masks the push.
+#
+# Whole-line comments are ignored, so prose that names the rule can't self-trip; this
+# guard and test trees are excluded (they carry example bad-patterns on purpose).
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+registries='ghcr\.io|docker\.io|quay\.io|public\.ecr\.aws'
+
+# GUARD_FILES is a DI-seam for the regression test: a newline-separated explicit file
+# list to scan instead of the tracked CI/deploy set (lets the test inject fixtures
+# hermetically, no git). Unset in CI → scan the real tree via git ls-files.
+if [[ -n "${GUARD_FILES:-}" ]]; then
+	mapfile -t files <<<"$GUARD_FILES"
+else
+	mapfile -t files < <(
+		git ls-files |
+			grep -E '\.(ya?ml|sh|toml|py)$|/Dockerfile$|/Makefile$' |
+			grep -E '^(\.github/|scripts/ci/|containers/|deploy/)' |
+			grep -vE 'lowercase-image-guard\.sh$|(^|/)tests?/' || true
+	)
+fi
+
+offenders=0
+for f in "${files[@]}"; do
+	[[ -f "$f" ]] || continue
+
+	# Strip comments before matching so prose that names the rule can't self-trip —
+	# BOTH whole-line and inline trailing comments. Only a '#' at line-start or after
+	# whitespace counts, which leaves shell parameter expansions (${VAR#prefix}) intact.
+	# sed preserves the line count, so grep -n still reports the true line number.
+	code="$(sed -E 's/(^|[[:space:]])#.*$//' "$f")"
+
+	# 1) uppercase inside a registry path
+	while IFS=: read -r ln rest; do
+		[[ -z "$ln" ]] && continue
+		echo "  [FAIL] $f:$ln — uppercase in image path:$rest"
+		offenders=$((offenders + 1))
+	done < <(printf '%s\n' "$code" | grep -nE "(${registries})/[A-Za-z0-9._/-]*[A-Z]" || true)
+
+	# 2) raw repository_owner interpolation in an image ref (interpolates capitals)
+	while IFS=: read -r ln rest; do
+		[[ -z "$ln" ]] && continue
+		echo "  [FAIL] $f:$ln — raw repository_owner in image ref:$rest"
+		offenders=$((offenders + 1))
+	done < <(printf '%s\n' "$code" | grep -niE "(${registries}).*repository_owner" || true)
+done
+
+if [[ "$offenders" -gt 0 ]]; then
+	echo "  [lowercase-image-guard] FAILED: $offenders offender(s) — image paths must be all-lowercase (#1031)"
+	exit 1
+fi
+echo "  [lowercase-image-guard] OK: all image paths lowercase (${#files[@]} files scanned)"

--- a/tests/regression/test_lowercase_image_guard.sh
+++ b/tests/regression/test_lowercase_image_guard.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# test_lowercase_image_guard.sh — #1031.
+#
+# Two jobs in one file:
+#   1. ENFORCE: the guard passes on the REAL tree — a capitalized image ref that lands
+#      in the repo fails CI here (this is the actual guard).
+#   2. PROVE: the guard actually catches capitalized + raw-owner refs, and ignores
+#      whole-line comments — a probe only ever run on a clean tree is unverified.
+# Fixtures are injected hermetically via the GUARD_FILES DI-seam (no git, no repo edits).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+GUARD="$ROOT/scripts/ci/lowercase-image-guard.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+check() { # want_exit  got_exit  label
+	if [[ "$1" == "$2" ]]; then
+		echo "  [PASS] $3"
+		pass=$((pass + 1))
+	else
+		echo "  [FAIL] $3 (want exit $1, got $2)"
+		fail=$((fail + 1))
+	fi
+}
+
+# 1) ENFORCEMENT — the real tree must be all-lowercase.
+"$GUARD" >/dev/null 2>&1
+check 0 "$?" "real tree is all-lowercase"
+
+# 2) a capitalized registry path is rejected.
+printf 'IMAGE: ghcr.io/Wave-Engineering/oakandwave-workflow\n' >"$tmp/caps.yml"
+GUARD_FILES="$tmp/caps.yml" "$GUARD" >/dev/null 2>&1
+check 1 "$?" "capitalized path is rejected"
+
+# 3) a raw repository_owner interpolation is rejected (the capital-generator).
+# shellcheck disable=SC2016  # the literal ${{ … }} is the fixture — no expansion wanted
+printf 'IMAGE: ghcr.io/${{ github.repository_owner }}/oakandwave-workflow\n' >"$tmp/owner.yml"
+GUARD_FILES="$tmp/owner.yml" "$GUARD" >/dev/null 2>&1
+check 1 "$?" "raw repository_owner is rejected"
+
+# 4) a clean lowercase ref passes.
+printf 'IMAGE: ghcr.io/wave-engineering/oakandwave-workflow\n' >"$tmp/ok.yml"
+GUARD_FILES="$tmp/ok.yml" "$GUARD" >/dev/null 2>&1
+check 0 "$?" "lowercase ref passes"
+
+# 5) a whole-line comment naming the bad pattern is ignored (prose can't self-trip).
+printf '# legacy: ghcr.io/Wave-Engineering used to break pulls\n' >"$tmp/comment.yml"
+GUARD_FILES="$tmp/comment.yml" "$GUARD" >/dev/null 2>&1
+check 0 "$?" "commented bad-ref is ignored"
+
+# 6) an INLINE trailing comment naming the bad pattern is ignored — the code ref on the
+#    same line is lowercase, only the comment carries the caps (#1031 review edge).
+printf 'IMAGE: ghcr.io/wave-engineering/foo  # was ghcr.io/Wave-Engineering\n' >"$tmp/inline.yml"
+GUARD_FILES="$tmp/inline.yml" "$GUARD" >/dev/null 2>&1
+check 0 "$?" "inline-comment bad-ref is ignored"
+
+echo "  $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary

Kills the GHCR "Wave-Engineering" casing trap: the oakandwave image workflow interpolated `ghcr.io/${{ github.repository_owner }}/…` → `ghcr.io/Wave-Engineering/…` (capitals), which GHCR + the Docker client reject. This hardcodes the lowercase path and adds a CI guard so it can never regress. **Docker Hub migration intentionally deferred** (tracked separately).

## Changes

- **`.github/workflows/oakandwave-workflow-image.yml`** — `IMAGE` → `ghcr.io/wave-engineering/oakandwave-workflow` (hardcoded lowercase, matching flightdeck + the sibling scripts); removes the raw `${{ github.repository_owner }}` interpolation.
- **`scripts/ci/lowercase-image-guard.sh`** (new) — fails CI on any uppercase char in a registry path, or a raw `repository_owner` in an image ref. Whole-line **and** inline comments are stripped before matching (shell `${VAR#prefix}` left intact) so prose can't self-trip; `GUARD_FILES` DI-seam for hermetic tests; scans `.github`, `scripts/ci`, `containers`, `deploy` (yaml/sh/toml/py/Dockerfile/Makefile).
- **`tests/regression/test_lowercase_image_guard.sh`** (new) — auto-run by validate.sh; enforces the real tree is lowercase **and** proves the guard catches caps + raw-owner (6 cases).

## Linked Issues

Closes #1031

## Test Plan

- `validate.sh` — **210 passed / 0 failed**
- Guard: 39 files scanned clean; regression test **6/6** (caps rejected · raw-owner rejected · lowercase passes · whole-line + inline comments ignored)
- shellcheck + shfmt clean
- Code review: no critical/important; 2 minors fixed (inline-comment robustness + `.py` scope)
- trivy: NO MANIFESTS (pure CI shell/YAML, zero dependencies)

**Note:** functional end-to-end proof is the next tagged image build resolving/pushing the lowercase path cleanly; the guard + this diff are the config-level guarantee.