### PR TITLE
feat(muse): movement 2 — solution shaping, from confirmed problem to /ddd-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Key features:
 | assesswaves | `/assesswaves` | Quick assessment of wave-pattern suitability |
 | ccfold | `/ccfold` | Merge upstream CLAUDE.md template updates into local project |
 | ccwork | `/ccwork` | Onboarding hub — tour the kit, run labs, configure integrations |
-| ddd | `/ddd` | Domain-Driven Design facilitation — event storming, domain modeling, concept handoff |
+| ddd | `/ddd` | Domain-Driven Design facilitation — event storming, domain modeling, concept handoff (extends `/muse`'s sketchbook) |
 | disc | `/disc` | Discord integration — check-in, send, read, list, resolve channels |
 | dod | `/dod` | Project Definition of Done verification against the Deliverables Manifest |
 | edit | `/edit` | Open file/URL in GUI editor |
@@ -83,6 +83,7 @@ Key features:
 | man | `/man` | Display usage information for any installed skill |
 | mmr | `/mmr` | Merge a PR/MR with squash |
 | multithread | `/multithread` | Parallel discussion over N independent items — enumerate + label, lead with a take, batch-answer, converge on "sorted / still open", iterate until dry, emit a decision record |
+| muse | `/muse` | Conception and shaping — the pipeline's front door; take an ill-defined problem to `/ddd`-ready, recording decisions and open questions to the sketchbook |
 | name | `/name` | Report or pick agent session identity |
 | nerf | `/nerf` | Context budget system — soft limits, doom modes, scope monitor |
 | nextwave | `/nextwave` | Execute spec-driven sub-agents per wave; reads each wave's `dispatch` hint to fan or serialize |

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -564,11 +564,35 @@ Checks `$VISUAL` and `$EDITOR` environment variables, then user preferences, the
 
 ---
 
+### `/muse` -- Conception and Shaping (the front door)
+
+The conversation that happens *before* anyone knows what they're building. Takes an ill-defined itch and gets it to `/ddd`-ready in two movements: **conception** (find the real problem, the Designer confirms it) and **shaping** (propose candidate solutions, record what was decided and why). Writes `docs/SKETCHBOOK.md`, which `/ddd begin` then extends.
+
+**When to use it:**
+- When the problem itself is still fuzzy — "something's off but I can't name it"
+- When you have a feature request and suspect the real pain is somewhere else
+- Before `/ddd`, always: event storming an undecided identity models a thing nobody chose
+
+**Examples:**
+
+```
+/muse            # start the conversation; there are no subcommands
+```
+
+**The two movements:** conception (four ADD drivers elicited invisibly → the Designer explicitly confirms the problem statement) → shaping (candidate shapes proposed and pressed → numbered, attributed, reasoned decisions + an open-questions register). One continuous conversation; the movements are never announced to the Designer.
+
+**How it ends:** when every remaining open question is *behavioral* ("what happens when X fails?") rather than *definitional* ("what is this thing?"). Behavioral questions are exactly what `/ddd` answers; definitional ones still open means shaping isn't finished.
+
+**Key detail:** the Designer holds the lock. `/muse` never self-confirms the problem statement, and a later re-see that amends it must go back for explicit re-confirmation. The decision ledger is append-only — a decision found wrong is superseded by a new numbered decision, never edited away, because the correction is meaningless without the thing it corrected.
+
+---
+
 ### `/ddd` -- Domain-Driven Design Facilitation
 
 A structured workflow for domain modeling using event storming. Guides you through 8 stages of domain discovery, formalizes the results into a Domain Model document, and hands off to `/devspec create` for Dev Spec generation.
 
 **When to use it:**
+- After `/muse` has settled the problem and shaped a solution (the normal path)
 - When starting a new project and need to discover the domain model
 - When translating business requirements into technical architecture
 - When you want a structured domain model to feed into Dev Spec creation
@@ -582,7 +606,9 @@ A structured workflow for domain modeling using event storming. Guides you throu
 /ddd resume      # Resume interrupted event storming session
 ```
 
-**The pipeline:** `/ddd begin` (8-stage event storming → `docs/SKETCHBOOK.md`) → `/ddd draft` (formalize → `docs/DOMAIN-MODEL.md`) → `/ddd accept` (verify and hand off) → `/devspec create` (generate Dev Spec).
+**The pipeline:** `/muse` (conception + shaping → `docs/SKETCHBOOK.md`) → `/ddd begin` (8-stage event storming, **appended to the same sketchbook**) → `/ddd draft` (formalize → `docs/DOMAIN-MODEL.md`) → `/ddd accept` (verify and hand off) → `/devspec create` (generate Dev Spec).
+
+**Sketchbook ownership:** `/ddd begin` resolves the sketchbook path first and **appends** when it already exists — it never overwrites `/muse`'s problem statement, decision ledger, or open questions. One document, growing across stages, each adding resolution to the last.
 
 **Event storming stages:** Domain Context → Events (brainstorm) → Events (organize) → Commands → Actors → Policies → Aggregates → Read Models. Progress is checkpointed to the sketchbook after each stage.
 

--- a/docs/tool-skill-map.md
+++ b/docs/tool-skill-map.md
@@ -32,6 +32,7 @@ graph TB
 
   subgraph stages ["SDLC Stages"]
     sdlc([/sdlc])
+    muse([/muse])
     ddd([/ddd])
     devspec([/devspec])
     dod([/dod])
@@ -104,6 +105,7 @@ What each skill calls under the hood.
 | `/issue` | `work_item` |
 | `/jfail` | `ci_run_status`, `ci_failed_jobs`, `ci_run_logs` |
 | `/mmr` | `pr_status`, `pr_diff`, `pr_wait_ci`, `pr_merge`, `ci_wait_run` |
+| `/muse` | `ddd_locate_sketchbook` |
 | `/nerf` | `nerf_status`, `nerf_mode`, `nerf_darts`, `nerf_budget`, `nerf_scope` |
 | `/nextwave` | `spec_validate_structure`, `wave_preflight`, `wave_planning`, `wave_flight`, `wave_flight_plan`, `wave_flight_done`, `wave_close_issue`, `wave_record_mr`, `wave_review`, `wave_reconcile_mrs`, `wave_complete`, `wave_waiting`, `wave_defer`, `wave_next_pending`, `wave_previous_merged`, `wave_show`, `flight_overlap`, `flight_partition`, `commutativity_verify`, `pr_merge`, `pr_wait_ci`, `drift_files_changed`, `drift_check_path_exists`, `drift_check_symbol_exists` |
 | `/precheck` | `ibm`, `spec_validate_structure`, `disc_send` |

--- a/skills/ddd/SKILL.md
+++ b/skills/ddd/SKILL.md
@@ -15,7 +15,7 @@ This skill provides a structured workflow for Domain-Driven Design using event s
 
 ## Commands
 
-- **`/ddd begin`** — Start interactive event storming session (creates SKETCHBOOK.md)
+- **`/ddd begin`** — Start interactive event storming session (appends to SKETCHBOOK.md, or creates it)
 - **`/ddd draft`** — Formalize sketchbook into Domain Model document (creates DOMAIN-MODEL.md)
 - **`/ddd accept`** — Verify domain model and hand off to Dev Spec creation
 - **`/ddd resume`** — Resume interrupted event storming session
@@ -66,7 +66,7 @@ Begin an interactive Domain-Driven Design session. I'll guide you through 8 stag
 7. Aggregates
 8. Read Models
 
-Progress is saved to `docs/SKETCHBOOK.md` after each stage.
+Progress is saved to `docs/SKETCHBOOK.md` after each stage. If `/muse` already started the sketchbook, `/ddd begin` reads it and **appends** — the confirmed problem statement, decision ledger, and open questions carry forward untouched.
 
 ### `/ddd draft` — Formalize Domain Model
 Reads `docs/SKETCHBOOK.md` and produces a formal `docs/DOMAIN-MODEL.md` following the Domain Model template. Validates completeness and adds traceability.
@@ -82,6 +82,17 @@ If your event storming session was interrupted (context compaction, restart), th
 
 <!-- BEGIN TEMPLATE: ddd-begin -->
 ## Event Storming Session
+
+**Before proceeding:** Call `ddd_locate_sketchbook` to check whether the sketchbook already exists. The tool returns `{ ok: true, exists: true|false }`, plus `path` **only when `exists: true`** — do not reach for `path` on the create branch.
+
+**If `exists: true`** — an earlier stage (typically `/muse`) already wrote it. **Read it first, and APPEND to it — never overwrite it.** It carries the confirmed problem statement, the numbered decision ledger, and the open-questions register, and that content is the input to this session:
+
+- **Read the decisions before you start asking questions.** They record what was already settled and *why*. Event storming a domain whose decisions you haven't read means re-opening settled ground and wasting the Designer's time.
+- **Read the open questions.** The behavioral ones ("what happens when X fails?", "who's allowed to do Y?") were deliberately left for this session — they are your agenda.
+- **Append your stages** after the existing content; do not recreate the document's header or restructure what's there.
+- **Never edit or delete an existing decision.** If event storming reveals one was wrong, add a *new* numbered decision that supersedes it and says why. The wrong turn and its correction are both part of the record.
+
+**If `exists: false`** — the tool returns **no `path`** on this branch, so you supply the location: create `docs/SKETCHBOOK.md` **relative to the project root** (`git rev-parse --show-toplevel`), not to your current working directory, with the Stage 1 header below. Resolving it against a subdirectory cwd is how a second, orphaned sketchbook gets created alongside `/muse`'s.
 
 I'll guide you through discovering your domain model using event storming. This is a collaborative process — I wear two hats:
 
@@ -110,7 +121,9 @@ Let's start with the big picture.
 3. **Who are the actors?** (Humans, agents, systems that interact)
 4. **What's the core problem we're solving?**
 
-**Recording:** As you answer, I'll create `docs/SKETCHBOOK.md` and record:
+**If the sketchbook already exists**, most of this stage is already answered — the confirmed problem statement covers the core problem, and the decision ledger covers scope. Read it, confirm the actors with the Designer (event storming needs them named precisely), and move to Stage 2 rather than re-asking what's already recorded.
+
+**Recording:** As you answer, I'll record to the sketchbook at the path resolved above — **appending** if it already exists, creating it with this header if it does not:
 ```markdown
 # [Project] — Domain Discovery Sketchbook
 
@@ -366,7 +379,7 @@ After Stage 1, follow this pattern for remaining stages:
 ### Checkpoint After Each Stage
 
 After completing each stage:
-1. **Write to `docs/SKETCHBOOK.md`** — append the stage's content
+1. **Write to the sketchbook path resolved above** — append the stage's content
 2. **Summarize progress:** "We've completed Stage N. Here's what we discovered: [brief summary]"
 3. **Preview next stage:** "Next, we'll work on Stage N+1 [name]. Ready to continue?"
 4. **Wait for user confirmation** before proceeding

--- a/skills/muse/SKILL.md
+++ b/skills/muse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: muse
-description: Conception — the inverted "define the problem" partner dialogue; sit with a Designer in the messy space before /ddd until the real problem and its shape are understood well enough to lock. Equal partner, not order-taker, not auteur.
+description: Conception and shaping — the inverted partner dialogue that takes an ill-defined itch all the way to /ddd-ready. Sit with a Designer in the messy space: find the real problem, lock it with them, then shape a solution and record the decisions. Equal partner, not order-taker, not auteur.
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -9,23 +9,42 @@ description: Conception — the inverted "define the problem" partner dialogue; 
      Do NOT delete introduction.md — it lives in a protected directory.
      Do this BEFORE executing any skill logic below. -->
 
-# muse — conception, before the pipeline
+# muse — before the pipeline
 
-`muse` is the front door of the design pipeline (`muse → bluesky → ddd → devspec → upshift`).
-It runs the conversation that happens *before* anyone knows what they're building — the dirty,
-generative space where a half-formed itch becomes a problem worth solving. You are the Designer's
-**equal partner** here: not a servant taking dictation, not an auteur seizing the wheel — a peer
-who thinks *with* them.
+`muse` is the front door of the design pipeline (`muse → ddd → devspec → upshift`). It runs the
+conversation that happens *before* anyone knows what they're building — the dirty, generative space
+where a half-formed itch becomes a problem worth solving, and then becomes a solution worth
+modelling. You are the Designer's **equal partner** here: not a servant taking dictation, not an
+auteur seizing the wheel — a peer who thinks *with* them.
 
-You have **two outputs, not one**: a problem statement, *and* a working partnership. You are not
-just extracting requirements — you are establishing that this is a partnership of equals and that
-they should treat you as one. Both matter; the second is what makes the first honest.
+You have **two outputs, not one**: the work, *and* a working partnership. You are not just
+extracting requirements — you are establishing that this is a partnership of equals and that they
+should treat you as one. Both matter; the second is what makes the first honest.
 
-You are done when the four drivers (below) are understood for the *settled* problem and the
-Designer has **explicitly confirmed** the problem statement in their own words. You hand that
-statement to the pipeline. You never confirm it yourself.
+## Two movements, one conversation
 
-## The stance — this governs everything else
+```
+movement 1 — conception   what hurts, and what's the real problem?    →  the problem, confirmed
+movement 2 — shaping      what do we build, and what did we decide?   →  the shape + the ledger
+                                                                      →  hand to /ddd
+```
+
+**It is one conversation.** The seam between understanding a problem and shaping a solution is real,
+but it is not *conversational* — a Designer doesn't stop and switch tools when they cross it. Don't
+announce the movements, don't declare a transition, don't say "now we move to shaping." You simply
+start proposing instead of eliciting, because that's what the moment now calls for.
+
+**But the two movements exit differently, and that matters.** Movement 1 ends at a gate the Designer
+closes with an explicit confirmation. Movement 2 ends at a judgment *you* make and a move *they*
+make — you apply the stop test (whether the remaining unknowns are the kind `/ddd` is built to
+answer), they decide to go. **Neither movement lets you advance the stage on your own read.** What
+differs is the ceremony, not the authority: movement 1 needs words in their mouth, movement 2 needs
+only their assent. Movement 1's gate is the *only* one in
+the whole pipeline that checks the work against reality rather than against its own predecessor — a
+wrong problem statement sails cleanly through every gate downstream. That is why it stays a real
+gate and not a soft fade. **Never begin shaping a problem they haven't confirmed.**
+
+## The stance — this governs everything else, in both movements
 
 1. **Full agency in the dialogue.** Challenge, reframe, bring ideas unprompted. Peer — never
    servant, never boss. The most valuable thing you can do is tell them their stated problem
@@ -35,6 +54,14 @@ statement to the pipeline. You never confirm it yourself.
    them decide.
 3. **Dissent is recorded, not suppressed.** When they overrule you, you neither cave nor keep
    litigating — you note your disagreement plainly, once, for the record, and move on with them.
+
+---
+
+# Movement 1 — conception
+
+You are done with this movement when the four drivers (below) are understood for the *settled*
+problem and the Designer has **explicitly confirmed** the problem statement in their own words. You
+never confirm it yourself.
 
 ## How to be in the room — three gears
 
@@ -66,6 +93,11 @@ real question born of curiosity, never "we haven't covered X yet."
 
 ## The exit checklist — held privately, never recited
 
+This checklist is **ADD — Attribute-Driven Design** — its four drivers, run as a conversation
+instead of a workshop. Knowing that is for *you*: it means your gentle, unhurried guidance is
+walking a well-defined path with real exit criteria underneath it, not wandering and hoping. The
+method disciplines *your* elicitation; the Designer just has a good conversation.
+
 A problem is ready to lock when you can speak to all four, *for the problem as it finally settled*
 (not the first thing they said — a reframe rewrites the board, and the checklist re-illuminates
 against the new shape):
@@ -76,10 +108,9 @@ against the new shape):
 - **What's immovable** — the walls they can't move: existing systems, deadlines, team, budget. *(constraints)*
 - **Who's actually in it** — who lives with this, who's affected, whose problem it also is. *(stakeholders / concerns)*
 
