### PR TITLE
feat(promote): GHA workflow to mirror :stable to Docker Hub + re-sign (cosign keyless)

### DIFF
--- a/.github/workflows/oakandwave-workflow-mirror.yml
+++ b/.github/workflows/oakandwave-workflow-mirror.yml
@@ -1,0 +1,82 @@
+name: Mirror :stable to Docker Hub
+
+# Mirror the already-promoted GHCR :stable image to the public Docker Hub OaW brand
+# (docker.io/oakandwave/oakandwave-workflow) and RE-SIGN it there.
+#
+# This is the OIDC half of publishing that cannot run in the operator's local
+# promote step: keyless cosign needs a Fulcio OIDC identity, which a GHA job has
+# (id-token: write) and an operator shell does not. The mechanical promotion gate +
+# edge->stable retag stay operator-side (scripts/ci/promote-oakandwave-image.sh) —
+# this workflow only ever touches an ALREADY-promoted :stable, so nothing unvetted
+# reaches the public brand and there is no gate-signal-in-CI problem.
+#
+# Run it AFTER a promotion:  gh workflow run oakandwave-workflow-mirror.yml
+on:
+  # Manual only — run it AFTER a promotion. No inputs on purpose: the workflow always
+  # mirrors the CURRENT promoted :stable, so there is no operator-facing way to point the
+  # public brand at an arbitrary (e.g. :edge) digest — the no-:edge invariant holds
+  # mechanically, not by discipline (#1038 review).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read # pull the :stable image + resolve its digest from ghcr
+  id-token: write # keyless cosign (Fulcio/Rekor) via OIDC — re-sign the Docker Hub digest
+
+env:
+  # Lowercase paths — Docker Hub rejects a mixed-case repository path (and GHCR the same).
+  GHCR_IMAGE: ghcr.io/wave-engineering/oakandwave-workflow
+  DOCKERHUB_IMAGE: docker.io/oakandwave/oakandwave-workflow
+  STABLE_TAG: stable
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io (source)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub (destination)
+        uses: docker/login-action@v3
+        with:
+          username: oakandwave
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          # Match the build workflow's pin (#995: SBOM attestation uses an RFC3161 TSA,
+          # off the public rekor tlog; cosign v3 dropped the --tlog-upload lever).
+          cosign-release: 'v2.6.4'
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Resolve the :stable digest to mirror
+        id: resolve
+        run: ./scripts/ci/resolve-stable-digest.sh
+
+      - name: Mirror the :stable digest to Docker Hub oakandwave
+        # Copy the EXACT digest (not the moving tag) cross-registry; imagetools copies the
+        # manifest + blobs using each registry's own creds and rebuilds nothing.
+        env:
+          SRC_DIGEST: ${{ steps.resolve.outputs.digest_ref }}
+        run: |
+          docker buildx imagetools create --tag "${DOCKERHUB_IMAGE}:${STABLE_TAG}" "$SRC_DIGEST"
+
+      - name: Re-sign the Docker Hub digest (cosign keyless + syft SBOM)
+        # cosign signatures are registry+digest-bound, so the cross-registry copy does NOT
+        # carry the GHCR signature — sign the Docker Hub digest fresh. Reuses the exact same
+        # signing script the build job uses; OIDC (id-token) makes keyless work here.
+        env:
+          DIGEST_REF: ${{ steps.resolve.outputs.dockerhub_digest_ref }}
+        run: ./scripts/ci/sign-oakandwave-image.sh

--- a/containers/oakandwave-workflow/Dockerfile
+++ b/containers/oakandwave-workflow/Dockerfile
@@ -211,7 +211,7 @@ WORKDIR /home/ubuntu
 # --- OCI provenance (CI stamps the authoritative semver/revision in Story 2.1) -
 LABEL org.opencontainers.image.title="oakandwave-workflow" \
 	org.opencontainers.image.description="Versioned OaW Claude Code kit image on the AoE sandbox base" \
-	org.opencontainers.image.source="https://github.com/Wave-Engineering/claudecode-workflow" \
+	org.opencontainers.image.source="https://github.com/wave-engineering/claudecode-workflow" \
 	org.opencontainers.image.base.name="${BASE_IMAGE}"
 
 # ENTRYPOINT/CMD inherited from the base (CMD ["sleep","infinity"]); aoe manages

--- a/docs/contained-workflow/deployment-verification.md
+++ b/docs/contained-workflow/deployment-verification.md
@@ -88,6 +88,27 @@ identity is the image workflow and whose issuer is GitHub Actions OIDC. A bare
 `cosign verify` that ignores the identity is **not** sufficient — anyone can sign
 a public digest; the identity binding is the security property.
 
