### PR TITLE
feat(ci): reusable oaw-sign-image composite action for fleetwide image signing

### DIFF
--- a/.github/actions/oaw-sign-image/action.yml
+++ b/.github/actions/oaw-sign-image/action.yml
@@ -1,0 +1,50 @@
+name: "OaW sign image"
+description: >-
+  Keyless cosign signature + optional syft SBOM attestation, bound to an image digest.
+  The DRY core of OaW fleet image signing — consume it via a SHA-pinned `uses:`. Needs the
+  calling job to grant `permissions: id-token: write` (keyless cosign OIDC) and to be logged
+  in to the digest's registry.
+inputs:
+  digest-ref:
+    description: "The immutable digest to sign (registry/image@sha256:...). Never a moving tag (R-23)."
+    required: true
+  attach-sbom:
+    description: "Also generate + attest a syft SPDX SBOM."
+    required: false
+    default: "true"
+  sbom-tlog:
+    description: >-
+      Upload the SBOM attestation to the public rekor tlog. Set "false" for large images
+      whose SBOM predicate exceeds rekor's body ceiling — it then uses an RFC3161 TSA
+      timestamp instead (#995). The signature always goes to rekor regardless.
+    required: false
+    default: "true"
+  tsa-server-url:
+    description: "RFC3161 TSA endpoint used when sbom-tlog=false."
+    required: false
+    default: "https://timestamp.sigstore.dev/api/v1/timestamp"
+  cosign-version:
+    description: "cosign release to install (pinned; v3 dropped the --tlog-upload lever used by the TSA path)."
+    required: false
+    default: "v2.6.4"
+runs:
+  using: "composite"
+  steps:
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v3
+      with:
+        cosign-release: ${{ inputs.cosign-version }}
+    - name: Install syft
+      if: ${{ inputs.attach-sbom == 'true' }}
+      uses: anchore/sbom-action/download-syft@v0
+    - name: Sign the digest (+ SBOM)
+      shell: bash
+      env:
+        DIGEST_REF: ${{ inputs.digest-ref }}
+        ATTACH_SBOM: ${{ inputs.attach-sbom }}
+        SBOM_TLOG: ${{ inputs.sbom-tlog }}
+        TSA_SERVER_URL: ${{ inputs.tsa-server-url }}
+      # Invoke via `bash` (not a direct exec) so the action never depends on the script's
+      # execute bit surviving a consuming repo's checkout — a mode loss would otherwise fail
+      # exit 126 in the CONSUMER's CI, which the local test (which also uses `bash`) can't catch.
+      run: bash "${GITHUB_ACTION_PATH}/oaw-sign-image.sh"

--- a/.github/actions/oaw-sign-image/oaw-sign-image.sh
+++ b/.github/actions/oaw-sign-image/oaw-sign-image.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# oaw-sign-image.sh — the fleetwide reusable core of OaW image signing: a keyless
+# cosign signature + (optionally) a syft SBOM attestation, both bound to an immutable
+# digest. Bundled inside the `oaw-sign-image` composite action so any OaW repo can sign
+# via a SHA-pinned `uses:` without copy-pasting this logic. Generalized from cc-workflow's
+# scripts/ci/sign-oakandwave-image.sh (#966/#995).
+#
+# Inputs (env — supplied by action.yml):
+#   DIGEST_REF     registry/image@sha256:… to sign (required; never a moving tag — R-23).
+#   ATTACH_SBOM    "true" (default) ⇒ also generate + attest a syft SPDX SBOM.
+#   SBOM_TLOG      "true" (default) ⇒ upload the SBOM attestation to the public rekor tlog.
+#                  "false" ⇒ keep the SBOM OFF rekor and bind an RFC3161 TSA timestamp
+#                  instead — needed only when the SBOM predicate exceeds rekor's request
+#                  body ceiling (large images, e.g. cc-workflow's ~10 GB image, #995). The
+#                  SIGNATURE itself always goes to rekor (small, publicly transparent).
+#   TSA_SERVER_URL RFC3161 TSA endpoint used when SBOM_TLOG=false
+#                  (default: https://timestamp.sigstore.dev/api/v1/timestamp).
+#   COSIGN_YES     "true" (default) ⇒ cosign --yes (non-interactive CI).
+set -euo pipefail
+
+: "${DIGEST_REF:?DIGEST_REF must be set (registry/image@sha256:...)}"
+
+if [[ "$DIGEST_REF" != *"@sha256:"* ]]; then
+	echo "  [!] refusing to sign a non-digest ref: $DIGEST_REF" >&2
+	echo "      (sign the immutable digest, never a moving tag — R-23)" >&2
+	exit 1
+fi
+
+command -v cosign >/dev/null 2>&1 || {
+	echo "  [!] cosign not found on PATH — the composite action installs it" >&2
+	exit 1
+}
+
+cosign_yes=()
+[[ "${COSIGN_YES:-true}" == "true" ]] && cosign_yes=(--yes)
+
+# --- cosign: keyless signature attached to the digest (always to rekor) -------
+echo "==> cosign sign (keyless) $DIGEST_REF"
+cosign sign "${cosign_yes[@]}" "$DIGEST_REF"
+
+# --- syft SBOM + cosign attest (optional; rekor or TSA per SBOM_TLOG) ----------
+if [[ "${ATTACH_SBOM:-true}" == "true" ]]; then
+	command -v syft >/dev/null 2>&1 || {
+		echo "  [!] syft not found on PATH (ATTACH_SBOM=true) — the composite action installs it" >&2
+		exit 1
+	}
+	sbom_file="$(mktemp -t oaw-sbom.XXXXXX.spdx.json)"
+	trap 'rm -f "$sbom_file"' EXIT
+
+	echo "==> syft SBOM (spdx-json) for $DIGEST_REF"
+	syft "$DIGEST_REF" -o spdx-json="$sbom_file"
+
+	attest_args=(--predicate "$sbom_file" --type spdxjson)
+	if [[ "${SBOM_TLOG:-true}" == "true" ]]; then
+		echo "==> cosign attest SBOM -> $DIGEST_REF (public rekor tlog)"
+	else
+		# Large-image path (#995): SBOM predicate exceeds rekor's body ceiling, so keep it
+		# off the public tlog and bind a trusted RFC3161 TSA timestamp instead.
+		echo "==> cosign attest SBOM -> $DIGEST_REF (TSA-timestamped, off the public rekor tlog)"
+		attest_args+=(--tlog-upload=false)
+		attest_args+=(--timestamp-server-url="${TSA_SERVER_URL:-https://timestamp.sigstore.dev/api/v1/timestamp}")
+	fi
+	cosign attest "${cosign_yes[@]}" "${attest_args[@]}" "$DIGEST_REF"
+fi
+
+sbom_note="no SBOM"
+if [[ "${ATTACH_SBOM:-true}" == "true" ]]; then
+	sbom_note="SBOM=$([[ "${SBOM_TLOG:-true}" == "true" ]] && echo rekor || echo TSA)"
+fi
+echo "==> signed $DIGEST_REF (signature=rekor, ${sbom_note})"

--- a/tests/regression/test_oaw_sign_image_action.sh
+++ b/tests/regression/test_oaw_sign_image_action.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test_oaw_sign_image_action.sh — #1040.
+#
+# The oaw-sign-image composite action is the DRY core of fleetwide image signing, so its
+# contract is load-bearing: sign the digest, attest the SBOM to rekor OR (for large images)
+# to a TSA off-rekor, skip the SBOM when asked, and refuse a non-digest ref. cosign + syft
+# are stubbed on PATH so the exact invocations are asserted hermetically (no network, no
+# real signing) — a signer only ever run against the happy path is unverified.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ACTION_DIR="$ROOT/.github/actions/oaw-sign-image"
+SCRIPT="$ACTION_DIR/oaw-sign-image.sh"
+ACTION_YML="$ACTION_DIR/action.yml"
+DIGEST="ghcr.io/wave-engineering/example@sha256:$(printf 'a%.0s' {1..64})"
+
+pass=0
+fail=0
+check() { # label  condition-already-evaluated($?)
+	if [[ "$1" == 0 ]]; then
+		echo "  [PASS] $2"
+		pass=$((pass + 1))
+	else
+		echo "  [FAIL] $2"
+		fail=$((fail + 1))
+	fi
+}
+
+# --- stub cosign + syft on PATH, logging every call ---------------------------
+stub_dir="$(mktemp -d)"
+calls="$stub_dir/calls.log"
+trap 'rm -rf "$stub_dir"' EXIT
+cat >"$stub_dir/cosign" <<EOF
+#!/usr/bin/env bash
+echo "cosign \$*" >> "$calls"
+exit 0
+EOF
+cat >"$stub_dir/syft" <<EOF
+#!/usr/bin/env bash
+echo "syft \$*" >> "$calls"
+exit 0
+EOF
+chmod +x "$stub_dir/cosign" "$stub_dir/syft"
+
+run() { # env-assignments...  → runs the signer with stubs on PATH, resets the call log
+	: >"$calls"
+	env PATH="$stub_dir:$PATH" DIGEST_REF="$DIGEST" "$@" bash "$SCRIPT" >/dev/null 2>&1
+}
+
+# 1. Default (SBOM to rekor): sign + attest, NO --tlog-upload=false.
+run
+grep -q "cosign sign" "$calls"
+check $? "default: cosign sign the digest"
+grep -q "syft .*spdx-json" "$calls"
+check $? "default: syft generates an SBOM"
+grep -q "cosign attest" "$calls"
+check $? "default: cosign attest the SBOM"
+! grep -q -- "--tlog-upload=false" "$calls"
+check $? "default: SBOM goes to rekor (no --tlog-upload=false)"
+! grep -q -- "--timestamp-server-url" "$calls"
+check $? "default: no TSA timestamp (fully rekor, not TSA)"
+
+# 2. Large-image path (SBOM_TLOG=false): attest off-rekor with a TSA timestamp.
+run SBOM_TLOG=false
+grep -q -- "--tlog-upload=false" "$calls"
+check $? "SBOM_TLOG=false: SBOM kept off rekor"
+grep -q -- "--timestamp-server-url" "$calls"
+check $? "SBOM_TLOG=false: binds an RFC3161 TSA timestamp"
+
+# 3. ATTACH_SBOM=false: sign only, no syft, no attest.
+run ATTACH_SBOM=false
+grep -q "cosign sign" "$calls"
+check $? "attach-sbom=false: still signs"
+! grep -q "syft " "$calls"
+check $? "attach-sbom=false: no syft"
+! grep -q "cosign attest" "$calls"
+check $? "attach-sbom=false: no attestation"
+
+# 4. Refuse a non-digest (moving-tag) ref — R-23.
+if env PATH="$stub_dir:$PATH" DIGEST_REF="ghcr.io/wave-engineering/example:latest" bash "$SCRIPT" >/dev/null 2>&1; then
+	check 1 "refuses a non-digest ref (moving tag)" # returned 0 = did NOT refuse → fail
+else
+	check 0 "refuses a non-digest ref (moving tag)" # non-zero = refused → pass
+fi
+
+# 5. action.yml contract: inputs + installers + runs the bundled script.
+grep -q "digest-ref:" "$ACTION_YML"
+check $? "action.yml exposes digest-ref input"
+grep -q "sbom-tlog:" "$ACTION_YML"
+check $? "action.yml exposes the sbom-tlog toggle"
+grep -q "sigstore/cosign-installer" "$ACTION_YML"
+check $? "action.yml installs cosign"
+grep -q 'GITHUB_ACTION_PATH.*/oaw-sign-image.sh' "$ACTION_YML"
+check $? "action.yml runs the bundled script via github.action_path"
+
+echo
+echo "  Results: $pass passed, $fail failed"
+[[ "$fail" == 0 ]]


### PR DESCRIPTION
## Summary
Extract cosign keyless sign + syft SBOM (proven in `sign-oakandwave-image.sh` / #995) into a self-contained composite action `.github/actions/oaw-sign-image` that any OaW repo can `uses:` (SHA-pinned) to sign a digest — the DRY core of the fleetwide signing rollout (project_dockerhub_migration_and_fleet_signing). Additive; cc-workflow's own signing is untouched.

## Changes
- `.github/actions/oaw-sign-image/action.yml` + bundled `oaw-sign-image.sh` (invoked via `bash` from `$GITHUB_ACTION_PATH` so a lost `+x` bit can't break a consumer's CI).
- Parameterized: `attach-sbom`, `sbom-tlog` (rekor vs TSA-off-rekor for large images — the #995 case), `tsa-server-url`, `cosign-version` (v2.6.4).
- `tests/regression/test_oaw_sign_image_action.sh` — stubs cosign/syft, asserts every mode + the action.yml contract.

## Linked Issues
Closes #1040

## Test Plan
- `validate.sh`: **215 passed, 0 failed**; the new test is 15/15; shellcheck + shfmt clean.
- Code review: core correct + parity with the original; 2 findings fixed (bash-invocation, TSA-absent assertion). Deferred: SHA-pin the installer actions (fleetwide follow-up).