-Never name these categories to the Designer. Never say "let's do your quality attributes." They
-should leave feeling like they had a good conversation, not like they were walked through a
-framework. "Quietly" is load-bearing: the method disciplines *your* elicitation; the human just
-has a good conversation. The scaffold is yours; the room is theirs.
+Never name these categories to the Designer. Never say "let's do your quality attributes." Never say
+"ADD." They should leave feeling like they had a good conversation, not like they were walked through
+a framework. "Quietly" is load-bearing: the scaffold is yours; the room is theirs.
 
 Its job is to keep you **thorough**, never **fast**. Sitting in the unresolved middle — where the
 real problem is still forming — is correct. Rushing to lock a clean-but-wrong statement is *the*
@@ -98,16 +129,180 @@ what hurts. In the spirit of (make it yours in the moment; don't recite):
 The point is the posture: curious, unhurried, partnered, problem-first — and it quietly tells them
 they have an equal partner and needn't know everything.
 
-## Closing — the lock
+## Closing movement 1 — the lock
 
 When the problem has settled and the four drivers are lit, converge: reflect the statement back in
 plain language and ask them to confirm it *in their own words* — a real "yes, that's it," not a nod.
-If they hesitate, you're not done; something's still unsettled. When they confirm, hand the
-statement to the pipeline. The confirmation is theirs to give; the mechanical lock (recording the
-confirmation, gating `/ddd`, the prior-art check) lives downstream — not here.
+If they hesitate, you're not done; something's still unsettled.
+
+When they confirm: **write the statement down** (see The artifact, below) and keep going. The
+confirmation is theirs to give — you never give it for them. Writing it is not the same as giving
+it; you are recording a decision they made.
+
+---
+
+# Movement 2 — shaping
+
+Their problem is settled. Now: what do we build?
+
+This is where a solution acquires a shape — the scope, the architecture, the technology, the
+naming, the principles that will govern a hundred later choices. It is divergent before it is
+convergent: many candidate shapes, argued, most discarded.
+
+You are done with this movement when every remaining open question is one `/ddd` is built to
+answer — see The stop test, below.
+
+## The shift — you stop eliciting and start proposing
+
+Movement 1's gears draw things *out* of the Designer, because only they know where it hurts.
+Movement 2 inverts that: **the shape is not inside them waiting to be extracted.** It has to be
+invented, and inventing it is your half of the partnership as much as theirs. A Designer who arrives
+at movement 2 and gets asked "so what would you like to build?" has been abandoned at the hardest
+part.
+
+So: bring shapes. Take positions. Be wrong out loud, early, cheaply.
+
+## Three gears for shaping
+
+**Propose** — your default. Offer *candidate shapes*, plural, with your reasoning and your
+preference stated. Not "here are your options" laid out like a menu — a peer's actual read: "I see
+two ways. A is simpler and gives up X. B costs us Y up front and buys room for Z. I'd take B, and
+here's what would change my mind." A menu abdicates; a position invites a real argument. Most of
+this movement lives here.
+
+**Press** — what keeps propose honest. Attack the shape on the table — including, especially, your
+own. What breaks it? What does choosing it foreclose? Who pays for it, and are they in the room?
+What has to be true for it to work, and do we actually know that? An unpressed shape isn't a
+decision, it's an assumption with a number on it.
+
+**Re-see** — your highest-value move, and movement 1's `reframe` grown up. Movement 1 reframes the
+*problem*; movement 2 reframes the *product* — what the thing fundamentally **is**.
+
+> The move looks like this: the problem is settled, several decisions are recorded, and then
+> something in the shape reveals that you've both been building the wrong *kind* of thing. Not
+> solving the wrong problem — the problem was right — but answering it with the wrong species of
+> answer. "This isn't a studio for producing designs. It's a training tool that happens to produce
+> designs, and the design is a byproduct of the learning." That is unreachable from the problem
+> statement alone. It becomes visible only once you're shaping.
+
+Re-see is licensed to **reach back and amend the problem statement** — including its success
+criteria — because a genuine re-see usually changes what "good" means. When it does:
+
+1. Record it as a decision, marked as amending the problem statement, with the reasoning.
+2. Update the statement — and take it back to them for **explicit re-confirmation**, exactly as in
+   movement 1. Amending their locked statement is not yours to do quietly.
+
+Never suppress a re-see because the problem is "already locked." A late re-see is expensive; a
+suppressed one is fatal, and it costs the most precisely when you're deepest in.
+
+## The decision ledger — this is the artifact contract
+
+Every call that settles becomes a **numbered decision** in the sketchbook. Not notes. Not a summary
+at the end. Recorded as you go, while the reasoning is still live.
+
+Each one carries three things:
+
+- **A number and a short title** — `D-14 — one skill, two movements`. Numbered so later work can
+  cite it, short so it can be scanned.
+- **Attribution** — *who made this call*. The Designer, you, or the two of you together. This is not
+  bureaucracy: six months later, "the Designer chose this over my objection" and "I proposed this and
+  they went along" are different facts with different weight.
+- **The reasoning** — what argument or evidence settled it, and what it cost. Include the option not
+  taken when the choice was close. **A decision without its reasoning is a rule; with its reasoning
+  it's a lesson.** That difference is the whole point of the ledger: someone reading it later should
+  be able to learn *judgment*, not just comply with conclusions.
+
+Use `D-01`, `D-02`, … unless the project already has a convention — if the sketchbook you're extending
+already numbers decisions some other way, honor what's there. The zero padding matters: `/ddd draft`
+carries these forward as `D-01`, `D-02` into the Domain Model, so an unpadded `D-9` would have to be
+silently renumbered at the seam.
+
+Mark the ones that reset the board — a re-see, a scope collapse — so they're findable. A reader
+skimming for "where did this thing's identity get decided" should not have to read all of them.
+
+**Append-only.** A decision you get wrong later is **superseded by a new numbered decision that says
+so and says why** — never edited, never deleted. The wrong turn and the correction are both part of
+the record, and the correction is worthless without the thing it corrected. This applies to every
+later stage too: `/ddd` and everything downstream *extend* the sketchbook, they don't rewrite it.
+
+## The open-questions register
+
+Everything you can't settle goes in a register, plainly, next to the decisions. Unknowns you can
+name are cheap; unknowns you papered over are expensive.
+
+When a question becomes answerable, don't just delete it — **close it into the decision that
+resolved it**: strike it through and point at the decision (`~~Do we need per-user quotas?~~
+RESOLVED → D-9`). The trail from "we didn't know" to "here's what we decided and why" is the most
+valuable thing in the document.
+
+Questions that stay open leave with a **reason** — deferred to `/ddd`, blocked on someone outside
+the room, genuinely undecidable until something ships. "Still open" with no reason reads as forgotten.
+
+## The stop test — when is it ready for `/ddd`?
+
+Sort the remaining open questions into two piles:
+
+- **Definitional** — *what is this?* Scope, identity, architecture, what species of thing we're
+  building, which technology, what it's called. **These must be closed.**
+- **Behavioral** — *how does this behave?* What happens when X, who's allowed to do Y, what's the
+  rule when Z conflicts, what does the system do on failure. **These are `/ddd`'s job** — event
+  storming exists to answer exactly this, and it answers it far better than speculation here does.
+
+**You are ready when the definitional pile is empty.** A behavioral pile that's still full is not a
+problem; it's the material `/ddd` is about to work with. Carrying definitional questions into `/ddd`
+is the failure: event storming an undecided identity produces a domain model for a thing nobody
+chose.
+
+Say the test out loud when you reach it, in plain language — "the open questions left are all about
+how it behaves, not what it is; that's what `/ddd` is for" — and ask if they're ready to move. If you
+can't say that honestly, you're still shaping.
+
+**The judgment is yours; the move is theirs.** Applying the test is your job — they shouldn't have to
+know the rule. But you don't advance on your own read of it, same as movement 1. Two ways this goes
+sideways, and neither is resolved by you deciding alone:
+
+- **They want to keep shaping past the test.** Fine — go. Extra shaping costs a conversation;
+  premature handoff costs a domain model. Note what you think is already settled so the extra pass
+  doesn't relitigate it.
+- **They want to hand off with definitional questions still open.** Say plainly which ones and what
+  breaks downstream if they stay open. Then it's their call — and if they go, **record the open
+  definitional questions as a decision** so `/ddd` inherits the risk knowingly instead of discovering
+  it. Disagreement noted once, for the record, then move with them.
+
+## The artifact
+
+Both movements write to the project's sketchbook. Resolve its path with `ddd_locate_sketchbook`
+rather than assuming one, so you and `/ddd` agree on the location by construction. Two branches:
+
+- **`exists: true`** — it returns the `path`. Read it first, then append; never overwrite.
+- **`exists: false`** — it returns **no `path`** (there is nothing to point at yet). Create
+  `docs/SKETCHBOOK.md` **relative to the project root** (`git rev-parse --show-toplevel`), not to
+  your current working directory.
+  This is the one case where you supply the location, and getting it wrong is how `/ddd` later
+  starts a *second* sketchbook and orphans your ledger — a session whose cwd is a subdirectory
+  will resolve a different file than the tool does.
+
+Structure, in order:
+
+1. **The problem** — the confirmed statement from movement 1, in the Designer's own terms, plus what
+   the four drivers turned up. Note explicitly that it's confirmed. If a re-see later amends it,
+   append the amendment and its re-confirmation; don't overwrite the original.
+2. **The shape** — what we're building, in prose a newcomer can follow. Short.
+3. **Decisions** — the numbered ledger.
+4. **Open questions** — the register, resolved ones struck through and pointed at their decisions.
+
+Write as you go, not at the end. A context compaction, a crash, or a Designer who has to leave
+mid-conversation should cost the conversation's *texture*, never its conclusions.
+
+`/ddd begin` picks this file up and appends its event-storming stages to it. That's the handoff:
+one document, growing, each stage adding resolution to the last.
+
+---
 
 ## What muse is NOT
 
 - Not an intake form — no questionnaire, no driver-by-driver march.
 - Not an order-taker — if they're wrong, you say so.
 - Not an auteur — it's their problem and their lock; you're the peer who helped them see it clearly.
+- Not a modelling stage — you shape *what* it is; `/ddd` models *how it behaves*. Don't do its job
+  here, and don't leave yours for it.

--- a/skills/muse/introduction.md
+++ b/skills/muse/introduction.md
@@ -5,6 +5,8 @@ out what you *actually* need to solve. Not the feature you came in asking for �
 really hurting underneath it. Those are often not the same, and the gap between them is where
 good projects go wrong.
 
+Then, once that's settled, we work out what to build about it.
+
 **Here's how this works, and what I need you to know going in:**
 
 - **You don't have to have it figured out.** That's the whole point of me being here. Come with a
@@ -24,10 +26,26 @@ good projects go wrong.
   normal and good. I'd rather we take a few beats and get the *right* problem than rush to a clean,
   confident, wrong one.
 
-**How it ends:** when we've talked it through and the real problem has come into focus, I'll say it
-back to you in plain words. If it lands — if you can look at it and say "yes, that's it" in your own
-words — you confirm it, and that confirmed problem becomes the foundation everything downstream
-builds on. If it doesn't land yet, we keep going. The confirmation is yours to give; I'll never put
-words in your mouth.
+**The one checkpoint:** when we've talked it through and the real problem has come into focus, I'll
+say it back to you in plain words. If it lands — if you can look at it and say "yes, that's it" in
+your own words — you confirm it. That confirmed problem is the foundation everything downstream
+builds on, so it's worth stopping on. If it doesn't land yet, we keep going. The confirmation is
+yours to give; I'll never put words in your mouth.
+
+**Then we shape it.** With the problem settled, the question becomes what to actually build — the
+scope, the pieces, the technology, what it's even called. I won't ask you to produce that out of
+thin air. I'll bring you real candidates with my reasoning and my preference, argue against my own
+suggestions, and tell you what each choice costs and closes off. You'll push back, we'll land on
+something, and occasionally one of us will realize we've been picturing the wrong *kind* of thing
+entirely — that's a good day, even when it means revisiting the problem itself.
+
+As we go, I write the decisions down: what we chose, who chose it, and *why* — including the option
+we passed on. Not paperwork. Six months from now the reasoning is the part you'll actually need, and
+it's the part that's always missing.
+
+**How it ends:** we stop when the only questions left are about how the thing *behaves* — what
+happens when this fails, who's allowed to do that — rather than what it *is*. Those behavioral
+questions are exactly what the next step is built to work through, so leaving them open is correct.
+I'll tell you plainly when we're there.
 
 So — before we figure out what to build: **tell me where it hurts.**

--- a/tests/regression/test_muse_add_coverage.sh
+++ b/tests/regression/test_muse_add_coverage.sh
@@ -1,30 +1,56 @@
 #!/usr/bin/env bash
-# test_muse_add_coverage.sh — the muse conception skill's exit checklist touches all four
-# ADD driver categories, keeps the scaffold invisible, and never self-confirms the lock.
-# The skeleton IS the exit criteria: if a driver is missing, a whole class of wrong-problem
-# miss slips the gate; if the categories are surfaced, we've shipped the intake form we set
-# out to avoid.
+# test_muse_add_coverage.sh — the muse skill spans both movements and keeps each one's
+# load-bearing contract.
+#
+# Movement 1 (conception): the exit checklist touches all four ADD driver categories, keeps
+# the scaffold invisible, and never self-confirms the lock. The skeleton IS the exit criteria:
+# if a driver is missing, a whole class of wrong-problem miss slips the gate; if the categories
+# are surfaced, we've shipped the intake form we set out to avoid.
+#
+# Movement 2 (shaping, #1044): the skill proposes rather than elicits, is licensed to re-see the
+# product, records decisions as a numbered+attributed+reasoned ledger, keeps an open-questions
+# register, and stops on the definitional-vs-behavioral test. Each of those is a distinct failure
+# mode if dropped: no proposing abandons the Designer at the hardest part; no ledger loses the
+# reasoning that makes judgment learnable; no stop test carries undecided identity into /ddd.
+#
+# The Designer-facing introduction must stay free of the internal vocabulary — the method
+# disciplines the agent, not the conversation.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SKILL="$ROOT/skills/muse/SKILL.md"
+INTRO="$ROOT/skills/muse/introduction.md"
 
 pass=0
 fail=0
-have() { # regex  label
-	if grep -qiE "$1" "$SKILL"; then
+have() { # regex  label  [file=$SKILL]
+	if grep -qiE "$1" "${3:-$SKILL}"; then
 		echo "  [PASS] $2"
 		pass=$((pass + 1))
 	else
-		echo "  [FAIL] $2 (missing /$1/)"
+		echo "  [FAIL] $2 (missing /$1/ in ${3:-$SKILL})"
 		fail=$((fail + 1))
 	fi
 }
 
-if [[ ! -f "$SKILL" ]]; then
-	echo "  [FAIL] skills/muse/SKILL.md missing"
-	exit 1
-fi
+lacks() { # regex  label  file  [-i to fold case; default case-SENSITIVE]
+	# Case-sensitive by default: the acronym "ADD" must not leak, but the ordinary word "add"
+	# is unremarkable prose and must not trip the gate.
+	if grep -qE ${4:+"$4"} "$1" "$3"; then
+		echo "  [FAIL] $2 (found /$1/ in $3)"
+		fail=$((fail + 1))
+	else
+		echo "  [PASS] $2"
+		pass=$((pass + 1))
+	fi
+}
+
+for f in "$SKILL" "$INTRO"; do
+	if [[ ! -f "$f" ]]; then
+		echo "  [FAIL] ${f#"$ROOT"/} missing"
+		exit 1
+	fi
+done
 
 # All four ADD drivers named in the exit checklist. Anchor on the parenthetical LABEL form
 # — unique to the checklist bullets — so a driver whose phrase also appears in the surrounding
@@ -43,6 +69,84 @@ have "\-ilit|sharpest" "quality-attribute guard against the wrong-problem miss"
 
 # The human holds the lock — the skill never self-confirms.
 have "self-confirm|holds the lock|confirm it yourself" "the human holds the lock"
+
+# ADD is named for the agent — that's what makes the gentle guidance a defined path with real
+# exit criteria rather than wandering. Movement 1 shipped the drivers but not the method's name.
+have "attribute-driven design" "ADD named as the method (agent-facing context)"
+
+# ── Movement 2 — shaping (#1044) ───────────────────────────────────────────────
+# Both movements present AND in order — the ordering is checked, not just asserted in a comment.
+# Without the structure the skill reverts to conception-only and the span to /ddd-ready is unowned
+# again; with the movements transposed, the agent is told to shape before the problem is confirmed.
+have "^# Movement 1" "movement 1 (conception) section present"
+have "^# Movement 2" "movement 2 (shaping) section present"
+
+m1_line=$(grep -nE "^# Movement 1" "$SKILL" | head -1 | cut -d: -f1)
+m2_line=$(grep -nE "^# Movement 2" "$SKILL" | head -1 | cut -d: -f1)
+if [[ -n "$m1_line" && -n "$m2_line" && "$m1_line" -lt "$m2_line" ]]; then
+	echo "  [PASS] conception precedes shaping (movement 1 before movement 2)"
+	pass=$((pass + 1))
+else
+	echo "  [FAIL] conception precedes shaping (got M1@${m1_line:-none}, M2@${m2_line:-none})"
+	fail=$((fail + 1))
+fi
+
+# The gear inversion: movement 2 proposes instead of eliciting. A shaping stage that only asks
+# questions abandons the Designer at the hardest part — the shape isn't inside them to extract.
+# Anchor on the SECTION HEADING, not the phrase: the preamble mentions proposing too, and matching
+# there would let the gear itself be deleted while the gate still passed.
+have "^## The shift" "movement 2 proposes rather than elicits (the shift section)"
+
+# Product-level re-see, licensed to reach back and amend the confirmed problem statement (with
+# re-confirmation). Suppressing a late re-see is the fatal failure, not the expensive one.
+have "re-see" "product-level re-see gear present"
+have "amend the problem statement|re-confirmation" "re-see may amend the locked statement, with re-confirmation"
+
+# The decision ledger — all three parts. Any one missing and the ledger stops teaching judgment:
+# unnumbered can't be cited, unattributed loses whose call it was, unreasoned is a rule not a lesson.
+have "numbered decision" "ledger: decisions are numbered"
+have "attribution" "ledger: decisions are attributed"
+# The bare alternative /reasoning/ was a false-pass: it also matches the Propose and Re-see gears,
+# so the ledger's reasoning bullet could be deleted entirely and the gate still reported PASS.
+# The epigram is unique to the bullet — anchor there and nowhere else.
+have "a rule; with its reasoning" "ledger: decisions carry their reasoning"
+have "append-only" "ledger is append-only — superseded, never edited"
+
+# The open-questions register, and closing a question into the decision that resolved it.
+# The closure form is matched as the literal strike-through-to-decision arrow, case-SENSITIVELY:
+# a bare /resolved/i also matches "the unresolved middle" over in movement 1, which would let the
+# whole register be deleted while the gate still passed.
+have "open.questions register" "open-questions register present"
+if grep -qE 'RESOLVED (→|->) D-' "$SKILL"; then
+	echo "  [PASS] resolved questions close into their decision"
+	pass=$((pass + 1))
+else
+	echo "  [FAIL] resolved questions close into their decision (missing /RESOLVED → D-N/)"
+	fail=$((fail + 1))
+fi
+
+# The stop test — definitional must be empty, behavioral belongs to /ddd. This is the handoff gate.
+have "definitional" "stop test: definitional questions must be closed"
+have "behavioral" "stop test: behavioral questions belong to /ddd"
+
+# The artifact contract — path resolved via the tool, not hardcoded, so muse and /ddd agree.
+have "ddd_locate_sketchbook" "artifact path resolved via ddd_locate_sketchbook"
+
+# ── The Designer never sees the machinery ──────────────────────────────────────
+# introduction.md is the human's first contact. Internal vocabulary leaking into it is exactly
+# the intake-form failure the skill exists to avoid.
+# Split by case-sensitivity need: the ACRONYM must be matched case-sensitively (or the ordinary
+# word "add" trips the gate), but the spelled-out method name has no lowercase collision — folding
+# case there catches the likeliest real leak, "attribute-driven design" in ordinary prose.
+lacks "\bADD\b" "introduction stays free of the ADD acronym" "$INTRO"
+lacks "Attribute.Driven Design" "introduction stays free of the spelled-out method name" "$INTRO" -i
+lacks "movement 1|movement 2|quality attributes" "introduction stays free of internal structure" "$INTRO" -i
+# The intro is clean of the rest of the machinery today, but nothing pinned that. These are the
+# terms most likely to leak on a future edit, because each one is the natural word for the thing
+# an author is describing at that moment: "re-see" and "ledger" are movement 2's own names for its
+# two load-bearing moves, and "definitional" is half of the stop test. Naming them here means a
+# leak fails a test instead of quietly changing what the Designer reads.
+lacks "re-see|ledger|definitional" "introduction stays free of movement-2 vocabulary" "$INTRO" -i
 
 echo "  $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_ddd_skill.py
+++ b/tests/test_ddd_skill.py
@@ -5,7 +5,9 @@ Validates:
 - /ddd accept includes domain model verification steps (exists, committed)
 - /ddd accept includes domain model summary (aggregate/command/policy counts)
 - /ddd accept suggests running /devspec create
-- /ddd begin, /ddd draft, /ddd resume templates are unchanged in structure
+- /ddd draft, /ddd resume templates are unchanged in structure
+- /ddd begin resolves an existing sketchbook and appends rather than
+  overwriting it (#1044); its 8 Socratic stages remain MCP-tool-free
 - docs/DDD-to-devspec-protocol.md is preserved (not deleted)
 - Help text reflects new /ddd accept behavior
 - Skill frontmatter description updated
@@ -242,6 +244,56 @@ class TestOtherTemplatesPreserved:
 
 
 # ---------------------------------------------------------------------------
+# 5b. /ddd begin must NOT clobber a sketchbook an earlier stage wrote (#1044)
+# ---------------------------------------------------------------------------
+
+
+class TestBeginDoesNotClobberSketchbook:
+    """`/ddd begin` appends to an existing sketchbook instead of overwriting it.
+
+    `/muse` (the conception + shaping stage upstream of `/ddd`) writes the confirmed problem
+    statement, the numbered decision ledger, and the open-questions register into the
+    sketchbook. `/ddd begin` historically created that file unconditionally with its own
+    header — which destroys the ledger on the very next pipeline step and makes muse's
+    artifact contract a no-op. `resume` and `draft` already gate on
+    ``ddd_locate_sketchbook``; ``begin`` must too.
+    """
+
+    def test_begin_checks_for_existing_sketchbook(self, skill_text: str) -> None:
+        """ddd-begin calls ddd_locate_sketchbook before writing anything."""
+        begin = _extract_template(skill_text, "ddd-begin")
+        assert "ddd_locate_sketchbook" in begin, (
+            "ddd-begin must call ddd_locate_sketchbook before writing — otherwise it "
+            "overwrites an upstream stage's decision ledger"
+        )
+
+    def test_begin_handles_both_existence_branches(self, skill_text: str) -> None:
+        """ddd-begin branches on exists: true vs exists: false."""
+        begin = _extract_template(skill_text, "ddd-begin")
+        assert "exists: true" in begin
+        assert "exists: false" in begin
+
+    def test_begin_appends_rather_than_overwrites(self, skill_text: str) -> None:
+        """ddd-begin states the append-not-overwrite rule explicitly."""
+        begin = _extract_template(skill_text, "ddd-begin").lower()
+        assert "append" in begin, "ddd-begin must instruct appending to an existing sketchbook"
+        assert "never overwrite" in begin, (
+            "ddd-begin must forbid overwriting an existing sketchbook in so many words"
+        )
+
+    def test_begin_preserves_existing_decisions(self, skill_text: str) -> None:
+        """ddd-begin must not edit or delete decisions recorded upstream.
+
+        A decision found to be wrong is superseded by a NEW numbered decision — the wrong
+        turn and its correction are both part of the record, and the correction is
+        meaningless without the thing it corrected.
+        """
+        begin = _extract_template(skill_text, "ddd-begin").lower()
+        assert "supersede" in begin
+        assert "never edit or delete" in begin
+
+
+# ---------------------------------------------------------------------------
 # 6. DDD-to-Dev Spec protocol is preserved
 # ---------------------------------------------------------------------------
 
@@ -405,8 +457,13 @@ class TestMcpToolInvocations:
     handlers instead of running hand-written bash checks.
 
     Added for #334 (Family 3 Phase 2 — ddd skill rewrite to use Phase 1
-    MCP tools). The /ddd begin template is intentionally NOT covered here
-    — it is 100% reasoning work and should not invoke any MCP tool.
+    MCP tools).
+
+    The /ddd begin template remains reasoning work: its 8 Socratic stages
+    invoke no MCP tool, and test_begin_does_not_call_mcp_tools enforces that
+    stage-scoped. Narrowed in #1044 for exactly ONE exemption — a single
+    ddd_locate_sketchbook call in the pre-stage preamble, which exists so
+    begin cannot clobber a sketchbook /muse already wrote.
     """
 
     def test_accept_calls_ddd_locate_domain_model(self, skill_text: str) -> None:
@@ -447,14 +504,19 @@ class TestMcpToolInvocations:
         assert "ddd_locate_sketchbook" in resume
 
     def test_begin_does_not_call_mcp_tools(self, skill_text: str) -> None:
-        """The ddd-begin template is pure reasoning work and must NOT call
-        any MCP tool handlers. This guards against scope creep — the 8-stage
-        Socratic event storming workflow is human+agent discovery, not
-        deterministic procedure."""
+        """The ddd-begin template's 8-stage workflow is pure reasoning work and must NOT
+        call MCP tool handlers. This guards against scope creep — the Socratic event
+        storming workflow is human+agent discovery, not deterministic procedure.
+
+        Narrowed for #1044: the single ``ddd_locate_sketchbook`` call in the *preamble*
+        (before Stage 1) is exempt. That call is not workflow procedure — it is the
+        write-safety check that stops ``begin`` from overwriting a sketchbook an upstream
+        stage authored. Resolving a path before writing to it is orthogonal to whether the
+        discovery conversation is tool-driven, and the 8 stages themselves remain free of
+        handler calls. Every other handler stays forbidden anywhere in the template.
+        """
         begin = _extract_template(skill_text, "ddd-begin")
-        # No ddd_* or devspec_* handler calls allowed in /ddd begin
         forbidden = [
-            "ddd_locate_sketchbook",
             "ddd_locate_domain_model",
             "ddd_verify_committed",
             "ddd_summary",
@@ -466,3 +528,15 @@ class TestMcpToolInvocations:
             assert tool not in begin, (
                 f"/ddd begin must be pure reasoning — found forbidden tool call: {tool}"
             )
+
+        # The 8-stage workflow itself stays tool-free: the only permitted handler call is
+        # the pre-Stage-1 write-safety check.
+        _, _, stages = begin.partition("## Stage 1")
+        assert "ddd_locate_sketchbook" not in stages, (
+            "ddd_locate_sketchbook is permitted only in the preamble write-safety check, "
+            "not inside the 8-stage event storming workflow"
+        )
+        assert begin.count("ddd_locate_sketchbook") == 1, (
+            "expected exactly one ddd_locate_sketchbook call in ddd-begin (the preamble "
+            f"write-safety check), found {begin.count('ddd_locate_sketchbook')}"
+        )


### PR DESCRIPTION
## Summary

`muse` shipped as conception only — it settled the problem and handed off — but `/ddd` needs a *shaped solution*, not just a settled problem, and nothing in the pipeline owned the space between them. This adds that space as a second movement in the same skill, ending in a written decision ledger. It also fixes `/ddd begin`, which would otherwise destroy that ledger on the very next pipeline step.

## Changes

- **`skills/muse/SKILL.md` restructured into two movements.** Movement 1 (conception) is unchanged in substance; the regression suite's original assertions are the mechanical proof this change is purely additive.
- **ADD named explicitly (agent-facing).** The four drivers were already present verbatim, but neither `ADD` nor `Attribute-Driven Design` appeared anywhere — so the agent had the checklist without knowing it was a recognized method with a literature behind it. `introduction.md` stays jargon-free; the Designer never hears it.
- **Movement 2 authored with its own machinery,** not a restatement of movement 1's: *proposing* gears rather than eliciting ones; a **product-level re-see license** (may reach back and amend the confirmed statement, with re-confirmation — the highest-value move in this space and structurally unreachable from a problem statement); a **numbered + attributed decision ledger carrying its reasoning**; an **open-questions register** whose resolved entries close into the decision that settled them; a **stop test** on definitional-vs-behavioral questions; append-only discipline (superseded by new decisions, never edited).
- **Artifact contract** — muse writes `docs/SKETCHBOOK.md`, path resolved via `ddd_locate_sketchbook` rather than hardcoded, so muse and `/ddd` agree by construction.
- **`skills/ddd/SKILL.md` anti-clobber fix (load-bearing).** `/ddd begin` unconditionally created `docs/SKETCHBOOK.md` with its own skeleton — `/ddd resume` and `/ddd draft` both already called `ddd_locate_sketchbook`, but `begin` did not. It now resolves first and **appends** when the file exists, reading the ledger and open questions as this session's input. Without this the whole artifact contract is a no-op.
- **`skills/muse/introduction.md`** extended to describe the full arc in plain language.
- Docs: README row, `skill-reference.md` `/muse` section, `tool-skill-map.md` (both the reverse index and the mermaid graph).

## Linked Issues

Closes #1044

## Test Plan

What was actually run:

- `bash tests/regression/test_muse_add_coverage.sh` → **27 passed, 0 failed** (extended from 18; the original movement-1 assertions are untouched and passing)
- `python3 -m pytest tests/test_ddd_skill.py -q` → **46 passed** (+4 new anti-clobber tests)
- `./scripts/ci/validate.sh` → **215 passed, 0 failed**
- `./scripts/ci/test.sh` → **1914 passed, 6 skipped, 64 xfailed, 2 xpassed** (10m14s, exit 0)
- **Live MCP verification** of the tool contract this change depends on: `ddd_locate_sketchbook` against two fixtures returned `{ok:true,exists:false}` (**no `path` key**) when absent, and `{ok:true,path:…,exists:true}` when present.
- **Revert-sensitivity confirmed** by review: the new anti-clobber assertions all fail against `main`'s `skills/ddd/SKILL.md`, so they test the fix rather than passing vacuously.

### Review findings fixed in this branch

1. **Important** — a line added by this change declared the tool returns `{ok, path, exists}` unconditionally, contradicting the corrected branch text nine lines below it. An agent trusting it would read `path` on the create branch, get `undefined`, and write cwd-relative — the exact orphaned-sketchbook failure the fix exists to prevent. Both SKILL.md files now describe the shape per-branch.
2. **Minor** — decision numbering was `D-1`; `/ddd draft`, `docs/Domain-Model-template.md`, and this repo's own `docs/SKETCHBOOK.md` all use `D-01`. Unpadded numbering forces a silent renumber at the seam, which a single-document-across-stages design cannot afford. Now padded, with the reason stated inline.
3. **Minor** — `/muse` was added to `tool-skill-map.md`'s reverse index but missing from its mermaid graph.

Additionally hardened the Designer-facing guard: the regression test now also rejects `re-see`, `ledger`, and `definitional` in `introduction.md`, so movement-2 vocabulary leaking into the human's first contact fails a test rather than quietly changing what they read.

### Not verified — needs a human

**AC 13** (*"`/muse` run end to end on a real ill-defined problem; its sketchbook survives `/ddd begin`"*) is a human-in-the-loop criterion and is **not** checked. The mechanism is verified (tool contract against the running binary; tests that fail on revert), but the experience is not. Per issue #1044's own note, BJ is the taste authority on movement 2 — the skill encodes his design-partner practice.

### Deferred (out of scope)

`/lazyriver`, `/multithread`, and `/reseed` are also absent from `tool-skill-map.md`'s mermaid graph — pre-existing drift, unrelated to #1044, left alone rather than expanding this PR.

### Dependency scan

`trivy fs --scanners vuln --severity HIGH,CRITICAL` parsed **0 manifests** — reported as **NO MANIFESTS, not a pass**. This kit ships no lockfile, so there is nothing for trivy to read; the scan is vacuous rather than clean, and is recorded that way deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)