+### 2a. Docker Hub `:stable` mirror signature (#1038)
+
+The public-brand image at `docker.io/oakandwave/oakandwave-workflow:stable` is
+**re-signed** by the mirror workflow (`.github/workflows/oakandwave-workflow-mirror.yml`),
+because a cosign signature is registry+digest-bound and does not survive the
+cross-registry copy. Its keyless cert identity is therefore the **mirror** workflow,
+not the image build — verifying the Docker Hub signature with §2's image-workflow
+regexp fails on a legitimately-signed image. Pin the mirror identity instead:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "https://github.com/Wave-Engineering/claudecode-workflow/.github/workflows/oakandwave-workflow-mirror.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "docker.io/oakandwave/oakandwave-workflow@sha256:<digest>"
+```
+
+The Docker Hub digest is **identical** to the GHCR `:stable` digest — the mirror
+copies the exact digest (R-23) — so §5's digest-continuity check ties the two
+registries to one content sha. (§3's SBOM regexp is the broad `.../.*`, so the
+attestation already verifies on either registry.)
+
 ---
 
 ## 3. Syft SBOM (R-24)

--- a/scripts/ci/oakandwave-oci-labels.sh
+++ b/scripts/ci/oakandwave-oci-labels.sh
@@ -54,7 +54,13 @@ fi
 if [[ -z "$source" ]]; then
 	source="$(_git remote get-url origin)" || source=""
 fi
-[[ -n "$source" ]] || source="https://github.com/Wave-Engineering/claudecode-workflow"
+[[ -n "$source" ]] || source="https://github.com/wave-engineering/claudecode-workflow"
+
+# Lowercase the source URL. GHCR tolerates a capitalized org in an OCI label, but the
+# Docker Hub mirror + the OaW lowercase-everywhere convention want it lowercase, and
+# GITHUB_REPOSITORY carries the org's capitals ("Wave-Engineering"). github.com paths
+# are case-insensitive, so this resolves to the identical repo.
+source="${source,,}"
 
 # --- build timestamp (RFC3339, UTC) -------------------------------------------
 created="${OAKANDWAVE_CREATED:-}"

--- a/scripts/ci/promote-oakandwave-image.sh
+++ b/scripts/ci/promote-oakandwave-image.sh
@@ -140,3 +140,11 @@ echo "==> promote: retag $promoted_digest → $stable_ref (exact digest, no rebu
 docker buildx imagetools create --tag "$stable_ref" "$promoted_digest"
 
 echo "==> promoted: $stable_ref now points at the digest E2E-01 tested"
+
+# Publishing :stable to the public Docker Hub OaW brand + re-signing it there needs a
+# keyless-cosign OIDC identity, which this operator shell does not have — it runs in
+# GitHub Actions (id-token). Print the follow-up so the operator chains it explicitly;
+# it only ever mirrors this already-promoted :stable (nothing unvetted reaches the brand).
+echo
+echo "==> next (public Docker Hub mirror + re-sign, runs in GitHub Actions):"
+echo "      gh workflow run oakandwave-workflow-mirror.yml"

--- a/scripts/ci/resolve-stable-digest.sh
+++ b/scripts/ci/resolve-stable-digest.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# resolve-stable-digest.sh — resolve the GHCR :stable moving tag to its immutable
+# digest (the source for the Docker Hub mirror), and derive the matching Docker Hub
+# digest ref (same content-addressed sha) for the re-sign.
+#
+# Used by .github/workflows/oakandwave-workflow-mirror.yml. The mirror copies the
+# EXACT digest (not the moving tag) so the digest signed on Docker Hub is provably
+# the digest promoted on GHCR (R-23: the digest tested is the digest promoted is the
+# digest published).
+#
+# Inputs (env):
+#   GHCR_IMAGE            ghcr.io/wave-engineering/oakandwave-workflow
+#   DOCKERHUB_IMAGE       docker.io/oakandwave/oakandwave-workflow
+#   STABLE_TAG            the moving tag to resolve (stable)
+#   STABLE_DIGEST_INPUT   test/DI seam ONLY — a pinned GHCR digest ref used verbatim as the
+#                         source instead of resolving :stable. Deliberately NOT wired to any
+#                         workflow input: the mirror workflow always resolves the live :stable
+#                         so the public brand can never be pointed at an arbitrary/:edge digest
+#                         (#1038 review). This seam only lets the resolver be unit-tested
+#                         without a live registry.
+# Outputs (GITHUB_OUTPUT):
+#   digest_ref            the GHCR source digest ref to mirror
+#   dockerhub_digest_ref  the Docker Hub digest ref to re-sign (same sha)
+set -euo pipefail
+
+: "${GHCR_IMAGE:?GHCR_IMAGE must be set}"
+: "${DOCKERHUB_IMAGE:?DOCKERHUB_IMAGE must be set}"
+: "${STABLE_TAG:?STABLE_TAG must be set}"
+
+if [[ -n "${STABLE_DIGEST_INPUT:-}" ]]; then
+	src_ref="$STABLE_DIGEST_INPUT"
+	if [[ "$src_ref" != *"@sha256:"* ]]; then
+		echo "  [!] STABLE_DIGEST_INPUT must be a digest ref (registry/image@sha256:...): $src_ref" >&2
+		exit 1
+	fi
+else
+	# Resolve the moving :stable tag to its immutable manifest digest.
+	digest="$(docker buildx imagetools inspect "${GHCR_IMAGE}:${STABLE_TAG}" --format '{{.Manifest.Digest}}')"
+	if [[ "$digest" != sha256:* ]]; then
+		echo "  [!] could not resolve ${GHCR_IMAGE}:${STABLE_TAG} to a sha256 digest (got: '$digest')" >&2
+		exit 1
+	fi
+	src_ref="${GHCR_IMAGE}@${digest}"
+fi
+
+# The Docker Hub copy is content-addressed identical, so it shares the same sha.
+sha="${src_ref#*@}"
+dockerhub_ref="${DOCKERHUB_IMAGE}@${sha}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "digest_ref=${src_ref}"
+		echo "dockerhub_digest_ref=${dockerhub_ref}"
+	} >>"$GITHUB_OUTPUT"
+fi
+
+echo "==> source (GHCR):       ${src_ref}"
+echo "==> dest   (Docker Hub): ${dockerhub_ref}"

--- a/tests/contained-workflow/test_mirror_workflow.py
+++ b/tests/contained-workflow/test_mirror_workflow.py
@@ -1,0 +1,113 @@
+"""Oracle for #1038 — the Docker Hub :stable mirror + re-sign, moved into GitHub Actions.
+
+Promotion is operator-run (no OIDC), so keyless cosign can't re-sign there; and
+`cosign copy` is deprecated in the pinned cosign v2.6.4. So the OIDC half — mirror the
+already-promoted GHCR :stable to docker.io/oakandwave and RE-SIGN it — runs in a GHA
+`workflow_dispatch` job (id-token: write). The mechanical gate + edge->stable retag stay
+operator-side; this workflow only ever touches an ALREADY-promoted :stable.
+
+Two things proved here:
+  1. The workflow's load-bearing shape (trigger, id-token, mirror target, re-sign, and the
+     safety invariant that it NEVER touches :edge).
+  2. resolve-stable-digest.sh derives the Docker Hub digest ref from the same content sha
+     and rejects a non-digest pin — exercised hermetically (no docker/registry needed).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml is a test dep
+    yaml = None
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "oakandwave-workflow-mirror.yml"
+RESOLVE_SCRIPT = REPO_ROOT / "scripts" / "ci" / "resolve-stable-digest.sh"
+
+GHCR_IMAGE = "ghcr.io/wave-engineering/oakandwave-workflow"
+DOCKERHUB_IMAGE = "docker.io/oakandwave/oakandwave-workflow"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+class TestMirrorWorkflowShape:
+    def test_workflow_exists(self) -> None:
+        assert WORKFLOW.exists(), f"mirror workflow not found at {WORKFLOW}"
+
+    @pytest.mark.skipif(yaml is None, reason="pyyaml not installed")
+    def test_workflow_dispatch_and_oidc(self) -> None:
+        doc = yaml.safe_load(_workflow_text())
+        # `on:` parses to the truthy key True in YAML 1.1 — accept either spelling.
+        triggers = doc.get("on", doc.get(True))
+        assert "workflow_dispatch" in triggers, "must be workflow_dispatch (operator-triggered)"
+        assert doc["permissions"]["id-token"] == "write", (
+            "keyless cosign re-sign needs id-token: write (the whole reason this is in GHA)"
+        )
+
+    def test_mirrors_to_dockerhub_and_resigns(self) -> None:
+        text = _workflow_text()
+        assert DOCKERHUB_IMAGE in text, "must mirror to docker.io/oakandwave/oakandwave-workflow"
+        assert "resolve-stable-digest.sh" in text, "must resolve the :stable digest"
+        assert "imagetools create" in text, "must mirror via imagetools create"
+        assert "sign-oakandwave-image.sh" in text, "must re-sign the mirrored Docker Hub digest"
+        assert "dockerhub_digest_ref" in text, "re-sign must target the Docker Hub digest ref"
+
+    def test_never_touches_edge(self) -> None:
+        # Safety invariant: only an already-promoted :stable reaches the public brand.
+        # Check the workflow LOGIC (YAML comments stripped) — an explanatory comment that
+        # names :edge to say we never use it is fine; an actual :edge tag/var is not.
+        code = "\n".join(line.split("#", 1)[0] for line in _workflow_text().splitlines())
+        assert ":edge" not in code, "the mirror workflow logic must never reference a :edge tag"
+        assert "edge" not in code, (
+            "the mirror workflow logic must carry no edge tag/var — only the promoted :stable"
+        )
+
+
+class TestResolveStableDigest:
+    def _run(self, env_extra: dict) -> subprocess.CompletedProcess:
+        env = {
+            "GHCR_IMAGE": GHCR_IMAGE,
+            "DOCKERHUB_IMAGE": DOCKERHUB_IMAGE,
+            "STABLE_TAG": "stable",
+            "PATH": os.environ.get("PATH", ""),
+            **env_extra,
+        }
+        return subprocess.run(
+            ["bash", str(RESOLVE_SCRIPT)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_pinned_digest_derives_matching_dockerhub_ref(self, tmp_path: Path) -> None:
+        # With an explicit digest pin, no registry access is needed; assert the Docker Hub
+        # ref is the same content sha under the oakandwave repo (R-23: same digest published).
+        out = tmp_path / "gh_output"
+        sha = "sha256:" + "a" * 64
+        proc = self._run(
+            {"STABLE_DIGEST_INPUT": f"{GHCR_IMAGE}@{sha}", "GITHUB_OUTPUT": str(out)}
+        )
+        assert proc.returncode == 0, proc.stderr
+        outputs = dict(
+            line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+        )
+        assert outputs["digest_ref"] == f"{GHCR_IMAGE}@{sha}"
+        assert outputs["dockerhub_digest_ref"] == f"{DOCKERHUB_IMAGE}@{sha}"
+
+    def test_rejects_a_non_digest_pin(self, tmp_path: Path) -> None:
+        # A moving tag can't be signed (sign-oakandwave-image.sh refuses non-digest refs);
+        # the resolver must reject it up front rather than pass a tag downstream.
+        proc = self._run(
+            {"STABLE_DIGEST_INPUT": f"{GHCR_IMAGE}:stable", "GITHUB_OUTPUT": str(tmp_path / "o")}
+        )
+        assert proc.returncode != 0, "a non-digest pin must be rejected"
+        assert "digest ref" in proc.stderr

--- a/tests/contained-workflow/test_provenance.py
+++ b/tests/contained-workflow/test_provenance.py
@@ -106,10 +106,14 @@ def test_oci_labels() -> None:
         labels["org.opencontainers.image.revision"]
         == "0123456789abcdef0123456789abcdef01234567"
     )
+    # The source URL is lowercased (#1038): GITHUB_REPOSITORY carries the org's capitals
+    # ("Wave-Engineering"), but the label — like the image path — must be lowercase so the
+    # Docker Hub mirror and the OaW lowercase-everywhere convention hold. github.com paths
+    # are case-insensitive, so this resolves to the identical repo.
     assert (
         labels["org.opencontainers.image.source"]
-        == "https://github.com/Wave-Engineering/claudecode-workflow"
-    )
+        == "https://github.com/wave-engineering/claudecode-workflow"
+    ), f"source must be lowercased; got {labels['org.opencontainers.image.source']!r}"
     assert labels["org.opencontainers.image.created"] == "2026-07-22T12:00:00Z"
 
 


### PR DESCRIPTION
## Summary
Move only the OIDC-needing half of Docker Hub distribution into GitHub Actions: a `workflow_dispatch` job (`id-token: write`) that mirrors the already-promoted GHCR `:stable` to `docker.io/oakandwave/oakandwave-workflow:stable` and re-signs it fresh (cosign keyless + SBOM). Promotion is operator-run (no OIDC), and `cosign copy` is deprecated in the pinned v2.6.4 — a GHA job's `id-token` is the clean path. The mechanical gate + `edge→stable` retag stay operator-side, unchanged; this workflow only ever touches an already-promoted `:stable`.

## Changes
- New `.github/workflows/oakandwave-workflow-mirror.yml` + `scripts/ci/resolve-stable-digest.sh`.
- Lowercase the OCI source label (`oakandwave-oci-labels.sh` + `Dockerfile`).
- `promote-oakandwave-image.sh`: print the `gh workflow run` follow-up hint.
- `deployment-verification.md §2a`: Docker Hub verify recipe (mirror-workflow cert identity).
- Tests: `test_mirror_workflow.py` + provenance lowercase assertion.

## Linked Issues
Closes #1038

## Test Plan
- `validate.sh`: **214 passed, 0 failed** (shellcheck + shfmt + guards).
- Unit: mirror-workflow shape + `:stable`-only invariant + resolver logic + provenance; 13 pass.
- Code review: all 6 invariants confirmed; 3 findings fixed (verify-doc identity, Dockerfile label, removed the `:edge` foot-gun input).