### PR TITLE
feat(nextwave): one campaign branch all the way through — no interim merge-backs

### DIFF
--- a/docs/campaign-workflow-design.md
+++ b/docs/campaign-workflow-design.md
@@ -88,7 +88,7 @@ The seed comprises:
   `deferrals[]`, rework / re-open events, the commutativity verdict, MRs/commits landed,
   issues closed. **Accumulated across waves** (see §5).
 
-- **The just-landed wave in full** — its kahuna-vs-protected diff, gate signals, reconcile report.
+- **The just-landed wave in full** — its kahuna-vs-integration-base diff, gate signals, reconcile report.
 
 - **The remaining plan** — so the judgment is "sound to proceed *into the rest*."
 

--- a/skills/nextwave/SEAMS.md
+++ b/skills/nextwave/SEAMS.md
@@ -97,23 +97,29 @@ calls. Promotion is wired as CODE that runs only on a live wave's auto+PASS succ
 { signal: string, passed: boolean, detail?: string }
 ```
 
-**Order (live-gate finding #5 — reorders §3.4):** the gate FIRST opens the kahuna→protected
-**draft PR** (`openPromotionPrPrompt` → `wave_finalize`, idempotent), THEN runs the four signals
+**Order (live-gate finding #5 — reorders §3.4):** the gate FIRST opens the kahuna→**integration
+base** draft PR (`openPromotionPrPrompt` → `wave_finalize`, idempotent), THEN runs the four signals
 in **parallel** (single `parallel([...])` block). The draft PR exists before the CI signal so
 `ci_wait_run` has a real merge-result pipeline to wait on — the old order created the PR at
 promotion (after the gate), so `ci_wait_run` returned `no_merge_result_pr`. If the PR cannot be
 opened (kahuna branch / artifacts missing), the gate **HOLDs** (no PR ⇒ no evidence ⇒ no PASS).
 Each signal is an `agent()` whose prompt names the real sdlc-server call:
 
+**The base is `integrationBase`, never "the protected branch" (#1052).** Inside a campaign that is
+the campaign branch; for a standalone `/nextwave` run the two coincide. `gate.js` takes no
+`protectedBranch` parameter at all — `tests/test_gate_contract.py` asserts its absence, because
+passing a campaign branch in a parameter named `protectedBranch` is how a wrong-target merge gets
+written. A wave never decides to write trunk; it writes whatever base it was handed.
+
 | Signal | `agentType` | Real sdlc-server call | pass = |
 |---|---|---|---|
-| commutativity | `general-purpose` | `commutativity_verify(base_ref=<protected>, changesets=[{id:"kahuna", head_ref:<kahuna>}])` | verdict ∈ {STRONG, MEDIUM}; `PROBE_UNAVAILABLE` **and** `ORACLE_REQUIRED` = **conservative-fail** (#6 — the gate HOLDs on what the probe can't prove safe; reconcile may adjudicate ORACLE_REQUIRED during integration, the gate does not) |
+| commutativity | `general-purpose` | `commutativity_verify(base_ref=<integrationBase>, changesets=[{id:"kahuna", head_ref:<kahuna>}])` | verdict ∈ {STRONG, MEDIUM}; `PROBE_UNAVAILABLE` **and** `ORACLE_REQUIRED` = **conservative-fail** (#6 — the gate HOLDs on what the probe can't prove safe; reconcile may adjudicate ORACLE_REQUIRED during integration, the gate does not) |
 | ci | `general-purpose` | `ci_wait_run(require_merge_result=true)` on the **gate-opened draft PR's merge-result pipeline** (passed in by number — NOT merge-commit branch HEAD) [sdlc #452, #476, #5] | `final_status == "success"`; `not_merge_result` HOLDs |
-| review | `feature-dev:code-reviewer` (`isolation:'worktree'` on kahuna [#667]) | code-reviewer over the **kahuna-vs-protected diff**, diff-scoped (§3.4) | no critical/important findings |
+| review | `feature-dev:code-reviewer` (`isolation:'worktree'` on kahuna [#667]) | code-reviewer over the **kahuna-vs-integration-base diff**, diff-scoped (§3.4) | no critical/important findings |
 | trivy | `general-purpose` | `trivy fs --scanners vuln --severity HIGH,CRITICAL` on kahuna | no HIGH/CRITICAL with available fixes |
 
 - The gate is a **unanimous** gate: `failed.length === 0` ⇒ PASS, else HOLD.
-- Static analysis must be **diff-scoped (kahuna-vs-main), never tree-scoped** (§3.4) — or
+- Static analysis must be **diff-scoped (kahuna-vs-integration-base), never tree-scoped** (§3.4) — or
   pre-existing baseline debt spuriously HOLDs an otherwise-clean wave. Lint/typecheck are
   **not** a fifth signal; they ride inside the CI signal.
 
@@ -130,11 +136,11 @@ Inside the (real) prompts, replace the `// TODO(#687 gate wiring)` lines with re
 
 ### Promotion (the success-exit terminal step)
 
-`#687` made it real; `#5` reordered it. The kahuna→protected **draft PR was already opened by
+`#687` made it real; `#5` reordered it. The kahuna→**integration base** draft PR was already opened by
 the gate's PR-OPEN node** and its merge-result CI already validated by the CI signal — so the
 `MODE === 'auto'` PASS branch (`promotePrompt`) no longer opens a PR. It **marks that same draft
 PR ready** (`gh pr ready`) and `pr_merge` lands it on all-green, then confirms the merge is
-actually observable on the protected branch (`pr_merge_wait`) before reporting `promoted`;
+actually observable on the integration base (`pr_merge_wait`) before reporting `promoted`;
 then deletes the kahuna branch and records disposition. It never opens a second PR. `interactive`
 mode never promotes — it returns the verdict (the return IS the human gate, §5), leaving the
 draft PR as the human's review artifact.

--- a/skills/nextwave/SKILL.md
+++ b/skills/nextwave/SKILL.md
@@ -41,8 +41,20 @@ rehydrate (durable resume)
    → flight loop  [ serial groups; parallel issues; dynamic re-plan; CLOSED legal exits ]
        per group:  plan(Prime) → parallel issue-workers → merge+reconcile(Prime)
    → trust gate   [ 4 signals in parallel → one more legal exit ]
-   → promote (kahuna→protected)  OR  hold-for-review
+   → integrate (kahuna→integration base)  OR  hold-for-review
 ```
+
+**Where the wave lands (#1052).** The final node merges the kahuna branch into this wave's
+**integration base**, which is *not* necessarily the protected branch:
+
+- **inside a campaign** (`/wavemachine`) the base is the campaign's own long-lived branch, so the
+  node performs an **integration**; the protected branch is written exactly once, by the campaign's
+  release gate, after every wave has integrated *and* the DoD is met.
+- **standalone** (a human running one wave) there is no campaign branch, the wave *is* the whole
+  increment, and the base defaults to the protected branch — so integration and release coincide.
+
+A wave never decides to write trunk; it writes whatever base it was handed. See the BRANCH TOPOLOGY
+note in `campaign-loop.js` for why the interim merge-backs were removed.
 
 Every halt is a coded condition; every judgment is an `agent()`; nothing can stall the
 campaign on a question it did not need to ask. The skill's job is thin: resolve the
@@ -75,10 +87,11 @@ Supplied by the caller (`/wavemachine` per wave, or a human launching one wave):
 | `issues` | the wave's issue numbers (one repo — single-repo-per-wave axiom, §4.1). **Required, non-empty.** |
 | `targetRepo` | `owner/repo` for `gh -R` scoping |
 | `targetRepoDir` | the clone the durable worktrees attach to (§4.2) |
-| `kahunaBranch` | the integration target; every flight PR targets this, never the protected branch |
-| `preserveKahuna` | #722: `true` ⇒ persistent per-plan kahuna (shared across a plan's waves) — promote does NOT delete it. Default `false` = per-wave disposable (deleted on promote). See lifecycle below. |
+| `kahunaBranch` | the wave's own integration target; every flight PR targets this, never the integration base and never the protected branch |
+| `integrationBase` | #1052: where the kahuna branch merges on the success exit — the **campaign branch** in a campaign, the protected branch for a standalone wave. Defaults to `protectedBranch` (the standalone shape). A campaign driver ALWAYS passes it. |
+| `preserveKahuna` | #722: `true` ⇒ persistent per-plan kahuna (shared across a plan's waves) — promote does NOT delete it. Default `false` = per-wave disposable. **Retired inside a campaign (#1052)** — accepted but ignored when `integrationBase !== protectedBranch`. See lifecycle below. |
 | `dispatch` | #824: the wave's dispatch hint from `phases-waves.json` (written by `/prepwaves` #823). `fan` ⇒ the planner's conflict-free group runs in parallel; `serialize` / `serialize-preferred` / **absent** ⇒ single-file (one issue per flight-group). Threaded into the engine and **enforced** by the flight loop — see "Dispatch enforcement" below. Absent ⇒ `serialize` (CT-01). |
-| `protectedBranch` | the promotion target on the success exit |
+| `protectedBranch` | the trunk. Used to *recognize* trunk (the engine derives "am I in a campaign?" from `integrationBase !== protectedBranch`), and as the default `integrationBase` for a standalone wave. A campaign wave never writes it. |
 | `mode` | `auto` (verdict drives promotion) \| `interactive` (verdict returned; human routes) |
 | `planId` | wave plan id — the gate's PR-open node needs it to assemble the kahuna→protected MR body (#687/#5) |
 | `budget` | optional `{ total, remaining() }` cost guard (the `cost` legal exit) |
@@ -86,25 +99,23 @@ Supplied by the caller (`/wavemachine` per wave, or a human launching one wave):
 The closed numeric guards (`maxGroups`, `maxRework`, `maxIdle`, `costFloor`) have
 safe defaults in the script and rarely need overriding.
 
-### Kahuna branch lifecycle — per-wave disposable vs per-plan persistent (#722)
+### Kahuna branch lifecycle — disposable again (#1052 supersedes #722)
 
-Two models; the campaign driver picks one by the **shape of the `kahunaBranch` it passes** and
-the `preserveKahuna` flag:
+**Inside a campaign, every wave's kahuna is disposable.** It is cut off the campaign branch, the
+wave integrates it there, and the promote node deletes it. Nothing continues from a kahuna across
+waves, so a **squash** merge is harmless — which is the whole reason the interim merge-backs went
+away (#892: a persistent branch plus a squash merge cannot show equality with its base, because the
+squash rewrites the history the equality check compares).
 
-- **Per-wave disposable (default, `preserveKahuna` omitted/false).** `kahunaBranch` defaults to
-  `kahuna/<waveId>`; the wave promotes it onto the protected branch and the promote node **deletes
-  it** — the integration branch existed only for this wave. Each wave branches fresh off the
-  protected/release HEAD.
-- **Per-plan persistent (`preserveKahuna: true`).** A campaign that threads ONE kahuna across a
-  plan's waves (e.g. `kahuna/56-quartermaster-docs-labs`, cumulative integration over waves 1..N)
-  passes `preserveKahuna: true` so the promote node **does NOT delete** the branch after each wave.
-  Deleting it after wave 1 (the old unconditional behavior) stranded waves 2..N off a **diverged
-  base** — origin recreated at the post-promotion HEAD while local work still descended from the
-  pre-promotion base, so the next wave's push was rejected non-fast-forward. `preserveKahuna: true`
-  eliminates that. The plan's final wave (or the driver) retires the branch.
+The cross-wave state that #722 needed a persistent kahuna for now lives on the **campaign branch**,
+which is long-lived by design and never squashed onto (waves merge *into* it; it merges onto trunk
+once). `preserveKahuna: true` is therefore **accepted but ignored** when `integrationBase !==
+protectedBranch` — a stale launcher passing it cannot resurrect the divergence. The engine logs when
+it ignores the flag.
 
-**Drivers MUST match the flag to the branch shape:** a shared per-plan `kahunaBranch` with
-`preserveKahuna` left false will delete the branch mid-plan and break the remaining waves.
+**Standalone waves keep the old semantics.** With no campaign branch, `integrationBase` is the
+protected branch, and `preserveKahuna` behaves exactly as #722 documented: `false` (default) ⇒ the
+promote node deletes the kahuna after the merge; `true` ⇒ it survives.
 
 ### Dispatch enforcement — the `dispatch` hint governs flight parallelism (#824)
 
@@ -139,7 +150,9 @@ annotated `serialize` and never reaches the executor as `fan`.
 1. **Resolve wave inputs.** Read the next pending wave for this Plan (`wave_next_pending`),
    its issue list, the `kahuna_branch` (always populated — `/wavemachine` bootstraps it
    at Plan launch), the target repo + clone dir, the protected branch (from
-   `.claude-project.md`), and the wave's **`dispatch`** field (from `phases-waves.json`;
+   `.claude-project.md`), the **`integrationBase`** (the campaign branch when running under
+   `/wavemachine`; omit for a standalone wave and it defaults to the protected branch, #1052),
+   and the wave's **`dispatch`** field (from `phases-waves.json`;
    absent ⇒ `serialize`, CT-01) to thread into `args.dispatch`. Refuse if `kahuna_branch` is
    unset — wave state was not bootstrapped through the campaign launch sequence.
 2. **Validate specs.** Confirm every wave issue is structurally buildable
@@ -147,27 +160,36 @@ annotated `serialize` and never reaches the executor as `fan`.
 3. **Launch the Workflow.** Invoke the single-file artifact `per-wave-workflow.bundled.js`
    (via the Workflow tool's `scriptPath`) with the inputs above passed as **`args` (a JSON
    object)**. The script owns everything from here: rehydrate → flight loop → trust gate (which
-   opens the kahuna→protected DRAFT PR first, then runs the four signals on it, #5) → promote.
+   opens the kahuna→base DRAFT PR first, then runs the four signals on it, #5) → integrate.
 4. **Consume the verdict.** The Workflow's return is the per-wave gate (§5): a Workflow
    cannot pause mid-run for human input, so its *ending with a verdict* IS the gate. The
-   return carries `gate` ∈ `PASS | HOLD | SKIPPED` **and** `promoted` ∈ `true | false`, plus
-   `concerns`/`deferrals` (informational — surfaced and continued, never halted-on). **`gate`
-   and `promoted` are distinct facts** — read both:
-   - `auto` + `{ gate:'PASS', promoted:true }` ⇒ the Workflow's promote node landed the
-     kahuna→protected merge. The wave is DONE on the protected branch. Report it.
-   - `auto` + `{ gate:'PASS', promoted:false }` ⇒ the gate passed but the promote node
+   return carries `gate` ∈ `PASS | HOLD | SKIPPED`, **`integrated`** ∈ `true | false` (did the
+   kahuna→base merge land — the field the campaign loop routes on), `promoted` (the same fact
+   under its legacy name, kept so a mid-campaign engine upgrade doesn't strand in-flight
+   records), `integrationBase`, plus `concerns`/`deferrals` (informational — surfaced and
+   continued, never halted-on). **`gate` and `integrated` are distinct facts** — read both:
+   - `auto` + `{ gate:'PASS', integrated:true }` ⇒ the promote node landed the kahuna→base
+     merge. In a campaign the wave is on the **campaign branch**, not trunk — it is *integrated,
+     not released*; the campaign's DoD gate decides release. Standalone, base *is* trunk, so the
+     wave is done. Report which one it was.
+   - `auto` + `{ gate:'PASS', integrated:false }` ⇒ the gate passed but the promote node
      **soft-failed — the merge did NOT land** (the wave is recorded HELD; `reason` carries the
-     promote error). The code is sound but not on the protected branch → surface as a HOLD for
-     manual promotion, NOT as success. (Promotion can be retried on resume — the kahuna branch
+     promote error). The code is sound but not on the integration base → surface as a HOLD for
+     manual integration, NOT as success. (It can be retried on resume — the kahuna branch
      is gate-clean.)
-   - `interactive` + `{ gate:'PASS', promoted:false }` ⇒ by design the Workflow never
-     auto-promotes; surface the verdict + the kahuna→protected diff and STOP for the human, who
-     routes promotion. When the human lands the kahuna→protected merge, the wave's terminal
+   - `interactive` + `{ gate:'PASS', integrated:false }` ⇒ by design the Workflow never
+     auto-promotes; surface the verdict + the kahuna→base diff and STOP for the human, who
+     routes the merge. When the human lands it, the wave's terminal
      disposition is updated to `promoted` in wave-status — that durable record is what
      `/wavemachine`'s interactive branch reads (`waveDisposition`) to advance, so it never
      advances on the operator's word alone. (`/wavemachine` owns this branch in a campaign.)
-   - `{ gate:'HOLD' }` / `{ gate:'SKIPPED' }` (always `promoted:false`) ⇒ a trust signal failed
+   - `{ gate:'HOLD' }` / `{ gate:'SKIPPED' }` (always `integrated:false`) ⇒ a trust signal failed
      or the flight loop hit a HOLD exit before the gate; surface the failing signals / halt reason.
+
+   **The durable disposition string is still `promoted | held`** and now means "landed on its
+   integration base". It was deliberately not renamed: in-flight campaigns and the `wave-status`
+   CLI both read that value, so renaming it would strand every existing record for a vocabulary
+   improvement. `released` is a separate, campaign-level fact that only the release node asserts.
 5. **Report.** Surface a human-readable summary: groups run, issues merged, any HOLD
    reason, collected concerns/deferrals. Post wave status to `#wave-status` if running
    under a campaign.
@@ -206,7 +228,7 @@ closed**: the only ways the per-wave Workflow stops are the script's coded exits
 
 | Exit | Condition | Meaning |
 |---|---|---|
-| success | `pending` empty | all issues merged to kahuna → trust gate runs |
+| success | `pending` empty | all issues merged to kahuna → trust gate runs, then kahuna→integration base |
 | runaway | `groupsRun ≥ MAX_GROUPS` | too many groups → human review |
 | thrash | `idleRounds ≥ MAX_IDLE` | groups with zero net merges → not converging |
 | cost | `budget` floor | stop before the ceiling |
@@ -224,9 +246,13 @@ stalling on (#78/#79/#90), now expressed as bounded control flow.
 ## Non-Negotiables
 
 - EXECUTION primitive — NO design decisions. Workers are SPEC EXECUTORS.
-- **NEVER merge directly to the protected branch.** Flight PRs target the kahuna branch;
-  the kahuna→protected merge is the only path to the protected branch and is gated by
-  the four-signal trust gate (§3.4).
+- **NEVER merge directly to the integration base from a flight.** Flight PRs target the kahuna
+  branch; the kahuna→base merge is the only path off the kahuna branch and is gated by the
+  four-signal trust gate (§3.4).
+- **A wave inside a campaign NEVER writes the protected branch (#1052).** Its base is the campaign
+  branch; the single trunk write belongs to the campaign's release gate, after the DoD. The engine
+  forces this structurally — every gate node takes `integrationBase`, and no wave-level path takes
+  `protectedBranch` as a merge target.
 - **Single-repo per wave** (§4.1) — a wave resolves to exactly one `target_repo`.
 - **Durable worktrees, not `/tmp`** (§4.2, `lesson_tmp_identity_boot_wipe`): the wave's
   worktrees live under `<target>/.claude/.worktrees/wave-<id>/`. Idempotent re-attach on

--- a/skills/nextwave/campaign-loop.js
+++ b/skills/nextwave/campaign-loop.js
@@ -14,7 +14,7 @@
 // THE KEY SEAM: `runCampaign` takes `runWave` (launch the per-wave spine) and `judge` (call the
 // wave-oversight sub-agent) as INJECTED async functions. The Workflow entrypoint injects the real
 // `workflow()` / `agent()` calls; the tests inject scripted fakes — so #749's "multi-wave advances
-// on PASS+promoted+continue, ends on a HOLD/flag" procedures are deterministic unit tests, not
+// on PASS+integrated+continue, ends on a HOLD/flag" procedures are deterministic unit tests, not
 // integration runs. No LLM in the loop CONTROL FLOW ⇒ it provably cannot stall (#736 dissolves).
 
 // ── args intake (same contract as per-wave-workflow.js #1/#3: the runtime global is `args`,
@@ -34,14 +34,89 @@ export function parseArgs(raw) {
   throw new Error(`campaign-workflow: \`args\` must be an object or JSON string, got ${typeof raw}.`)
 }
 
+// ── BRANCH TOPOLOGY (#1052 — one campaign branch all the way through) ────────────────────────
+//
+// TWO LEVELS, TWO NAMES. A campaign writes the protected branch EXACTLY ONCE, at the DoD gate:
+//
+//   protected ──┬──────────────────────────────────────────────────────► (one merge, at DoD)
+//               │                                                      ▲
+//               └─► campaign/<plan>-<slug> ──W1──W2──W3── … ──WN ──────┘
+//                        ▲         ▲        ▲
+//                     kahuna/<plan>-<waveId>  (one per wave, disposable)
+//
+// WHY (BJ, 2026-07-26): waves 1..N-1 landed on the protected branch are a half-delivered feature
+// wearing a released commit's clothes. It is not an increment until the DoD is met. Three costs of
+// the interim merge-back: (1) an abort at wave 4 of 7 must REVERT four promoted waves from trunk
+// history instead of deleting one unmerged branch; (2) everyone else working from the protected
+// branch pulls half-finished work; (3) it is not a real increment, so calling it one is a lie the
+// board tells. The single merge at DoD removes all three by construction.
+//
+// WHY THIS DISSOLVES #892 (rather than needing a better merge method). #892 is "squash-merge +
+// a long-lived integration branch are incompatible": the squash rewrites history the persistent
+// kahuna still carries, so wave 2's promotion hits add/add. Here every wave gets a FRESH
+// DISPOSABLE kahuna cut off the campaign branch, and nothing continues from it after it lands —
+// so a squash is harmless, and there is no interim merge-back for the protected branch to
+// diverge from either. The failure mode is unreachable, not mitigated. `preserveKahuna` (#722)
+// therefore has nothing left to express in campaign mode: the branch that persists is the
+// CAMPAIGN branch, and the per-wave kahuna is disposable again as it was originally.
+//
+// WHY THE PREFIXES DIFFER (a git constraint, verified empirically, not a style choice). The
+// tempting name for a wave branch is a child of the campaign branch — `kahuna/56-plan/w1` under
+// `kahuna/56-plan`. That ref is IMPOSSIBLE: git stores branches as files under refs/heads/, so a
+// branch cannot be a directory prefix of another branch. Reproduced locally:
+//     $ git branch kahuna/56-plan && git branch kahuna/56-plan/w1
+//     fatal: cannot lock ref 'refs/heads/kahuna/56-plan/w1':
+//            'refs/heads/kahuna/56-plan' exists; cannot create 'refs/heads/kahuna/56-plan/w1'
+// Distinct top-level prefixes (`campaign/` vs `kahuna/`) put the two levels in separate
+// namespaces, so the D/F conflict cannot arise at any nesting depth. Do NOT "tidy" these into
+// one prefix — it re-creates an unrepresentable ref.
+const safeRef = (s) => String(s ?? '').replace(/[^A-Za-z0-9._-]/g, '-').replace(/^-+|-+$/g, '')
+
+// The campaign branch: cut off the protected branch once, at campaign start; merged to protected
+// once, at the DoD gate. Lives for the whole campaign.
+//
+// LOWERCASED. The slug comes from a plan title, so it arrives mixed-case, and git refs ARE
+// case-sensitive while macOS/Windows checkouts are not — `campaign/56-Blueshift` and
+// `campaign/56-blueshift` are two refs that cannot coexist in one working tree. Since the whole
+// point of this name is that a resume recomputes it identically, a case-only difference between a
+// plan title and its restatement would silently start a SECOND campaign. Lowercase removes the
+// axis.
+export function campaignBranchFor({ planId, slug } = {}) {
+  const p = safeRef(planId)
+  const s = safeRef(slug)
+  if (!p || !s) throw new Error(`campaignBranchFor: need both planId and slug, got ${JSON.stringify({ planId, slug })}`)
+  return `campaign/${p}-${s}`.toLowerCase()
+}
+
+// A wave's integration branch: cut off the CAMPAIGN branch, merged into it, then deleted.
+// Disposable — see the #892 note above for why that is now safe.
+//
+// The waveId is kept VERBATIM (unlike the campaign slug above): wave ids are engine-generated
+// (`W-1`), not human-typed, so there is no case-drift to guard against. And it must stay verbatim
+// so ONE wave has ONE spelling everywhere — resume.js embeds the same id, sanitized but not
+// lowercased (`safeWaveId`), in every flight branch (`<type>/<n>-<waveId>-<slug>`) and in the
+// terminal cleanup glob that matches them. Lowercasing only here would split a single wave's
+// branch names across two casings for no gain.
+export function waveKahunaFor({ planId, waveId } = {}) {
+  const w = safeRef(waveId)
+  if (!w) throw new Error(`waveKahunaFor: need a waveId, got ${JSON.stringify(waveId)}`)
+  const p = safeRef(planId)
+  return p ? `kahuna/${p}-${w}` : `kahuna/${w}`
+}
+
 // ── cold-start rehydrate / prune (§6.1 step 3, reboot-proof) ─────────────────────────────────
-// Given the campaign's full ordered wave list and the set of wave ids already PROMOTED (read back
-// from durable wave-status on cold start), return the pending waves IN ORDER. Pure: a reboot at
-// wave 5 prunes waves 1–4 and resumes at 5. Idempotent — re-running with the same promoted set
-// yields the same pending list.
-export function computePending(allWaves, promotedWaveIds) {
-  const promoted = new Set((promotedWaveIds ?? []).map(String))
-  return (allWaves ?? []).filter((w) => !promoted.has(String(waveIdOf(w))))
+// Given the campaign's full ordered wave list and the set of wave ids already INTEGRATED (read
+// back from durable wave-status on cold start), return the pending waves IN ORDER. Pure: a reboot
+// at wave 5 prunes waves 1–4 and resumes at 5. Idempotent — re-running with the same integrated
+// set yields the same pending list.
+//
+// #1052: the pruning predicate is INTEGRATED (landed on the campaign branch), NOT released
+// (landed on protected). Under the single-merge shape nothing is released until every wave is
+// integrated, so a released-keyed prune would never prune anything and every resume would re-run
+// the whole campaign. This is one of the four `promoted` consumers the split had to reach.
+export function computePending(allWaves, integratedWaveIds) {
+  const integrated = new Set((integratedWaveIds ?? []).map(String))
+  return (allWaves ?? []).filter((w) => !integrated.has(String(waveIdOf(w))))
 }
 
 // A wave entry may be a bare id or an object carrying {id|waveId|wave, issues, ...}. One accessor
@@ -52,17 +127,41 @@ export function waveIdOf(wave) {
   return wave
 }
 
-// ── verdict routing (§6.1 step 1) — the per-wave spine's {gate, promoted} return ─────────────
-// ADVANCE only on a wave that PASSED its trust gate AND actually landed on the protected branch
-// (promoted===true). A PASS that did not promote (interactive, or a promotion that did not land)
-// HOLDs — the campaign never builds the next wave on a baseline that never reached the trunk
-// (catalog signal I: "promoted ≠ delivered"). Anything else (HOLD/SKIPPED) HOLDs.
+// ── verdict routing (§6.1 step 1) — the per-wave spine's {gate, integrated} return ────────────
+//
+// #1052 — THE `promoted` SPLIT. `promoted` used to mean one thing because there was one merge per
+// wave and it went to the protected branch. Under the single-merge shape those are two different
+// events, and conflating them is a correctness bug in both directions:
+//
+//   integrated — the wave landed on the CAMPAIGN branch. Per-wave. Gates advancing to wave N+1,
+//                and is the prune predicate on resume.
+//   released   — the CAMPAIGN landed on the protected branch. Once, at the DoD gate. Gates
+//                closing issues (#1046) and is the only thing that means "delivered".
+//
+// A wave that is integrated-but-not-released is the NORMAL mid-campaign state, not a failure —
+// which is exactly why the old `promoted`-keyed router would hold every wave forever here.
+//
+// COMPATIBILITY, and why it is not merely defensive: an in-flight campaign launched by the
+// PREVIOUS engine returns `{promoted:true}` from a wave whose spine promoted straight to the
+// protected branch, and a resumed campaign can mix old and new records in one trajectory. Reading
+// `integrated ?? promoted` treats the old field as what it factually was — that wave DID land
+// somewhere the next wave can build on — so a mid-campaign engine upgrade advances instead of
+// stalling. (Catalog F: engine drift mid-campaign is a real event, not a hypothetical.)
+export function isIntegrated(verdict) {
+  if (verdict?.integrated != null) return verdict.integrated === true
+  return verdict?.promoted === true // legacy record (pre-#1052 engine) — landed, per the shape of its day
+}
+
+// ADVANCE only on a wave that PASSED its trust gate AND actually landed on the campaign branch.
+// A PASS that did not land (interactive, or a merge that did not complete) HOLDs — the campaign
+// never builds the next wave on a baseline that never landed (catalog signal I: "promoted ≠
+// delivered"). Anything else (HOLD/SKIPPED) HOLDs.
 export function routeVerdict(verdict) {
   const gate = verdict?.gate ?? null
-  const promoted = verdict?.promoted === true
-  if (gate === 'PASS' && promoted) return { advance: true, reason: 'gate PASS and promoted' }
-  if (gate === 'PASS' && !promoted) {
-    return { advance: false, reason: `gate PASS but NOT promoted (${verdict?.reason || 'did not land on protected branch'}) — campaign holds rather than build on an un-landed baseline` }
+  const integrated = isIntegrated(verdict)
+  if (gate === 'PASS' && integrated) return { advance: true, reason: 'gate PASS and integrated onto the campaign branch' }
+  if (gate === 'PASS' && !integrated) {
+    return { advance: false, reason: `gate PASS but NOT integrated (${verdict?.reason || 'did not land on the campaign branch'}) — campaign holds rather than build on an un-landed baseline` }
   }
   return { advance: false, reason: `gate ${gate ?? 'UNKNOWN'}${verdict?.reason ? `: ${verdict.reason}` : ''}` }
 }
@@ -78,7 +177,8 @@ export function routeJudgment(judgment) {
 }
 
 // ── the loop DRIVER (pure given its injected seams) ──────────────────────────────────────────
-// runWave(wave, index)  → Promise<verdict>   (the per-wave spine; verdict carries {gate, promoted})
+// runWave(wave, index)  → Promise<verdict>   (the per-wave spine; verdict carries {gate, integrated}
+//                                             — or legacy {gate, promoted}, read via isIntegrated)
 // judge(wave, context)  → Promise<judgment>  (the wave-oversight sub-agent; {continue, concern, ...})
 //                          context = { completed:[{wave,verdict}], remaining:[waveId], index }
 // onEvent(event)        → void               (optional progress sink: {type, wave, ...})
@@ -105,7 +205,10 @@ export async function runCampaign({ pending, runWave, judge, onEvent }) {
       return hold(id, `per-wave spine errored: ${e?.message || e}`, completed, wavesAdvanced)
     }
     const vr = routeVerdict(verdict)
-    emit({ type: 'verdict', wave: id, gate: verdict?.gate ?? null, promoted: verdict?.promoted === true, advance: vr.advance })
+    // Emit `integrated` via the same predicate the router used (#1052) — reading raw `promoted`
+    // here would log `integrated=false` for a legacy-record wave that just advanced, i.e. the
+    // progress line would contradict the decision it is narrating.
+    emit({ type: 'verdict', wave: id, gate: verdict?.gate ?? null, integrated: isIntegrated(verdict), advance: vr.advance })
     if (!vr.advance) {
       completed.push({ wave: id, verdict, judgment: null })
       return hold(id, vr.reason, completed, wavesAdvanced)
@@ -149,6 +252,185 @@ function hold(heldAt, heldReason, completed, wavesAdvanced) {
   return { outcome: 'held', heldAt, heldReason, wavesAdvanced, completed }
 }
 
+// ── THE RELEASE GATE (#1052) — the single write to the protected branch ───────────────────────
+//
+// Every wave integrated onto the campaign branch. This is the ONE moment the protected branch is
+// written, and it is the only place in the engine allowed to do so. Two conditions, both required:
+//
+//   1. the campaign COMPLETED — every wave in the plan integrated (not "every pending wave this
+//      run"; a resumed run's `pending` is a subset, so completeness is judged against the FULL plan);
+//   2. the DoD is met.
+//
+// WHY THE FULL-PLAN CHECK IS LOAD-BEARING. `runCampaign` returns outcome:'completed' when it
+// exhausts the waves IT was given. On a resume that list was already pruned to the pending subset,
+// so 'completed' there means "the rest finished" — not "all of them did". Releasing on that alone
+// would ship a campaign whose earlier waves were pruned because they were integrated... which is
+// fine... OR pruned from a DIFFERENT plan revision, which is not. Comparing against the full
+// ordered plan makes the predicate independent of how the run was sliced.
+//
+// WHY DoD-FAILS-MEANS-NO-MERGE IS THE WHOLE POINT. Without it, "one merge at the end" is
+// indistinguishable from "one unconditional merge at the end" — the DoD gate would be decoration
+// and the campaign would release whatever it happened to build. This predicate is why the shape is
+// safer than per-wave promotion rather than merely tidier.
+//
+// CONSERVATIVE ON ABSENCE: an unreadable/missing DoD, a malformed verdict, or an unmet criterion
+// all BLOCK. An undeterminable DoD is not a met DoD (SEAMS invariant 6). The campaign branch is
+// durable, so a blocked release is fully resumable once the DoD is genuinely satisfied — the cost
+// of holding is a conversation; the cost of releasing wrongly is a revert of the whole campaign.
+export function routeRelease({ report, allWaves, dod } = {}) {
+  const outcome = report?.outcome ?? null
+  if (outcome !== 'completed') {
+    return { release: false, reason: `campaign did not complete (outcome=${outcome ?? 'unknown'}${report?.heldAt ? `, held at ${report.heldAt}` : ''}) — the protected branch is written only on a complete campaign` }
+  }
+
+  // Completeness against the FULL plan, not this run's slice (see above).
+  const planIds = (allWaves ?? []).map((w) => String(waveIdOf(w)))
+  const landed = new Set([
+    ...(report?.wavesAdvanced ?? []).map(String),
+    // A wave pruned before this run is already integrated durably; the caller passes it through
+    // `alreadyIntegrated` on the report when resuming.
+    ...(report?.alreadyIntegrated ?? []).map(String),
+  ])
+  const missing = planIds.filter((id) => !landed.has(id))
+  if (missing.length > 0) {
+    return { release: false, reason: `campaign incomplete — ${missing.length} of ${planIds.length} wave(s) not integrated: [${missing.join(', ')}]` }
+  }
+  if (planIds.length === 0) {
+    return { release: false, reason: 'empty wave plan — nothing to release (a campaign with no waves is a misconfiguration, not a no-op)' }
+  }
+
+  // The DoD verdict. `met:true` is the ONLY release token; everything else holds.
+  if (dod == null) {
+    return { release: false, reason: 'DoD verdict absent — cannot prove the Definition of Done is met, so the protected branch is not written (an undeterminable DoD is not a met DoD)' }
+  }
+  if (dod.met !== true) {
+    const unmet = Array.isArray(dod.unmet) && dod.unmet.length > 0 ? `: [${dod.unmet.join('; ')}]` : ''
+    return { release: false, reason: `DoD not met${unmet}${dod.reason ? ` — ${dod.reason}` : ''}` }
+  }
+
+  return { release: true, reason: `campaign complete (${planIds.length} wave(s) integrated) and DoD met` }
+}
+
+// The DoD verdict contract the release-gate agent returns. `met` is the only field routed on;
+// `unmet` + `reason` exist so a blocked release explains itself to the human without a re-run.
+export const DOD_VERDICT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['met'],
+  properties: {
+    met: { type: 'boolean' },
+    unmet: { type: 'array', items: { type: 'string' } },
+    reason: { type: 'string' },
+    evidence: { type: 'string' },
+  },
+}
+
+// The release-node result contract — `released` must reflect an ACTUALLY-LANDED merge, never a
+// merge-requested-but-pending one (the same discipline the per-wave promote node carries: catalog
+// signal I, "promoted ≠ delivered").
+export const RELEASE_RESULT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['released'],
+  properties: {
+    released: { type: 'boolean' },
+    pr_ref: { type: 'string' },
+    merge_sha: { type: 'string' },
+    notes: { type: 'string' },
+  },
+}
+
+// ── DoD verification prompt (#1052 — the release gate's evidence step) ───────────────────────
+// Runs ONCE, after every wave integrated, BEFORE anything touches the protected branch. It only
+// ANSWERS; routeRelease() decides. Keeping the judgment out of the prompt is why "DoD unmet ⇒ no
+// merge" is testable without an agent in the loop.
+export function dodVerificationPrompt({ planId, targetRepo, targetRepoDir, campaignBranch, protectedBranch, wavesIntegrated }) {
+  return [
+    `You are the CAMPAIGN RELEASE-GATE DoD node for plan ${planId ?? '<unknown>'} of ${targetRepo}.`,
+    `Every wave has integrated onto ${campaignBranch}. NOTHING has touched ${protectedBranch} yet, and`,
+    `nothing will unless you can show the Definition of Done is MET. Answer only — do NOT merge, do NOT`,
+    `push, do NOT open a PR, do NOT modify any branch. Your verdict is evidence, not a decision.`,
+    ``,
+    `Waves integrated: [${(wavesIntegrated ?? []).join(', ') || 'none'}].`,
+    ``,
+    `1. Load the plan's Definition of Done: sdlc-server plan_load_dod(plan_id=${planId ?? '<plan>'},`,
+    `   repo="${targetRepo}"). If the plan has a DoD manifest, ALSO run dod_load_manifest +`,
+    `   dod_verify_deliverable for each declared deliverable — a wave suite passing is NOT the same as`,
+    `   a manifest deliverable existing (the flights wrote both their code and their tests; the manifest`,
+    `   is the reference they did not author).`,
+    `2. Verify each DoD criterion against the CAMPAIGN BRANCH state, in ${targetRepoDir}:`,
+    `     git -C ${targetRepoDir} fetch origin && git -C ${targetRepoDir} diff --stat origin/${protectedBranch}...origin/${campaignBranch}`,
+    `   Check the ACTUAL tree, not the issue checkboxes — a checked box is a claim, the tree is the fact.`,
+    `   Where a criterion names a test suite, RUN it (dod_run_test_suite / the project's own tooling).`,
+    `3. Be specific about what is NOT met. A blocked release must explain itself well enough that the`,
+    `   human does not have to re-derive it: name the criterion, not "some criteria failed".`,
+    ``,
+    `CONSERVATIVE ON ABSENCE — this is the contract, not a preference: if the DoD cannot be LOADED, is`,
+    `absent, is ambiguous, or you cannot verify a criterion, return met=false and say why. An`,
+    `undeterminable DoD is NOT a met DoD. You are the last check before ${protectedBranch} is written`,
+    `for the first and only time in this campaign; a wrong "met" ships a half-built campaign to trunk`,
+    `and costs a multi-wave revert, while a wrong "not met" costs one conversation. Bias accordingly.`,
+    ``,
+    `Return EXACTLY: met (bool), unmet (array of strings — the criteria not satisfied, empty if met),`,
+    `reason (1-2 sentences), evidence (what you actually ran/read to decide).`,
+  ].join('\n')
+}
+
+// ── release-merge prompt (#1052 — the ONE write to the protected branch) ─────────────────────
+// Reached only when routeRelease() returned release:true. Carries its own merge-result CI gate
+// against the protected branch, which is NOT redundant with the per-wave signals — see below.
+export function releaseMergePrompt({ planId, targetRepo, campaignBranch, protectedBranch, wavesIntegrated }) {
+  return [
+    `You are the CAMPAIGN RELEASE node for plan ${planId ?? '<unknown>'} of ${targetRepo}. The campaign`,
+    `is complete (waves [${(wavesIntegrated ?? []).join(', ') || 'none'}] all integrated onto`,
+    `${campaignBranch}) and the DoD gate PASSED. Land ${campaignBranch} → ${protectedBranch}.`,
+    ``,
+    `THIS IS THE ONLY WRITE TO ${protectedBranch} IN THE ENTIRE CAMPAIGN. It is a real increment for the`,
+    `first time: until this merge, ${protectedBranch} has been untouched since the campaign began, and`,
+    `everyone else has been working from a trunk this campaign never disturbed. Treat it accordingly.`,
+    ``,
+    `1. Open the ${campaignBranch}→${protectedBranch} PR (sdlc-server pr_create, or find the existing one`,
+    `   — idempotent on the branch pair; do NOT open a second). Title: the plan's release summary.`,
+    `   Body: the wave list + the DoD verdict. Open it as a DRAFT so a green CI cannot auto-merge it`,
+    `   before you have verified the merge-result pipeline yourself.`,
+    ``,
+    `2. GATE ON THE MERGE-RESULT PIPELINE AGAINST ${protectedBranch}. This is a REQUIRED, INDEPENDENT`,
+    `   check — not a re-run of the per-wave signals, and not optional:`,
+    `     sdlc-server ci_wait_run(repo="${targetRepo}", require_merge_result=true, pr_number=<n>,`,
+    `                             timeout_sec=1800, poll_interval_sec=20)`,
+    `   WHY IT CANNOT BE SKIPPED even though every wave was green: each wave's CI validated`,
+    `   kahuna→${campaignBranch}, i.e. the wave against the CAMPAIGN branch. ${campaignBranch} itself`,
+    `   drifts from ${protectedBranch} for the whole campaign — other people's merges land on trunk`,
+    `   while this campaign runs. So NO per-wave pipeline ever tested this composed diff against the`,
+    `   CURRENT ${protectedBranch}. A campaign of all-green waves can still break trunk, and this is`,
+    `   the only pipeline that would ever catch it. Use require_merge_result=true (a branch pipeline`,
+    `   proves nothing about the merge) and the explicit timeout (#1035 — the default idle bleeds`,
+    `   ~30-57 min/run). timeout_sec is 1800 here, not 420: this is a whole-campaign diff, and its`,
+    `   pipeline is legitimately longer than a single wave's.`,
+    `   If it is NOT green: STOP. Return released=false with the failure in notes. Leave the PR open as`,
+    `   a DRAFT and do NOT merge — a red merge-result on the release is exactly the signal the whole`,
+    `   no-interim-merge-back shape exists to be able to act on, while trunk is still clean.`,
+    ``,
+    `3. On green: mark ready (gh -R ${targetRepo} pr ready <n>) and merge it. Then CONFIRM IT LANDED`,
+    `   before reporting released — poll until state=MERGED with a merge commit (pr_merge_wait, or`,
+    `   gh -R ${targetRepo} pr view <n> --json state,mergeCommit). Never treat a pending merge as done.`,
+    `   The merge METHOD does not matter here (squash is fine): nothing continues from ${campaignBranch}`,
+    `   after this point, so there is no persistent branch left to diverge (this is what dissolves #892`,
+    `   rather than working around it).`,
+    ``,
+    `4. Only AFTER the merge is confirmed landed: close the campaign's issues (#1046 — an issue closes`,
+    `   when its work is on ${protectedBranch}, never before). Honor an explicit do-not-close: if a`,
+    `   flight body used "Refs #N" rather than "Closes #N", do NOT close that issue by number — that`,
+    `   was a deliberate signal, and overriding it is the #1046 defect. Verify each close by READING`,
+    `   THE ISSUE STATE BACK, not by the mutation's return code.`,
+    ``,
+    `5. Delete ${campaignBranch} on origin — the campaign is released and the branch is spent.`,
+    ``,
+    `Return: released (true ONLY if the merge actually landed on ${protectedBranch}), pr_ref, merge_sha,`,
+    `notes (1-2 sentences; on any failure released=false with the reason).`,
+  ].join('\n')
+}
+
 // ── intent-tier resolver (§3 — tiered intent, graceful degradation) ──────────────────────────
 // A rehydrate agent reports what intent artifacts EXIST (it runs devspec_locate / ddd_locate_*);
 // this PURE fn picks the richest available tier so the choice is deterministic + testable. The
@@ -167,7 +449,7 @@ export function resolveIntentTier({ devspec, domainModel, sketchbook } = {}) {
 // cross-wave catalog (A–J, [[project_wave_oversight_failure_catalog]]) — "go with what came in over
 // Discord" (BJ, 2026-06-20). routeJudgment + JUDGMENT_RESULT are the stable contract; this body is
 // the lens. Same record + wrong lens = a checkpoint that rubber-stamps; this is the difference.
-export function waveOversightPrompt({ justLanded, trajectory, remainingPlan, intentTier, intentRefs, kahunaBranch }) {
+export function waveOversightPrompt({ justLanded, trajectory, remainingPlan, intentTier, intentRefs, kahunaBranch, campaignBranch, protectedBranch }) {
   const tier = intentTier ?? 'issues-only'
   const calibration = {
     'devspec': `DEVSPEC tier — the un-gameable reference the flights did not write. Hold spec-fidelity: run dod_check_coverage / dod_verify_deliverable for HARD VRTM + Deliverables-Manifest traceability, and devspec_* checks. A wave that passed its own tests but misses a manifest deliverable is DRIFT.`,
@@ -176,11 +458,27 @@ export function waveOversightPrompt({ justLanded, trajectory, remainingPlan, int
   }[tier] ?? `ISSUES-ONLY tier.`
   return [
     `You are the WAVE-OVERSIGHT judgment agent — the campaign-layer checkpoint BETWEEN waves. A wave`,
-    `just PASSED its per-wave trust gate and promoted to the protected branch. Your question (§4):`,
-    `given the INTENT and the TRAJECTORY so far, is it sound to continue into the rest of the`,
-    `campaign — or is something lurking that every individual per-wave gate structurally could NOT`,
-    `catch? You are the only view with the whole trajectory + the un-gameable intent; the flights`,
-    `wrote both their code AND their tests, so "green per wave" is not "correct to intent".`,
+    `just PASSED its per-wave trust gate and INTEGRATED onto the campaign branch`,
+    `${campaignBranch ? `(${campaignBranch})` : ''}. Your question (§4): given the INTENT and the`,
+    `TRAJECTORY so far, is it sound to continue into the rest of the campaign — or is something lurking`,
+    `that every individual per-wave gate structurally could NOT catch? You are the only view with the`,
+    `whole trajectory + the un-gameable intent; the flights wrote both their code AND their tests, so`,
+    `"green per wave" is not "correct to intent".`,
+    ``,
+    `#1052 — WHAT "INTEGRATED" MEANS HERE, AND WHY IT RAISES YOUR STAKES. Nothing in this campaign has`,
+    `reached ${protectedBranch || 'the protected branch'} yet, and nothing will until every wave lands`,
+    `and the DoD gate passes — then it lands in ONE merge. Two consequences for your judgment:`,
+    `  • A flag from you is CHEAP right now. The protected branch is untouched, so acting on a concern`,
+    `    costs deleting or reworking an unmerged branch — not reverting promoted commits out of trunk`,
+    `    history. This is the window where a lurking problem is cheapest to name. Use it.`,
+    `  • Trajectory entries reading released:false mid-campaign are the NORMAL state, not a failure`,
+    `    signal. Judge on `+'`integrated`'+` and the trust signals. Do NOT read "not yet on the protected`,
+    `    branch" as catalog-I evidence ("promoted ≠ delivered") — that shape is about a landed merge whose`,
+    `    artifact never actually shipped, not about a campaign correctly withholding its single trunk`,
+    `    write until the DoD is met.`,
+    `  • Vocabulary note: in a post-#1052 record `+'`promoted`'+` is a SYNONYM for `+'`integrated`'+` (both mean`,
+    `    "landed on the campaign branch"), NOT a claim about trunk. So `+'`promoted:false`'+` on a recent entry`,
+    `    means the wave did not land — read it as such. Only `+'`released`'+` speaks to the protected branch.`,
     ``,
     `── INTENT TIER: ${tier} ──`,
     calibration,

--- a/skills/nextwave/campaign-workflow.bundled.js
+++ b/skills/nextwave/campaign-workflow.bundled.js
@@ -6,10 +6,12 @@
 export const meta = {
   name: 'campaign-workflow',
   description:
-    'Deterministic auto-mode campaign Workflow (#749, design §6.1): rehydrate pending waves from durable wave-status → per wave run the per-wave spine, route on {gate, promoted}, call the wave-oversight judgment sub-agent → advance on continue, hold-and-end on a flag. No LLM in the loop ⇒ cannot stall (#736 dissolves). Parameterized by the wave plan + per-wave launch blob via args.',
+    'Deterministic auto-mode campaign Workflow (#749/#1052, design §6.1): bootstrap ONE campaign branch → rehydrate pending waves from durable wave-status → per wave run the per-wave spine onto the campaign branch, route on {gate, integrated}, call the wave-oversight judgment sub-agent → advance on continue, hold-and-end on a flag → at the end verify the DoD and land the campaign on the protected branch in a SINGLE merge. No LLM in the loop ⇒ cannot stall (#736 dissolves). Parameterized by the wave plan + per-wave launch blob via args.',
   phases: [
-    { title: 'Rehydrate', detail: 'cold-start: read promoted waves + trajectory from durable wave-status, prune (§6.1.3)' },
+    { title: 'Bootstrap', detail: 'ensure the campaign branch exists off the protected branch (#1052)' },
+    { title: 'Rehydrate', detail: 'cold-start: read integrated waves + trajectory from durable wave-status, prune (§6.1.3)' },
     { title: 'Campaign loop', detail: 'per wave: spine → verdict route → wave-oversight judgment → advance/hold (§2)' },
+    { title: 'Release', detail: 'DoD verification, then the single campaign→protected merge (#1052)' },
   ],
 }
 
@@ -30,7 +32,7 @@ export const meta = {
 // THE KEY SEAM: `runCampaign` takes `runWave` (launch the per-wave spine) and `judge` (call the
 // wave-oversight sub-agent) as INJECTED async functions. The Workflow entrypoint injects the real
 // `workflow()` / `agent()` calls; the tests inject scripted fakes — so #749's "multi-wave advances
-// on PASS+promoted+continue, ends on a HOLD/flag" procedures are deterministic unit tests, not
+// on PASS+integrated+continue, ends on a HOLD/flag" procedures are deterministic unit tests, not
 // integration runs. No LLM in the loop CONTROL FLOW ⇒ it provably cannot stall (#736 dissolves).
 
 // ── args intake (same contract as per-wave-workflow.js #1/#3: the runtime global is `args`,
@@ -50,14 +52,89 @@ function parseArgs(raw) {
   throw new Error(`campaign-workflow: \`args\` must be an object or JSON string, got ${typeof raw}.`)
 }
 
+// ── BRANCH TOPOLOGY (#1052 — one campaign branch all the way through) ────────────────────────
+//
+// TWO LEVELS, TWO NAMES. A campaign writes the protected branch EXACTLY ONCE, at the DoD gate:
+//
+//   protected ──┬──────────────────────────────────────────────────────► (one merge, at DoD)
+//               │                                                      ▲
+//               └─► campaign/<plan>-<slug> ──W1──W2──W3── … ──WN ──────┘
+//                        ▲         ▲        ▲
+//                     kahuna/<plan>-<waveId>  (one per wave, disposable)
+//
+// WHY (BJ, 2026-07-26): waves 1..N-1 landed on the protected branch are a half-delivered feature
+// wearing a released commit's clothes. It is not an increment until the DoD is met. Three costs of
+// the interim merge-back: (1) an abort at wave 4 of 7 must REVERT four promoted waves from trunk
+// history instead of deleting one unmerged branch; (2) everyone else working from the protected
+// branch pulls half-finished work; (3) it is not a real increment, so calling it one is a lie the
+// board tells. The single merge at DoD removes all three by construction.
+//
+// WHY THIS DISSOLVES #892 (rather than needing a better merge method). #892 is "squash-merge +
+// a long-lived integration branch are incompatible": the squash rewrites history the persistent
+// kahuna still carries, so wave 2's promotion hits add/add. Here every wave gets a FRESH
+// DISPOSABLE kahuna cut off the campaign branch, and nothing continues from it after it lands —
+// so a squash is harmless, and there is no interim merge-back for the protected branch to
+// diverge from either. The failure mode is unreachable, not mitigated. `preserveKahuna` (#722)
+// therefore has nothing left to express in campaign mode: the branch that persists is the
+// CAMPAIGN branch, and the per-wave kahuna is disposable again as it was originally.
+//
+// WHY THE PREFIXES DIFFER (a git constraint, verified empirically, not a style choice). The
+// tempting name for a wave branch is a child of the campaign branch — `kahuna/56-plan/w1` under
+// `kahuna/56-plan`. That ref is IMPOSSIBLE: git stores branches as files under refs/heads/, so a
+// branch cannot be a directory prefix of another branch. Reproduced locally:
+//     $ git branch kahuna/56-plan && git branch kahuna/56-plan/w1
+//     fatal: cannot lock ref 'refs/heads/kahuna/56-plan/w1':
+//            'refs/heads/kahuna/56-plan' exists; cannot create 'refs/heads/kahuna/56-plan/w1'
+// Distinct top-level prefixes (`campaign/` vs `kahuna/`) put the two levels in separate
+// namespaces, so the D/F conflict cannot arise at any nesting depth. Do NOT "tidy" these into
+// one prefix — it re-creates an unrepresentable ref.
+const safeRef = (s) => String(s ?? '').replace(/[^A-Za-z0-9._-]/g, '-').replace(/^-+|-+$/g, '')
+
+// The campaign branch: cut off the protected branch once, at campaign start; merged to protected
+// once, at the DoD gate. Lives for the whole campaign.
+//
+// LOWERCASED. The slug comes from a plan title, so it arrives mixed-case, and git refs ARE
+// case-sensitive while macOS/Windows checkouts are not — `campaign/56-Blueshift` and
+// `campaign/56-blueshift` are two refs that cannot coexist in one working tree. Since the whole
+// point of this name is that a resume recomputes it identically, a case-only difference between a
+// plan title and its restatement would silently start a SECOND campaign. Lowercase removes the
+// axis.
+function campaignBranchFor({ planId, slug } = {}) {
+  const p = safeRef(planId)
+  const s = safeRef(slug)
+  if (!p || !s) throw new Error(`campaignBranchFor: need both planId and slug, got ${JSON.stringify({ planId, slug })}`)
+  return `campaign/${p}-${s}`.toLowerCase()
+}
+
+// A wave's integration branch: cut off the CAMPAIGN branch, merged into it, then deleted.
+// Disposable — see the #892 note above for why that is now safe.
+//
+// The waveId is kept VERBATIM (unlike the campaign slug above): wave ids are engine-generated
+// (`W-1`), not human-typed, so there is no case-drift to guard against. And it must stay verbatim
+// so ONE wave has ONE spelling everywhere — resume.js embeds the same id, sanitized but not
+// lowercased (`safeWaveId`), in every flight branch (`<type>/<n>-<waveId>-<slug>`) and in the
+// terminal cleanup glob that matches them. Lowercasing only here would split a single wave's
+// branch names across two casings for no gain.
+function waveKahunaFor({ planId, waveId } = {}) {
+  const w = safeRef(waveId)
+  if (!w) throw new Error(`waveKahunaFor: need a waveId, got ${JSON.stringify(waveId)}`)
+  const p = safeRef(planId)
+  return p ? `kahuna/${p}-${w}` : `kahuna/${w}`
+}
+
 // ── cold-start rehydrate / prune (§6.1 step 3, reboot-proof) ─────────────────────────────────
-// Given the campaign's full ordered wave list and the set of wave ids already PROMOTED (read back
-// from durable wave-status on cold start), return the pending waves IN ORDER. Pure: a reboot at
-// wave 5 prunes waves 1–4 and resumes at 5. Idempotent — re-running with the same promoted set
-// yields the same pending list.
-function computePending(allWaves, promotedWaveIds) {
-  const promoted = new Set((promotedWaveIds ?? []).map(String))
-  return (allWaves ?? []).filter((w) => !promoted.has(String(waveIdOf(w))))
+// Given the campaign's full ordered wave list and the set of wave ids already INTEGRATED (read
+// back from durable wave-status on cold start), return the pending waves IN ORDER. Pure: a reboot
+// at wave 5 prunes waves 1–4 and resumes at 5. Idempotent — re-running with the same integrated
+// set yields the same pending list.
+//
+// #1052: the pruning predicate is INTEGRATED (landed on the campaign branch), NOT released
+// (landed on protected). Under the single-merge shape nothing is released until every wave is
+// integrated, so a released-keyed prune would never prune anything and every resume would re-run
+// the whole campaign. This is one of the four `promoted` consumers the split had to reach.
+function computePending(allWaves, integratedWaveIds) {
+  const integrated = new Set((integratedWaveIds ?? []).map(String))
+  return (allWaves ?? []).filter((w) => !integrated.has(String(waveIdOf(w))))
 }
 
 // A wave entry may be a bare id or an object carrying {id|waveId|wave, issues, ...}. One accessor
@@ -68,17 +145,41 @@ function waveIdOf(wave) {
   return wave
 }
 
-// ── verdict routing (§6.1 step 1) — the per-wave spine's {gate, promoted} return ─────────────
-// ADVANCE only on a wave that PASSED its trust gate AND actually landed on the protected branch
-// (promoted===true). A PASS that did not promote (interactive, or a promotion that did not land)
-// HOLDs — the campaign never builds the next wave on a baseline that never reached the trunk
-// (catalog signal I: "promoted ≠ delivered"). Anything else (HOLD/SKIPPED) HOLDs.
+// ── verdict routing (§6.1 step 1) — the per-wave spine's {gate, integrated} return ────────────
+//
+// #1052 — THE `promoted` SPLIT. `promoted` used to mean one thing because there was one merge per
+// wave and it went to the protected branch. Under the single-merge shape those are two different
+// events, and conflating them is a correctness bug in both directions:
+//
+//   integrated — the wave landed on the CAMPAIGN branch. Per-wave. Gates advancing to wave N+1,
+//                and is the prune predicate on resume.
+//   released   — the CAMPAIGN landed on the protected branch. Once, at the DoD gate. Gates
+//                closing issues (#1046) and is the only thing that means "delivered".
+//
+// A wave that is integrated-but-not-released is the NORMAL mid-campaign state, not a failure —
+// which is exactly why the old `promoted`-keyed router would hold every wave forever here.
+//
+// COMPATIBILITY, and why it is not merely defensive: an in-flight campaign launched by the
+// PREVIOUS engine returns `{promoted:true}` from a wave whose spine promoted straight to the
+// protected branch, and a resumed campaign can mix old and new records in one trajectory. Reading
+// `integrated ?? promoted` treats the old field as what it factually was — that wave DID land
+// somewhere the next wave can build on — so a mid-campaign engine upgrade advances instead of
+// stalling. (Catalog F: engine drift mid-campaign is a real event, not a hypothetical.)
+function isIntegrated(verdict) {
+  if (verdict?.integrated != null) return verdict.integrated === true
+  return verdict?.promoted === true // legacy record (pre-#1052 engine) — landed, per the shape of its day
+}
+
+// ADVANCE only on a wave that PASSED its trust gate AND actually landed on the campaign branch.
+// A PASS that did not land (interactive, or a merge that did not complete) HOLDs — the campaign
+// never builds the next wave on a baseline that never landed (catalog signal I: "promoted ≠
+// delivered"). Anything else (HOLD/SKIPPED) HOLDs.
 function routeVerdict(verdict) {
   const gate = verdict?.gate ?? null
-  const promoted = verdict?.promoted === true
-  if (gate === 'PASS' && promoted) return { advance: true, reason: 'gate PASS and promoted' }
-  if (gate === 'PASS' && !promoted) {
-    return { advance: false, reason: `gate PASS but NOT promoted (${verdict?.reason || 'did not land on protected branch'}) — campaign holds rather than build on an un-landed baseline` }
+  const integrated = isIntegrated(verdict)
+  if (gate === 'PASS' && integrated) return { advance: true, reason: 'gate PASS and integrated onto the campaign branch' }
+  if (gate === 'PASS' && !integrated) {
+    return { advance: false, reason: `gate PASS but NOT integrated (${verdict?.reason || 'did not land on the campaign branch'}) — campaign holds rather than build on an un-landed baseline` }
   }
   return { advance: false, reason: `gate ${gate ?? 'UNKNOWN'}${verdict?.reason ? `: ${verdict.reason}` : ''}` }
 }
@@ -94,7 +195,8 @@ function routeJudgment(judgment) {
 }
 
 // ── the loop DRIVER (pure given its injected seams) ──────────────────────────────────────────
-// runWave(wave, index)  → Promise<verdict>   (the per-wave spine; verdict carries {gate, promoted})
+// runWave(wave, index)  → Promise<verdict>   (the per-wave spine; verdict carries {gate, integrated}
+//                                             — or legacy {gate, promoted}, read via isIntegrated)
 // judge(wave, context)  → Promise<judgment>  (the wave-oversight sub-agent; {continue, concern, ...})
 //                          context = { completed:[{wave,verdict}], remaining:[waveId], index }
 // onEvent(event)        → void               (optional progress sink: {type, wave, ...})
@@ -121,7 +223,10 @@ async function runCampaign({ pending, runWave, judge, onEvent }) {
       return hold(id, `per-wave spine errored: ${e?.message || e}`, completed, wavesAdvanced)
     }
     const vr = routeVerdict(verdict)
-    emit({ type: 'verdict', wave: id, gate: verdict?.gate ?? null, promoted: verdict?.promoted === true, advance: vr.advance })
+    // Emit `integrated` via the same predicate the router used (#1052) — reading raw `promoted`
+    // here would log `integrated=false` for a legacy-record wave that just advanced, i.e. the
+    // progress line would contradict the decision it is narrating.
+    emit({ type: 'verdict', wave: id, gate: verdict?.gate ?? null, integrated: isIntegrated(verdict), advance: vr.advance })
     if (!vr.advance) {
       completed.push({ wave: id, verdict, judgment: null })
       return hold(id, vr.reason, completed, wavesAdvanced)
@@ -165,6 +270,185 @@ function hold(heldAt, heldReason, completed, wavesAdvanced) {
   return { outcome: 'held', heldAt, heldReason, wavesAdvanced, completed }
 }
 
+// ── THE RELEASE GATE (#1052) — the single write to the protected branch ───────────────────────
+//
+// Every wave integrated onto the campaign branch. This is the ONE moment the protected branch is
+// written, and it is the only place in the engine allowed to do so. Two conditions, both required:
+//
+//   1. the campaign COMPLETED — every wave in the plan integrated (not "every pending wave this
+//      run"; a resumed run's `pending` is a subset, so completeness is judged against the FULL plan);
+//   2. the DoD is met.
+//
+// WHY THE FULL-PLAN CHECK IS LOAD-BEARING. `runCampaign` returns outcome:'completed' when it
+// exhausts the waves IT was given. On a resume that list was already pruned to the pending subset,
+// so 'completed' there means "the rest finished" — not "all of them did". Releasing on that alone
+// would ship a campaign whose earlier waves were pruned because they were integrated... which is
+// fine... OR pruned from a DIFFERENT plan revision, which is not. Comparing against the full
+// ordered plan makes the predicate independent of how the run was sliced.
+//
+// WHY DoD-FAILS-MEANS-NO-MERGE IS THE WHOLE POINT. Without it, "one merge at the end" is
+// indistinguishable from "one unconditional merge at the end" — the DoD gate would be decoration
+// and the campaign would release whatever it happened to build. This predicate is why the shape is
+// safer than per-wave promotion rather than merely tidier.
+//
+// CONSERVATIVE ON ABSENCE: an unreadable/missing DoD, a malformed verdict, or an unmet criterion
+// all BLOCK. An undeterminable DoD is not a met DoD (SEAMS invariant 6). The campaign branch is
+// durable, so a blocked release is fully resumable once the DoD is genuinely satisfied — the cost
+// of holding is a conversation; the cost of releasing wrongly is a revert of the whole campaign.
+function routeRelease({ report, allWaves, dod } = {}) {
+  const outcome = report?.outcome ?? null
+  if (outcome !== 'completed') {
+    return { release: false, reason: `campaign did not complete (outcome=${outcome ?? 'unknown'}${report?.heldAt ? `, held at ${report.heldAt}` : ''}) — the protected branch is written only on a complete campaign` }
+  }
+
+  // Completeness against the FULL plan, not this run's slice (see above).
+  const planIds = (allWaves ?? []).map((w) => String(waveIdOf(w)))
+  const landed = new Set([
+    ...(report?.wavesAdvanced ?? []).map(String),
+    // A wave pruned before this run is already integrated durably; the caller passes it through
+    // `alreadyIntegrated` on the report when resuming.
+    ...(report?.alreadyIntegrated ?? []).map(String),
+  ])
+  const missing = planIds.filter((id) => !landed.has(id))
+  if (missing.length > 0) {
+    return { release: false, reason: `campaign incomplete — ${missing.length} of ${planIds.length} wave(s) not integrated: [${missing.join(', ')}]` }
+  }
+  if (planIds.length === 0) {
+    return { release: false, reason: 'empty wave plan — nothing to release (a campaign with no waves is a misconfiguration, not a no-op)' }
+  }
+
+  // The DoD verdict. `met:true` is the ONLY release token; everything else holds.
+  if (dod == null) {
+    return { release: false, reason: 'DoD verdict absent — cannot prove the Definition of Done is met, so the protected branch is not written (an undeterminable DoD is not a met DoD)' }
+  }
+  if (dod.met !== true) {
+    const unmet = Array.isArray(dod.unmet) && dod.unmet.length > 0 ? `: [${dod.unmet.join('; ')}]` : ''
+    return { release: false, reason: `DoD not met${unmet}${dod.reason ? ` — ${dod.reason}` : ''}` }
+  }
+
+  return { release: true, reason: `campaign complete (${planIds.length} wave(s) integrated) and DoD met` }
+}
+
+// The DoD verdict contract the release-gate agent returns. `met` is the only field routed on;
+// `unmet` + `reason` exist so a blocked release explains itself to the human without a re-run.
+const DOD_VERDICT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['met'],
+  properties: {
+    met: { type: 'boolean' },
+    unmet: { type: 'array', items: { type: 'string' } },
+    reason: { type: 'string' },
+    evidence: { type: 'string' },
+  },
+}
+
+// The release-node result contract — `released` must reflect an ACTUALLY-LANDED merge, never a
+// merge-requested-but-pending one (the same discipline the per-wave promote node carries: catalog
+// signal I, "promoted ≠ delivered").
+const RELEASE_RESULT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['released'],
+  properties: {
+    released: { type: 'boolean' },
+    pr_ref: { type: 'string' },
+    merge_sha: { type: 'string' },
+    notes: { type: 'string' },
+  },
+}
+
+// ── DoD verification prompt (#1052 — the release gate's evidence step) ───────────────────────
+// Runs ONCE, after every wave integrated, BEFORE anything touches the protected branch. It only
+// ANSWERS; routeRelease() decides. Keeping the judgment out of the prompt is why "DoD unmet ⇒ no
+// merge" is testable without an agent in the loop.
+function dodVerificationPrompt({ planId, targetRepo, targetRepoDir, campaignBranch, protectedBranch, wavesIntegrated }) {
+  return [
+    `You are the CAMPAIGN RELEASE-GATE DoD node for plan ${planId ?? '<unknown>'} of ${targetRepo}.`,
+    `Every wave has integrated onto ${campaignBranch}. NOTHING has touched ${protectedBranch} yet, and`,
+    `nothing will unless you can show the Definition of Done is MET. Answer only — do NOT merge, do NOT`,
+    `push, do NOT open a PR, do NOT modify any branch. Your verdict is evidence, not a decision.`,
+    ``,
+    `Waves integrated: [${(wavesIntegrated ?? []).join(', ') || 'none'}].`,
+    ``,
+    `1. Load the plan's Definition of Done: sdlc-server plan_load_dod(plan_id=${planId ?? '<plan>'},`,
+    `   repo="${targetRepo}"). If the plan has a DoD manifest, ALSO run dod_load_manifest +`,
+    `   dod_verify_deliverable for each declared deliverable — a wave suite passing is NOT the same as`,
+    `   a manifest deliverable existing (the flights wrote both their code and their tests; the manifest`,
+    `   is the reference they did not author).`,
+    `2. Verify each DoD criterion against the CAMPAIGN BRANCH state, in ${targetRepoDir}:`,
+    `     git -C ${targetRepoDir} fetch origin && git -C ${targetRepoDir} diff --stat origin/${protectedBranch}...origin/${campaignBranch}`,
+    `   Check the ACTUAL tree, not the issue checkboxes — a checked box is a claim, the tree is the fact.`,
+    `   Where a criterion names a test suite, RUN it (dod_run_test_suite / the project's own tooling).`,
+    `3. Be specific about what is NOT met. A blocked release must explain itself well enough that the`,
+    `   human does not have to re-derive it: name the criterion, not "some criteria failed".`,
+    ``,
+    `CONSERVATIVE ON ABSENCE — this is the contract, not a preference: if the DoD cannot be LOADED, is`,
+    `absent, is ambiguous, or you cannot verify a criterion, return met=false and say why. An`,
+    `undeterminable DoD is NOT a met DoD. You are the last check before ${protectedBranch} is written`,
+    `for the first and only time in this campaign; a wrong "met" ships a half-built campaign to trunk`,
+    `and costs a multi-wave revert, while a wrong "not met" costs one conversation. Bias accordingly.`,
+    ``,
+    `Return EXACTLY: met (bool), unmet (array of strings — the criteria not satisfied, empty if met),`,
+    `reason (1-2 sentences), evidence (what you actually ran/read to decide).`,
+  ].join('\n')
+}
+
+// ── release-merge prompt (#1052 — the ONE write to the protected branch) ─────────────────────
+// Reached only when routeRelease() returned release:true. Carries its own merge-result CI gate
+// against the protected branch, which is NOT redundant with the per-wave signals — see below.
+function releaseMergePrompt({ planId, targetRepo, campaignBranch, protectedBranch, wavesIntegrated }) {
+  return [
+    `You are the CAMPAIGN RELEASE node for plan ${planId ?? '<unknown>'} of ${targetRepo}. The campaign`,
+    `is complete (waves [${(wavesIntegrated ?? []).join(', ') || 'none'}] all integrated onto`,
+    `${campaignBranch}) and the DoD gate PASSED. Land ${campaignBranch} → ${protectedBranch}.`,
+    ``,
+    `THIS IS THE ONLY WRITE TO ${protectedBranch} IN THE ENTIRE CAMPAIGN. It is a real increment for the`,
+    `first time: until this merge, ${protectedBranch} has been untouched since the campaign began, and`,
+    `everyone else has been working from a trunk this campaign never disturbed. Treat it accordingly.`,
+    ``,
+    `1. Open the ${campaignBranch}→${protectedBranch} PR (sdlc-server pr_create, or find the existing one`,
+    `   — idempotent on the branch pair; do NOT open a second). Title: the plan's release summary.`,
+    `   Body: the wave list + the DoD verdict. Open it as a DRAFT so a green CI cannot auto-merge it`,
+    `   before you have verified the merge-result pipeline yourself.`,
+    ``,
+    `2. GATE ON THE MERGE-RESULT PIPELINE AGAINST ${protectedBranch}. This is a REQUIRED, INDEPENDENT`,
+    `   check — not a re-run of the per-wave signals, and not optional:`,
+    `     sdlc-server ci_wait_run(repo="${targetRepo}", require_merge_result=true, pr_number=<n>,`,
+    `                             timeout_sec=1800, poll_interval_sec=20)`,
+    `   WHY IT CANNOT BE SKIPPED even though every wave was green: each wave's CI validated`,
+    `   kahuna→${campaignBranch}, i.e. the wave against the CAMPAIGN branch. ${campaignBranch} itself`,
+    `   drifts from ${protectedBranch} for the whole campaign — other people's merges land on trunk`,
+    `   while this campaign runs. So NO per-wave pipeline ever tested this composed diff against the`,
+    `   CURRENT ${protectedBranch}. A campaign of all-green waves can still break trunk, and this is`,
+    `   the only pipeline that would ever catch it. Use require_merge_result=true (a branch pipeline`,
+    `   proves nothing about the merge) and the explicit timeout (#1035 — the default idle bleeds`,
+    `   ~30-57 min/run). timeout_sec is 1800 here, not 420: this is a whole-campaign diff, and its`,
+    `   pipeline is legitimately longer than a single wave's.`,
+    `   If it is NOT green: STOP. Return released=false with the failure in notes. Leave the PR open as`,
+    `   a DRAFT and do NOT merge — a red merge-result on the release is exactly the signal the whole`,
+    `   no-interim-merge-back shape exists to be able to act on, while trunk is still clean.`,
+    ``,
+    `3. On green: mark ready (gh -R ${targetRepo} pr ready <n>) and merge it. Then CONFIRM IT LANDED`,
+    `   before reporting released — poll until state=MERGED with a merge commit (pr_merge_wait, or`,
+    `   gh -R ${targetRepo} pr view <n> --json state,mergeCommit). Never treat a pending merge as done.`,
+    `   The merge METHOD does not matter here (squash is fine): nothing continues from ${campaignBranch}`,
+    `   after this point, so there is no persistent branch left to diverge (this is what dissolves #892`,
+    `   rather than working around it).`,
+    ``,
+    `4. Only AFTER the merge is confirmed landed: close the campaign's issues (#1046 — an issue closes`,
+    `   when its work is on ${protectedBranch}, never before). Honor an explicit do-not-close: if a`,
+    `   flight body used "Refs #N" rather than "Closes #N", do NOT close that issue by number — that`,
+    `   was a deliberate signal, and overriding it is the #1046 defect. Verify each close by READING`,
+    `   THE ISSUE STATE BACK, not by the mutation's return code.`,
+    ``,
+    `5. Delete ${campaignBranch} on origin — the campaign is released and the branch is spent.`,
+    ``,
+    `Return: released (true ONLY if the merge actually landed on ${protectedBranch}), pr_ref, merge_sha,`,
+    `notes (1-2 sentences; on any failure released=false with the reason).`,
+  ].join('\n')
+}
+
 // ── intent-tier resolver (§3 — tiered intent, graceful degradation) ──────────────────────────
 // A rehydrate agent reports what intent artifacts EXIST (it runs devspec_locate / ddd_locate_*);
 // this PURE fn picks the richest available tier so the choice is deterministic + testable. The
@@ -183,7 +467,7 @@ function resolveIntentTier({ devspec, domainModel, sketchbook } = {}) {
 // cross-wave catalog (A–J, [[project_wave_oversight_failure_catalog]]) — "go with what came in over
 // Discord" (BJ, 2026-06-20). routeJudgment + JUDGMENT_RESULT are the stable contract; this body is
 // the lens. Same record + wrong lens = a checkpoint that rubber-stamps; this is the difference.
-function waveOversightPrompt({ justLanded, trajectory, remainingPlan, intentTier, intentRefs, kahunaBranch }) {
+function waveOversightPrompt({ justLanded, trajectory, remainingPlan, intentTier, intentRefs, kahunaBranch, campaignBranch, protectedBranch }) {
   const tier = intentTier ?? 'issues-only'
   const calibration = {
     'devspec': `DEVSPEC tier — the un-gameable reference the flights did not write. Hold spec-fidelity: run dod_check_coverage / dod_verify_deliverable for HARD VRTM + Deliverables-Manifest traceability, and devspec_* checks. A wave that passed its own tests but misses a manifest deliverable is DRIFT.`,
@@ -192,11 +476,27 @@ function waveOversightPrompt({ justLanded, trajectory, remainingPlan, intentTier
   }[tier] ?? `ISSUES-ONLY tier.`
   return [
     `You are the WAVE-OVERSIGHT judgment agent — the campaign-layer checkpoint BETWEEN waves. A wave`,
-    `just PASSED its per-wave trust gate and promoted to the protected branch. Your question (§4):`,
-    `given the INTENT and the TRAJECTORY so far, is it sound to continue into the rest of the`,
-    `campaign — or is something lurking that every individual per-wave gate structurally could NOT`,
-    `catch? You are the only view with the whole trajectory + the un-gameable intent; the flights`,
-    `wrote both their code AND their tests, so "green per wave" is not "correct to intent".`,
+    `just PASSED its per-wave trust gate and INTEGRATED onto the campaign branch`,
+    `${campaignBranch ? `(${campaignBranch})` : ''}. Your question (§4): given the INTENT and the`,
+    `TRAJECTORY so far, is it sound to continue into the rest of the campaign — or is something lurking`,
+    `that every individual per-wave gate structurally could NOT catch? You are the only view with the`,
+    `whole trajectory + the un-gameable intent; the flights wrote both their code AND their tests, so`,
+    `"green per wave" is not "correct to intent".`,
+    ``,
+    `#1052 — WHAT "INTEGRATED" MEANS HERE, AND WHY IT RAISES YOUR STAKES. Nothing in this campaign has`,
+    `reached ${protectedBranch || 'the protected branch'} yet, and nothing will until every wave lands`,
+    `and the DoD gate passes — then it lands in ONE merge. Two consequences for your judgment:`,
+    `  • A flag from you is CHEAP right now. The protected branch is untouched, so acting on a concern`,
+    `    costs deleting or reworking an unmerged branch — not reverting promoted commits out of trunk`,
+    `    history. This is the window where a lurking problem is cheapest to name. Use it.`,
+    `  • Trajectory entries reading released:false mid-campaign are the NORMAL state, not a failure`,
+    `    signal. Judge on `+'`integrated`'+` and the trust signals. Do NOT read "not yet on the protected`,
+    `    branch" as catalog-I evidence ("promoted ≠ delivered") — that shape is about a landed merge whose`,
+    `    artifact never actually shipped, not about a campaign correctly withholding its single trunk`,
+    `    write until the DoD is met.`,
+    `  • Vocabulary note: in a post-#1052 record `+'`promoted`'+` is a SYNONYM for `+'`integrated`'+` (both mean`,
+    `    "landed on the campaign branch"), NOT a claim about trunk. So `+'`promoted:false`'+` on a recent entry`,
+    `    means the wave did not land — read it as such. Only `+'`released`'+` speaks to the protected branch.`,
     ``,
     `── INTENT TIER: ${tier} ──`,
     calibration,
@@ -292,16 +592,23 @@ const JUDGMENT_RESULT = {
 //
 // Design of record: docs/campaign-workflow-design.md §2/§6.1. The auto-mode campaign loop is a
 // deterministic Workflow: it iterates the pending waves, runs each per-wave spine
-// (per-wave-workflow.js) as a nested workflow(), routes on the {gate, promoted} verdict, calls the
+// (per-wave-workflow.js) as a nested workflow(), routes on the {gate, integrated} verdict, calls the
 // wave-oversight judgment sub-agent (§2.2 — the launching session cannot re-invoke itself), and
 // advances on continue / holds-and-ends on a flag. NO LLM in the loop control flow ⇒ it provably
 // cannot stall ⇒ the stall-guard (#736) dissolves.
 //
-// THIN BY DESIGN: every deterministic decision (parse, rehydrate/prune, verdict + judgment routing,
-// the loop driver) lives in campaign-loop.js (pure, unit-tested). This file only WIRES the real
-// side-effecting seams — workflow() for the spine, agent() for rehydrate + judgment — into
-// runCampaign(). Source-of-truth modules are inlined by campaign-bundle.mjs into the single-file
-// artifact campaign-workflow.bundled.js the Workflow tool invokes.
+// #1052 — ONE BRANCH ALL THE WAY THROUGH. Every wave integrates onto a single long-lived CAMPAIGN
+// branch; the protected branch is written EXACTLY ONCE, at the end, and only if the DoD is met.
+// The topology, the three costs of interim merge-backs, and why this dissolves #892 rather than
+// mitigating it are documented in campaign-loop.js (BRANCH TOPOLOGY). This file owns the two nodes
+// that shape makes necessary: the campaign-branch BOOTSTRAP (phase 1) and the RELEASE gate
+// (phase 3 — DoD verification, then the single trunk merge).
+//
+// THIN BY DESIGN: every deterministic decision (parse, rehydrate/prune, verdict + judgment + release
+// routing, the loop driver) lives in campaign-loop.js (pure, unit-tested). This file only WIRES the
+// real side-effecting seams — workflow() for the spine, agent() for bootstrap + rehydrate + judgment
+// + DoD + release — into runCampaign(). Source-of-truth modules are inlined by campaign-bundle.mjs
+// into the single-file artifact campaign-workflow.bundled.js the Workflow tool invokes.
 
 
 
@@ -322,23 +629,123 @@ if (ALL_WAVES.length === 0) {
       `Launch with {waves:[{id, issues:[...]}, ...], targetRepo, targetRepoDir} via the Workflow tool's \`args\`.`,
   )
 }
+// #1052 — THE CAMPAIGN BRANCH. Every wave integrates here; the protected branch is untouched until
+// the release gate. An explicit params.campaignBranch wins (a resumed campaign MUST be handed the
+// same branch it started on); otherwise derive it deterministically from the plan so a resume that
+// forgot to pass it still recomputes the same name rather than silently starting a second campaign.
+//
+// A random or timestamped component would be WRONG here — it would make the derived name unstable
+// across resumes, which is precisely the failure the determinism is protecting against.
+//
+// There is NO placeholder for a missing planId or slug. campaignBranchFor throws on either, and that
+// throw is load-bearing: defaulting them (e.g. to 'plan'/'campaign') makes EVERY under-specified
+// campaign resolve to the same `campaign/plan-campaign`, whereupon the bootstrap's reuse-wins rule
+// adopts a DIFFERENT campaign's branch and its commits, and the release node lands both campaigns'
+// work on trunk as one increment. A campaign launched without a plan id and slug is a
+// misconfiguration, not a defaultable case — same fail-loud stance as the empty-plan and
+// branch-equals-trunk guards below.
+// The explicit override is lowercased through the SAME normalization as the derived name. Otherwise a
+// launcher that hand-builds `campaign/56-Blueshift` and a resume that omits the param (deriving
+// `campaign/56-blueshift`) would name two different case-sensitive server refs for one campaign — the
+// exact fork the derived-path lowercasing exists to prevent, reached by nothing more exotic than
+// forgetting to re-pass the parameter.
+const CAMPAIGN_BRANCH = String(params.campaignBranch ?? campaignBranchFor({
+  planId: PLAN_ID,
+  slug: params.slug ?? params.campaignSlug,
+})).toLowerCase()
+if (CAMPAIGN_BRANCH === PROTECTED_BRANCH) {
+  // Fail loud rather than run a campaign whose "integration branch" IS trunk — that would restore
+  // per-wave trunk writes under a name that claims otherwise, the exact shape #1052 removes.
+  throw new Error(
+    `campaign-workflow: campaignBranch (${CAMPAIGN_BRANCH}) must not equal protectedBranch (${PROTECTED_BRANCH}). ` +
+      `A campaign integrates onto its own branch and writes the protected branch exactly once, at the DoD gate (#1052).`,
+  )
+}
 // The per-wave spine artifact this campaign drives (nested workflow()). Default to the committed
 // bundle next to this file; overridable for tests / alternate deployments.
 const PER_WAVE_SCRIPT = params.perWaveScriptPath ?? 'skills/nextwave/per-wave-workflow.bundled.js'
+// Skip the trunk merge and end with the campaign branch intact + the DoD verdict reported. For a
+// campaign whose release is a human decision (or a dry run). The DoD node still runs — its verdict
+// is the useful artifact; only the merge is withheld.
+const RELEASE_MODE = params.release === false ? 'hold' : 'auto'
 
-// ── PHASE 1 — REHYDRATE (§6.1.3, reboot-proof) ───────────────────────────────────────────────
-// Read the durable wave-status: which waves already PROMOTED (prune them) + the cross-wave
+// ── PHASE 1 — BOOTSTRAP THE CAMPAIGN BRANCH (#1052) ──────────────────────────────────────────
+// Idempotent create-or-reuse, and the ORDER of those two matters: on a resume the branch already
+// exists and carries every previously-integrated wave, so re-cutting it from the protected branch
+// would silently discard the whole campaign to date. Reuse-if-exists is the correctness case;
+// create-if-absent is the fresh-campaign case.
+//
+// Hard-fails the campaign on error. This is the one place where a soft-fail would be actively
+// dangerous: if the campaign branch does not exist, every wave's INTEGRATION_BASE resolves to a
+// missing ref, and the recovery an agent would most plausibly reach for is "base it on the
+// protected branch instead" — which is exactly the per-wave trunk write this shape exists to
+// prevent. No branch, no campaign.
+phase('Bootstrap')
+const BOOTSTRAP_RESULT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['ready'],
+  properties: {
+    ready: { type: 'boolean' },
+    created: { type: 'boolean' }, // true = fresh cut off the protected branch; false = reused an existing campaign branch
+    head_sha: { type: 'string' },
+    notes: { type: 'string' },
+  },
+}
+const bootstrap = await agent(
+  [
+    `You are the CAMPAIGN BRANCH BOOTSTRAP node for plan ${PLAN_ID ?? 'n/a'} of ${TARGET_REPO}.`,
+    `Ensure the campaign branch ${CAMPAIGN_BRANCH} exists on origin. Do NOT do any other work — do not`,
+    `merge anything, do not touch ${PROTECTED_BRANCH}, do not create any wave/kahuna branches.`,
+    ``,
+    `Work in ${TARGET_REPO_DIR}:`,
+    `1. git -C ${TARGET_REPO_DIR} fetch origin --prune`,
+    `2. If origin/${CAMPAIGN_BRANCH} ALREADY EXISTS: REUSE it. Return ready=true, created=false, and its`,
+    `   head sha. Do NOT reset, re-cut, or force-push it — this is a RESUMED campaign and that branch`,
+    `   carries every wave integrated so far. Re-cutting it from ${PROTECTED_BRANCH} would silently`,
+    `   discard the whole campaign to date; that is the single worst outcome available at this step.`,
+    `3. If it does NOT exist: create it from the CURRENT tip of origin/${PROTECTED_BRANCH} and push it:`,
+    `     git -C ${TARGET_REPO_DIR} branch ${CAMPAIGN_BRANCH} origin/${PROTECTED_BRANCH}`,
+    `     git -C ${TARGET_REPO_DIR} push -u origin ${CAMPAIGN_BRANCH}`,
+    `   Return ready=true, created=true, head sha.`,
+    `4. VERIFY BY READING BACK — not by the push's exit code: confirm origin/${CAMPAIGN_BRANCH} resolves`,
+    `   (git -C ${TARGET_REPO_DIR} rev-parse origin/${CAMPAIGN_BRANCH}) and report that sha.`,
+    ``,
+    `If the branch can NEITHER be found NOR created, return ready=false with the reason in notes. Do NOT`,
+    `substitute ${PROTECTED_BRANCH} or any other ref as a fallback — the campaign will abort, which is`,
+    `the correct outcome (#1052: waves must never integrate onto the protected branch).`,
+    ``,
+    `Return: ready (bool), created (bool), head_sha (string), notes (1-2 sentences).`,
+  ].join('\n'),
+  { label: 'bootstrap:campaign-branch', phase: 'Bootstrap', schema: BOOTSTRAP_RESULT, agentType: 'general-purpose' },
+).catch((e) => ({ ready: false, notes: `bootstrap error: ${e?.message || e}` }))
+
+if (!bootstrap?.ready) {
+  throw new Error(
+    `campaign-workflow: could not establish the campaign branch ${CAMPAIGN_BRANCH} (${bootstrap?.notes || 'unknown reason'}). ` +
+      `Aborting — waves must integrate onto the campaign branch, never onto ${PROTECTED_BRANCH} (#1052).`,
+  )
+}
+log(`[#1052] campaign branch ${CAMPAIGN_BRANCH} ${bootstrap.created ? 'CREATED off' : 'REUSED (resume) — not re-cut from'} ${PROTECTED_BRANCH}${bootstrap.head_sha ? ` @ ${bootstrap.head_sha}` : ''}`)
+
+// ── PHASE 2 — REHYDRATE (§6.1.3, reboot-proof) ───────────────────────────────────────────────
+// Read the durable wave-status: which waves already INTEGRATED (prune them) + the cross-wave
 // trajectory (#748) that seeds the judgment agent. The script cannot call the CLI directly, so a
 // cheap agent reads it (wave-status trajectory-show + the wave-completion records) and returns the
-// structured rehydrate. A read failure is conservative: assume nothing promoted (re-run waves —
+// structured rehydrate. A read failure is conservative: assume nothing integrated (re-run waves —
 // the per-wave spine is idempotent) and an empty trajectory.
+//
+// #1052: the prune predicate is INTEGRATED, not released. Nothing is released until the campaign
+// ends, so a released-keyed rehydrate would prune nothing and re-run the whole campaign on every
+// resume. The persisted disposition is still the string 'promoted' (durable value, deliberately not
+// renamed — see wave-status.js) and now MEANS "landed on the integration base".
 phase('Rehydrate')
 const REHYDRATE_RESULT = {
   type: 'object',
   additionalProperties: false,
-  required: ['promotedWaveIds'],
+  required: ['integratedWaveIds'],
   properties: {
-    promotedWaveIds: { type: 'array', items: { type: 'string' } },
+    integratedWaveIds: { type: 'array', items: { type: 'string' } },
     trajectory: { type: 'array', items: { type: 'object', additionalProperties: true } },
   },
 }
@@ -348,25 +755,61 @@ const rehydrated = await agent(
     `wave-status in the target clone and return the cold-start campaign state. Do NOT do any other work.`,
     ``,
     `Run FROM the target clone (cd ${TARGET_REPO_DIR}) so the CLI resolves its .claude/status/:`,
-    `  1. promotedWaveIds: the wave ids whose terminal disposition is 'promoted' (a wave that landed`,
-    `     on ${PROTECTED_BRANCH}). Read the durable trajectory + wave-completion records:`,
-    `       wave-status trajectory-show   (JSON array; entries with promoted:true are promoted)`,
-    `     plus any wave-completion record the store exposes. Be CONSERVATIVE — only list a wave as`,
-    `     promoted if the record clearly says so; when unsure, omit it (the spine re-runs idempotently).`,
+    `  1. integratedWaveIds: the wave ids that have LANDED ON THE CAMPAIGN BRANCH ${CAMPAIGN_BRANCH}`,
+    `     — i.e. whose terminal disposition is 'promoted' (that durable value means "landed on its`,
+    `     integration base", which in a campaign is the campaign branch, NOT ${PROTECTED_BRANCH};`,
+    `     #1052). Read the durable trajectory + wave-completion records:`,
+    `       wave-status trajectory-show   (JSON array; entries with integrated:true — or, from a`,
+    `                                      pre-#1052 record, promoted:true — have landed)`,
+    `     plus any wave-completion record the store exposes. Do NOT require anything to be on`,
+    `     ${PROTECTED_BRANCH}: nothing in this campaign reaches it until the release gate at the end,`,
+    `     so a protected-branch test would report every wave as un-run and re-run the whole campaign.`,
+    `     Be CONSERVATIVE — only list a wave as integrated if the record clearly says so; when unsure,`,
+    `     omit it (the spine re-runs idempotently, so a false omission costs time, not correctness).`,
     `  2. trajectory: the full \`wave-status trajectory-show\` array verbatim (seeds the judgment agent).`,
     ``,
-    `If wave-status is absent/empty (fresh campaign) return { promotedWaveIds: [], trajectory: [] }.`,
-    `Return EXACTLY: promotedWaveIds (array of strings), trajectory (array of objects).`,
+    `If wave-status is absent/empty (fresh campaign) return { integratedWaveIds: [], trajectory: [] }.`,
+    `Return EXACTLY: integratedWaveIds (array of strings), trajectory (array of objects).`,
   ].join('\n'),
   { label: 'rehydrate', phase: 'Rehydrate', schema: REHYDRATE_RESULT, agentType: 'general-purpose' },
 ).catch((e) => {
   log(`[#749] rehydrate soft-fail → assume fresh campaign (spine is idempotent): ${e?.message || e}`)
-  return { promotedWaveIds: [], trajectory: [] }
+  return { integratedWaveIds: [], trajectory: [] }
 })
 
-const pending = computePending(ALL_WAVES, rehydrated?.promotedWaveIds ?? [])
+// The waves already integrated before this run. Kept because the release gate judges completeness
+// against the FULL plan (routeRelease): a resumed run's `wavesAdvanced` covers only its own slice,
+// so without these a resumed campaign could never satisfy the completeness predicate and would
+// never release — it would hold forever with every wave actually integrated.
+//
+// FILTERED to the plan's own wave ids. This list is agent-reported, and it feeds the completeness
+// half of routeRelease — the predicate that authorizes the one write to the protected branch. An
+// id that is not in the plan cannot be evidence about the plan, so an over-reporting or confused
+// rehydrate agent must not be able to shrink `missing[]` and manufacture a release. (The DoD node is
+// the other, independent half of that gate; this makes the completeness half self-consistent too.)
+const PLAN_WAVE_IDS = new Set(ALL_WAVES.map((w) => String(waveIdOf(w))))
+const reportedIntegrated = (rehydrated?.integratedWaveIds ?? []).map(String)
+const ALREADY_INTEGRATED = reportedIntegrated.filter((id) => PLAN_WAVE_IDS.has(id))
+for (const id of reportedIntegrated.filter((id) => !PLAN_WAVE_IDS.has(id))) {
+  log(`[#1052] discarding rehydrated wave id '${id}' — not in this plan; it cannot count toward release completeness.`)
+}
+// A freshly-CUT campaign branch and "waves already integrated onto it" cannot both be true. When they
+// co-occur, those integrations landed on some OTHER branch (a renamed/case-drifted campaign, a deleted
+// and re-cut branch, a stale durable store) — yet ALREADY_INTEGRATED still feeds routeRelease's landed
+// set, so `missing[]` could empty and the completeness half of the ONE trunk-write gate would pass on
+// evidence about a branch this run never touched. The plan-id filter above hardened this predicate
+// against out-of-plan ids; wrong-branch ids are the same class, and both facts are already in hand here.
+if (bootstrap.created === true && ALREADY_INTEGRATED.length > 0) {
+  throw new Error(
+    `campaign-workflow: ${CAMPAIGN_BRANCH} was just CUT FRESH off ${PROTECTED_BRANCH}, but wave-status reports ` +
+      `[${ALREADY_INTEGRATED.join(', ')}] already integrated — those landed on a DIFFERENT branch, so they are ` +
+      `not on this one. Aborting rather than count them toward release completeness (#1052). Resolve the ` +
+      `mismatch (recover the original campaign branch, or clear the stale wave-status records) and re-run.`,
+  )
+}
+const pending = computePending(ALL_WAVES, ALREADY_INTEGRATED)
 const baseTrajectory = Array.isArray(rehydrated?.trajectory) ? rehydrated.trajectory : []
-log(`[#749] rehydrated — ${(rehydrated?.promotedWaveIds ?? []).length} promoted, ${pending.length} pending: [${pending.map(waveIdOf).join(', ') || 'none'}]`)
+log(`[#749] rehydrated — ${ALREADY_INTEGRATED.length} integrated, ${pending.length} pending: [${pending.map(waveIdOf).join(', ') || 'none'}]`)
 
 // #750 INTENT-TIER RESOLVER (§3 — tiered intent, graceful degradation). One-time discovery: an
 // agent runs the sdlc-server locators (devspec_locate → ddd_locate_domain_model / ddd_locate_sketchbook)
@@ -403,8 +846,29 @@ const INTENT_TIER = INTENT_TIER_OVERRIDE ?? resolveIntentTier({ devspec: intent.
 const INTENT_REFS = { devspec: intent.devspec ?? null, domainModel: intent.domainModel ?? null, sketchbook: intent.sketchbook ?? null }
 log(`[#750] intent tier: ${INTENT_TIER}${INTENT_TIER_OVERRIDE ? ' (override)' : ''} — refs ${JSON.stringify(INTENT_REFS)}`)
 
-// ── PHASE 2 — CAMPAIGN LOOP (§2 — control flow is code; judgment is a seam) ───────────────────
+// ── PHASE 3 — CAMPAIGN LOOP (§2 — control flow is code; judgment is a seam) ───────────────────
 phase('Campaign loop')
+
+// This wave's disposable integration branch. Namespaced under the PLAN so two concurrent campaigns
+// in one repo cannot collide on `kahuna/W-1`, and deliberately under a DIFFERENT top-level prefix
+// from the campaign branch — a branch cannot be a directory prefix of another branch, so
+// `campaign/56-x` + `campaign/56-x/W-1` is an unrepresentable ref (see campaign-loop.js topology).
+//
+// The per-wave name ALWAYS wins inside a campaign — a plan-supplied `wave.kahunaBranch` is ignored.
+// That field is populated by server-side `wave_init`, which cuts ONE plan-scoped
+// `kahuna/<plan>-<slug>` off the plan's base_branch (default: trunk). Honoring it here would
+// reintroduce exactly what #1052 removes: a branch SHARED across waves (so wave 1's promote deletes
+// wave 2's base, since a campaign wave's kahuna is disposable) and cut off TRUNK rather than the
+// campaign branch (so each wave's flights would build on a baseline missing every previously
+// integrated wave). Log the override rather than dropping it silently — a stale launcher passing the
+// field is a real configuration the operator should see named.
+const kahunaFor = (wave, id) => {
+  const derived = waveKahunaFor({ planId: PLAN_ID, waveId: id })
+  if (wave.kahunaBranch && wave.kahunaBranch !== derived) {
+    log(`[#1052] ignoring plan-supplied kahunaBranch '${wave.kahunaBranch}' for wave ${id} — using ${derived}, cut off ${CAMPAIGN_BRANCH} (a wave_init plan-scoped branch is shared across waves and based on trunk).`)
+  }
+  return derived
+}
 
 // Seam 1 — run the per-wave spine as a nested Workflow (one level, §ok: per-wave does not nest).
 async function runWave(wave) {
@@ -412,16 +876,25 @@ async function runWave(wave) {
   const perWaveArgs = {
     waveId: id,
     issues: wave.issues ?? [],
-    kahunaBranch: wave.kahunaBranch ?? `kahuna/${id}`,
+    kahunaBranch: kahunaFor(wave, id),
     targetRepo: TARGET_REPO,
     targetRepoDir: TARGET_REPO_DIR,
+    // #1052 — the wave integrates onto the CAMPAIGN branch and promotes nowhere else. Both are
+    // passed: integrationBase is where the wave's PR targets and where its diffs are scoped, while
+    // protectedBranch is passed so the spine can tell the two apart (it derives IN_CAMPAIGN from
+    // integrationBase !== protectedBranch, which is what retires preserveKahuna and moves the
+    // platform issue-close to the release node). Omitting protectedBranch would make the spine
+    // default it to 'main' and mis-detect a campaign on any repo whose trunk is named otherwise.
+    integrationBase: CAMPAIGN_BRANCH,
     protectedBranch: PROTECTED_BRANCH,
     planId: PLAN_ID,
     mode: 'auto', // the campaign Workflow is auto-mode by definition (§2.4); interactive is the skill driver
-    preserveKahuna: wave.preserveKahuna ?? params.preserveKahuna ?? false,
     dispatch: wave.dispatch ?? 'serialize', // #824 R-06: thread the per-wave dispatch hint (/prepwaves #823) into the spine's args; absent → serialize (CT-01)
+    // NB: preserveKahuna is deliberately NOT threaded (#722 retired in campaign mode, #1052). The
+    // branch that must survive across waves is the campaign branch, and it does; each wave's kahuna
+    // is disposable again, which is what makes a squash merge harmless and #892 unreachable.
   }
-  log(`[#749] launching per-wave spine for ${id} (issues ${JSON.stringify(perWaveArgs.issues)})`)
+  log(`[#749] launching per-wave spine for ${id} → ${perWaveArgs.kahunaBranch} onto ${CAMPAIGN_BRANCH} (issues ${JSON.stringify(perWaveArgs.issues)})`)
   return workflow({ scriptPath: PER_WAVE_SCRIPT }, perWaveArgs)
 }
 
@@ -445,7 +918,11 @@ async function judge(wave, context) {
       remainingPlan: context.remaining,
       intentTier: INTENT_TIER,
       intentRefs: INTENT_REFS,
-      kahunaBranch: wave.kahunaBranch ?? `kahuna/${id}`,
+      kahunaBranch: kahunaFor(wave, id),
+      // #1052: the judge is told BOTH branches so it reads a mid-campaign `promoted:false` as the
+      // normal state it now is, and knows a flag here is cheap (trunk is still untouched).
+      campaignBranch: CAMPAIGN_BRANCH,
+      protectedBranch: PROTECTED_BRANCH,
     }),
     { label: `judgment:${id}`, phase: 'Campaign loop', schema: JUDGMENT_RESULT, agentType: 'general-purpose' },
   )
@@ -456,26 +933,115 @@ const report = await runCampaign({
   runWave,
   judge,
   onEvent: (e) => {
-    if (e.type === 'verdict') log(`[#749] ${e.wave}: gate=${e.gate} promoted=${e.promoted} → ${e.advance ? 'gate-advance' : 'HOLD'}`)
+    if (e.type === 'verdict') log(`[#749] ${e.wave}: gate=${e.gate} integrated=${e.integrated} → ${e.advance ? 'gate-advance' : 'HOLD'}`)
     else if (e.type === 'judgment') log(`[#749] ${e.wave}: judgment → ${e.advance ? 'continue' : 'FLAG/hold'}`)
     else if (e.type === 'advanced') log(`[#749] ${e.wave}: ADVANCED`)
   },
 })
 
 if (report.outcome === 'completed') {
-  log(`[#749] campaign COMPLETE — ${report.wavesAdvanced.length}/${pending.length} waves advanced: [${report.wavesAdvanced.join(', ')}]`)
+  log(`[#749] all pending waves integrated — ${report.wavesAdvanced.length}/${pending.length} advanced: [${report.wavesAdvanced.join(', ')}]`)
 } else {
   log(`[#749] campaign HELD at ${report.heldAt}: ${report.heldReason} (advanced: [${report.wavesAdvanced.join(', ') || 'none'}])`)
 }
 
+// ── PHASE 4 — RELEASE (#1052) — the ONE write to the protected branch ─────────────────────────
+// Two gates, in order, and neither is skippable:
+//   1. completeness — every wave in the FULL plan integrated (routeRelease; a resumed run's
+//      wavesAdvanced is only its own slice, hence alreadyIntegrated),
+//   2. the DoD is met — verified against the campaign branch's actual tree, not the checkboxes.
+//
+// The DoD node runs whenever the loop completed, INCLUDING when release is withheld: the verdict is
+// the thing a human needs in order to decide, so producing it is not conditional on acting on it.
+// It never runs after a HOLD — verifying a DoD against a knowingly-incomplete campaign would burn a
+// long agent turn to restate what routeRelease already knows.
+phase('Release')
+const wavesIntegrated = [...ALREADY_INTEGRATED, ...report.wavesAdvanced.map(String)]
+let dod = null
+if (report.outcome === 'completed') {
+  dod = await agent(
+    dodVerificationPrompt({
+      planId: PLAN_ID,
+      targetRepo: TARGET_REPO,
+      targetRepoDir: TARGET_REPO_DIR,
+      campaignBranch: CAMPAIGN_BRANCH,
+      protectedBranch: PROTECTED_BRANCH,
+      wavesIntegrated,
+    }),
+    { label: 'release:dod', phase: 'Release', schema: DOD_VERDICT, agentType: 'general-purpose' },
+  ).catch((e) => {
+    // Conservative on absence (SEAMS invariant 6): a DoD node that ERRORED has not shown the DoD is
+    // met, and an undeterminable DoD is not a met DoD. met:false BLOCKS the release; the campaign
+    // branch is durable, so this is fully resumable once the DoD genuinely holds.
+    log(`[#1052] DoD verification errored → release BLOCKED (conservative): ${e?.message || e}`)
+    return { met: false, reason: `DoD verification errored: ${e?.message || e}`, unmet: [] }
+  })
+  log(`[#1052] DoD verdict: met=${dod?.met === true}${dod?.reason ? ` — ${dod.reason}` : ''}`)
+} else {
+  log(`[#1052] campaign held before completion — skipping DoD verification (nothing to release)`)
+}
+
+// Pass the pre-run integrations through on the report so the pure predicate can judge completeness
+// against the whole plan without needing to know how this run was sliced.
+const releaseRoute = routeRelease({
+  report: { ...report, alreadyIntegrated: ALREADY_INTEGRATED },
+  allWaves: ALL_WAVES,
+  dod,
+})
+
+let release = null
+if (releaseRoute.release && RELEASE_MODE === 'auto') {
+  log(`[#1052] RELEASE GATE PASSED — ${releaseRoute.reason}. Landing ${CAMPAIGN_BRANCH} → ${PROTECTED_BRANCH} (the campaign's only trunk write).`)
+  release = await agent(
+    releaseMergePrompt({
+      planId: PLAN_ID,
+      targetRepo: TARGET_REPO,
+      campaignBranch: CAMPAIGN_BRANCH,
+      protectedBranch: PROTECTED_BRANCH,
+      wavesIntegrated,
+    }),
+    { label: 'release:merge', phase: 'Release', schema: RELEASE_RESULT, agentType: 'general-purpose' },
+  ).catch((e) => {
+    // A failed release is NOT reported as released, and it is NOT a campaign failure either: every
+    // wave is integrated and durable on the campaign branch, so the merge is retryable. Never claim
+    // a merge that did not land (catalog signal I).
+    log(`[#1052] release merge soft-fail — campaign branch intact, release retryable: ${e?.message || e}`)
+    return { released: false, notes: `release error: ${e?.message || e}` }
+  })
+  log(release?.released
+    ? `[#1052] RELEASED — ${CAMPAIGN_BRANCH} landed on ${PROTECTED_BRANCH}${release.merge_sha ? ` @ ${release.merge_sha}` : ''}`
+    : `[#1052] NOT released — ${release?.notes || 'see release node'}. ${CAMPAIGN_BRANCH} is intact; retry once the blocker clears.`)
+} else if (releaseRoute.release) {
+  log(`[#1052] release gate PASSED but release:false was requested — holding. ${CAMPAIGN_BRANCH} is ready to land on ${PROTECTED_BRANCH}.`)
+} else {
+  log(`[#1052] release BLOCKED — ${releaseRoute.reason}. ${PROTECTED_BRANCH} untouched; ${CAMPAIGN_BRANCH} preserved for inspection/resume.`)
+}
+
 // The return IS the campaign result the launching session / operator routes on (§2.2: a Workflow
-// ending with a report is the human handoff).
+// ending with a report is the human handoff). `integrated` and `released` are reported SEPARATELY
+// and are not interchangeable: waves can be fully integrated while released is false, which is a
+// campaign awaiting its DoD, not a delivered increment (#1052).
 return {
   outcome: report.outcome,
   plan: PLAN_ID,
   targetRepo: TARGET_REPO,
+  campaignBranch: CAMPAIGN_BRANCH,
+  protectedBranch: PROTECTED_BRANCH,
   wavesAdvanced: report.wavesAdvanced,
+  wavesIntegrated,
   heldAt: report.heldAt ?? null,
   heldReason: report.heldReason ?? null,
-  wavesCompleted: report.completed.map((c) => ({ wave: c.wave, gate: c.verdict?.gate ?? null, promoted: c.verdict?.promoted === true, judgment: c.judgment ? (c.judgment.continue ? 'continue' : 'flag') : null })),
+  dod: dod ? { met: dod.met === true, unmet: dod.unmet ?? [], reason: dod.reason ?? null } : null,
+  release: {
+    attempted: release != null,
+    released: release?.released === true,
+    reason: releaseRoute.reason,
+    pr_ref: release?.pr_ref ?? null,
+    merge_sha: release?.merge_sha ?? null,
+    notes: release?.notes ?? null,
+  },
+  // isIntegrated(), not an inline OR: the predicate gives an explicit `integrated:false` precedence
+  // over a stale `promoted:true`, and an OR-form silently inverts that — reporting a wave the loop
+  // correctly HELD as integrated. One predicate, one place (campaign-loop.js).
+  wavesCompleted: report.completed.map((c) => ({ wave: c.wave, gate: c.verdict?.gate ?? null, integrated: isIntegrated(c.verdict), judgment: c.judgment ? (c.judgment.continue ? 'continue' : 'flag') : null })),
 }

--- a/skills/nextwave/campaign-workflow.js
+++ b/skills/nextwave/campaign-workflow.js
@@ -2,33 +2,50 @@
 //
 // Design of record: docs/campaign-workflow-design.md §2/§6.1. The auto-mode campaign loop is a
 // deterministic Workflow: it iterates the pending waves, runs each per-wave spine
-// (per-wave-workflow.js) as a nested workflow(), routes on the {gate, promoted} verdict, calls the
+// (per-wave-workflow.js) as a nested workflow(), routes on the {gate, integrated} verdict, calls the
 // wave-oversight judgment sub-agent (§2.2 — the launching session cannot re-invoke itself), and
 // advances on continue / holds-and-ends on a flag. NO LLM in the loop control flow ⇒ it provably
 // cannot stall ⇒ the stall-guard (#736) dissolves.
 //
-// THIN BY DESIGN: every deterministic decision (parse, rehydrate/prune, verdict + judgment routing,
-// the loop driver) lives in campaign-loop.js (pure, unit-tested). This file only WIRES the real
-// side-effecting seams — workflow() for the spine, agent() for rehydrate + judgment — into
-// runCampaign(). Source-of-truth modules are inlined by campaign-bundle.mjs into the single-file
-// artifact campaign-workflow.bundled.js the Workflow tool invokes.
+// #1052 — ONE BRANCH ALL THE WAY THROUGH. Every wave integrates onto a single long-lived CAMPAIGN
+// branch; the protected branch is written EXACTLY ONCE, at the end, and only if the DoD is met.
+// The topology, the three costs of interim merge-backs, and why this dissolves #892 rather than
+// mitigating it are documented in campaign-loop.js (BRANCH TOPOLOGY). This file owns the two nodes
+// that shape makes necessary: the campaign-branch BOOTSTRAP (phase 1) and the RELEASE gate
+// (phase 3 — DoD verification, then the single trunk merge).
+//
+// THIN BY DESIGN: every deterministic decision (parse, rehydrate/prune, verdict + judgment + release
+// routing, the loop driver) lives in campaign-loop.js (pure, unit-tested). This file only WIRES the
+// real side-effecting seams — workflow() for the spine, agent() for bootstrap + rehydrate + judgment
+// + DoD + release — into runCampaign(). Source-of-truth modules are inlined by campaign-bundle.mjs
+// into the single-file artifact campaign-workflow.bundled.js the Workflow tool invokes.
 import {
   parseArgs,
   computePending,
   waveIdOf,
+  campaignBranchFor,
+  waveKahunaFor,
+  isIntegrated,
   resolveIntentTier,
   runCampaign,
+  routeRelease,
   waveOversightPrompt,
+  dodVerificationPrompt,
+  releaseMergePrompt,
   JUDGMENT_RESULT,
+  DOD_VERDICT,
+  RELEASE_RESULT,
 } from './campaign-loop.js'
 
 export const meta = {
   name: 'campaign-workflow',
   description:
-    'Deterministic auto-mode campaign Workflow (#749, design §6.1): rehydrate pending waves from durable wave-status → per wave run the per-wave spine, route on {gate, promoted}, call the wave-oversight judgment sub-agent → advance on continue, hold-and-end on a flag. No LLM in the loop ⇒ cannot stall (#736 dissolves). Parameterized by the wave plan + per-wave launch blob via args.',
+    'Deterministic auto-mode campaign Workflow (#749/#1052, design §6.1): bootstrap ONE campaign branch → rehydrate pending waves from durable wave-status → per wave run the per-wave spine onto the campaign branch, route on {gate, integrated}, call the wave-oversight judgment sub-agent → advance on continue, hold-and-end on a flag → at the end verify the DoD and land the campaign on the protected branch in a SINGLE merge. No LLM in the loop ⇒ cannot stall (#736 dissolves). Parameterized by the wave plan + per-wave launch blob via args.',
   phases: [
-    { title: 'Rehydrate', detail: 'cold-start: read promoted waves + trajectory from durable wave-status, prune (§6.1.3)' },
+    { title: 'Bootstrap', detail: 'ensure the campaign branch exists off the protected branch (#1052)' },
+    { title: 'Rehydrate', detail: 'cold-start: read integrated waves + trajectory from durable wave-status, prune (§6.1.3)' },
     { title: 'Campaign loop', detail: 'per wave: spine → verdict route → wave-oversight judgment → advance/hold (§2)' },
+    { title: 'Release', detail: 'DoD verification, then the single campaign→protected merge (#1052)' },
   ],
 }
 
@@ -48,23 +65,123 @@ if (ALL_WAVES.length === 0) {
       `Launch with {waves:[{id, issues:[...]}, ...], targetRepo, targetRepoDir} via the Workflow tool's \`args\`.`,
   )
 }
+// #1052 — THE CAMPAIGN BRANCH. Every wave integrates here; the protected branch is untouched until
+// the release gate. An explicit params.campaignBranch wins (a resumed campaign MUST be handed the
+// same branch it started on); otherwise derive it deterministically from the plan so a resume that
+// forgot to pass it still recomputes the same name rather than silently starting a second campaign.
+//
+// A random or timestamped component would be WRONG here — it would make the derived name unstable
+// across resumes, which is precisely the failure the determinism is protecting against.
+//
+// There is NO placeholder for a missing planId or slug. campaignBranchFor throws on either, and that
+// throw is load-bearing: defaulting them (e.g. to 'plan'/'campaign') makes EVERY under-specified
+// campaign resolve to the same `campaign/plan-campaign`, whereupon the bootstrap's reuse-wins rule
+// adopts a DIFFERENT campaign's branch and its commits, and the release node lands both campaigns'
+// work on trunk as one increment. A campaign launched without a plan id and slug is a
+// misconfiguration, not a defaultable case — same fail-loud stance as the empty-plan and
+// branch-equals-trunk guards below.
+// The explicit override is lowercased through the SAME normalization as the derived name. Otherwise a
+// launcher that hand-builds `campaign/56-Blueshift` and a resume that omits the param (deriving
+// `campaign/56-blueshift`) would name two different case-sensitive server refs for one campaign — the
+// exact fork the derived-path lowercasing exists to prevent, reached by nothing more exotic than
+// forgetting to re-pass the parameter.
+const CAMPAIGN_BRANCH = String(params.campaignBranch ?? campaignBranchFor({
+  planId: PLAN_ID,
+  slug: params.slug ?? params.campaignSlug,
+})).toLowerCase()
+if (CAMPAIGN_BRANCH === PROTECTED_BRANCH) {
+  // Fail loud rather than run a campaign whose "integration branch" IS trunk — that would restore
+  // per-wave trunk writes under a name that claims otherwise, the exact shape #1052 removes.
+  throw new Error(
+    `campaign-workflow: campaignBranch (${CAMPAIGN_BRANCH}) must not equal protectedBranch (${PROTECTED_BRANCH}). ` +
+      `A campaign integrates onto its own branch and writes the protected branch exactly once, at the DoD gate (#1052).`,
+  )
+}
 // The per-wave spine artifact this campaign drives (nested workflow()). Default to the committed
 // bundle next to this file; overridable for tests / alternate deployments.
 const PER_WAVE_SCRIPT = params.perWaveScriptPath ?? 'skills/nextwave/per-wave-workflow.bundled.js'
+// Skip the trunk merge and end with the campaign branch intact + the DoD verdict reported. For a
+// campaign whose release is a human decision (or a dry run). The DoD node still runs — its verdict
+// is the useful artifact; only the merge is withheld.
+const RELEASE_MODE = params.release === false ? 'hold' : 'auto'
 
-// ── PHASE 1 — REHYDRATE (§6.1.3, reboot-proof) ───────────────────────────────────────────────
-// Read the durable wave-status: which waves already PROMOTED (prune them) + the cross-wave
+// ── PHASE 1 — BOOTSTRAP THE CAMPAIGN BRANCH (#1052) ──────────────────────────────────────────
+// Idempotent create-or-reuse, and the ORDER of those two matters: on a resume the branch already
+// exists and carries every previously-integrated wave, so re-cutting it from the protected branch
+// would silently discard the whole campaign to date. Reuse-if-exists is the correctness case;
+// create-if-absent is the fresh-campaign case.
+//
+// Hard-fails the campaign on error. This is the one place where a soft-fail would be actively
+// dangerous: if the campaign branch does not exist, every wave's INTEGRATION_BASE resolves to a
+// missing ref, and the recovery an agent would most plausibly reach for is "base it on the
+// protected branch instead" — which is exactly the per-wave trunk write this shape exists to
+// prevent. No branch, no campaign.
+phase('Bootstrap')
+const BOOTSTRAP_RESULT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['ready'],
+  properties: {
+    ready: { type: 'boolean' },
+    created: { type: 'boolean' }, // true = fresh cut off the protected branch; false = reused an existing campaign branch
+    head_sha: { type: 'string' },
+    notes: { type: 'string' },
+  },
+}
+const bootstrap = await agent(
+  [
+    `You are the CAMPAIGN BRANCH BOOTSTRAP node for plan ${PLAN_ID ?? 'n/a'} of ${TARGET_REPO}.`,
+    `Ensure the campaign branch ${CAMPAIGN_BRANCH} exists on origin. Do NOT do any other work — do not`,
+    `merge anything, do not touch ${PROTECTED_BRANCH}, do not create any wave/kahuna branches.`,
+    ``,
+    `Work in ${TARGET_REPO_DIR}:`,
+    `1. git -C ${TARGET_REPO_DIR} fetch origin --prune`,
+    `2. If origin/${CAMPAIGN_BRANCH} ALREADY EXISTS: REUSE it. Return ready=true, created=false, and its`,
+    `   head sha. Do NOT reset, re-cut, or force-push it — this is a RESUMED campaign and that branch`,
+    `   carries every wave integrated so far. Re-cutting it from ${PROTECTED_BRANCH} would silently`,
+    `   discard the whole campaign to date; that is the single worst outcome available at this step.`,
+    `3. If it does NOT exist: create it from the CURRENT tip of origin/${PROTECTED_BRANCH} and push it:`,
+    `     git -C ${TARGET_REPO_DIR} branch ${CAMPAIGN_BRANCH} origin/${PROTECTED_BRANCH}`,
+    `     git -C ${TARGET_REPO_DIR} push -u origin ${CAMPAIGN_BRANCH}`,
+    `   Return ready=true, created=true, head sha.`,
+    `4. VERIFY BY READING BACK — not by the push's exit code: confirm origin/${CAMPAIGN_BRANCH} resolves`,
+    `   (git -C ${TARGET_REPO_DIR} rev-parse origin/${CAMPAIGN_BRANCH}) and report that sha.`,
+    ``,
+    `If the branch can NEITHER be found NOR created, return ready=false with the reason in notes. Do NOT`,
+    `substitute ${PROTECTED_BRANCH} or any other ref as a fallback — the campaign will abort, which is`,
+    `the correct outcome (#1052: waves must never integrate onto the protected branch).`,
+    ``,
+    `Return: ready (bool), created (bool), head_sha (string), notes (1-2 sentences).`,
+  ].join('\n'),
+  { label: 'bootstrap:campaign-branch', phase: 'Bootstrap', schema: BOOTSTRAP_RESULT, agentType: 'general-purpose' },
+).catch((e) => ({ ready: false, notes: `bootstrap error: ${e?.message || e}` }))
+
+if (!bootstrap?.ready) {
+  throw new Error(
+    `campaign-workflow: could not establish the campaign branch ${CAMPAIGN_BRANCH} (${bootstrap?.notes || 'unknown reason'}). ` +
+      `Aborting — waves must integrate onto the campaign branch, never onto ${PROTECTED_BRANCH} (#1052).`,
+  )
+}
+log(`[#1052] campaign branch ${CAMPAIGN_BRANCH} ${bootstrap.created ? 'CREATED off' : 'REUSED (resume) — not re-cut from'} ${PROTECTED_BRANCH}${bootstrap.head_sha ? ` @ ${bootstrap.head_sha}` : ''}`)
+
+// ── PHASE 2 — REHYDRATE (§6.1.3, reboot-proof) ───────────────────────────────────────────────
+// Read the durable wave-status: which waves already INTEGRATED (prune them) + the cross-wave
 // trajectory (#748) that seeds the judgment agent. The script cannot call the CLI directly, so a
 // cheap agent reads it (wave-status trajectory-show + the wave-completion records) and returns the
-// structured rehydrate. A read failure is conservative: assume nothing promoted (re-run waves —
+// structured rehydrate. A read failure is conservative: assume nothing integrated (re-run waves —
 // the per-wave spine is idempotent) and an empty trajectory.
+//
+// #1052: the prune predicate is INTEGRATED, not released. Nothing is released until the campaign
+// ends, so a released-keyed rehydrate would prune nothing and re-run the whole campaign on every
+// resume. The persisted disposition is still the string 'promoted' (durable value, deliberately not
+// renamed — see wave-status.js) and now MEANS "landed on the integration base".
 phase('Rehydrate')
 const REHYDRATE_RESULT = {
   type: 'object',
   additionalProperties: false,
-  required: ['promotedWaveIds'],
+  required: ['integratedWaveIds'],
   properties: {
-    promotedWaveIds: { type: 'array', items: { type: 'string' } },
+    integratedWaveIds: { type: 'array', items: { type: 'string' } },
     trajectory: { type: 'array', items: { type: 'object', additionalProperties: true } },
   },
 }
@@ -74,25 +191,61 @@ const rehydrated = await agent(
     `wave-status in the target clone and return the cold-start campaign state. Do NOT do any other work.`,
     ``,
     `Run FROM the target clone (cd ${TARGET_REPO_DIR}) so the CLI resolves its .claude/status/:`,
-    `  1. promotedWaveIds: the wave ids whose terminal disposition is 'promoted' (a wave that landed`,
-    `     on ${PROTECTED_BRANCH}). Read the durable trajectory + wave-completion records:`,
-    `       wave-status trajectory-show   (JSON array; entries with promoted:true are promoted)`,
-    `     plus any wave-completion record the store exposes. Be CONSERVATIVE — only list a wave as`,
-    `     promoted if the record clearly says so; when unsure, omit it (the spine re-runs idempotently).`,
+    `  1. integratedWaveIds: the wave ids that have LANDED ON THE CAMPAIGN BRANCH ${CAMPAIGN_BRANCH}`,
+    `     — i.e. whose terminal disposition is 'promoted' (that durable value means "landed on its`,
+    `     integration base", which in a campaign is the campaign branch, NOT ${PROTECTED_BRANCH};`,
+    `     #1052). Read the durable trajectory + wave-completion records:`,
+    `       wave-status trajectory-show   (JSON array; entries with integrated:true — or, from a`,
+    `                                      pre-#1052 record, promoted:true — have landed)`,
+    `     plus any wave-completion record the store exposes. Do NOT require anything to be on`,
+    `     ${PROTECTED_BRANCH}: nothing in this campaign reaches it until the release gate at the end,`,
+    `     so a protected-branch test would report every wave as un-run and re-run the whole campaign.`,
+    `     Be CONSERVATIVE — only list a wave as integrated if the record clearly says so; when unsure,`,
+    `     omit it (the spine re-runs idempotently, so a false omission costs time, not correctness).`,
     `  2. trajectory: the full \`wave-status trajectory-show\` array verbatim (seeds the judgment agent).`,
     ``,
-    `If wave-status is absent/empty (fresh campaign) return { promotedWaveIds: [], trajectory: [] }.`,
-    `Return EXACTLY: promotedWaveIds (array of strings), trajectory (array of objects).`,
+    `If wave-status is absent/empty (fresh campaign) return { integratedWaveIds: [], trajectory: [] }.`,
+    `Return EXACTLY: integratedWaveIds (array of strings), trajectory (array of objects).`,
   ].join('\n'),
   { label: 'rehydrate', phase: 'Rehydrate', schema: REHYDRATE_RESULT, agentType: 'general-purpose' },
 ).catch((e) => {
   log(`[#749] rehydrate soft-fail → assume fresh campaign (spine is idempotent): ${e?.message || e}`)
-  return { promotedWaveIds: [], trajectory: [] }
+  return { integratedWaveIds: [], trajectory: [] }
 })
 
-const pending = computePending(ALL_WAVES, rehydrated?.promotedWaveIds ?? [])
+// The waves already integrated before this run. Kept because the release gate judges completeness
+// against the FULL plan (routeRelease): a resumed run's `wavesAdvanced` covers only its own slice,
+// so without these a resumed campaign could never satisfy the completeness predicate and would
+// never release — it would hold forever with every wave actually integrated.
+//
+// FILTERED to the plan's own wave ids. This list is agent-reported, and it feeds the completeness
+// half of routeRelease — the predicate that authorizes the one write to the protected branch. An
+// id that is not in the plan cannot be evidence about the plan, so an over-reporting or confused
+// rehydrate agent must not be able to shrink `missing[]` and manufacture a release. (The DoD node is
+// the other, independent half of that gate; this makes the completeness half self-consistent too.)
+const PLAN_WAVE_IDS = new Set(ALL_WAVES.map((w) => String(waveIdOf(w))))
+const reportedIntegrated = (rehydrated?.integratedWaveIds ?? []).map(String)
+const ALREADY_INTEGRATED = reportedIntegrated.filter((id) => PLAN_WAVE_IDS.has(id))
+for (const id of reportedIntegrated.filter((id) => !PLAN_WAVE_IDS.has(id))) {
+  log(`[#1052] discarding rehydrated wave id '${id}' — not in this plan; it cannot count toward release completeness.`)
+}
+// A freshly-CUT campaign branch and "waves already integrated onto it" cannot both be true. When they
+// co-occur, those integrations landed on some OTHER branch (a renamed/case-drifted campaign, a deleted
+// and re-cut branch, a stale durable store) — yet ALREADY_INTEGRATED still feeds routeRelease's landed
+// set, so `missing[]` could empty and the completeness half of the ONE trunk-write gate would pass on
+// evidence about a branch this run never touched. The plan-id filter above hardened this predicate
+// against out-of-plan ids; wrong-branch ids are the same class, and both facts are already in hand here.
+if (bootstrap.created === true && ALREADY_INTEGRATED.length > 0) {
+  throw new Error(
+    `campaign-workflow: ${CAMPAIGN_BRANCH} was just CUT FRESH off ${PROTECTED_BRANCH}, but wave-status reports ` +
+      `[${ALREADY_INTEGRATED.join(', ')}] already integrated — those landed on a DIFFERENT branch, so they are ` +
+      `not on this one. Aborting rather than count them toward release completeness (#1052). Resolve the ` +
+      `mismatch (recover the original campaign branch, or clear the stale wave-status records) and re-run.`,
+  )
+}
+const pending = computePending(ALL_WAVES, ALREADY_INTEGRATED)
 const baseTrajectory = Array.isArray(rehydrated?.trajectory) ? rehydrated.trajectory : []
-log(`[#749] rehydrated — ${(rehydrated?.promotedWaveIds ?? []).length} promoted, ${pending.length} pending: [${pending.map(waveIdOf).join(', ') || 'none'}]`)
+log(`[#749] rehydrated — ${ALREADY_INTEGRATED.length} integrated, ${pending.length} pending: [${pending.map(waveIdOf).join(', ') || 'none'}]`)
 
 // #750 INTENT-TIER RESOLVER (§3 — tiered intent, graceful degradation). One-time discovery: an
 // agent runs the sdlc-server locators (devspec_locate → ddd_locate_domain_model / ddd_locate_sketchbook)
@@ -129,8 +282,29 @@ const INTENT_TIER = INTENT_TIER_OVERRIDE ?? resolveIntentTier({ devspec: intent.
 const INTENT_REFS = { devspec: intent.devspec ?? null, domainModel: intent.domainModel ?? null, sketchbook: intent.sketchbook ?? null }
 log(`[#750] intent tier: ${INTENT_TIER}${INTENT_TIER_OVERRIDE ? ' (override)' : ''} — refs ${JSON.stringify(INTENT_REFS)}`)
 
-// ── PHASE 2 — CAMPAIGN LOOP (§2 — control flow is code; judgment is a seam) ───────────────────
+// ── PHASE 3 — CAMPAIGN LOOP (§2 — control flow is code; judgment is a seam) ───────────────────
 phase('Campaign loop')
+
+// This wave's disposable integration branch. Namespaced under the PLAN so two concurrent campaigns
+// in one repo cannot collide on `kahuna/W-1`, and deliberately under a DIFFERENT top-level prefix
+// from the campaign branch — a branch cannot be a directory prefix of another branch, so
+// `campaign/56-x` + `campaign/56-x/W-1` is an unrepresentable ref (see campaign-loop.js topology).
+//
+// The per-wave name ALWAYS wins inside a campaign — a plan-supplied `wave.kahunaBranch` is ignored.
+// That field is populated by server-side `wave_init`, which cuts ONE plan-scoped
+// `kahuna/<plan>-<slug>` off the plan's base_branch (default: trunk). Honoring it here would
+// reintroduce exactly what #1052 removes: a branch SHARED across waves (so wave 1's promote deletes
+// wave 2's base, since a campaign wave's kahuna is disposable) and cut off TRUNK rather than the
+// campaign branch (so each wave's flights would build on a baseline missing every previously
+// integrated wave). Log the override rather than dropping it silently — a stale launcher passing the
+// field is a real configuration the operator should see named.
+const kahunaFor = (wave, id) => {
+  const derived = waveKahunaFor({ planId: PLAN_ID, waveId: id })
+  if (wave.kahunaBranch && wave.kahunaBranch !== derived) {
+    log(`[#1052] ignoring plan-supplied kahunaBranch '${wave.kahunaBranch}' for wave ${id} — using ${derived}, cut off ${CAMPAIGN_BRANCH} (a wave_init plan-scoped branch is shared across waves and based on trunk).`)
+  }
+  return derived
+}
 
 // Seam 1 — run the per-wave spine as a nested Workflow (one level, §ok: per-wave does not nest).
 async function runWave(wave) {
@@ -138,16 +312,25 @@ async function runWave(wave) {
   const perWaveArgs = {
     waveId: id,
     issues: wave.issues ?? [],
-    kahunaBranch: wave.kahunaBranch ?? `kahuna/${id}`,
+    kahunaBranch: kahunaFor(wave, id),
     targetRepo: TARGET_REPO,
     targetRepoDir: TARGET_REPO_DIR,
+    // #1052 — the wave integrates onto the CAMPAIGN branch and promotes nowhere else. Both are
+    // passed: integrationBase is where the wave's PR targets and where its diffs are scoped, while
+    // protectedBranch is passed so the spine can tell the two apart (it derives IN_CAMPAIGN from
+    // integrationBase !== protectedBranch, which is what retires preserveKahuna and moves the
+    // platform issue-close to the release node). Omitting protectedBranch would make the spine
+    // default it to 'main' and mis-detect a campaign on any repo whose trunk is named otherwise.
+    integrationBase: CAMPAIGN_BRANCH,
     protectedBranch: PROTECTED_BRANCH,
     planId: PLAN_ID,
     mode: 'auto', // the campaign Workflow is auto-mode by definition (§2.4); interactive is the skill driver
-    preserveKahuna: wave.preserveKahuna ?? params.preserveKahuna ?? false,
     dispatch: wave.dispatch ?? 'serialize', // #824 R-06: thread the per-wave dispatch hint (/prepwaves #823) into the spine's args; absent → serialize (CT-01)
+    // NB: preserveKahuna is deliberately NOT threaded (#722 retired in campaign mode, #1052). The
+    // branch that must survive across waves is the campaign branch, and it does; each wave's kahuna
+    // is disposable again, which is what makes a squash merge harmless and #892 unreachable.
   }
-  log(`[#749] launching per-wave spine for ${id} (issues ${JSON.stringify(perWaveArgs.issues)})`)
+  log(`[#749] launching per-wave spine for ${id} → ${perWaveArgs.kahunaBranch} onto ${CAMPAIGN_BRANCH} (issues ${JSON.stringify(perWaveArgs.issues)})`)
   return workflow({ scriptPath: PER_WAVE_SCRIPT }, perWaveArgs)
 }
 
@@ -171,7 +354,11 @@ async function judge(wave, context) {
       remainingPlan: context.remaining,
       intentTier: INTENT_TIER,
       intentRefs: INTENT_REFS,
-      kahunaBranch: wave.kahunaBranch ?? `kahuna/${id}`,
+      kahunaBranch: kahunaFor(wave, id),
+      // #1052: the judge is told BOTH branches so it reads a mid-campaign `promoted:false` as the
+      // normal state it now is, and knows a flag here is cheap (trunk is still untouched).
+      campaignBranch: CAMPAIGN_BRANCH,
+      protectedBranch: PROTECTED_BRANCH,
     }),
     { label: `judgment:${id}`, phase: 'Campaign loop', schema: JUDGMENT_RESULT, agentType: 'general-purpose' },
   )
@@ -182,26 +369,115 @@ const report = await runCampaign({
   runWave,
   judge,
   onEvent: (e) => {
-    if (e.type === 'verdict') log(`[#749] ${e.wave}: gate=${e.gate} promoted=${e.promoted} → ${e.advance ? 'gate-advance' : 'HOLD'}`)
+    if (e.type === 'verdict') log(`[#749] ${e.wave}: gate=${e.gate} integrated=${e.integrated} → ${e.advance ? 'gate-advance' : 'HOLD'}`)
     else if (e.type === 'judgment') log(`[#749] ${e.wave}: judgment → ${e.advance ? 'continue' : 'FLAG/hold'}`)
     else if (e.type === 'advanced') log(`[#749] ${e.wave}: ADVANCED`)
   },
 })
 
 if (report.outcome === 'completed') {
-  log(`[#749] campaign COMPLETE — ${report.wavesAdvanced.length}/${pending.length} waves advanced: [${report.wavesAdvanced.join(', ')}]`)
+  log(`[#749] all pending waves integrated — ${report.wavesAdvanced.length}/${pending.length} advanced: [${report.wavesAdvanced.join(', ')}]`)
 } else {
   log(`[#749] campaign HELD at ${report.heldAt}: ${report.heldReason} (advanced: [${report.wavesAdvanced.join(', ') || 'none'}])`)
 }
 
+// ── PHASE 4 — RELEASE (#1052) — the ONE write to the protected branch ─────────────────────────
+// Two gates, in order, and neither is skippable:
+//   1. completeness — every wave in the FULL plan integrated (routeRelease; a resumed run's
+//      wavesAdvanced is only its own slice, hence alreadyIntegrated),
+//   2. the DoD is met — verified against the campaign branch's actual tree, not the checkboxes.
+//
+// The DoD node runs whenever the loop completed, INCLUDING when release is withheld: the verdict is
+// the thing a human needs in order to decide, so producing it is not conditional on acting on it.
+// It never runs after a HOLD — verifying a DoD against a knowingly-incomplete campaign would burn a
+// long agent turn to restate what routeRelease already knows.
+phase('Release')
+const wavesIntegrated = [...ALREADY_INTEGRATED, ...report.wavesAdvanced.map(String)]
+let dod = null
+if (report.outcome === 'completed') {
+  dod = await agent(
+    dodVerificationPrompt({
+      planId: PLAN_ID,
+      targetRepo: TARGET_REPO,
+      targetRepoDir: TARGET_REPO_DIR,
+      campaignBranch: CAMPAIGN_BRANCH,
+      protectedBranch: PROTECTED_BRANCH,
+      wavesIntegrated,
+    }),
+    { label: 'release:dod', phase: 'Release', schema: DOD_VERDICT, agentType: 'general-purpose' },
+  ).catch((e) => {
+    // Conservative on absence (SEAMS invariant 6): a DoD node that ERRORED has not shown the DoD is
+    // met, and an undeterminable DoD is not a met DoD. met:false BLOCKS the release; the campaign
+    // branch is durable, so this is fully resumable once the DoD genuinely holds.
+    log(`[#1052] DoD verification errored → release BLOCKED (conservative): ${e?.message || e}`)
+    return { met: false, reason: `DoD verification errored: ${e?.message || e}`, unmet: [] }
+  })
+  log(`[#1052] DoD verdict: met=${dod?.met === true}${dod?.reason ? ` — ${dod.reason}` : ''}`)
+} else {
+  log(`[#1052] campaign held before completion — skipping DoD verification (nothing to release)`)
+}
+
+// Pass the pre-run integrations through on the report so the pure predicate can judge completeness
+// against the whole plan without needing to know how this run was sliced.
+const releaseRoute = routeRelease({
+  report: { ...report, alreadyIntegrated: ALREADY_INTEGRATED },
+  allWaves: ALL_WAVES,
+  dod,
+})
+
+let release = null
+if (releaseRoute.release && RELEASE_MODE === 'auto') {
+  log(`[#1052] RELEASE GATE PASSED — ${releaseRoute.reason}. Landing ${CAMPAIGN_BRANCH} → ${PROTECTED_BRANCH} (the campaign's only trunk write).`)
+  release = await agent(
+    releaseMergePrompt({
+      planId: PLAN_ID,
+      targetRepo: TARGET_REPO,
+      campaignBranch: CAMPAIGN_BRANCH,
+      protectedBranch: PROTECTED_BRANCH,
+      wavesIntegrated,
+    }),
+    { label: 'release:merge', phase: 'Release', schema: RELEASE_RESULT, agentType: 'general-purpose' },
+  ).catch((e) => {
+    // A failed release is NOT reported as released, and it is NOT a campaign failure either: every
+    // wave is integrated and durable on the campaign branch, so the merge is retryable. Never claim
+    // a merge that did not land (catalog signal I).
+    log(`[#1052] release merge soft-fail — campaign branch intact, release retryable: ${e?.message || e}`)
+    return { released: false, notes: `release error: ${e?.message || e}` }
+  })
+  log(release?.released
+    ? `[#1052] RELEASED — ${CAMPAIGN_BRANCH} landed on ${PROTECTED_BRANCH}${release.merge_sha ? ` @ ${release.merge_sha}` : ''}`
+    : `[#1052] NOT released — ${release?.notes || 'see release node'}. ${CAMPAIGN_BRANCH} is intact; retry once the blocker clears.`)
+} else if (releaseRoute.release) {
+  log(`[#1052] release gate PASSED but release:false was requested — holding. ${CAMPAIGN_BRANCH} is ready to land on ${PROTECTED_BRANCH}.`)
+} else {
+  log(`[#1052] release BLOCKED — ${releaseRoute.reason}. ${PROTECTED_BRANCH} untouched; ${CAMPAIGN_BRANCH} preserved for inspection/resume.`)
+}
+
 // The return IS the campaign result the launching session / operator routes on (§2.2: a Workflow
-// ending with a report is the human handoff).
+// ending with a report is the human handoff). `integrated` and `released` are reported SEPARATELY
+// and are not interchangeable: waves can be fully integrated while released is false, which is a
+// campaign awaiting its DoD, not a delivered increment (#1052).
 return {
   outcome: report.outcome,
   plan: PLAN_ID,
   targetRepo: TARGET_REPO,
+  campaignBranch: CAMPAIGN_BRANCH,
+  protectedBranch: PROTECTED_BRANCH,
   wavesAdvanced: report.wavesAdvanced,
+  wavesIntegrated,
   heldAt: report.heldAt ?? null,
   heldReason: report.heldReason ?? null,
-  wavesCompleted: report.completed.map((c) => ({ wave: c.wave, gate: c.verdict?.gate ?? null, promoted: c.verdict?.promoted === true, judgment: c.judgment ? (c.judgment.continue ? 'continue' : 'flag') : null })),
+  dod: dod ? { met: dod.met === true, unmet: dod.unmet ?? [], reason: dod.reason ?? null } : null,
+  release: {
+    attempted: release != null,
+    released: release?.released === true,
+    reason: releaseRoute.reason,
+    pr_ref: release?.pr_ref ?? null,
+    merge_sha: release?.merge_sha ?? null,
+    notes: release?.notes ?? null,
+  },
+  // isIntegrated(), not an inline OR: the predicate gives an explicit `integrated:false` precedence
+  // over a stale `promoted:true`, and an OR-form silently inverts that — reporting a wave the loop
+  // correctly HELD as integrated. One predicate, one place (campaign-loop.js).
+  wavesCompleted: report.completed.map((c) => ({ wave: c.wave, gate: c.verdict?.gate ?? null, integrated: isIntegrated(c.verdict), judgment: c.judgment ? (c.judgment.continue ? 'continue' : 'flag') : null })),
 }

--- a/skills/nextwave/gate.js
+++ b/skills/nextwave/gate.js
@@ -14,12 +14,21 @@
 //      production replacement for the skeleton's always-pass gateSignalStub(): an agent or
 //      tool error HOLDs the wave, it NEVER silently PASSes (SEAMS invariant 6).
 //   3. the promotion agent PROMPT (the success-exit terminal step): wave_finalize opens the
-//      kahuna→protected MR, pr_merge lands it on all-green, the kahuna branch is deleted,
-//      disposition recorded. CODE ONLY — the loop calls it solely on a live wave's success
-//      exit (gated by the human cutover, #691); never during a build.
+//      kahuna→integration-base MR, pr_merge lands it on all-green, the kahuna branch is
+//      deleted, disposition recorded. CODE ONLY — the loop calls it solely on a live wave's
+//      success exit (gated by the human cutover, #691); never during a build.
+//
+// THE INTEGRATION BASE IS NOT NECESSARILY THE PROTECTED BRANCH (#1052). Every branch name in
+// this module was called `protectedBranch` until #1052, and that name was a latent bug: inside a
+// campaign a wave integrates onto the CAMPAIGN branch (`campaign/<plan>-<slug>`), and the
+// protected branch is not written at all until the whole campaign lands at DoD. Passing a
+// non-protected ref in a parameter named `protectedBranch` is how the next wrong-target merge
+// gets written, so the parameter is `integrationBase` throughout and the prose says the same.
+// Standalone /nextwave still passes the protected branch — that is one value of the parameter,
+// not its definition.
 //
 // DIFF-SCOPING (§3.4): every static signal is scoped to the wave's CHANGED FILES
-// (kahuna-vs-protected), NEVER the whole tree — otherwise pre-existing baseline debt
+// (kahuna-vs-integration-base), NEVER the whole tree — otherwise pre-existing baseline debt
 // spuriously HOLDs an otherwise-clean wave. Lint/typecheck are NOT a fifth signal; they
 // ride INSIDE the CI signal (ci_wait_run runs the project's full gate on the merge result).
 
@@ -39,23 +48,27 @@ export function conservativeFail(signal, err) {
 
 // ── 1. commutativity signal ──────────────────────────────────────────────────────────
 // Single-target mode (one changeset = the whole kahuna composed diff): is kahuna safe to
-// land in the protected branch? pass = verdict ∈ {STRONG, MEDIUM}; every other verdict —
+// land on the integration base? pass = verdict ∈ {STRONG, MEDIUM}; every other verdict —
 // explicitly PROBE_UNAVAILABLE and ORACLE_REQUIRED (and any timeout sharing their body
 // shape) — is conservative-fail (HOLD), per the tool's own contract.
 //
 // #6 (live-gate finding) — gate-vs-reconcile consistency: the RECONCILE node MAY adjudicate
 // an ORACLE_REQUIRED verdict via judgment DURING integration (it has the cross-flight view and
-// can run the suite to decide the composed diff is safe). The trust GATE — the auto-promotion
-// decision to land kahuna on the PROTECTED branch — does NOT: it HOLDs on ORACLE_REQUIRED so a
-// human reviews. "Don't auto-promote what the probe can't prove safe." The two are not
-// inconsistent — they answer different questions (is this group mergeable now? vs. is the whole
-// wave safe to ff onto the protected branch unattended?); the gate is the conservative one.
-export function commutativitySignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepoDir }) {
+// can run the suite to decide the composed diff is safe). The trust GATE — the UNATTENDED
+// auto-promotion decision to land kahuna on the integration base — does NOT: it HOLDs on
+// ORACLE_REQUIRED so a human reviews. "Don't auto-promote what the probe can't prove safe." The
+// two are not inconsistent — they answer different questions (is this group mergeable now? vs. is
+// the whole wave safe to land on the integration base unattended?); the gate is the conservative
+// one. This stays equally strict when the base is a campaign branch rather than the protected one
+// (#1052): a bad wave integrated into a campaign poisons every later wave built on top of it, and
+// unpicking it costs more than the HOLD did — the campaign branch buys the protected branch
+// safety, not the gate laxity.
+export function commutativitySignalPrompt({ waveId, kahunaBranch, integrationBase, targetRepoDir }) {
   return [
     `Trust-gate COMMUTATIVITY signal for wave ${waveId}.`,
     `Call sdlc-server commutativity_verify in SINGLE-TARGET mode — the KAHUNA composed-diff safety gate:`,
     `  repo_path=${targetRepoDir}`,
-    `  base_ref=${protectedBranch}`,
+    `  base_ref=${integrationBase}`,
     `  changesets=[{ id: "kahuna", head_ref: "${kahunaBranch}" }]`,
     `Apply the pass predicate EXACTLY: passed = (verdict ∈ {STRONG, MEDIUM}). Every other verdict FAILS,`,
     `INCLUDING PROBE_UNAVAILABLE and ORACLE_REQUIRED and any timeout/handler-synthesized body — those are`,
@@ -68,27 +81,27 @@ export function commutativitySignalPrompt({ waveId, kahunaBranch, protectedBranc
 }
 
 // ── Open the promotion PR (DRAFT) — runs FIRST in the gate, before the signals ─────────
-// #5 (live-gate finding, BLOCKING): the CI signal's ci_wait_run on the kahuna→protected
-// merge-result pipeline returned `no_merge_result_pr` because the promotion PR used to be
-// created AT promotion — AFTER the gate. Chicken-and-egg. Fix (reorders §3.4): the gate opens
-// the kahuna→protected PR as a DRAFT FIRST, so there is a real PR (and its merge-result
+// #5 (live-gate finding, BLOCKING): the CI signal's ci_wait_run on the kahuna→base merge-result
+// pipeline returned `no_merge_result_pr` because the promotion PR used to be created AT
+// promotion — AFTER the gate. Chicken-and-egg. Fix (reorders §3.4): the gate opens the
+// kahuna→base PR as a DRAFT FIRST, so there is a real PR (and its merge-result
 // pipeline) for the CI signal to wait on; the gate then decides; on PASS+auto the promote node
 // marks it ready and merges THAT SAME PR (it never opens a second one). DRAFT so a green CI
 // can't let the platform auto-merge it before the gate has aggregated all four signals.
 //
-// Idempotent: re-opening an already-open kahuna→protected PR returns the existing one (wave_finalize
+// Idempotent: re-opening an already-open kahuna→base PR returns the existing one (wave_finalize
 // is idempotent on the branch pair). opened=false (with a reason) ONLY when the branch/artifacts are
 // missing — in which case the gate HOLDs (it cannot prove a wave it can't even PR). Never fabricates.
-export function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, targetRepoDir, planId }) {
+export function openPromotionPrPrompt({ waveId, kahunaBranch, integrationBase, targetRepo, targetRepoDir, planId }) {
   return [
     `You are the wave GATE PR-OPEN node for wave ${waveId} of ${targetRepo}. Open (idempotently) the`,
-    `${kahunaBranch}→${protectedBranch} promotion PR/MR as a DRAFT, then return its number. This runs`,
+    `${kahunaBranch}→${integrationBase} promotion PR/MR as a DRAFT, then return its number. This runs`,
     `BEFORE the trust signals so the CI signal has a real merge-result pipeline to wait on [#5].`,
     `Do NOT merge anything, do NOT mark the PR ready, do NOT run the gate — just open-or-find the draft PR.`,
     ``,
-    `1. Open (or return the existing — idempotent) ${kahunaBranch}→${protectedBranch} PR via sdlc-server`,
+    `1. Open (or return the existing — idempotent) ${kahunaBranch}→${integrationBase} PR via sdlc-server`,
     `   wave_finalize(plan_id=${planId ?? '<the wave plan id>'}, kahuna_branch="${kahunaBranch}",`,
-    `   target_branch="${protectedBranch}", root="${targetRepoDir}"). The root is LOAD-BEARING (#699 finding`,
+    `   target_branch="${integrationBase}", root="${targetRepoDir}"). The root is LOAD-BEARING (#699 finding`,
     `   #8): wave_finalize defaults to the SESSION's project for both the plan's durable wave-status AND the`,
     `   git branch check — but this wave's plan + the ${kahunaBranch} branch live in the TARGET repo clone`,
     `   ${targetRepoDir}, NOT the session project. Without root it returns kahuna_branch_not_found even though`,
@@ -109,7 +122,7 @@ export const OPEN_PR_RESULT = {
   additionalProperties: false,
   required: ['opened'],
   properties: {
-    opened: { type: 'boolean' }, // a kahuna→protected PR exists for the pair (draft)
+    opened: { type: 'boolean' }, // a kahuna→integrationBase PR exists for the pair (draft)
     pr_number: { type: 'integer' }, // the CI signal waits on this PR; promote merges it
     pr_ref: { type: 'string' },
     notes: { type: 'string' },
@@ -117,14 +130,14 @@ export const OPEN_PR_RESULT = {
 }
 
 // ── 2. CI signal (#452: MR merge-result pipeline, NOT merge-commit branch HEAD) ───────
-// ci_wait_run on the kahuna→protected MR — the DRAFT PR the gate's PR-OPEN node already
+// ci_wait_run on the kahuna→integrationBase MR — the DRAFT PR the gate's PR-OPEN node already
 // opened (#5), passed in by number so this signal never races to "find" it (the old
 // `no_merge_result_pr` failure). Lint/typecheck ride INSIDE this signal (the project's full
 // gate runs in CI), diff-scoped to the wave's changed files (§3.4).
-export function ciSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber }) {
-  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${protectedBranch} PR/MR`
+export function ciSignalPrompt({ waveId, kahunaBranch, integrationBase, targetRepo, prNumber }) {
+  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${integrationBase} PR/MR`
   return [
-    `Trust-gate CI signal for wave ${waveId}. Wait on the ${kahunaBranch}→${protectedBranch} MERGE-RESULT`,
+    `Trust-gate CI signal for wave ${waveId}. Wait on the ${kahunaBranch}→${integrationBase} MERGE-RESULT`,
     `pipeline — NOT the merge-commit branch HEAD [sdlc #452].`,
     ``,
     `1. The gate's PR-OPEN node already opened the draft promotion PR: ${prRef} (repo=${targetRepo}).`,
@@ -132,7 +145,7 @@ export function ciSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRe
       ? `   Use that number directly — do NOT search for it. (If for any reason it is not found, that is a`
       : `   Find it via sdlc-server pr_status / pr_list (or gh -R ${targetRepo}). (If none is found, that is a`,
     `   CONSERVATIVE-FAIL: return passed=false — the gate must not PASS without a pipeline to verify.)`,
-    `   The CI you wait on is the pipeline produced by MERGING kahuna INTO ${protectedBranch} (the merge`,
+    `   The CI you wait on is the pipeline produced by MERGING kahuna INTO ${integrationBase} (the merge`,
     `   result), not the branch's own latest push.`,
     `2. Call sdlc-server ci_wait_run (repo=${targetRepo}) with require_merge_result=true, pr_number=${prNumber != null ? prNumber : '<the PR number>'},`,
     `   AND explicit timeout_sec=420 + poll_interval_sec=15 (#1035 — do NOT omit them). All are load-bearing:`,
@@ -179,30 +192,30 @@ export function ciSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRe
 // `origin/main`: on repos where main is a bare scaffold and real work lives on a release branch,
 // an origin/main worktree reviews an EMPTY tree → passed:false → spurious HOLD on every wave
 // (ENG-5). It is therefore a 2-STEP sub-pipeline (assembled at the call site): a Bash-capable
-// general-purpose STAGE agent fetches + diffs origin/<protected>...origin/<kahuna> and
+// general-purpose STAGE agent fetches + diffs origin/<integrationBase>...origin/<kahuna> and
 // materializes the changed-file set into a durable review workspace; then the SPECIALIZED
 // feature-dev:code-reviewer reviews that workspace. Keeping code-reviewer — NOT the EC-1 swap to
 // general-purpose — is the whole point: code-reviewer has no Bash to fetch/materialize the diff
-// itself, so the stage step feeds it. The diff is ALWAYS origin/<protected>...origin/<kahuna>,
+// itself, so the stage step feeds it. The diff is ALWAYS origin/<integrationBase>...origin/<kahuna>,
 // NEVER a hard-coded `main`. Scoped to the CHANGED FILES only (§3.4). pass = no critical/important.
 
 // 3a. STAGE — general-purpose (Bash) agent prepares the review workspace + changed-file set.
-export function reviewStagePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, targetRepoDir }) {
+export function reviewStagePrompt({ waveId, kahunaBranch, integrationBase, targetRepo, targetRepoDir }) {
   return [
     `Trust-gate REVIEW STAGE for wave ${waveId} of ${targetRepo}. You PREPARE the diff the code`,
     `reviewer will read — you do NOT review anything. Work in ${targetRepoDir}.`,
     ``,
-    `1. Fetch BOTH refs from origin (never assume the protected branch is 'main' — it is ${protectedBranch}):`,
-    `     git -C ${targetRepoDir} fetch origin ${protectedBranch} ${kahunaBranch}`,
-    `2. Compute the wave's changed-file set — the ${kahunaBranch}-vs-${protectedBranch} diff:`,
-    `     git -C ${targetRepoDir} diff --name-only origin/${protectedBranch}...origin/${kahunaBranch}`,
-    `   (three-dot: what changed on ${kahunaBranch} since it diverged from ${protectedBranch}.)`,
+    `1. Fetch BOTH refs from origin (never assume the base is 'main' — this wave's base is ${integrationBase}):`,
+    `     git -C ${targetRepoDir} fetch origin ${integrationBase} ${kahunaBranch}`,
+    `2. Compute the wave's changed-file set — the ${kahunaBranch}-vs-${integrationBase} diff:`,
+    `     git -C ${targetRepoDir} diff --name-only origin/${integrationBase}...origin/${kahunaBranch}`,
+    `   (three-dot: what changed on ${kahunaBranch} since it diverged from ${integrationBase}.)`,
     `3. Materialize a durable REVIEW WORKSPACE the (Bash-less) reviewer can read natively — EITHER:`,
     `     • a git worktree checked out at origin/${kahunaBranch}:`,
     `         git -C ${targetRepoDir} worktree add --force <workspaceDir> origin/${kahunaBranch}`,
     `       and return its absolute path as workspaceDir; OR`,
     `     • if a worktree cannot be created, write the full unified diff to a file in a workspace dir:`,
-    `         git -C ${targetRepoDir} diff origin/${protectedBranch}...origin/${kahunaBranch} > <workspaceDir>/kahuna.diff`,
+    `         git -C ${targetRepoDir} diff origin/${integrationBase}...origin/${kahunaBranch} > <workspaceDir>/kahuna.diff`,
     `       and return that dir as workspaceDir.`,
     `CONSERVATIVE-FAIL: if the fetch errors OR the changed-file set is EMPTY (zero files), return`,
     `staged=false with the reason in notes — an empty/failed stage must HOLD the gate (the reviewer has`,
@@ -220,23 +233,23 @@ export const REVIEW_STAGE = {
   properties: {
     staged: { type: 'boolean' }, // true only if a NON-EMPTY diff was materialized
     workspaceDir: { type: 'string' }, // abs path the reviewer reads (worktree of kahuna, or diff-manifest dir)
-    changedFiles: { type: 'array', items: { type: 'string' } }, // origin/<protected>...origin/<kahuna>
+    changedFiles: { type: 'array', items: { type: 'string' } }, // origin/<integrationBase>...origin/<kahuna>
     notes: { type: 'string' },
   },
 }
 
 // 3b. REVIEW — the SPECIALIZED feature-dev:code-reviewer reads the STAGED workspace (no Bash needed).
-export function reviewSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepoDir, workspaceDir, changedFiles }) {
+export function reviewSignalPrompt({ waveId, kahunaBranch, integrationBase, targetRepoDir, workspaceDir, changedFiles }) {
   const fileList = Array.isArray(changedFiles) && changedFiles.length
     ? changedFiles.join(', ')
     : '(the staged changed-file set)'
   return [
     `Trust-gate REVIEW signal for wave ${waveId}. The STAGE step already prepared the diff FOR you:`,
-    `the ${kahunaBranch}-vs-${protectedBranch} changed files are materialized in the review workspace`,
+    `the ${kahunaBranch}-vs-${integrationBase} changed files are materialized in the review workspace`,
     `${workspaceDir || '<the prepared workspace>'} (a worktree checked out at origin/${kahunaBranch}, or a`,
     `written diff manifest there). You do NOT need Bash and must NOT fetch anything — read that workspace.`,
     ``,
-    `Review the ${kahunaBranch}-vs-${protectedBranch} diff (origin/${protectedBranch}...origin/${kahunaBranch},`,
+    `Review the ${kahunaBranch}-vs-${integrationBase} diff (origin/${integrationBase}...origin/${kahunaBranch},`,
     `NEVER a hard-coded 'main') for correctness / architecture / unstated intent — the rung a test cannot`,
     `encode (§9 verification ladder).`,
     ``,
@@ -267,21 +280,33 @@ export function trivySignalPrompt({ waveId, kahunaBranch, targetRepoDir }) {
 
 // ── Promotion (the success-exit terminal step — CODE ONLY) ────────────────────────────
 // Called by the workflow ONLY when MODE==='auto' AND the gate verdict is PASS — i.e. only on
-// a live wave's success exit. The kahuna→protected DRAFT PR was ALREADY OPENED by the gate's
+// a live wave's success exit. The kahuna→integrationBase DRAFT PR was ALREADY OPENED by the gate's
 // PR-OPEN node (#5) and its merge-result CI was already validated by the CI signal — so promotion
 // no longer opens a PR; it marks the EXISTING draft ready and merges it. pr_merge lands it; the
 // kahuna branch is deleted; disposition recorded. promoted=true ONLY once the merge is observable
-// on the protected branch — enrolled/pending is never treated as done.
+// on the integration base — enrolled/pending is never treated as done.
 //
-// SAFETY (#691): this prompt is the CODE for promotion. It executes a real kahuna→protected
-// merge, so it runs SOLELY from the workflow's auto+PASS branch on a live wave that reached the
-// success exit — which is itself gated by the human cutover (#691). Building/validating this
-// module never invokes it.
-export function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber, preserveKahuna = false }) {
-  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${protectedBranch} PR`
+// WHAT THIS NODE DOES *NOT* DO (#1052): inside a campaign this merge lands the wave on the
+// CAMPAIGN branch, not the protected branch. It is integration, not release. Nothing here closes
+// issues, tags, or touches trunk — the campaign's single release merge does that once, at DoD
+// (campaign-loop.js releaseMergePrompt). The field is still named `promoted` because it is the
+// per-wave spine's existing contract; the campaign loop reads it through isIntegrated().
+//
+// SAFETY (#691): this prompt is the CODE for promotion. It executes a real merge, so it runs
+// SOLELY from the workflow's auto+PASS branch on a live wave that reached the success exit —
+// which is itself gated by the human cutover (#691). Building/validating this module never
+// invokes it.
+export function promotePrompt({ waveId, kahunaBranch, integrationBase, targetRepo, prNumber, preserveKahuna = false }) {
+  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${integrationBase} PR`
   // #722: a PER-PLAN kahuna (e.g. kahuna/56-…, shared across a plan's waves 1..N) must PERSIST —
   // deleting it after wave 1 strands waves 2..N off a diverged base. The default (false) keeps the
   // current per-wave disposable behavior: KAHUNA_BRANCH defaults to kahuna/<waveId>, deleted here.
+  //
+  // #1052 retires the preserve case INSIDE a campaign: the thing that has to persist across waves
+  // is the CAMPAIGN branch, and it now does, so each wave's kahuna is disposable again. The caller
+  // (per-wave-workflow.js) forces preserveKahuna=false whenever integrationBase !== the protected
+  // branch. The flag survives here for standalone /nextwave, where a per-plan kahuna is still the
+  // only cross-wave carrier.
   const step4 = preserveKahuna
     ? [
       `4. Do NOT delete ${kahunaBranch} (#722: preserveKahuna) — it is a PERSISTENT per-plan integration`,
@@ -289,12 +314,12 @@ export function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRep
       `   base. Leave it on origin; the plan's final wave (or the campaign driver) retires it.`,
     ]
     : [
-      `4. Once ${kahunaBranch} is on ${protectedBranch}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
+      `4. Once ${kahunaBranch} is on ${integrationBase}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
       `   api / git push origin --delete) — the wave is done; this per-wave integration branch is disposable.`,
     ]
   return [
     `You are the wave PROMOTION node for wave ${waveId} of ${targetRepo}. The trust gate returned PASS`,
-    `and the wave is in AUTO mode. The ${kahunaBranch}→${protectedBranch} DRAFT PR is ALREADY OPEN (${prRef})`,
+    `and the wave is in AUTO mode. The ${kahunaBranch}→${integrationBase} DRAFT PR is ALREADY OPEN (${prRef})`,
     `and its merge-result CI was already validated by the gate's CI signal. Land it, then return. Do NOT`,
     `open a new PR (the gate's PR-OPEN node already did, #5); do NOT re-run the gate (it already PASSed).`,
     ``,
@@ -303,12 +328,12 @@ export function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRep
     `   merge — the gate should have opened it; its absence is an error, not a green light).`,
     `2. Mark it ready for review (un-draft): gh -R ${targetRepo} pr ready <number>. (No-op if already ready.)`,
     `3. Merge it: sdlc-server pr_merge(number=<the PR number>) — commutativity_verify already proved`,
-    `   the composed diff safe. Then CONFIRM it actually landed on ${protectedBranch} before reporting`,
+    `   the composed diff safe. Then CONFIRM it actually landed on ${integrationBase} before reporting`,
     `   promoted: poll until the PR reads state=MERGED with a merge commit (pr_merge_wait, or`,
     `   gh -R ${targetRepo} pr view <number> --json state,mergeCommit). Never treat a pending merge as done.`,
     ...step4,
     ``,
-    `Return: promoted (true ONLY if the merge actually landed on ${protectedBranch}), mr_ref (the PR`,
+    `Return: promoted (true ONLY if the merge actually landed on ${integrationBase}), mr_ref (the PR`,
     `URL/number), notes (1-2 sentences; include any error — and on error, promoted=false).`,
   ].join('\n')
 }
@@ -319,7 +344,7 @@ export const PROMOTE_RESULT = {
   additionalProperties: false,
   required: ['promoted'],
   properties: {
-    promoted: { type: 'boolean' }, // true ONLY if the merge actually landed on the protected branch
+    promoted: { type: 'boolean' }, // true ONLY if the merge actually landed on the integration base
     mr_ref: { type: 'string' },
     notes: { type: 'string' },
   },

--- a/skills/nextwave/per-wave-workflow.bundled.js
+++ b/skills/nextwave/per-wave-workflow.bundled.js
@@ -82,12 +82,47 @@ function toBlob(state) {
 //   2. the full-overwrite blob write.
 // `newlyMerged` is the issues merged THIS iteration that still need their MR recorded +
 // issue closed; `blob` is the already-normalized object to write verbatim.
-function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newlyMerged, blob, path }) {
+// #1046/#1052 — WHERE THE ISSUE CLOSES. Until #1052 this node closed the issue on the platform at
+// the moment its flight merged into kahuna. Under the campaign shape that is factually wrong: the
+// work is on a campaign branch, the protected branch has not been written, and nothing has shipped.
+// A closed issue is the board's claim that the work is delivered, and closing here would make that
+// claim N waves early — then a campaign abort would leave a trail of closed issues for work that
+// was deleted. So: durable engine state (wave_close_issue) is recorded HERE, because the flight
+// genuinely did land on the integration base; the PLATFORM close moves to the campaign's release
+// node (campaign-loop.js releaseMergePrompt step 4), which runs after the one trunk merge.
+//
+// `inCampaign` selects between the two. A standalone /nextwave wave promotes straight to the
+// protected branch, so for it merge and release coincide and the platform close still belongs here
+// — there is no later node to do it, and omitting it would silently stop closing issues.
+function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newlyMerged, blob, path, inCampaign = false, integrationBase }) {
+  const closeStep = inCampaign
+    ? [
+        `    c. Record the merge in DURABLE ENGINE STATE ONLY — do NOT close the issue on the platform:`,
+        `         - wave_close_issue(issue_number=<n>) — updates durable wave state (NO-OP if already`,
+        `           closed). This records that the flight LANDED, which it did.`,
+        `         - Do NOT run 'gh issue close' / 'glab issue close'. This wave landed on`,
+        `           ${integrationBase || 'the campaign branch'}, NOT the protected branch — the work has`,
+        `           not shipped yet, and a closed issue would claim it had (#1046/#1052). The campaign's`,
+        `           release node closes these issues after the single protected-branch merge. If the`,
+        `           campaign is later aborted, these issues must still be open.`,
+        `         - Leave the issue in its in-review/In Test marker if the project has one; never set a`,
+        `           terminal state by hand before the merge that earns it.`,
+      ]
+    : [
+        `    c. Close the issue on BOTH surfaces (idempotent; runs for EVERY newly-merged issue,`,
+        `       regardless of which merge path A/B/C landed it). This is a STANDALONE wave — it promotes`,
+        `       straight to the protected branch, so its merge IS the delivery:`,
+        `         - wave_close_issue(issue_number=<n>) — updates durable wave state (NO-OP if already closed).`,
+        `         - Platform-close the issue itself: a kahuna-targeted MR/PR does NOT auto-close via`,
+        `           "Closes #N" because the kahuna branch is not the protected base, so close it explicitly —`,
+        `           GitHub: gh issue close <n> -R ${targetRepo} ; GitLab: glab issue close <n> (use the`,
+        `           project's platform). Closing an already-closed issue is a NO-OP (#633).`,
+      ]
   return [
     `You are the wave-status PERSISTENCE node for wave ${waveId} of ${targetRepo}. You perform two`,
     `DURABLE, IDEMPOTENT side-effects, then return. Do NOT do any other work.`,
     ``,
-    `STEP 1 — per newly-merged issue (record MR + close), idempotent:`,
+    `STEP 1 — per newly-merged issue (record MR${inCampaign ? '' : ' + close'}), idempotent:`,
     `  Newly-merged issues this iteration: [${newlyMerged.join(', ') || 'none'}].`,
     `  For EACH, in order:`,
     `    a. Resolve the merge reference into ${kahunaBranch}: the PR/MR that merged the issue's`,
@@ -95,13 +130,7 @@ function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newlyMerged,
     `       PR ref if discoverable (gh -R ${targetRepo}); else fall back to the ref "${kahunaBranch}".`,
     `    b. Call wave_record_mr(issue_number=<n>, mr_ref=<resolved ref>). This is keyed on the issue —`,
     `       re-recording an already-recorded issue is an OVERWRITE, not a duplicate. Safe to repeat.`,
-    `    c. Close the issue on BOTH surfaces (idempotent; runs for EVERY newly-merged issue,`,
-    `       regardless of which merge path A/B/C landed it):`,
-    `         - wave_close_issue(issue_number=<n>) — updates durable wave state (NO-OP if already closed).`,
-    `         - Platform-close the issue itself: a kahuna-targeted MR/PR does NOT auto-close via`,
-    `           "Closes #N" because the kahuna branch is not the protected base, so close it explicitly —`,
-    `           GitHub: gh issue close <n> -R ${targetRepo} ; GitLab: glab issue close <n> (use the`,
-    `           project's platform). Closing an already-closed issue is a NO-OP (#633).`,
+    ...closeStep,
     `  If a tool errors, record it in notes and CONTINUE — persistence must not halt the wave.`,
     ``,
     `STEP 2 — write the durable loop blob (full overwrite, idempotent):`,
@@ -119,19 +148,28 @@ function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newlyMerged,
 
 // ── persistTerminal agent prompt ────────────────────────────────────────────────────
 // Records the wave's terminal disposition into BOTH (a) wave-status's wave-completion
-// record (so the campaign driver's cold-start rehydrate can prune a promoted wave, §5),
+// record (so the campaign driver's cold-start rehydrate can prune an integrated wave, §5),
 // and (b) the durable blob's `terminal` field (so a resume sees the same disposition).
-function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahunaBranch, protectedBranch, disposition, detail, blob, path, trajectoryEntry }) {
+//
+// #1052: the disposition vocabulary stays `promoted | held` — it is a persisted durable value that
+// mid-campaign resumes and the wave-status CLI both read, so renaming it would strand every
+// in-flight campaign's records for a vocabulary improvement. What changed is what it MEANS:
+// "landed on the integration base", which the campaign loop reads through isIntegrated(). The
+// campaign's release is recorded separately, once, by the release node.
+function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahunaBranch, integrationBase, disposition, detail, blob, path, trajectoryEntry }) {
   return [
     `You are the wave-status PERSISTENCE node for wave ${waveId} of ${targetRepo}. Record the wave's`,
     `TERMINAL disposition durably + idempotently, then return. Do NOT do any other work.`,
     ``,
     `Disposition: "${disposition}" (one of promoted | held). Detail: ${JSON.stringify(detail)}.`,
+    `"promoted" here means the wave LANDED ON ITS INTEGRATION BASE (${integrationBase}) — inside a`,
+    `campaign that is the campaign branch, not the protected branch (#1052). The wave-completion`,
+    `record is what lets the campaign advance and prune on resume; it is NOT a delivery claim.`,
     ``,
     ...(disposition === 'promoted'
       ? [
-          `STEP 1 — wave-completion record (idempotent, PROMOTED): the wave reached the protected`,
-          `  branch, so mark it COMPLETED and advance the campaign pointer. Run FROM the target clone`,
+          `STEP 1 — wave-completion record (idempotent, PROMOTED): the wave landed on ${integrationBase},`,
+          `  so mark it COMPLETED and advance the campaign pointer. Run FROM the target clone`,
           `  so the CLI resolves the same .claude/status/ that holds the blob (the pre-flight`,
           `  'command -v wave-status' probe guarantees the deployed console command is on PATH):`,
           `    cd ${targetRepoDir} && wave-status complete ${waveId}`,
@@ -139,8 +177,8 @@ function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahunaBranch
           `  current_wave marks the wrong wave). 'complete' is idempotent for an already-completed wave.`,
         ]
       : [
-          `STEP 1 — wave-completion record (idempotent, HELD): the wave did NOT reach the protected`,
-          `  branch (gate HOLD/SKIPPED, reconcile-blocked, or PASS-not-promoted). Mark it HELD and do`,
+          `STEP 1 — wave-completion record (idempotent, HELD): the wave did NOT land on ${integrationBase}`,
+          `  (gate HOLD/SKIPPED, reconcile-blocked, or PASS-not-promoted). Mark it HELD and do`,
           `  NOT advance the campaign pointer — NEVER call 'complete' on a held wave (ENG-1/#846: a`,
           `  'completed' write on a non-promoted exit corrupts durable resume/prune state). Run FROM`,
           `  the target clone so the CLI resolves the same .claude/status/ (the pre-flight`,
@@ -162,8 +200,11 @@ function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahunaBranch
     `  oversight judgment seed). The base entry below is authored by the loop; you ADD two best-effort,`,
     `  shell-derived fields, then upsert it. The append is idempotent per wave (keyed on the wave id —`,
     `  re-running OVERWRITES this wave's entry, never duplicates), so it is safe on resume.`,
-    `    a. Compute "files_touched": the changed-file set of this wave, i.e. run`,
-    `         git -C ${targetRepoDir} diff --name-only ${protectedBranch}...${kahunaBranch}`,
+    `    a. Compute "files_touched": the changed-file set of THIS WAVE — diffed against its own`,
+    `       integration base, so in a campaign it is what this wave added on top of the waves before`,
+    `       it, not the whole campaign re-attributed to every wave (which would make the oversight`,
+    `       judge's per-wave file sets monotonically grow and read as a hotspot, #1052):`,
+    `         git -C ${targetRepoDir} diff --name-only ${integrationBase}...${kahunaBranch}`,
     `       and put the resulting path list (JSON array of strings) on the entry. On any git error,`,
     `       set files_touched to [] and note it — do NOT fail the step.`,
     `    b. Compute "engine_fingerprint": the md5 of the running per-wave-workflow bundle if you can`,
@@ -511,12 +552,21 @@ function cleanupTerminalPrompt({ waveId, targetRepo, targetRepoDir }) {
 //      production replacement for the skeleton's always-pass gateSignalStub(): an agent or
 //      tool error HOLDs the wave, it NEVER silently PASSes (SEAMS invariant 6).
 //   3. the promotion agent PROMPT (the success-exit terminal step): wave_finalize opens the
-//      kahuna→protected MR, pr_merge lands it on all-green, the kahuna branch is deleted,
-//      disposition recorded. CODE ONLY — the loop calls it solely on a live wave's success
-//      exit (gated by the human cutover, #691); never during a build.
+//      kahuna→integration-base MR, pr_merge lands it on all-green, the kahuna branch is
+//      deleted, disposition recorded. CODE ONLY — the loop calls it solely on a live wave's
+//      success exit (gated by the human cutover, #691); never during a build.
+//
+// THE INTEGRATION BASE IS NOT NECESSARILY THE PROTECTED BRANCH (#1052). Every branch name in
+// this module was called `protectedBranch` until #1052, and that name was a latent bug: inside a
+// campaign a wave integrates onto the CAMPAIGN branch (`campaign/<plan>-<slug>`), and the
+// protected branch is not written at all until the whole campaign lands at DoD. Passing a
+// non-protected ref in a parameter named `protectedBranch` is how the next wrong-target merge
+// gets written, so the parameter is `integrationBase` throughout and the prose says the same.
+// Standalone /nextwave still passes the protected branch — that is one value of the parameter,
+// not its definition.
 //
 // DIFF-SCOPING (§3.4): every static signal is scoped to the wave's CHANGED FILES
-// (kahuna-vs-protected), NEVER the whole tree — otherwise pre-existing baseline debt
+// (kahuna-vs-integration-base), NEVER the whole tree — otherwise pre-existing baseline debt
 // spuriously HOLDs an otherwise-clean wave. Lint/typecheck are NOT a fifth signal; they
 // ride INSIDE the CI signal (ci_wait_run runs the project's full gate on the merge result).
 
@@ -536,23 +586,27 @@ function conservativeFail(signal, err) {
 
 // ── 1. commutativity signal ──────────────────────────────────────────────────────────
 // Single-target mode (one changeset = the whole kahuna composed diff): is kahuna safe to
-// land in the protected branch? pass = verdict ∈ {STRONG, MEDIUM}; every other verdict —
+// land on the integration base? pass = verdict ∈ {STRONG, MEDIUM}; every other verdict —
 // explicitly PROBE_UNAVAILABLE and ORACLE_REQUIRED (and any timeout sharing their body
 // shape) — is conservative-fail (HOLD), per the tool's own contract.
 //
 // #6 (live-gate finding) — gate-vs-reconcile consistency: the RECONCILE node MAY adjudicate
 // an ORACLE_REQUIRED verdict via judgment DURING integration (it has the cross-flight view and
-// can run the suite to decide the composed diff is safe). The trust GATE — the auto-promotion
-// decision to land kahuna on the PROTECTED branch — does NOT: it HOLDs on ORACLE_REQUIRED so a
-// human reviews. "Don't auto-promote what the probe can't prove safe." The two are not
-// inconsistent — they answer different questions (is this group mergeable now? vs. is the whole
-// wave safe to ff onto the protected branch unattended?); the gate is the conservative one.
-function commutativitySignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepoDir }) {
+// can run the suite to decide the composed diff is safe). The trust GATE — the UNATTENDED
+// auto-promotion decision to land kahuna on the integration base — does NOT: it HOLDs on
+// ORACLE_REQUIRED so a human reviews. "Don't auto-promote what the probe can't prove safe." The
+// two are not inconsistent — they answer different questions (is this group mergeable now? vs. is
+// the whole wave safe to land on the integration base unattended?); the gate is the conservative
+// one. This stays equally strict when the base is a campaign branch rather than the protected one
+// (#1052): a bad wave integrated into a campaign poisons every later wave built on top of it, and
+// unpicking it costs more than the HOLD did — the campaign branch buys the protected branch
+// safety, not the gate laxity.
+function commutativitySignalPrompt({ waveId, kahunaBranch, integrationBase, targetRepoDir }) {
   return [
     `Trust-gate COMMUTATIVITY signal for wave ${waveId}.`,
     `Call sdlc-server commutativity_verify in SINGLE-TARGET mode — the KAHUNA composed-diff safety gate:`,
     `  repo_path=${targetRepoDir}`,
-    `  base_ref=${protectedBranch}`,
+    `  base_ref=${integrationBase}`,
     `  changesets=[{ id: "kahuna", head_ref: "${kahunaBranch}" }]`,
     `Apply the pass predicate EXACTLY: passed = (verdict ∈ {STRONG, MEDIUM}). Every other verdict FAILS,`,
     `INCLUDING PROBE_UNAVAILABLE and ORACLE_REQUIRED and any timeout/handler-synthesized body — those are`,
@@ -565,27 +619,27 @@ function commutativitySignalPrompt({ waveId, kahunaBranch, protectedBranch, targ
 }
 
 // ── Open the promotion PR (DRAFT) — runs FIRST in the gate, before the signals ─────────
-// #5 (live-gate finding, BLOCKING): the CI signal's ci_wait_run on the kahuna→protected
-// merge-result pipeline returned `no_merge_result_pr` because the promotion PR used to be
-// created AT promotion — AFTER the gate. Chicken-and-egg. Fix (reorders §3.4): the gate opens
-// the kahuna→protected PR as a DRAFT FIRST, so there is a real PR (and its merge-result
+// #5 (live-gate finding, BLOCKING): the CI signal's ci_wait_run on the kahuna→base merge-result
+// pipeline returned `no_merge_result_pr` because the promotion PR used to be created AT
+// promotion — AFTER the gate. Chicken-and-egg. Fix (reorders §3.4): the gate opens the
+// kahuna→base PR as a DRAFT FIRST, so there is a real PR (and its merge-result
 // pipeline) for the CI signal to wait on; the gate then decides; on PASS+auto the promote node
 // marks it ready and merges THAT SAME PR (it never opens a second one). DRAFT so a green CI
 // can't let the platform auto-merge it before the gate has aggregated all four signals.
 //
-// Idempotent: re-opening an already-open kahuna→protected PR returns the existing one (wave_finalize
+// Idempotent: re-opening an already-open kahuna→base PR returns the existing one (wave_finalize
 // is idempotent on the branch pair). opened=false (with a reason) ONLY when the branch/artifacts are
 // missing — in which case the gate HOLDs (it cannot prove a wave it can't even PR). Never fabricates.
-function openPromotionPrPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, targetRepoDir, planId }) {
+function openPromotionPrPrompt({ waveId, kahunaBranch, integrationBase, targetRepo, targetRepoDir, planId }) {
   return [
     `You are the wave GATE PR-OPEN node for wave ${waveId} of ${targetRepo}. Open (idempotently) the`,
-    `${kahunaBranch}→${protectedBranch} promotion PR/MR as a DRAFT, then return its number. This runs`,
+    `${kahunaBranch}→${integrationBase} promotion PR/MR as a DRAFT, then return its number. This runs`,
     `BEFORE the trust signals so the CI signal has a real merge-result pipeline to wait on [#5].`,
     `Do NOT merge anything, do NOT mark the PR ready, do NOT run the gate — just open-or-find the draft PR.`,
     ``,
-    `1. Open (or return the existing — idempotent) ${kahunaBranch}→${protectedBranch} PR via sdlc-server`,
+    `1. Open (or return the existing — idempotent) ${kahunaBranch}→${integrationBase} PR via sdlc-server`,
     `   wave_finalize(plan_id=${planId ?? '<the wave plan id>'}, kahuna_branch="${kahunaBranch}",`,
-    `   target_branch="${protectedBranch}", root="${targetRepoDir}"). The root is LOAD-BEARING (#699 finding`,
+    `   target_branch="${integrationBase}", root="${targetRepoDir}"). The root is LOAD-BEARING (#699 finding`,
     `   #8): wave_finalize defaults to the SESSION's project for both the plan's durable wave-status AND the`,
     `   git branch check — but this wave's plan + the ${kahunaBranch} branch live in the TARGET repo clone`,
     `   ${targetRepoDir}, NOT the session project. Without root it returns kahuna_branch_not_found even though`,
@@ -606,7 +660,7 @@ const OPEN_PR_RESULT = {
   additionalProperties: false,
   required: ['opened'],
   properties: {
-    opened: { type: 'boolean' }, // a kahuna→protected PR exists for the pair (draft)
+    opened: { type: 'boolean' }, // a kahuna→integrationBase PR exists for the pair (draft)
     pr_number: { type: 'integer' }, // the CI signal waits on this PR; promote merges it
     pr_ref: { type: 'string' },
     notes: { type: 'string' },
@@ -614,14 +668,14 @@ const OPEN_PR_RESULT = {
 }
 
 // ── 2. CI signal (#452: MR merge-result pipeline, NOT merge-commit branch HEAD) ───────
-// ci_wait_run on the kahuna→protected MR — the DRAFT PR the gate's PR-OPEN node already
+// ci_wait_run on the kahuna→integrationBase MR — the DRAFT PR the gate's PR-OPEN node already
 // opened (#5), passed in by number so this signal never races to "find" it (the old
 // `no_merge_result_pr` failure). Lint/typecheck ride INSIDE this signal (the project's full
 // gate runs in CI), diff-scoped to the wave's changed files (§3.4).
-function ciSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber }) {
-  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${protectedBranch} PR/MR`
+function ciSignalPrompt({ waveId, kahunaBranch, integrationBase, targetRepo, prNumber }) {
+  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${integrationBase} PR/MR`
   return [
-    `Trust-gate CI signal for wave ${waveId}. Wait on the ${kahunaBranch}→${protectedBranch} MERGE-RESULT`,
+    `Trust-gate CI signal for wave ${waveId}. Wait on the ${kahunaBranch}→${integrationBase} MERGE-RESULT`,
     `pipeline — NOT the merge-commit branch HEAD [sdlc #452].`,
     ``,
     `1. The gate's PR-OPEN node already opened the draft promotion PR: ${prRef} (repo=${targetRepo}).`,
@@ -629,7 +683,7 @@ function ciSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prN
       ? `   Use that number directly — do NOT search for it. (If for any reason it is not found, that is a`
       : `   Find it via sdlc-server pr_status / pr_list (or gh -R ${targetRepo}). (If none is found, that is a`,
     `   CONSERVATIVE-FAIL: return passed=false — the gate must not PASS without a pipeline to verify.)`,
-    `   The CI you wait on is the pipeline produced by MERGING kahuna INTO ${protectedBranch} (the merge`,
+    `   The CI you wait on is the pipeline produced by MERGING kahuna INTO ${integrationBase} (the merge`,
     `   result), not the branch's own latest push.`,
     `2. Call sdlc-server ci_wait_run (repo=${targetRepo}) with require_merge_result=true, pr_number=${prNumber != null ? prNumber : '<the PR number>'},`,
     `   AND explicit timeout_sec=420 + poll_interval_sec=15 (#1035 — do NOT omit them). All are load-bearing:`,
@@ -676,30 +730,30 @@ function ciSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prN
 // `origin/main`: on repos where main is a bare scaffold and real work lives on a release branch,
 // an origin/main worktree reviews an EMPTY tree → passed:false → spurious HOLD on every wave
 // (ENG-5). It is therefore a 2-STEP sub-pipeline (assembled at the call site): a Bash-capable
-// general-purpose STAGE agent fetches + diffs origin/<protected>...origin/<kahuna> and
+// general-purpose STAGE agent fetches + diffs origin/<integrationBase>...origin/<kahuna> and
 // materializes the changed-file set into a durable review workspace; then the SPECIALIZED
 // feature-dev:code-reviewer reviews that workspace. Keeping code-reviewer — NOT the EC-1 swap to
 // general-purpose — is the whole point: code-reviewer has no Bash to fetch/materialize the diff
-// itself, so the stage step feeds it. The diff is ALWAYS origin/<protected>...origin/<kahuna>,
+// itself, so the stage step feeds it. The diff is ALWAYS origin/<integrationBase>...origin/<kahuna>,
 // NEVER a hard-coded `main`. Scoped to the CHANGED FILES only (§3.4). pass = no critical/important.
 
 // 3a. STAGE — general-purpose (Bash) agent prepares the review workspace + changed-file set.
-function reviewStagePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, targetRepoDir }) {
+function reviewStagePrompt({ waveId, kahunaBranch, integrationBase, targetRepo, targetRepoDir }) {
   return [
     `Trust-gate REVIEW STAGE for wave ${waveId} of ${targetRepo}. You PREPARE the diff the code`,
     `reviewer will read — you do NOT review anything. Work in ${targetRepoDir}.`,
     ``,
-    `1. Fetch BOTH refs from origin (never assume the protected branch is 'main' — it is ${protectedBranch}):`,
-    `     git -C ${targetRepoDir} fetch origin ${protectedBranch} ${kahunaBranch}`,
-    `2. Compute the wave's changed-file set — the ${kahunaBranch}-vs-${protectedBranch} diff:`,
-    `     git -C ${targetRepoDir} diff --name-only origin/${protectedBranch}...origin/${kahunaBranch}`,
-    `   (three-dot: what changed on ${kahunaBranch} since it diverged from ${protectedBranch}.)`,
+    `1. Fetch BOTH refs from origin (never assume the base is 'main' — this wave's base is ${integrationBase}):`,
+    `     git -C ${targetRepoDir} fetch origin ${integrationBase} ${kahunaBranch}`,
+    `2. Compute the wave's changed-file set — the ${kahunaBranch}-vs-${integrationBase} diff:`,
+    `     git -C ${targetRepoDir} diff --name-only origin/${integrationBase}...origin/${kahunaBranch}`,
+    `   (three-dot: what changed on ${kahunaBranch} since it diverged from ${integrationBase}.)`,
     `3. Materialize a durable REVIEW WORKSPACE the (Bash-less) reviewer can read natively — EITHER:`,
     `     • a git worktree checked out at origin/${kahunaBranch}:`,
     `         git -C ${targetRepoDir} worktree add --force <workspaceDir> origin/${kahunaBranch}`,
     `       and return its absolute path as workspaceDir; OR`,
     `     • if a worktree cannot be created, write the full unified diff to a file in a workspace dir:`,
-    `         git -C ${targetRepoDir} diff origin/${protectedBranch}...origin/${kahunaBranch} > <workspaceDir>/kahuna.diff`,
+    `         git -C ${targetRepoDir} diff origin/${integrationBase}...origin/${kahunaBranch} > <workspaceDir>/kahuna.diff`,
     `       and return that dir as workspaceDir.`,
     `CONSERVATIVE-FAIL: if the fetch errors OR the changed-file set is EMPTY (zero files), return`,
     `staged=false with the reason in notes — an empty/failed stage must HOLD the gate (the reviewer has`,
@@ -717,23 +771,23 @@ const REVIEW_STAGE = {
   properties: {
     staged: { type: 'boolean' }, // true only if a NON-EMPTY diff was materialized
     workspaceDir: { type: 'string' }, // abs path the reviewer reads (worktree of kahuna, or diff-manifest dir)
-    changedFiles: { type: 'array', items: { type: 'string' } }, // origin/<protected>...origin/<kahuna>
+    changedFiles: { type: 'array', items: { type: 'string' } }, // origin/<integrationBase>...origin/<kahuna>
     notes: { type: 'string' },
   },
 }
 
 // 3b. REVIEW — the SPECIALIZED feature-dev:code-reviewer reads the STAGED workspace (no Bash needed).
-function reviewSignalPrompt({ waveId, kahunaBranch, protectedBranch, targetRepoDir, workspaceDir, changedFiles }) {
+function reviewSignalPrompt({ waveId, kahunaBranch, integrationBase, targetRepoDir, workspaceDir, changedFiles }) {
   const fileList = Array.isArray(changedFiles) && changedFiles.length
     ? changedFiles.join(', ')
     : '(the staged changed-file set)'
   return [
     `Trust-gate REVIEW signal for wave ${waveId}. The STAGE step already prepared the diff FOR you:`,
-    `the ${kahunaBranch}-vs-${protectedBranch} changed files are materialized in the review workspace`,
+    `the ${kahunaBranch}-vs-${integrationBase} changed files are materialized in the review workspace`,
     `${workspaceDir || '<the prepared workspace>'} (a worktree checked out at origin/${kahunaBranch}, or a`,
     `written diff manifest there). You do NOT need Bash and must NOT fetch anything — read that workspace.`,
     ``,
-    `Review the ${kahunaBranch}-vs-${protectedBranch} diff (origin/${protectedBranch}...origin/${kahunaBranch},`,
+    `Review the ${kahunaBranch}-vs-${integrationBase} diff (origin/${integrationBase}...origin/${kahunaBranch},`,
     `NEVER a hard-coded 'main') for correctness / architecture / unstated intent — the rung a test cannot`,
     `encode (§9 verification ladder).`,
     ``,
@@ -764,21 +818,33 @@ function trivySignalPrompt({ waveId, kahunaBranch, targetRepoDir }) {
 
 // ── Promotion (the success-exit terminal step — CODE ONLY) ────────────────────────────
 // Called by the workflow ONLY when MODE==='auto' AND the gate verdict is PASS — i.e. only on
-// a live wave's success exit. The kahuna→protected DRAFT PR was ALREADY OPENED by the gate's
+// a live wave's success exit. The kahuna→integrationBase DRAFT PR was ALREADY OPENED by the gate's
 // PR-OPEN node (#5) and its merge-result CI was already validated by the CI signal — so promotion
 // no longer opens a PR; it marks the EXISTING draft ready and merges it. pr_merge lands it; the
 // kahuna branch is deleted; disposition recorded. promoted=true ONLY once the merge is observable
-// on the protected branch — enrolled/pending is never treated as done.
+// on the integration base — enrolled/pending is never treated as done.
 //
-// SAFETY (#691): this prompt is the CODE for promotion. It executes a real kahuna→protected
-// merge, so it runs SOLELY from the workflow's auto+PASS branch on a live wave that reached the
-// success exit — which is itself gated by the human cutover (#691). Building/validating this
-// module never invokes it.
-function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNumber, preserveKahuna = false }) {
-  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${protectedBranch} PR`
+// WHAT THIS NODE DOES *NOT* DO (#1052): inside a campaign this merge lands the wave on the
+// CAMPAIGN branch, not the protected branch. It is integration, not release. Nothing here closes
+// issues, tags, or touches trunk — the campaign's single release merge does that once, at DoD
+// (campaign-loop.js releaseMergePrompt). The field is still named `promoted` because it is the
+// per-wave spine's existing contract; the campaign loop reads it through isIntegrated().
+//
+// SAFETY (#691): this prompt is the CODE for promotion. It executes a real merge, so it runs
+// SOLELY from the workflow's auto+PASS branch on a live wave that reached the success exit —
+// which is itself gated by the human cutover (#691). Building/validating this module never
+// invokes it.
+function promotePrompt({ waveId, kahunaBranch, integrationBase, targetRepo, prNumber, preserveKahuna = false }) {
+  const prRef = prNumber != null ? `PR #${prNumber}` : `the open ${kahunaBranch}→${integrationBase} PR`
   // #722: a PER-PLAN kahuna (e.g. kahuna/56-…, shared across a plan's waves 1..N) must PERSIST —
   // deleting it after wave 1 strands waves 2..N off a diverged base. The default (false) keeps the
   // current per-wave disposable behavior: KAHUNA_BRANCH defaults to kahuna/<waveId>, deleted here.
+  //
+  // #1052 retires the preserve case INSIDE a campaign: the thing that has to persist across waves
+  // is the CAMPAIGN branch, and it now does, so each wave's kahuna is disposable again. The caller
+  // (per-wave-workflow.js) forces preserveKahuna=false whenever integrationBase !== the protected
+  // branch. The flag survives here for standalone /nextwave, where a per-plan kahuna is still the
+  // only cross-wave carrier.
   const step4 = preserveKahuna
     ? [
       `4. Do NOT delete ${kahunaBranch} (#722: preserveKahuna) — it is a PERSISTENT per-plan integration`,
@@ -786,12 +852,12 @@ function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNu
       `   base. Leave it on origin; the plan's final wave (or the campaign driver) retires it.`,
     ]
     : [
-      `4. Once ${kahunaBranch} is on ${protectedBranch}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
+      `4. Once ${kahunaBranch} is on ${integrationBase}, delete the ${kahunaBranch} branch (gh -R ${targetRepo}`,
       `   api / git push origin --delete) — the wave is done; this per-wave integration branch is disposable.`,
     ]
   return [
     `You are the wave PROMOTION node for wave ${waveId} of ${targetRepo}. The trust gate returned PASS`,
-    `and the wave is in AUTO mode. The ${kahunaBranch}→${protectedBranch} DRAFT PR is ALREADY OPEN (${prRef})`,
+    `and the wave is in AUTO mode. The ${kahunaBranch}→${integrationBase} DRAFT PR is ALREADY OPEN (${prRef})`,
     `and its merge-result CI was already validated by the gate's CI signal. Land it, then return. Do NOT`,
     `open a new PR (the gate's PR-OPEN node already did, #5); do NOT re-run the gate (it already PASSed).`,
     ``,
@@ -800,12 +866,12 @@ function promotePrompt({ waveId, kahunaBranch, protectedBranch, targetRepo, prNu
     `   merge — the gate should have opened it; its absence is an error, not a green light).`,
     `2. Mark it ready for review (un-draft): gh -R ${targetRepo} pr ready <number>. (No-op if already ready.)`,
     `3. Merge it: sdlc-server pr_merge(number=<the PR number>) — commutativity_verify already proved`,
-    `   the composed diff safe. Then CONFIRM it actually landed on ${protectedBranch} before reporting`,
+    `   the composed diff safe. Then CONFIRM it actually landed on ${integrationBase} before reporting`,
     `   promoted: poll until the PR reads state=MERGED with a merge commit (pr_merge_wait, or`,
     `   gh -R ${targetRepo} pr view <number> --json state,mergeCommit). Never treat a pending merge as done.`,
     ...step4,
     ``,
-    `Return: promoted (true ONLY if the merge actually landed on ${protectedBranch}), mr_ref (the PR`,
+    `Return: promoted (true ONLY if the merge actually landed on ${integrationBase}), mr_ref (the PR`,
     `URL/number), notes (1-2 sentences; include any error — and on error, promoted=false).`,
   ].join('\n')
 }
@@ -816,7 +882,7 @@ const PROMOTE_RESULT = {
   additionalProperties: false,
   required: ['promoted'],
   properties: {
-    promoted: { type: 'boolean' }, // true ONLY if the merge actually landed on the protected branch
+    promoted: { type: 'boolean' }, // true ONLY if the merge actually landed on the integration base
     mr_ref: { type: 'string' },
     notes: { type: 'string' },
   },
@@ -982,16 +1048,38 @@ const params = parseArgs(typeof args !== 'undefined' ? args : undefined) // #1: 
 const WAVE_ID = params.waveId ?? 'W-?'
 const TARGET_REPO = params.targetRepo ?? 'Wave-Engineering/ccwork-testtarget' // owner/repo for gh -R scoping
 const TARGET_REPO_DIR = params.targetRepoDir ?? '/home/bakerb/sandbox/github/ccwork-testtarget' // clone the worktrees attach to
-const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // integration target; never the protected branch
-const PRESERVE_KAHUNA = params.preserveKahuna ?? false // #722: true ⇒ persistent per-plan kahuna (shared across a plan's waves) — promote does NOT delete it; default false = per-wave disposable (delete on promote)
-const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // promotion target on the success exit
+const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // this wave's integration target; never the protected branch
+const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // the trunk — see INTEGRATION_BASE: this wave never writes it
+// #1052 — WHERE THIS WAVE INTEGRATES TO. The wave lands on the CAMPAIGN branch, not the protected
+// branch; the protected branch is written exactly once, by the campaign's release gate, after every
+// wave has integrated AND the DoD is met (routeRelease in campaign-loop.js). A wave has no license
+// to touch trunk — see docs/campaign-workflow-design.md and the topology note in campaign-loop.js.
+//
+// The fallback is PROTECTED_BRANCH, which preserves the legacy single-wave shape for a bare
+// /nextwave run (one wave, no campaign, no campaign branch to integrate onto) — there the wave IS
+// the whole increment, so promoting to trunk is correct. A campaign driver ALWAYS passes this.
+const INTEGRATION_BASE = params.integrationBase ?? PROTECTED_BRANCH
+// True when this wave is part of a campaign (integrating onto a campaign branch) rather than a
+// standalone /nextwave run. Governs the terminal vocabulary: a campaign wave reports `integrated`,
+// a standalone wave reports `released` too, because for it the two events coincide.
+const IN_CAMPAIGN = INTEGRATION_BASE !== PROTECTED_BRANCH
+// #722/#1052: `preserveKahuna` is RETIRED for campaign waves. It existed because a per-plan kahuna
+// had to survive across waves, which is precisely the persistent-branch-plus-squash combination
+// that broke (#892). The campaign branch now holds cross-wave state, so every wave's kahuna is
+// disposable again — deleted on integration, nothing continues from it, so a squash is harmless.
+// Accepted-but-ignored in campaign mode (a stale launcher passing true must not resurrect the
+// divergence); still honored for a standalone wave, where no campaign branch exists.
+const PRESERVE_KAHUNA = IN_CAMPAIGN ? false : (params.preserveKahuna ?? false)
+if (IN_CAMPAIGN && params.preserveKahuna === true) {
+  log(`[#1052] ignoring preserveKahuna:true — this wave integrates onto ${INTEGRATION_BASE}, so its kahuna is disposable (the campaign branch carries cross-wave state; see #892).`)
+}
 const ALL_ISSUES = (params.issues ?? []).map(Number).filter(Number.isFinite) // the wave's issue numbers
 // #4 fail-loud: refuse an empty wave rather than silently defaulting the gate at the protected branch.
 if (ALL_ISSUES.length === 0) {
   throw new Error(
     `per-wave-workflow: empty wave issue list (params.issues=${JSON.stringify(params.issues ?? null)}). ` +
       `Refusing to run — an empty wave reaches the trust gate with nothing merged and would open/promote ` +
-      `at ${PROTECTED_BRANCH}. Launch with {issues:[...]} (and waveId/kahunaBranch/targetRepo) via the ` +
+      `at ${INTEGRATION_BASE}. Launch with {issues:[...]} (and waveId/kahunaBranch/targetRepo) via the ` +
       `Workflow tool's \`args\` as a JSON OBJECT.`,
   )
 }
@@ -1250,7 +1338,9 @@ async function persistIteration(state) {
   const newlyMerged = [...(state.newlyMerged || [])].map(Number)
   const path = blobPath(TARGET_REPO_DIR, WAVE_ID)
   await agent(
-    persistIterationPrompt({ waveId: WAVE_ID, targetRepo: TARGET_REPO, kahunaBranch: KAHUNA_BRANCH, newlyMerged, blob, path }),
+    // #1046/#1052: inCampaign moves the PLATFORM issue-close to the campaign's release node (the
+    // work is not delivered until trunk is written); durable engine state is still recorded here.
+    persistIterationPrompt({ waveId: WAVE_ID, targetRepo: TARGET_REPO, kahunaBranch: KAHUNA_BRANCH, newlyMerged, blob, path, inCampaign: IN_CAMPAIGN, integrationBase: INTEGRATION_BASE }),
     {
       label: `persist:${state.groupsRun}`,
       phase: 'Flight loop',
@@ -1285,6 +1375,14 @@ async function persistTerminal(disposition, detail) {
   // trust signals; `commutativity` lifts that signal's verdict out for the intent-drift lens.
   const trajectoryEntry = {
     gate: gate?.verdict ?? null,                 // PASS | HOLD | SKIPPED
+    // #1052: BOTH fields, deliberately. `integrated` is the current vocabulary ("landed on this
+    // wave's integration base"); `promoted` is retained for readers not yet upgraded. Writing only
+    // `promoted` would make THIS engine's records indistinguishable from pre-#1052 ones, and the
+    // campaign's rehydrate prompt — which is told to be conservative and omit anything ambiguous —
+    // would decline to count the wave as integrated. That re-runs an already-integrated wave, whose
+    // diff is now empty, and an empty review stage conservative-fails: a HOLD on a wave that in fact
+    // landed, stalling the campaign short of its release gate.
+    integrated: disposition === 'promoted',
     promoted: disposition === 'promoted',
     detail,
     signals: (gate?.signals || []).map((s) => ({ signal: s.signal, passed: s.passed, detail: s.detail })),
@@ -1302,7 +1400,7 @@ async function persistTerminal(disposition, detail) {
     // so it lands on the same card as the activity_start denominator.
     persistTerminalPrompt({
       waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR,
-      kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH,
+      kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE,
       disposition, detail, blob, path, trajectoryEntry,
     }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition })
        + '\n' + flightdeckGateMetrics(gate), // #1026 AC5: confidence + drift from the resolved gate
@@ -1409,7 +1507,8 @@ function workerPrompt(n, worktree) {
   return [
     `You are a FLIGHT worker for issue #${n} of ${TARGET_REPO}, wave ${WAVE_ID}.`,
     `Working directory: ${worktree} (handed to you — do NOT create your own worktree). Branch: ${branch}`,
-    `(already checked out, based on origin/${KAHUNA_BRANCH}). Your PR targets ${KAHUNA_BRANCH}, NEVER ${PROTECTED_BRANCH}.`,
+    `(already checked out, based on origin/${KAHUNA_BRANCH}). Your PR targets ${KAHUNA_BRANCH} — NEVER`,
+    `${INTEGRATION_BASE}${IN_CAMPAIGN ? ` (this wave's integration base)` : ''} and NEVER ${PROTECTED_BRANCH} (the trunk).`,
     ``,
     `IDEMPOTENT RESUME (§3.3): FIRST check if your branch already contains this implementation (e.g. the spec's`,
     `target files exist + the acceptance test passes). If so, return status="already-present" and do NOT redo work.`,
@@ -1474,6 +1573,97 @@ function primeReconcilePrompt(built, merged) {
 // ─────────────────────────────────────────────────────────────────────────────
 phase('Rehydrate')
 const seed = await rehydrate() // SEAM #686
+
+// ── #1052 KAHUNA BOOTSTRAP — establish this wave's integration branch off the BASE ────────────
+// Every downstream node assumes `origin/<KAHUNA_BRANCH>` exists: the worktree setup bases each
+// flight on it (`worktree add -b <flight> origin/<kahuna>`), the gate diffs
+// `origin/<base>...origin/<kahuna>`, and the promote node merges it. Nothing in this engine created
+// it — before #1052 the only creator was server-side `wave_init`, which cuts ONE plan-scoped
+// `kahuna/<plan>-<slug>` off the plan's base_branch. Inside a campaign that is doubly wrong: the
+// branch is shared across waves (so the disposable-kahuna model deletes wave N+1's base when wave N
+// promotes) and it is cut off TRUNK, not the campaign branch — so wave 2's flights would build on a
+// baseline missing wave 1's integrated work. This node makes the wave's kahuna real and correctly
+// based, which is what lets the branch be genuinely disposable (#892).
+//
+// Create-or-reuse, never re-cut: an existing branch carries this wave's already-integrated flights,
+// so re-cutting it would silently discard them. Fail loud rather than fall back — a wave whose
+// kahuna could not be established must not proceed to open a PR from a ref that does not exist.
+const KAHUNA_BOOTSTRAP = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['ready'],
+  properties: {
+    ready: { type: 'boolean' }, // origin/<kahuna> verifiably exists, based on origin/<base>
+    created: { type: 'boolean' }, // true = cut fresh this run; false = reused an existing branch
+    head_sha: { type: 'string' }, // REQUIRED in practice — see the sha guard below
+    based_on_base: { type: 'boolean' }, // reuse path: is origin/<base> an ancestor of origin/<kahuna>?
+    notes: { type: 'string' },
+  },
+}
+const kahunaBootstrap = await agent(
+  [
+    `You are the wave KAHUNA-BOOTSTRAP node for wave ${WAVE_ID} of ${TARGET_REPO}. Establish this`,
+    `wave's integration branch ${KAHUNA_BRANCH} off ${INTEGRATION_BASE}, then return. Do NOT do any`,
+    `other work — do not touch issues, flights, or PRs.`,
+    ``,
+    `Run every command FROM ${TARGET_REPO_DIR}.`,
+    ``,
+    `1. Fetch: git -C ${TARGET_REPO_DIR} fetch origin`,
+    `2. If origin/${KAHUNA_BRANCH} ALREADY EXISTS — REUSE it. Return created:false. Do NOT re-cut,`,
+    `   reset, or force-push it: it carries the flights this wave already integrated (a resume), and`,
+    `   re-cutting would silently discard them. Then CHECK its ancestry and report it — do not assume it:`,
+    `     git -C ${TARGET_REPO_DIR} merge-base --is-ancestor origin/${INTEGRATION_BASE} origin/${KAHUNA_BRANCH}`,
+    `   exit 0 → based_on_base:true; non-zero → based_on_base:false (say so in notes; this is NOT fatal —`,
+    `   the base may simply have advanced since the branch was cut, and the gate's commutativity +`,
+    `   merge-result CI signals are what adjudicate a genuinely divergent base).`,
+    `3. Otherwise cut it from the integration base and publish it:`,
+    `     git -C ${TARGET_REPO_DIR} branch ${KAHUNA_BRANCH} origin/${INTEGRATION_BASE}`,
+    `     git -C ${TARGET_REPO_DIR} push -u origin ${KAHUNA_BRANCH}`,
+    `   The base is ${INTEGRATION_BASE} — NEVER the protected branch (${PROTECTED_BRANCH}) when those`,
+    `   differ. Inside a campaign, basing on trunk would give this wave a baseline missing every`,
+    `   previously-integrated wave's work (#1052).`,
+    `4. VERIFY by reading it back, and report the sha you actually observed:`,
+    `     git -C ${TARGET_REPO_DIR} rev-parse refs/remotes/origin/${KAHUNA_BRANCH}`,
+    ``,
+    `Return ready:true ONLY if step 4 printed a sha. If the branch could not be established, return`,
+    `ready:false with notes — do NOT substitute another ref (least of all ${PROTECTED_BRANCH}) and do`,
+    `not report success on an unverified push. The wave will abort, which is correct: every later node`,
+    `assumes origin/${KAHUNA_BRANCH} exists.`,
+  ].join('\n'),
+  { label: `kahuna-bootstrap:${WAVE_ID}`, phase: 'Rehydrate', schema: KAHUNA_BOOTSTRAP, agentType: 'general-purpose' },
+).catch((e) => ({ ready: false, notes: `kahuna bootstrap threw: ${e?.message || e}` }))
+// The sha is what makes `ready` mean "verified", not "reported". `head_sha` is optional in the schema,
+// so a schema-valid `{ready:true}` with no sha would pass a bare `ready` check on an unobserved branch —
+// the same defect the promotion-PR node closes by requiring a concrete `pr_number`. Requiring a
+// sha-shaped value keeps the read-back structural instead of a behavioral request in the prompt.
+const bootstrapSha = String(kahunaBootstrap?.head_sha ?? '')
+if (!kahunaBootstrap?.ready || !/^[0-9a-f]{7,40}$/.test(bootstrapSha)) {
+  throw new Error(
+    `per-wave-workflow: could not establish the wave's integration branch ${KAHUNA_BRANCH} off ` +
+      `${INTEGRATION_BASE} (${kahunaBootstrap?.notes || 'no detail'}${kahunaBootstrap?.ready && !bootstrapSha ? '; ready:true but no verified head sha' : ''}). ` +
+      `Refusing to run the wave — the flight worktrees, the trust gate's diff and the promote merge all ` +
+      `read origin/${KAHUNA_BRANCH}, so proceeding would fail later and less clearly. Nothing has been ` +
+      `written; re-run once the base is reachable.`,
+  )
+}
+// A kahuna that IS the base (or trunk) would send every flight merge straight into the branch the
+// gate is supposed to protect, with the gate's own diff empty by the time it looked. campaign-workflow
+// makes the symmetric assertion for the campaign branch; this is the per-wave half, and the bootstrap
+// is the right chokepoint — it is the last node before anything writes.
+for (const [label, ref] of [['the integration base', INTEGRATION_BASE], ['the protected branch', PROTECTED_BRANCH]]) {
+  if (KAHUNA_BRANCH === ref) {
+    throw new Error(
+      `per-wave-workflow: kahunaBranch (${KAHUNA_BRANCH}) must not equal ${label} (${ref}). Flights merge ` +
+        `into the kahuna and the trust gate diffs it AGAINST the base — if they are the same ref, every ` +
+        `flight lands on the base ungated and the gate's diff is empty (#1052).`,
+    )
+  }
+}
+// Report the ancestry the node actually observed — never assert it from the fact that a branch exists.
+const kahunaBasing = kahunaBootstrap.created
+  ? `cut from ${INTEGRATION_BASE}`
+  : `reused (${kahunaBootstrap.based_on_base === true ? `${INTEGRATION_BASE} is an ancestor` : kahunaBootstrap.based_on_base === false ? `NOT descended from current ${INTEGRATION_BASE} — the gate's commutativity + merge-result CI adjudicate` : 'ancestry unverified'})`
+log(`[#1052] kahuna ${KAHUNA_BRANCH} ${kahunaBasing} @ ${bootstrapSha.slice(0, 8)}`)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PHASE 2 — THE DYNAMIC FLIGHT LOOP (§3.1) — REAL, complete. The validated part.
@@ -1595,14 +1785,14 @@ let gate
 let promotionPrNumber = null // #5: the draft promotion PR the gate opens; the promote step merges THIS one (never a 2nd)
 if (!halt && pending.size === 0) {
   // #5 (live-gate finding, BLOCKING) — OPEN THE PROMOTION PR (DRAFT) FIRST, before the signals.
-  // The CI signal waits on the kahuna→protected MERGE-RESULT pipeline (#452); that pipeline only
+  // The CI signal waits on the kahuna→base MERGE-RESULT pipeline (#452); that pipeline only
   // exists once the PR exists. The old order created the PR at promotion (AFTER the gate), so
   // ci_wait_run found `no_merge_result_pr` and the signal had nothing to verify. Opening a DRAFT
   // PR here gives the CI signal a real pipeline AND prevents a green CI from auto-merging before
   // the gate has weighed all four signals. If the PR can't be opened (kahuna branch/artifacts
   // missing), the gate HOLDs — we cannot prove a wave we cannot even PR (conservative, §3.4).
   const prOpen = await teeAgent(
-    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
+    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
     { label: 'gate:open-pr', phase: 'Trust gate', schema: OPEN_PR_RESULT, agentType: 'general-purpose' },
   ).catch((e) => {
     log(`[#5] open promotion PR soft-fail → gate HOLDs (no PR to verify): ${e?.message || e}`)
@@ -1617,7 +1807,7 @@ if (!halt && pending.size === 0) {
   // Requiring a concrete number here keeps both structural (#699 independent review).
   if (!prOpen || !prOpen.opened || promotionPrNumber == null) {
     const detail = !prOpen || !prOpen.opened
-      ? `could not open ${KAHUNA_BRANCH}→${PROTECTED_BRANCH} draft PR: ${prOpen?.notes || 'unknown'}`
+      ? `could not open ${KAHUNA_BRANCH}→${INTEGRATION_BASE} draft PR: ${prOpen?.notes || 'unknown'}`
       : `PR-open returned opened:true but no pr_number — cannot identify the merge-result pipeline to verify`
     gate = { verdict: 'HOLD', failing: [{ signal: 'open-pr', passed: false, detail }], signals: [] }
   } else {
@@ -1628,26 +1818,28 @@ if (!halt && pending.size === 0) {
     // conservativeFail() (passed:false → HOLD), NOT an always-pass stub — an agent/tool error is
     // the absence of evidence, and a trust gate HOLDs on absence of evidence (SEAMS invariant 6).
     const signals = (await parallel([
-      // 1. commutativity — kahuna composed-diff safety vs the protected branch (single-target mode)
+      // 1. commutativity — kahuna composed-diff safety vs the integration base (single-target mode)
       () => agent(
-        commutativitySignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepoDir: TARGET_REPO_DIR }),
+        commutativitySignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepoDir: TARGET_REPO_DIR }),
         { label: 'gate:commutativity', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
       ).catch((e) => conservativeFail('commutativity', e)),
       // 2. CI on the MR MERGE-RESULT pipeline of the draft PR opened above — NOT the merge-commit branch HEAD (sdlc #452, #5)
       () => agent(
-        ciSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber }),
+        ciSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, prNumber: promotionPrNumber }),
         { label: 'gate:ci', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
       ).catch((e) => conservativeFail('ci', e)),
-      // 3. review the kahuna-vs-protected diff via a 2-STEP stage→review sub-pipeline (#847/ENG-5):
-      //    a Bash-capable general-purpose STAGE agent fetches + diffs origin/<protected>...origin/<kahuna>
+      // 3. review the kahuna-vs-base diff via a 2-STEP stage→review sub-pipeline (#847/ENG-5):
+      //    a Bash-capable general-purpose STAGE agent fetches + diffs origin/<base>...origin/<kahuna>
       //    and materializes the changed-file set into a durable workspace; then the SPECIALIZED
       //    feature-dev:code-reviewer reviews that workspace. code-reviewer is PRESERVED (NOT swapped to
       //    general-purpose — the EC-1 shortcut): it has no Bash to fetch the diff, so the stage step feeds
-      //    it. The diff is ALWAYS origin/<protected>...origin/<kahuna>, never a hard-coded `main` (the
-      //    empty-tree provisioning bug: an origin/main worktree reviews nothing on release-branch repos).
+      //    it. The diff is ALWAYS origin/<INTEGRATION_BASE>...origin/<kahuna>, never a hard-coded `main`
+      //    (the empty-tree provisioning bug: an origin/main worktree reviews nothing on release-branch
+      //    repos) — and inside a campaign the base is the campaign branch, so this is the diff the wave
+      //    actually adds on top of the waves before it, not a re-review of the whole campaign (#1052).
       () => (async () => {
         const staged = await agent(
-          reviewStagePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
+          reviewStagePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
           { label: 'gate:review:stage', phase: 'Trust gate', schema: REVIEW_STAGE, agentType: 'general-purpose' },
         )
         // Conservative-fail on a failed/empty stage (fetch error or zero changed files): the reviewer has
@@ -1656,7 +1848,7 @@ if (!halt && pending.size === 0) {
           return conservativeFail('review', `stage step produced no diff to review: ${staged?.notes || 'staged=false'}`)
         }
         return agent(
-          reviewSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepoDir: TARGET_REPO_DIR, workspaceDir: staged.workspaceDir, changedFiles: staged.changedFiles }),
+          reviewSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepoDir: TARGET_REPO_DIR, workspaceDir: staged.workspaceDir, changedFiles: staged.changedFiles }),
           { label: 'gate:review', phase: 'Trust gate', schema: SIG, agentType: 'feature-dev:code-reviewer' },
         )
       })().catch((e) => conservativeFail('review', e)),
@@ -1672,7 +1864,7 @@ if (!halt && pending.size === 0) {
 
     const failed = signals.filter((s) => !s.passed)
     gate = failed.length === 0
-      ? { verdict: 'PASS', promote: `${KAHUNA_BRANCH}→${PROTECTED_BRANCH}`, prNumber: promotionPrNumber, signals }
+      ? { verdict: 'PASS', promote: `${KAHUNA_BRANCH}→${INTEGRATION_BASE}`, prNumber: promotionPrNumber, signals }
       : { verdict: 'HOLD', failing: failed, signals }
   }
 } else {
@@ -1680,8 +1872,9 @@ if (!halt && pending.size === 0) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PHASE 4 — PROMOTE or HOLD-FOR-REVIEW.
-//   AUTO: promote kahuna→protected on PASS.
+// PHASE 4 — PROMOTE (INTEGRATE) or HOLD-FOR-REVIEW.
+//   AUTO: promote kahuna→INTEGRATION_BASE on PASS. In a campaign that base is the campaign
+//         branch, so this is integration, never a trunk write (#1052).
 //   INTERACTIVE: the workflow ENDS returning the verdict (the return IS the human gate, §5).
 // ─────────────────────────────────────────────────────────────────────────────
 phase('Promote')
@@ -1689,13 +1882,13 @@ let result
 if (gate.verdict === 'PASS') {
   if (MODE === 'auto') {
     // #687/#5 promotion (CODE, runs ONLY here — a live wave's auto+PASS success exit, itself gated
-    // by the human cutover #691). The kahuna→protected DRAFT PR (#${promotionPrNumber}) was already
+    // by the human cutover #691). The kahuna→base DRAFT PR (#${promotionPrNumber}) was already
     // opened by the gate's PR-OPEN node and its merge-result CI already validated — so promotion
     // marks THAT SAME PR ready and pr_merge lands it (commutativity already proved the composed diff
     // safe); the kahuna branch is deleted. It never opens a second PR. The script can't call MCP/CLI
     // directly (§3.3) — the promote agent does it.
     const promo = await teeAgent(
-      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
+      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
       { label: 'promote', phase: 'Promote', schema: PROMOTE_RESULT, agentType: 'general-purpose' },
     ).catch((e) => {
       // A promotion error must NOT be reported as a successful promote (conservative): record HELD,
@@ -1707,22 +1900,27 @@ if (gate.verdict === 'PASS') {
     const promoted = !!(promo && promo.promoted)
     await persistTerminal(promoted ? 'promoted' : 'held',
       promoted
-        ? `gate PASS, promoted ${KAHUNA_BRANCH}→${PROTECTED_BRANCH}${promo.mr_ref ? ` (${promo.mr_ref})` : ''}`
+        ? `gate PASS, promoted ${KAHUNA_BRANCH}→${INTEGRATION_BASE}${promo.mr_ref ? ` (${promo.mr_ref})` : ''}`
         : `gate PASS, promotion did not land — ${promo?.notes || 'see promote node'}; HELD for manual promotion`) // SEAM #688
+    // #1052: report BOTH fields. `integrated` is what the campaign loop routes and prunes on;
+    // `promoted` is kept for the pre-#1052 campaign engine and any consumer still reading it, and
+    // is the SAME boolean — this merge landed on the integration base, which is the only merge a
+    // wave ever performs. `released` is deliberately absent: only the campaign's release node can
+    // assert that, and a wave claiming it would be the exact conflation #1052 exists to remove.
     result = promoted
-      ? { gate: 'PASS', promoted: true, wave: WAVE_ID, mr_ref: promo.mr_ref }
-      : { gate: 'PASS', promoted: false, wave: WAVE_ID, reason: `promotion did not land: ${promo?.notes || 'see promote node'}` }
+      ? { gate: 'PASS', integrated: true, promoted: true, wave: WAVE_ID, integrationBase: INTEGRATION_BASE, mr_ref: promo.mr_ref }
+      : { gate: 'PASS', integrated: false, promoted: false, wave: WAVE_ID, integrationBase: INTEGRATION_BASE, reason: `promotion did not land: ${promo?.notes || 'see promote node'}` }
   } else {
     // INTERACTIVE: do NOT promote — return the verdict; the campaign driver surfaces it + the human routes.
     await persistTerminal('held', 'gate PASS, interactive — awaiting human promotion') // SEAM #688
-    result = { gate: 'PASS', promoted: false, wave: WAVE_ID, reason: 'interactive: human routes promotion' }
+    result = { gate: 'PASS', integrated: false, promoted: false, wave: WAVE_ID, integrationBase: INTEGRATION_BASE, reason: 'interactive: human routes promotion' }
   }
 } else if (gate.verdict === 'HOLD') {
   await persistTerminal('held', `gate HOLD: ${(gate.failing || []).map((s) => s.signal).join(', ')}`) // SEAM #688
-  result = { gate: 'HOLD', wave: WAVE_ID, failing: gate.failing }
+  result = { gate: 'HOLD', integrated: false, promoted: false, wave: WAVE_ID, failing: gate.failing }
 } else {
   await persistTerminal('held', `gate SKIPPED: ${gate.reason}`) // SEAM #688
-  result = { gate: 'SKIPPED', wave: WAVE_ID, reason: gate.reason, haltReason: halt }
+  result = { gate: 'SKIPPED', integrated: false, promoted: false, wave: WAVE_ID, reason: gate.reason, haltReason: halt }
 }
 
 // Wave-terminal cleanup (§4.3): remove remaining worktrees + prune (both ends, not end-only).

--- a/skills/nextwave/per-wave-workflow.js
+++ b/skills/nextwave/per-wave-workflow.js
@@ -119,16 +119,38 @@ const params = parseArgs(typeof args !== 'undefined' ? args : undefined) // #1: 
 const WAVE_ID = params.waveId ?? 'W-?'
 const TARGET_REPO = params.targetRepo ?? 'Wave-Engineering/ccwork-testtarget' // owner/repo for gh -R scoping
 const TARGET_REPO_DIR = params.targetRepoDir ?? '/home/bakerb/sandbox/github/ccwork-testtarget' // clone the worktrees attach to
-const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // integration target; never the protected branch
-const PRESERVE_KAHUNA = params.preserveKahuna ?? false // #722: true ⇒ persistent per-plan kahuna (shared across a plan's waves) — promote does NOT delete it; default false = per-wave disposable (delete on promote)
-const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // promotion target on the success exit
+const KAHUNA_BRANCH = params.kahunaBranch ?? `kahuna/${WAVE_ID}` // this wave's integration target; never the protected branch
+const PROTECTED_BRANCH = params.protectedBranch ?? 'main' // the trunk — see INTEGRATION_BASE: this wave never writes it
+// #1052 — WHERE THIS WAVE INTEGRATES TO. The wave lands on the CAMPAIGN branch, not the protected
+// branch; the protected branch is written exactly once, by the campaign's release gate, after every
+// wave has integrated AND the DoD is met (routeRelease in campaign-loop.js). A wave has no license
+// to touch trunk — see docs/campaign-workflow-design.md and the topology note in campaign-loop.js.
+//
+// The fallback is PROTECTED_BRANCH, which preserves the legacy single-wave shape for a bare
+// /nextwave run (one wave, no campaign, no campaign branch to integrate onto) — there the wave IS
+// the whole increment, so promoting to trunk is correct. A campaign driver ALWAYS passes this.
+const INTEGRATION_BASE = params.integrationBase ?? PROTECTED_BRANCH
+// True when this wave is part of a campaign (integrating onto a campaign branch) rather than a
+// standalone /nextwave run. Governs the terminal vocabulary: a campaign wave reports `integrated`,
+// a standalone wave reports `released` too, because for it the two events coincide.
+const IN_CAMPAIGN = INTEGRATION_BASE !== PROTECTED_BRANCH
+// #722/#1052: `preserveKahuna` is RETIRED for campaign waves. It existed because a per-plan kahuna
+// had to survive across waves, which is precisely the persistent-branch-plus-squash combination
+// that broke (#892). The campaign branch now holds cross-wave state, so every wave's kahuna is
+// disposable again — deleted on integration, nothing continues from it, so a squash is harmless.
+// Accepted-but-ignored in campaign mode (a stale launcher passing true must not resurrect the
+// divergence); still honored for a standalone wave, where no campaign branch exists.
+const PRESERVE_KAHUNA = IN_CAMPAIGN ? false : (params.preserveKahuna ?? false)
+if (IN_CAMPAIGN && params.preserveKahuna === true) {
+  log(`[#1052] ignoring preserveKahuna:true — this wave integrates onto ${INTEGRATION_BASE}, so its kahuna is disposable (the campaign branch carries cross-wave state; see #892).`)
+}
 const ALL_ISSUES = (params.issues ?? []).map(Number).filter(Number.isFinite) // the wave's issue numbers
 // #4 fail-loud: refuse an empty wave rather than silently defaulting the gate at the protected branch.
 if (ALL_ISSUES.length === 0) {
   throw new Error(
     `per-wave-workflow: empty wave issue list (params.issues=${JSON.stringify(params.issues ?? null)}). ` +
       `Refusing to run — an empty wave reaches the trust gate with nothing merged and would open/promote ` +
-      `at ${PROTECTED_BRANCH}. Launch with {issues:[...]} (and waveId/kahunaBranch/targetRepo) via the ` +
+      `at ${INTEGRATION_BASE}. Launch with {issues:[...]} (and waveId/kahunaBranch/targetRepo) via the ` +
       `Workflow tool's \`args\` as a JSON OBJECT.`,
   )
 }
@@ -387,7 +409,9 @@ async function persistIteration(state) {
   const newlyMerged = [...(state.newlyMerged || [])].map(Number)
   const path = blobPath(TARGET_REPO_DIR, WAVE_ID)
   await agent(
-    persistIterationPrompt({ waveId: WAVE_ID, targetRepo: TARGET_REPO, kahunaBranch: KAHUNA_BRANCH, newlyMerged, blob, path }),
+    // #1046/#1052: inCampaign moves the PLATFORM issue-close to the campaign's release node (the
+    // work is not delivered until trunk is written); durable engine state is still recorded here.
+    persistIterationPrompt({ waveId: WAVE_ID, targetRepo: TARGET_REPO, kahunaBranch: KAHUNA_BRANCH, newlyMerged, blob, path, inCampaign: IN_CAMPAIGN, integrationBase: INTEGRATION_BASE }),
     {
       label: `persist:${state.groupsRun}`,
       phase: 'Flight loop',
@@ -422,6 +446,14 @@ async function persistTerminal(disposition, detail) {
   // trust signals; `commutativity` lifts that signal's verdict out for the intent-drift lens.
   const trajectoryEntry = {
     gate: gate?.verdict ?? null,                 // PASS | HOLD | SKIPPED
+    // #1052: BOTH fields, deliberately. `integrated` is the current vocabulary ("landed on this
+    // wave's integration base"); `promoted` is retained for readers not yet upgraded. Writing only
+    // `promoted` would make THIS engine's records indistinguishable from pre-#1052 ones, and the
+    // campaign's rehydrate prompt — which is told to be conservative and omit anything ambiguous —
+    // would decline to count the wave as integrated. That re-runs an already-integrated wave, whose
+    // diff is now empty, and an empty review stage conservative-fails: a HOLD on a wave that in fact
+    // landed, stalling the campaign short of its release gate.
+    integrated: disposition === 'promoted',
     promoted: disposition === 'promoted',
     detail,
     signals: (gate?.signals || []).map((s) => ({ signal: s.signal, passed: s.passed, detail: s.detail })),
@@ -439,7 +471,7 @@ async function persistTerminal(disposition, detail) {
     // so it lands on the same card as the activity_start denominator.
     persistTerminalPrompt({
       waveId: WAVE_ID, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR,
-      kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH,
+      kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE,
       disposition, detail, blob, path, trajectoryEntry,
     }) + '\n' + flightdeckTee({ phase: 'Promote', label: disposition })
        + '\n' + flightdeckGateMetrics(gate), // #1026 AC5: confidence + drift from the resolved gate
@@ -546,7 +578,8 @@ function workerPrompt(n, worktree) {
   return [
     `You are a FLIGHT worker for issue #${n} of ${TARGET_REPO}, wave ${WAVE_ID}.`,
     `Working directory: ${worktree} (handed to you — do NOT create your own worktree). Branch: ${branch}`,
-    `(already checked out, based on origin/${KAHUNA_BRANCH}). Your PR targets ${KAHUNA_BRANCH}, NEVER ${PROTECTED_BRANCH}.`,
+    `(already checked out, based on origin/${KAHUNA_BRANCH}). Your PR targets ${KAHUNA_BRANCH} — NEVER`,
+    `${INTEGRATION_BASE}${IN_CAMPAIGN ? ` (this wave's integration base)` : ''} and NEVER ${PROTECTED_BRANCH} (the trunk).`,
     ``,
     `IDEMPOTENT RESUME (§3.3): FIRST check if your branch already contains this implementation (e.g. the spec's`,
     `target files exist + the acceptance test passes). If so, return status="already-present" and do NOT redo work.`,
@@ -611,6 +644,97 @@ function primeReconcilePrompt(built, merged) {
 // ─────────────────────────────────────────────────────────────────────────────
 phase('Rehydrate')
 const seed = await rehydrate() // SEAM #686
+
+// ── #1052 KAHUNA BOOTSTRAP — establish this wave's integration branch off the BASE ────────────
+// Every downstream node assumes `origin/<KAHUNA_BRANCH>` exists: the worktree setup bases each
+// flight on it (`worktree add -b <flight> origin/<kahuna>`), the gate diffs
+// `origin/<base>...origin/<kahuna>`, and the promote node merges it. Nothing in this engine created
+// it — before #1052 the only creator was server-side `wave_init`, which cuts ONE plan-scoped
+// `kahuna/<plan>-<slug>` off the plan's base_branch. Inside a campaign that is doubly wrong: the
+// branch is shared across waves (so the disposable-kahuna model deletes wave N+1's base when wave N
+// promotes) and it is cut off TRUNK, not the campaign branch — so wave 2's flights would build on a
+// baseline missing wave 1's integrated work. This node makes the wave's kahuna real and correctly
+// based, which is what lets the branch be genuinely disposable (#892).
+//
+// Create-or-reuse, never re-cut: an existing branch carries this wave's already-integrated flights,
+// so re-cutting it would silently discard them. Fail loud rather than fall back — a wave whose
+// kahuna could not be established must not proceed to open a PR from a ref that does not exist.
+const KAHUNA_BOOTSTRAP = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['ready'],
+  properties: {
+    ready: { type: 'boolean' }, // origin/<kahuna> verifiably exists, based on origin/<base>
+    created: { type: 'boolean' }, // true = cut fresh this run; false = reused an existing branch
+    head_sha: { type: 'string' }, // REQUIRED in practice — see the sha guard below
+    based_on_base: { type: 'boolean' }, // reuse path: is origin/<base> an ancestor of origin/<kahuna>?
+    notes: { type: 'string' },
+  },
+}
+const kahunaBootstrap = await agent(
+  [
+    `You are the wave KAHUNA-BOOTSTRAP node for wave ${WAVE_ID} of ${TARGET_REPO}. Establish this`,
+    `wave's integration branch ${KAHUNA_BRANCH} off ${INTEGRATION_BASE}, then return. Do NOT do any`,
+    `other work — do not touch issues, flights, or PRs.`,
+    ``,
+    `Run every command FROM ${TARGET_REPO_DIR}.`,
+    ``,
+    `1. Fetch: git -C ${TARGET_REPO_DIR} fetch origin`,
+    `2. If origin/${KAHUNA_BRANCH} ALREADY EXISTS — REUSE it. Return created:false. Do NOT re-cut,`,
+    `   reset, or force-push it: it carries the flights this wave already integrated (a resume), and`,
+    `   re-cutting would silently discard them. Then CHECK its ancestry and report it — do not assume it:`,
+    `     git -C ${TARGET_REPO_DIR} merge-base --is-ancestor origin/${INTEGRATION_BASE} origin/${KAHUNA_BRANCH}`,
+    `   exit 0 → based_on_base:true; non-zero → based_on_base:false (say so in notes; this is NOT fatal —`,
+    `   the base may simply have advanced since the branch was cut, and the gate's commutativity +`,
+    `   merge-result CI signals are what adjudicate a genuinely divergent base).`,
+    `3. Otherwise cut it from the integration base and publish it:`,
+    `     git -C ${TARGET_REPO_DIR} branch ${KAHUNA_BRANCH} origin/${INTEGRATION_BASE}`,
+    `     git -C ${TARGET_REPO_DIR} push -u origin ${KAHUNA_BRANCH}`,
+    `   The base is ${INTEGRATION_BASE} — NEVER the protected branch (${PROTECTED_BRANCH}) when those`,
+    `   differ. Inside a campaign, basing on trunk would give this wave a baseline missing every`,
+    `   previously-integrated wave's work (#1052).`,
+    `4. VERIFY by reading it back, and report the sha you actually observed:`,
+    `     git -C ${TARGET_REPO_DIR} rev-parse refs/remotes/origin/${KAHUNA_BRANCH}`,
+    ``,
+    `Return ready:true ONLY if step 4 printed a sha. If the branch could not be established, return`,
+    `ready:false with notes — do NOT substitute another ref (least of all ${PROTECTED_BRANCH}) and do`,
+    `not report success on an unverified push. The wave will abort, which is correct: every later node`,
+    `assumes origin/${KAHUNA_BRANCH} exists.`,
+  ].join('\n'),
+  { label: `kahuna-bootstrap:${WAVE_ID}`, phase: 'Rehydrate', schema: KAHUNA_BOOTSTRAP, agentType: 'general-purpose' },
+).catch((e) => ({ ready: false, notes: `kahuna bootstrap threw: ${e?.message || e}` }))
+// The sha is what makes `ready` mean "verified", not "reported". `head_sha` is optional in the schema,
+// so a schema-valid `{ready:true}` with no sha would pass a bare `ready` check on an unobserved branch —
+// the same defect the promotion-PR node closes by requiring a concrete `pr_number`. Requiring a
+// sha-shaped value keeps the read-back structural instead of a behavioral request in the prompt.
+const bootstrapSha = String(kahunaBootstrap?.head_sha ?? '')
+if (!kahunaBootstrap?.ready || !/^[0-9a-f]{7,40}$/.test(bootstrapSha)) {
+  throw new Error(
+    `per-wave-workflow: could not establish the wave's integration branch ${KAHUNA_BRANCH} off ` +
+      `${INTEGRATION_BASE} (${kahunaBootstrap?.notes || 'no detail'}${kahunaBootstrap?.ready && !bootstrapSha ? '; ready:true but no verified head sha' : ''}). ` +
+      `Refusing to run the wave — the flight worktrees, the trust gate's diff and the promote merge all ` +
+      `read origin/${KAHUNA_BRANCH}, so proceeding would fail later and less clearly. Nothing has been ` +
+      `written; re-run once the base is reachable.`,
+  )
+}
+// A kahuna that IS the base (or trunk) would send every flight merge straight into the branch the
+// gate is supposed to protect, with the gate's own diff empty by the time it looked. campaign-workflow
+// makes the symmetric assertion for the campaign branch; this is the per-wave half, and the bootstrap
+// is the right chokepoint — it is the last node before anything writes.
+for (const [label, ref] of [['the integration base', INTEGRATION_BASE], ['the protected branch', PROTECTED_BRANCH]]) {
+  if (KAHUNA_BRANCH === ref) {
+    throw new Error(
+      `per-wave-workflow: kahunaBranch (${KAHUNA_BRANCH}) must not equal ${label} (${ref}). Flights merge ` +
+        `into the kahuna and the trust gate diffs it AGAINST the base — if they are the same ref, every ` +
+        `flight lands on the base ungated and the gate's diff is empty (#1052).`,
+    )
+  }
+}
+// Report the ancestry the node actually observed — never assert it from the fact that a branch exists.
+const kahunaBasing = kahunaBootstrap.created
+  ? `cut from ${INTEGRATION_BASE}`
+  : `reused (${kahunaBootstrap.based_on_base === true ? `${INTEGRATION_BASE} is an ancestor` : kahunaBootstrap.based_on_base === false ? `NOT descended from current ${INTEGRATION_BASE} — the gate's commutativity + merge-result CI adjudicate` : 'ancestry unverified'})`
+log(`[#1052] kahuna ${KAHUNA_BRANCH} ${kahunaBasing} @ ${bootstrapSha.slice(0, 8)}`)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PHASE 2 — THE DYNAMIC FLIGHT LOOP (§3.1) — REAL, complete. The validated part.
@@ -732,14 +856,14 @@ let gate
 let promotionPrNumber = null // #5: the draft promotion PR the gate opens; the promote step merges THIS one (never a 2nd)
 if (!halt && pending.size === 0) {
   // #5 (live-gate finding, BLOCKING) — OPEN THE PROMOTION PR (DRAFT) FIRST, before the signals.
-  // The CI signal waits on the kahuna→protected MERGE-RESULT pipeline (#452); that pipeline only
+  // The CI signal waits on the kahuna→base MERGE-RESULT pipeline (#452); that pipeline only
   // exists once the PR exists. The old order created the PR at promotion (AFTER the gate), so
   // ci_wait_run found `no_merge_result_pr` and the signal had nothing to verify. Opening a DRAFT
   // PR here gives the CI signal a real pipeline AND prevents a green CI from auto-merging before
   // the gate has weighed all four signals. If the PR can't be opened (kahuna branch/artifacts
   // missing), the gate HOLDs — we cannot prove a wave we cannot even PR (conservative, §3.4).
   const prOpen = await teeAgent(
-    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
+    openPromotionPrPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR, planId: PLAN_ID }),
     { label: 'gate:open-pr', phase: 'Trust gate', schema: OPEN_PR_RESULT, agentType: 'general-purpose' },
   ).catch((e) => {
     log(`[#5] open promotion PR soft-fail → gate HOLDs (no PR to verify): ${e?.message || e}`)
@@ -754,7 +878,7 @@ if (!halt && pending.size === 0) {
   // Requiring a concrete number here keeps both structural (#699 independent review).
   if (!prOpen || !prOpen.opened || promotionPrNumber == null) {
     const detail = !prOpen || !prOpen.opened
-      ? `could not open ${KAHUNA_BRANCH}→${PROTECTED_BRANCH} draft PR: ${prOpen?.notes || 'unknown'}`
+      ? `could not open ${KAHUNA_BRANCH}→${INTEGRATION_BASE} draft PR: ${prOpen?.notes || 'unknown'}`
       : `PR-open returned opened:true but no pr_number — cannot identify the merge-result pipeline to verify`
     gate = { verdict: 'HOLD', failing: [{ signal: 'open-pr', passed: false, detail }], signals: [] }
   } else {
@@ -765,26 +889,28 @@ if (!halt && pending.size === 0) {
     // conservativeFail() (passed:false → HOLD), NOT an always-pass stub — an agent/tool error is
     // the absence of evidence, and a trust gate HOLDs on absence of evidence (SEAMS invariant 6).
     const signals = (await parallel([
-      // 1. commutativity — kahuna composed-diff safety vs the protected branch (single-target mode)
+      // 1. commutativity — kahuna composed-diff safety vs the integration base (single-target mode)
       () => agent(
-        commutativitySignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepoDir: TARGET_REPO_DIR }),
+        commutativitySignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepoDir: TARGET_REPO_DIR }),
         { label: 'gate:commutativity', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
       ).catch((e) => conservativeFail('commutativity', e)),
       // 2. CI on the MR MERGE-RESULT pipeline of the draft PR opened above — NOT the merge-commit branch HEAD (sdlc #452, #5)
       () => agent(
-        ciSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber }),
+        ciSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, prNumber: promotionPrNumber }),
         { label: 'gate:ci', phase: 'Trust gate', schema: SIG, agentType: 'general-purpose' },
       ).catch((e) => conservativeFail('ci', e)),
-      // 3. review the kahuna-vs-protected diff via a 2-STEP stage→review sub-pipeline (#847/ENG-5):
-      //    a Bash-capable general-purpose STAGE agent fetches + diffs origin/<protected>...origin/<kahuna>
+      // 3. review the kahuna-vs-base diff via a 2-STEP stage→review sub-pipeline (#847/ENG-5):
+      //    a Bash-capable general-purpose STAGE agent fetches + diffs origin/<base>...origin/<kahuna>
       //    and materializes the changed-file set into a durable workspace; then the SPECIALIZED
       //    feature-dev:code-reviewer reviews that workspace. code-reviewer is PRESERVED (NOT swapped to
       //    general-purpose — the EC-1 shortcut): it has no Bash to fetch the diff, so the stage step feeds
-      //    it. The diff is ALWAYS origin/<protected>...origin/<kahuna>, never a hard-coded `main` (the
-      //    empty-tree provisioning bug: an origin/main worktree reviews nothing on release-branch repos).
+      //    it. The diff is ALWAYS origin/<INTEGRATION_BASE>...origin/<kahuna>, never a hard-coded `main`
+      //    (the empty-tree provisioning bug: an origin/main worktree reviews nothing on release-branch
+      //    repos) — and inside a campaign the base is the campaign branch, so this is the diff the wave
+      //    actually adds on top of the waves before it, not a re-review of the whole campaign (#1052).
       () => (async () => {
         const staged = await agent(
-          reviewStagePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
+          reviewStagePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, targetRepoDir: TARGET_REPO_DIR }),
           { label: 'gate:review:stage', phase: 'Trust gate', schema: REVIEW_STAGE, agentType: 'general-purpose' },
         )
         // Conservative-fail on a failed/empty stage (fetch error or zero changed files): the reviewer has
@@ -793,7 +919,7 @@ if (!halt && pending.size === 0) {
           return conservativeFail('review', `stage step produced no diff to review: ${staged?.notes || 'staged=false'}`)
         }
         return agent(
-          reviewSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepoDir: TARGET_REPO_DIR, workspaceDir: staged.workspaceDir, changedFiles: staged.changedFiles }),
+          reviewSignalPrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepoDir: TARGET_REPO_DIR, workspaceDir: staged.workspaceDir, changedFiles: staged.changedFiles }),
           { label: 'gate:review', phase: 'Trust gate', schema: SIG, agentType: 'feature-dev:code-reviewer' },
         )
       })().catch((e) => conservativeFail('review', e)),
@@ -809,7 +935,7 @@ if (!halt && pending.size === 0) {
 
     const failed = signals.filter((s) => !s.passed)
     gate = failed.length === 0
-      ? { verdict: 'PASS', promote: `${KAHUNA_BRANCH}→${PROTECTED_BRANCH}`, prNumber: promotionPrNumber, signals }
+      ? { verdict: 'PASS', promote: `${KAHUNA_BRANCH}→${INTEGRATION_BASE}`, prNumber: promotionPrNumber, signals }
       : { verdict: 'HOLD', failing: failed, signals }
   }
 } else {
@@ -817,8 +943,9 @@ if (!halt && pending.size === 0) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PHASE 4 — PROMOTE or HOLD-FOR-REVIEW.
-//   AUTO: promote kahuna→protected on PASS.
+// PHASE 4 — PROMOTE (INTEGRATE) or HOLD-FOR-REVIEW.
+//   AUTO: promote kahuna→INTEGRATION_BASE on PASS. In a campaign that base is the campaign
+//         branch, so this is integration, never a trunk write (#1052).
 //   INTERACTIVE: the workflow ENDS returning the verdict (the return IS the human gate, §5).
 // ─────────────────────────────────────────────────────────────────────────────
 phase('Promote')
@@ -826,13 +953,13 @@ let result
 if (gate.verdict === 'PASS') {
   if (MODE === 'auto') {
     // #687/#5 promotion (CODE, runs ONLY here — a live wave's auto+PASS success exit, itself gated
-    // by the human cutover #691). The kahuna→protected DRAFT PR (#${promotionPrNumber}) was already
+    // by the human cutover #691). The kahuna→base DRAFT PR (#${promotionPrNumber}) was already
     // opened by the gate's PR-OPEN node and its merge-result CI already validated — so promotion
     // marks THAT SAME PR ready and pr_merge lands it (commutativity already proved the composed diff
     // safe); the kahuna branch is deleted. It never opens a second PR. The script can't call MCP/CLI
     // directly (§3.3) — the promote agent does it.
     const promo = await teeAgent(
-      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, protectedBranch: PROTECTED_BRANCH, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
+      promotePrompt({ waveId: WAVE_ID, kahunaBranch: KAHUNA_BRANCH, integrationBase: INTEGRATION_BASE, targetRepo: TARGET_REPO, prNumber: promotionPrNumber, preserveKahuna: PRESERVE_KAHUNA }),
       { label: 'promote', phase: 'Promote', schema: PROMOTE_RESULT, agentType: 'general-purpose' },
     ).catch((e) => {
       // A promotion error must NOT be reported as a successful promote (conservative): record HELD,
@@ -844,22 +971,27 @@ if (gate.verdict === 'PASS') {
     const promoted = !!(promo && promo.promoted)
     await persistTerminal(promoted ? 'promoted' : 'held',
       promoted
-        ? `gate PASS, promoted ${KAHUNA_BRANCH}→${PROTECTED_BRANCH}${promo.mr_ref ? ` (${promo.mr_ref})` : ''}`
+        ? `gate PASS, promoted ${KAHUNA_BRANCH}→${INTEGRATION_BASE}${promo.mr_ref ? ` (${promo.mr_ref})` : ''}`
         : `gate PASS, promotion did not land — ${promo?.notes || 'see promote node'}; HELD for manual promotion`) // SEAM #688
+    // #1052: report BOTH fields. `integrated` is what the campaign loop routes and prunes on;
+    // `promoted` is kept for the pre-#1052 campaign engine and any consumer still reading it, and
+    // is the SAME boolean — this merge landed on the integration base, which is the only merge a
+    // wave ever performs. `released` is deliberately absent: only the campaign's release node can
+    // assert that, and a wave claiming it would be the exact conflation #1052 exists to remove.
     result = promoted
-      ? { gate: 'PASS', promoted: true, wave: WAVE_ID, mr_ref: promo.mr_ref }
-      : { gate: 'PASS', promoted: false, wave: WAVE_ID, reason: `promotion did not land: ${promo?.notes || 'see promote node'}` }
+      ? { gate: 'PASS', integrated: true, promoted: true, wave: WAVE_ID, integrationBase: INTEGRATION_BASE, mr_ref: promo.mr_ref }
+      : { gate: 'PASS', integrated: false, promoted: false, wave: WAVE_ID, integrationBase: INTEGRATION_BASE, reason: `promotion did not land: ${promo?.notes || 'see promote node'}` }
   } else {
     // INTERACTIVE: do NOT promote — return the verdict; the campaign driver surfaces it + the human routes.
     await persistTerminal('held', 'gate PASS, interactive — awaiting human promotion') // SEAM #688
-    result = { gate: 'PASS', promoted: false, wave: WAVE_ID, reason: 'interactive: human routes promotion' }
+    result = { gate: 'PASS', integrated: false, promoted: false, wave: WAVE_ID, integrationBase: INTEGRATION_BASE, reason: 'interactive: human routes promotion' }
   }
 } else if (gate.verdict === 'HOLD') {
   await persistTerminal('held', `gate HOLD: ${(gate.failing || []).map((s) => s.signal).join(', ')}`) // SEAM #688
-  result = { gate: 'HOLD', wave: WAVE_ID, failing: gate.failing }
+  result = { gate: 'HOLD', integrated: false, promoted: false, wave: WAVE_ID, failing: gate.failing }
 } else {
   await persistTerminal('held', `gate SKIPPED: ${gate.reason}`) // SEAM #688
-  result = { gate: 'SKIPPED', wave: WAVE_ID, reason: gate.reason, haltReason: halt }
+  result = { gate: 'SKIPPED', integrated: false, promoted: false, wave: WAVE_ID, reason: gate.reason, haltReason: halt }
 }
 
 // Wave-terminal cleanup (§4.3): remove remaining worktrees + prune (both ends, not end-only).

--- a/skills/nextwave/wave-status.js
+++ b/skills/nextwave/wave-status.js
@@ -64,12 +64,47 @@ export function toBlob(state) {
 //   2. the full-overwrite blob write.
 // `newlyMerged` is the issues merged THIS iteration that still need their MR recorded +
 // issue closed; `blob` is the already-normalized object to write verbatim.
-export function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newlyMerged, blob, path }) {
+// #1046/#1052 — WHERE THE ISSUE CLOSES. Until #1052 this node closed the issue on the platform at
+// the moment its flight merged into kahuna. Under the campaign shape that is factually wrong: the
+// work is on a campaign branch, the protected branch has not been written, and nothing has shipped.
+// A closed issue is the board's claim that the work is delivered, and closing here would make that
+// claim N waves early — then a campaign abort would leave a trail of closed issues for work that
+// was deleted. So: durable engine state (wave_close_issue) is recorded HERE, because the flight
+// genuinely did land on the integration base; the PLATFORM close moves to the campaign's release
+// node (campaign-loop.js releaseMergePrompt step 4), which runs after the one trunk merge.
+//
+// `inCampaign` selects between the two. A standalone /nextwave wave promotes straight to the
+// protected branch, so for it merge and release coincide and the platform close still belongs here
+// — there is no later node to do it, and omitting it would silently stop closing issues.
+export function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newlyMerged, blob, path, inCampaign = false, integrationBase }) {
+  const closeStep = inCampaign
+    ? [
+        `    c. Record the merge in DURABLE ENGINE STATE ONLY — do NOT close the issue on the platform:`,
+        `         - wave_close_issue(issue_number=<n>) — updates durable wave state (NO-OP if already`,
+        `           closed). This records that the flight LANDED, which it did.`,
+        `         - Do NOT run 'gh issue close' / 'glab issue close'. This wave landed on`,
+        `           ${integrationBase || 'the campaign branch'}, NOT the protected branch — the work has`,
+        `           not shipped yet, and a closed issue would claim it had (#1046/#1052). The campaign's`,
+        `           release node closes these issues after the single protected-branch merge. If the`,
+        `           campaign is later aborted, these issues must still be open.`,
+        `         - Leave the issue in its in-review/In Test marker if the project has one; never set a`,
+        `           terminal state by hand before the merge that earns it.`,
+      ]
+    : [
+        `    c. Close the issue on BOTH surfaces (idempotent; runs for EVERY newly-merged issue,`,
+        `       regardless of which merge path A/B/C landed it). This is a STANDALONE wave — it promotes`,
+        `       straight to the protected branch, so its merge IS the delivery:`,
+        `         - wave_close_issue(issue_number=<n>) — updates durable wave state (NO-OP if already closed).`,
+        `         - Platform-close the issue itself: a kahuna-targeted MR/PR does NOT auto-close via`,
+        `           "Closes #N" because the kahuna branch is not the protected base, so close it explicitly —`,
+        `           GitHub: gh issue close <n> -R ${targetRepo} ; GitLab: glab issue close <n> (use the`,
+        `           project's platform). Closing an already-closed issue is a NO-OP (#633).`,
+      ]
   return [
     `You are the wave-status PERSISTENCE node for wave ${waveId} of ${targetRepo}. You perform two`,
     `DURABLE, IDEMPOTENT side-effects, then return. Do NOT do any other work.`,
     ``,
-    `STEP 1 — per newly-merged issue (record MR + close), idempotent:`,
+    `STEP 1 — per newly-merged issue (record MR${inCampaign ? '' : ' + close'}), idempotent:`,
     `  Newly-merged issues this iteration: [${newlyMerged.join(', ') || 'none'}].`,
     `  For EACH, in order:`,
     `    a. Resolve the merge reference into ${kahunaBranch}: the PR/MR that merged the issue's`,
@@ -77,13 +112,7 @@ export function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newly
     `       PR ref if discoverable (gh -R ${targetRepo}); else fall back to the ref "${kahunaBranch}".`,
     `    b. Call wave_record_mr(issue_number=<n>, mr_ref=<resolved ref>). This is keyed on the issue —`,
     `       re-recording an already-recorded issue is an OVERWRITE, not a duplicate. Safe to repeat.`,
-    `    c. Close the issue on BOTH surfaces (idempotent; runs for EVERY newly-merged issue,`,
-    `       regardless of which merge path A/B/C landed it):`,
-    `         - wave_close_issue(issue_number=<n>) — updates durable wave state (NO-OP if already closed).`,
-    `         - Platform-close the issue itself: a kahuna-targeted MR/PR does NOT auto-close via`,
-    `           "Closes #N" because the kahuna branch is not the protected base, so close it explicitly —`,
-    `           GitHub: gh issue close <n> -R ${targetRepo} ; GitLab: glab issue close <n> (use the`,
-    `           project's platform). Closing an already-closed issue is a NO-OP (#633).`,
+    ...closeStep,
     `  If a tool errors, record it in notes and CONTINUE — persistence must not halt the wave.`,
     ``,
     `STEP 2 — write the durable loop blob (full overwrite, idempotent):`,
@@ -101,19 +130,28 @@ export function persistIterationPrompt({ waveId, targetRepo, kahunaBranch, newly
 
 // ── persistTerminal agent prompt ────────────────────────────────────────────────────
 // Records the wave's terminal disposition into BOTH (a) wave-status's wave-completion
-// record (so the campaign driver's cold-start rehydrate can prune a promoted wave, §5),
+// record (so the campaign driver's cold-start rehydrate can prune an integrated wave, §5),
 // and (b) the durable blob's `terminal` field (so a resume sees the same disposition).
-export function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahunaBranch, protectedBranch, disposition, detail, blob, path, trajectoryEntry }) {
+//
+// #1052: the disposition vocabulary stays `promoted | held` — it is a persisted durable value that
+// mid-campaign resumes and the wave-status CLI both read, so renaming it would strand every
+// in-flight campaign's records for a vocabulary improvement. What changed is what it MEANS:
+// "landed on the integration base", which the campaign loop reads through isIntegrated(). The
+// campaign's release is recorded separately, once, by the release node.
+export function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahunaBranch, integrationBase, disposition, detail, blob, path, trajectoryEntry }) {
   return [
     `You are the wave-status PERSISTENCE node for wave ${waveId} of ${targetRepo}. Record the wave's`,
     `TERMINAL disposition durably + idempotently, then return. Do NOT do any other work.`,
     ``,
     `Disposition: "${disposition}" (one of promoted | held). Detail: ${JSON.stringify(detail)}.`,
+    `"promoted" here means the wave LANDED ON ITS INTEGRATION BASE (${integrationBase}) — inside a`,
+    `campaign that is the campaign branch, not the protected branch (#1052). The wave-completion`,
+    `record is what lets the campaign advance and prune on resume; it is NOT a delivery claim.`,
     ``,
     ...(disposition === 'promoted'
       ? [
-          `STEP 1 — wave-completion record (idempotent, PROMOTED): the wave reached the protected`,
-          `  branch, so mark it COMPLETED and advance the campaign pointer. Run FROM the target clone`,
+          `STEP 1 — wave-completion record (idempotent, PROMOTED): the wave landed on ${integrationBase},`,
+          `  so mark it COMPLETED and advance the campaign pointer. Run FROM the target clone`,
           `  so the CLI resolves the same .claude/status/ that holds the blob (the pre-flight`,
           `  'command -v wave-status' probe guarantees the deployed console command is on PATH):`,
           `    cd ${targetRepoDir} && wave-status complete ${waveId}`,
@@ -121,8 +159,8 @@ export function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahun
           `  current_wave marks the wrong wave). 'complete' is idempotent for an already-completed wave.`,
         ]
       : [
-          `STEP 1 — wave-completion record (idempotent, HELD): the wave did NOT reach the protected`,
-          `  branch (gate HOLD/SKIPPED, reconcile-blocked, or PASS-not-promoted). Mark it HELD and do`,
+          `STEP 1 — wave-completion record (idempotent, HELD): the wave did NOT land on ${integrationBase}`,
+          `  (gate HOLD/SKIPPED, reconcile-blocked, or PASS-not-promoted). Mark it HELD and do`,
           `  NOT advance the campaign pointer — NEVER call 'complete' on a held wave (ENG-1/#846: a`,
           `  'completed' write on a non-promoted exit corrupts durable resume/prune state). Run FROM`,
           `  the target clone so the CLI resolves the same .claude/status/ (the pre-flight`,
@@ -144,8 +182,11 @@ export function persistTerminalPrompt({ waveId, targetRepo, targetRepoDir, kahun
     `  oversight judgment seed). The base entry below is authored by the loop; you ADD two best-effort,`,
     `  shell-derived fields, then upsert it. The append is idempotent per wave (keyed on the wave id —`,
     `  re-running OVERWRITES this wave's entry, never duplicates), so it is safe on resume.`,
-    `    a. Compute "files_touched": the changed-file set of this wave, i.e. run`,
-    `         git -C ${targetRepoDir} diff --name-only ${protectedBranch}...${kahunaBranch}`,
+    `    a. Compute "files_touched": the changed-file set of THIS WAVE — diffed against its own`,
+    `       integration base, so in a campaign it is what this wave added on top of the waves before`,
+    `       it, not the whole campaign re-attributed to every wave (which would make the oversight`,
+    `       judge's per-wave file sets monotonically grow and read as a hotspot, #1052):`,
+    `         git -C ${targetRepoDir} diff --name-only ${integrationBase}...${kahunaBranch}`,
     `       and put the resulting path list (JSON array of strings) on the entry. On any git error,`,
     `       set files_touched to [] and note it — do NOT fail the step.`,
     `    b. Compute "engine_fingerprint": the md5 of the running per-wave-workflow bundle if you can`,

--- a/skills/wavemachine/SKILL.md
+++ b/skills/wavemachine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wavemachine
-description: Campaign driver — loops one per-wave Workflow per pending wave; advances ONLY on gate PASS AND promoted (a PASS that did not land on the protected branch HOLDs); closed campaign exits; auto-vs-interactive is a one-line advance-vs-wait branch; cold-start rehydrate prunes already-promoted waves
+description: Campaign driver — loops one per-wave Workflow per pending wave onto ONE campaign branch; advances ONLY on gate PASS AND integrated (a PASS that did not land on the campaign branch HOLDs); the protected branch is written exactly once, at the end, gated on the DoD; closed campaign exits; auto-vs-interactive is a one-line advance-vs-wait branch; cold-start rehydrate prunes already-integrated waves
 ---
 
 # Wavemachine — Campaign Driver for the per-wave Workflow
@@ -16,7 +16,7 @@ description: Campaign driver — loops one per-wave Workflow per pending wave; a
 Bound by WAVE_AXIOMS 2, 3, 4, 5, 6, 8, 9 (`WAVE_AXIOMS.md`). The campaign autonomy
 contract (loop runs to terminal state or Legal Exit), the closed-list exits, the
 Concerns Channel, the cost-asymmetry default-forward stance, the approval-frequency
-rule (`auto` advances on a wave that PASSED **and promoted** with no per-wave human gate;
+rule (`auto` advances on a wave that PASSED **and integrated** with no per-wave human gate;
 `interactive` surfaces the verdict per wave), and user-attention-as-cost all live in that
 file. This skill is the operational binding.
 
@@ -40,6 +40,32 @@ top-level session because:
 sdlc-server tools are the runtime; **`/wavemachine` is `make all` for the wave
 compiler.**
 
+## One branch all the way through (#1052)
+
+**A campaign has exactly ONE integration branch — `campaign/<planId>-<slug>` — and it writes the
+protected branch exactly once, at the end, only if the DoD is met.** Every wave cuts a disposable
+`kahuna/<planId>-<waveId>` off the campaign branch and integrates back into it. No wave, at any
+point, merges to trunk.
+
+This replaced per-wave merge-backs to the protected branch, which carried three costs:
+
+1. **Rollback got harder.** An interim merge-back makes each wave a published trunk increment, so
+   abandoning a campaign at wave 5 means reverting 4 merges from trunk instead of deleting a branch.
+2. **It broke other people's environments.** Anyone branching off trunk mid-campaign inherited a
+   *partial* increment — half a feature, by construction.
+3. **It was never a real increment.** Nothing is deliverable until every wave lands *and* the DoD is
+   met. A merge-back claimed delivery N waves early.
+
+It also **dissolves #892** rather than mitigating it. The equality check that failed there compared a
+long-lived integration branch against a base it had been **squash**-merged into — an impossible
+comparison, because the squash rewrites the history being compared. With no interim merge-back, each
+wave's kahuna is disposable and nothing continues from it, so a squash is harmless.
+
+**The two prefixes are distinct on purpose.** git cannot hold a branch that is a directory prefix of
+another branch — `campaign/56-plan` and `campaign/56-plan/W-1` cannot coexist
+(`fatal: cannot lock ref … 'refs/heads/campaign/56-plan' exists`). Hence `campaign/…` for the
+campaign and `kahuna/…` for the waves.
+
 ## The campaign loop (§5 — this is the whole skill)
 
 Campaign state is script-held in the main session and mirrored to wave-status each
@@ -49,110 +75,134 @@ empty and nothing else (the §3.1 `plan.done`/success sentinel-collision is desi
 not guarded against).
 
 ```
-pendingWaves = approved phase/wave plan   # rehydrate prunes already-promoted
-halt = null                               # null = converging; else a HOLD reason (NEVER a success)
-waveRetry = {}; promoted = {}
+campaignBranch = campaign/<planId>-<slug>  # bootstrapped ONCE off the protected branch (#1052)
+pendingWaves = approved phase/wave plan    # rehydrate prunes already-INTEGRATED waves
+halt = null                                # null = converging; else a HOLD reason (NEVER a success)
+waveRetry = {}; integrated = {}
 MAX_WAVES = 64, MAX_WAVE_RETRY = 2, CAMPAIGN_FLOOR = 120_000
 
 loop:
   # ── CLOSED LEGAL EXITS (campaign level) ──
-  if pendingWaves empty:                         break                  # success — all waves promoted
-  if promoted.size >= MAX_WAVES:                 halt='runaway'; break  # defensive bound → human
+  if pendingWaves empty:                         break                  # loop done — all waves INTEGRATED (not yet released)
+  if integrated.size >= MAX_WAVES:               halt='runaway'; break  # defensive bound → human
   if budget.total and budget.remaining() < CAMPAIGN_FLOOR: halt='cost'; break
 
   wave    = nextPendingWave()                    # from the approved plan
-  verdict = run /nextwave for `wave`        # §3 spine → { gate, promoted, ... } (per-wave-workflow.js return)
+  verdict = run /nextwave for `wave`             # §3 spine, integrationBase=campaignBranch
+                                                 # → { gate, integrated, ... } (per-wave-workflow.js return)
 
-  # ── INTERACTIVE: a clean gate returns { gate:'PASS', promoted:false } BY DESIGN (the Workflow
-  #    never auto-promotes in interactive). Surface verdict + kahuna→protected diff, STOP for the
-  #    human; the human routes the kahuna→protected merge. Resume ONLY after they confirm it landed. ──
+  # ── INTERACTIVE: a clean gate returns { gate:'PASS', integrated:false } BY DESIGN (the Workflow
+  #    never auto-promotes in interactive). Surface verdict + kahuna→campaign diff, STOP for the
+  #    human; the human routes the kahuna→campaign merge. Resume ONLY after they confirm it landed. ──
   if MODE == 'interactive' and verdict.gate == 'PASS':
-      surface verdict + kahuna→protected diff; STOP for human
+      surface verdict + kahuna→campaignBranch diff; STOP for human
       # On resume, VERIFY the merge actually landed — do NOT advance on the operator's word alone.
       # The human (or a /nextwave interactive-promote step) records the wave's terminal disposition
-      # in wave-status when the kahuna→protected merge lands. Re-read it; advance ONLY if it is durably
-      # 'promoted' — structurally symmetric with the auto branch's verdict.promoted check (a durable
-      # FACT, not an assertion). A human "go" without a recorded promotion (conflict mid-merge, aborted,
+      # in wave-status when the kahuna→campaign merge lands. Re-read it; advance ONLY if it is durably
+      # 'promoted' — structurally symmetric with the auto branch's verdict.integrated check (a durable
+      # FACT, not an assertion). A human "go" without a recorded merge (conflict mid-merge, aborted,
       # not yet run) is NOT advanceable.
       if waveDisposition(wave) != 'promoted':       # read from wave-status (the same record auto checks)
-          halt = 'wave-hold'; break                 # not on the protected branch → human review
-      promoted.add(wave); pendingWaves.delete(wave); waveRetry[wave] = 0; continue
+          halt = 'wave-hold'; break                 # not on the campaign branch → human review
+      integrated.add(wave); pendingWaves.delete(wave); waveRetry[wave] = 0; continue
 
-  # ── AUTO: advance ONLY on PASS-AND-promoted (the #687 correctness rule) ──
-  if verdict.gate == 'PASS' and verdict.promoted == true:
-      promoted.add(wave); pendingWaves.delete(wave); waveRetry[wave] = 0; continue
+  # ── AUTO: advance ONLY on PASS-AND-integrated (the #687 correctness rule, #1052 vocabulary) ──
+  if verdict.gate == 'PASS' and (verdict.integrated == true or verdict.promoted == true):
+      integrated.add(wave); pendingWaves.delete(wave); waveRetry[wave] = 0; continue
 
-  # AUTO gate:'PASS' with promoted:false (kahuna→protected merge did NOT land — the Workflow's
+  # AUTO gate:'PASS' with integrated:false (kahuna→campaign merge did NOT land — the Workflow's
   # promote node soft-failed and recorded the wave HELD) falls through here. It is NOT advanceable:
-  # the wave's CODE is sound but it is not on the protected branch → HOLD for human attention.
+  # the wave's CODE is sound but it is not on the campaign branch → HOLD for human attention.
   if (waveRetry[wave] = (waveRetry[wave]||0)+1) > MAX_WAVE_RETRY: halt=`wave-breaker:${wave}`; break
-  halt = 'wave-hold'; break                       # HOLD | SKIPPED | (auto) PASS-not-promoted → human review
+  halt = 'wave-hold'; break                       # HOLD | SKIPPED | (auto) PASS-not-integrated → human review
+
+# ── RELEASE (#1052) — reached ONLY on the clean loop exit; the campaign's single trunk write ──
+if halt == null:
+    dod = verify the DoD against campaignBranch's actual tree   # not the checkboxes
+    if every wave in the FULL plan integrated and dod.met == true:
+        merge campaignBranch → protectedBranch    # ONE PR, its own CI run, then close the issues
+    else:
+        HOLD — protectedBranch untouched, campaignBranch preserved for inspection/resume
 ```
+
+**`integrated` is not `released`.** The loop emptying `pendingWaves` means every wave is on the
+campaign branch; it does **not** mean anything shipped. The release is a separate, single, DoD-gated
+event — and a campaign that holds there is a campaign awaiting its DoD, not a failed one (the work
+is durable on the campaign branch and fully resumable). The `verdict.promoted` fallback in the
+advance predicate is the legacy-record path: a wave recorded by a pre-#1052 engine mid-campaign
+still advances rather than stalling the upgrade.
 
 On every `continue` (the OK-path that advances to the next wave), the next iteration's
 launch is a **single tool-use boundary** — it follows the **Per-wave handoff (no narrator
 gap)** contract below: no narrative text between waves.
 
-**CRITICAL — advance ONLY on PASS AND promoted.** `verdict.gate === 'PASS'` is NOT
-sufficient. The per-wave Workflow (`per-wave-workflow.js`) returns `{ gate, promoted, ... }`,
+**CRITICAL — advance ONLY on PASS AND integrated.** `verdict.gate === 'PASS'` is NOT
+sufficient. The per-wave Workflow (`per-wave-workflow.js`) returns `{ gate, integrated, … }`,
 and the two are distinct facts:
 
-- `{ gate: 'PASS', promoted: true }` — trust gate passed **and** the kahuna→protected merge
-  landed. In `auto` this is the only auto-advanceable verdict. Add to `promoted`, drop from
+- `{ gate: 'PASS', integrated: true }` — trust gate passed **and** the kahuna→campaign-branch
+  merge landed. In `auto` this is the only auto-advanceable verdict. Add to `integrated`, drop from
   `pendingWaves`.
-- `{ gate: 'PASS', promoted: false }` — the trust gate passed but the wave is NOT on the
-  protected branch. Two causes, distinguished by mode:
-  - **`auto`:** the promote node soft-failed — the kahuna→protected merge **did not land** and
+- `{ gate: 'PASS', integrated: false }` — the trust gate passed but the wave is NOT on the
+  campaign branch. Two causes, distinguished by mode:
+  - **`auto`:** the promote node soft-failed — the kahuna→campaign merge **did not land** and
     the Workflow recorded the wave HELD. → **HOLD for human attention, do NOT advance.** Treating
-    this as success would mark a wave done while its code never reached the protected branch.
+    this as success would mark a wave done while its code never reached the campaign branch, and the
+    release gate would later count it as integrated on the strength of a merge that never happened.
   - **`interactive`:** the Workflow never auto-promotes by design — it returns the clean verdict
     for the human to route. → STOP, surface the diff, and on resume advance **only if wave-status
     durably records the wave `promoted`** — the same fact the auto branch reads off the verdict, now
     read off the durable record. The operator's "go" alone is not sufficient: a go without a recorded
-    promotion (mid-merge conflict, aborted, not yet run) HOLDs (`wave-hold`). Interactive is thus
-    structurally symmetric with auto — both require a durable `promoted` fact, never an assertion.
+    merge (mid-merge conflict, aborted, not yet run) HOLDs (`wave-hold`). Interactive is thus
+    structurally symmetric with auto — both require a durable fact, never an assertion.
 - `{ gate: 'HOLD' }` / `{ gate: 'SKIPPED' }` — a trust signal failed, or the flight loop hit a
   HOLD exit before the gate → wave-hold (both modes).
 
-The auto-advance predicate is therefore `gate === 'PASS' && promoted === true`, evaluated
-against the verdict's own fields — never inferred from `gate` alone. In `interactive`, the
-PASS verdict (necessarily `promoted:false`) gates on the human routing the promotion **and** on
+The auto-advance predicate is therefore `gate === 'PASS' && integrated === true`, evaluated
+against the verdict's own fields — never inferred from `gate` alone. (`promoted === true` is
+accepted as the same fact under its legacy name, so a wave recorded by a pre-#1052 engine does not
+stall a mid-campaign upgrade.) In `interactive`, the
+PASS verdict (necessarily `integrated:false`) gates on the human routing the merge **and** on
 wave-status durably recording it `promoted` — the human owns the *decision*, the durable record
 is the *fact* the loop advances on.
 
 **Mode is a one-line advance-vs-wait branch, NOT two architectures.** `auto` advances on
-PASS-and-promoted (a verdict fact); `interactive` runs the wave Workflow in interactive mode
-(which returns `{ gate:'PASS', promoted:false }` on a clean gate), surfaces the verdict +
-kahuna→protected diff, STOPS for the human, and — once the human routes the promotion — advances
+PASS-and-integrated (a verdict fact); `interactive` runs the wave Workflow in interactive mode
+(which returns `{ gate:'PASS', integrated:false }` on a clean gate), surfaces the verdict +
+kahuna→campaign diff, STOPS for the human, and — once the human routes the merge — advances
 **only if wave-status records the wave `promoted`** (a durable fact). Both run the identical loop
-body and both gate on a durable `promoted` fact; only *where* that fact comes from (the verdict
+body and both gate on a durable landed-fact; only *where* that fact comes from (the verdict
 vs. the post-STOP wave-status read) differs.
 
 ## Closed campaign-exit set (mirrors §3.1)
 
 | Exit | Condition | Meaning |
 |---|---|---|
-| success | `pendingWaves` empty | every wave promoted to the protected branch |
-| runaway | `promoted ≥ MAX_WAVES` | defensive bound → human |
+| success | `pendingWaves` empty | every wave integrated onto the campaign branch → the release gate runs |
+| runaway | `integrated ≥ MAX_WAVES` | defensive bound → human |
 | cost | budget floor | stop before the ceiling |
-| wave-hold | a wave returns HOLD/SKIPPED, **or (auto) PASS-but-not-promoted** | the per-wave gate fired, or the gate passed but the kahuna→protected merge did not land → human review |
-| wave-breaker | a wave hit a non-advanceable verdict > `MAX_WAVE_RETRY` times | one wave won't reach PASS-and-promoted → human |
+| wave-hold | a wave returns HOLD/SKIPPED, **or (auto) PASS-but-not-integrated** | the per-wave gate fired, or the gate passed but the kahuna→campaign merge did not land → human review |
+| wave-breaker | a wave hit a non-advanceable verdict > `MAX_WAVE_RETRY` times | one wave won't reach PASS-and-integrated → human |
+| release-hold | the loop completed but the DoD is not met (or is undeterminable) | **not a failure** — the protected branch is untouched and the campaign branch holds every wave; resumable once the DoD genuinely holds (#1052) |
 
 - **`waveRetry` counts EVERY non-advanceable verdict, regardless of cause.** A trust-gate `HOLD`,
-  a `SKIPPED`, and an auto PASS-but-not-promoted all increment the same counter — the campaign
+  a `SKIPPED`, and an auto PASS-but-not-integrated all increment the same counter — the campaign
   re-runs the wave (the inner Workflow rehydrates and resumes its loop) until it either reaches
-  PASS-and-promoted or burns `MAX_WAVE_RETRY` attempts and trips `wave-breaker`. "Retry" here is
+  PASS-and-integrated or burns `MAX_WAVE_RETRY` attempts and trips `wave-breaker`. "Retry" here is
   "the wave was re-driven", not specifically "an issue was reworked" (the inner §3.1 per-issue
   rework breaker is a separate, finer-grained guard). The single counter is deliberate: the
-  campaign does not distinguish *why* a wave failed to land — a wave that can't reach the protected
+  campaign does not distinguish *why* a wave failed to land — a wave that can't reach the campaign
   branch after N attempts needs a human either way.
 - **No campaign-level planner → no `plan done`/success collision.** Waves come from the
   pre-approved plan; there is no planner verdict to misread.
-- **Progress is structural.** Each iteration either promotes a wave (`PASS` **and** `promoted`)
+- **Progress is structural.** Each iteration either integrates a wave (`PASS` **and** `integrated`)
   or halts — a campaign iteration cannot make zero net progress and continue, so no idle-round
   detector is needed; the retry breaker covers a wave that repeatedly fails to reach
-  PASS-and-promoted. A `gate:'PASS'` that did not promote is NOT progress: it does not advance,
+  PASS-and-integrated. A `gate:'PASS'` that did not integrate is NOT progress: it does not advance,
   it HOLDs (auto) or waits on the human (interactive).
+- **`release-hold` is conservative on absence.** An unreadable DoD manifest, a malformed verdict, or
+  an errored DoD node all block the release: an undeterminable DoD is not a met DoD (SEAMS invariant
+  6). Holding costs a conversation; releasing wrongly costs a revert of the whole campaign.
 
 ## Pre-flight (refuse to start on failure)
 
@@ -194,10 +244,30 @@ then accrues the numerator (`per-wave-workflow.js`, #1026 incr 2).
 1. Set the `wavemachine_active` flag (`wave-status wavemachine-start --launcher main`).
    Unset it on EVERY exit path (`wave-status wavemachine-stop`) — treat as a `finally`.
 2. Regenerate + open the status panel (`generate-status-panel` then `xdg-open`).
-3. **Pre-wave kahuna bootstrap** — once per Plan: `wave_init` with `kahuna:{plan_id, slug}`
-   creates `kahuna/<plan_id>-<slug>` off the protected branch and writes `kahuna_branch`
-   into wave state. Idempotent — a resume invocation sees the field populated and skips.
-   Every per-wave Workflow is launched with that `kahunaBranch`.
+3. **Campaign-branch bootstrap (#1052)** — once per Plan: ensure `campaign/<plan_id>-<slug>` exists
+   on origin, cut from the **current tip of the protected branch**, and push it. Then thread it into
+   every per-wave launch as `integrationBase`.
+
+   **Create-or-reuse, and reuse wins.** On a resume the branch already exists and carries every
+   previously-integrated wave, so re-cutting it from the protected branch would silently discard the
+   whole campaign to date. Verify by reading the ref back (`git rev-parse origin/campaign/…`), not by
+   the push's exit code.
+
+   **If the branch can be neither found nor created, the campaign ABORTS.** Do not substitute the
+   protected branch as a fallback: that recovery is exactly the per-wave trunk write this shape
+   exists to prevent. No campaign branch, no campaign.
+
+   Each wave then gets its own disposable `kahuna/<plan_id>-<waveId>`, cut off the campaign branch by
+   the per-wave Workflow's KAHUNA-BOOTSTRAP node (create-or-reuse, read-back verified, fail-loud —
+   never re-cut an existing one, which would discard the flights already integrated into it).
+
+   **A plan-supplied `kahuna_branch` is IGNORED inside a campaign** (the override is logged, not
+   silent). `wave_init`'s `kahuna:{plan_id, slug}` bootstraps ONE plan-scoped `kahuna/<plan_id>-<slug>`
+   off the plan's `base_branch` — shared across every wave and based on trunk. Both properties are
+   wrong here: a campaign wave's kahuna is *disposable*, so wave 1's promote would delete wave 2's
+   base; and a trunk-based branch gives wave 2 a baseline missing wave 1's integrated work. The
+   campaign branch is a separate, client-side ref — and the two prefixes must stay distinct because
+   git cannot hold a branch that is a directory prefix of another branch.
 4. Announce to `#wave-status`; emit `mcp-log wavemachine_start`.
 
 ## Launching a wave (the input blob — consistent with `/nextwave`)
@@ -210,15 +280,20 @@ campaign driver supplies, per wave, from the approved phase/wave plan + project 
 |---|---|
 | `waveId`, `issues` | `nextPendingWave()` + that wave's issue list (single repo, §4.1) |
 | `targetRepo`, `targetRepoDir` | the wave's resolved repo + its durable clone dir |
-| `kahunaBranch` | the per-Plan `kahuna_branch` from the launch-sequence bootstrap (step 3) |
-| `protectedBranch` | from `.claude-project.md` |
+| `kahunaBranch` | this wave's **disposable** integration branch, `kahuna/<planId>-<waveId>` (namespaced by plan so two concurrent campaigns can't collide on `kahuna/W-1`) |
+| `integrationBase` | **the campaign branch** from the launch-sequence bootstrap (step 3). This is where the wave lands (#1052). |
+| `protectedBranch` | from `.claude-project.md`. Passed so the engine can *recognize* trunk — it derives "am I in a campaign?" from `integrationBase !== protectedBranch`, which is what retires `preserveKahuna` and moves the platform issue-close to the release node. Omit it and the engine defaults to `'main'` and mis-detects a campaign on any repo whose trunk is named otherwise. |
 | `mode` | the campaign's `MODE` (`auto` \| `interactive`) — passed through unchanged |
 | `planId` | the wave Plan id (the promote node assembles the MR body from it) |
 | `budget` | the campaign cost guard, if any |
 
-The verdict consumed back is exactly `per-wave-workflow.js`'s return — `{ gate, promoted, … }`
+**`preserveKahuna` is deliberately NOT threaded (#1052).** The branch that must survive across waves
+is the campaign branch, and it does; each wave's kahuna is disposable again. A campaign wave ignores
+the flag even if a stale launcher passes it.
+
+The verdict consumed back is exactly `per-wave-workflow.js`'s return — `{ gate, integrated, … }`
 — routed by the loop above. The driver passes `mode` straight through: in `interactive` the
-Workflow returns `{ gate:'PASS', promoted:false }` on a clean gate (it never auto-promotes),
+Workflow returns `{ gate:'PASS', integrated:false }` on a clean gate (it never auto-promotes),
 which the loop's interactive branch turns into the human STOP.
 
 ## Per-wave handoff (no narrator gap)
@@ -289,18 +364,25 @@ stalled). Following this section alone is sufficient to recover; no source/memor
 ## Resumability (mirrors §3.3, one level up)
 
 On cold start the campaign rehydrates from wave-status's wave-completion records
-(`wave_previous_merged` / `wave_topology`) and skips already-promoted waves;
-`promoted` / `pendingWaves` seed from there. Same durable substrate as the inner loop.
+(`wave_previous_merged` / `wave_topology`) and skips already-integrated waves;
+`integrated` / `pendingWaves` seed from there. Same durable substrate as the inner loop.
 
-A wave is "already-promoted" (and therefore pruned from `pendingWaves` on resume) only when
+A wave is "already-integrated" (and therefore pruned from `pendingWaves` on resume) only when
 its per-wave Workflow recorded the terminal disposition `promoted` — i.e. `gate:'PASS'` **and**
-the kahuna→protected merge landed (`persistTerminal('promoted', …)`, SEAM #688). A wave whose
-Workflow recorded `held` (gate PASS-but-not-promoted, HOLD, or SKIPPED) is NOT pruned — it
+the kahuna→campaign merge landed (`persistTerminal('promoted', …)`, SEAM #688). A wave whose
+Workflow recorded `held` (gate PASS-but-not-integrated, HOLD, or SKIPPED) is NOT pruned — it
 re-enters `pendingWaves` and the campaign re-runs it. This is the resume-side mirror of the
-advance rule: the same fact (did the wave reach the protected branch?) gates both the live
+advance rule: the same fact (did the wave land on its integration base?) gates both the live
 advance and the cold-start prune, so a resumed campaign never skips a wave that only *looked*
 done. The per-wave Workflow itself rehydrates its own inner loop state (`per-wave-workflow.js`
 rehydrate phase, SEAM #686) — the campaign driver only tracks wave-grain completion.
+
+**The prune predicate is INTEGRATED, not released (#1052).** Nothing is released until the campaign
+ends, so a released-keyed rehydrate would prune nothing and re-run the entire campaign on every
+resume. Equally, a resumed run must carry its pre-run integrations forward into the release gate:
+that gate judges completeness against the **full plan**, and a resumed run's own advance list covers
+only its slice, so without the rehydrated set a resumed campaign could never satisfy completeness and
+would hold forever with every wave actually integrated.
 
 ## Exhaustive Legal Exits
 
@@ -322,10 +404,18 @@ absence of those is presumption of healthy operation.
   session can launch a Workflow.)
 - **The per-wave Workflow owns all wave-internal work.** `/wavemachine` only launches
   one per wave and routes on its verdict — it never spawns flights/Prime/reconcile itself.
-- **The kahuna→protected merge is the per-wave Workflow's trust-gate job**, not the
-  campaign driver's. The driver advances on `PASS` **AND** `promoted` (auto), or on the human's
-  confirmation that the merge landed (interactive); it never merges to the protected branch
-  itself. A `gate:'PASS'` without `promoted` is never treated as advanceable.
+- **The kahuna→campaign-branch merge is the per-wave Workflow's trust-gate job**, not the
+  campaign driver's. The driver advances on `PASS` **AND** `integrated` (auto), or on the human's
+  confirmation that the merge landed (interactive); it never merges a wave itself. A `gate:'PASS'`
+  without `integrated` is never treated as advanceable.
+- **The campaign→protected merge happens EXACTLY ONCE, at the end, and only if the DoD is met
+  (#1052).** No wave may write the protected branch. The DoD is verified against the campaign
+  branch's actual tree, not its checkboxes, and an undeterminable DoD blocks the release.
+- **Issues close at the release, not at each wave (#1046).** A wave's merge records durable engine
+  state (`wave_close_issue`); the platform close (`gh issue close` / `glab issue close`) runs in the
+  release node after the trunk merge. A closed issue is the board's claim that the work is delivered
+  — closing at wave N makes that claim early, and an aborted campaign would leave closed issues for
+  work that was deleted.
 - **Per-wave handoff is a single tool-use boundary** — no inter-wave narration.
 - **Structured blocker report on any abort** — name the wave (or failing signals), the
   exit type, and the remediation path.

--- a/tests/regression/campaign_loop.mjs
+++ b/tests/regression/campaign_loop.mjs
@@ -9,11 +9,19 @@ import {
   parseArgs,
   computePending,
   waveIdOf,
+  campaignBranchFor,
+  waveKahunaFor,
+  isIntegrated,
   resolveIntentTier,
   routeVerdict,
   routeJudgment,
+  routeRelease,
   runCampaign,
   waveOversightPrompt,
+  dodVerificationPrompt,
+  releaseMergePrompt,
+  DOD_VERDICT,
+  RELEASE_RESULT,
   JUDGMENT_RESULT,
 } from '../../skills/nextwave/campaign-loop.js'
 
@@ -53,12 +61,65 @@ ok(computePending(allWaves, ['wave-1', 'wave-2', 'wave-3', 'wave-4']).length ===
 // idempotent: same promoted set → same pending
 ok(JSON.stringify(computePending(allWaves, ['wave-1'])) === JSON.stringify(computePending(allWaves, ['wave-1'])), 'computePending is idempotent')
 
+// ── #1052 branch topology (campaign/ vs kahuna/ — the git D/F constraint) ─────
+ok(campaignBranchFor({ planId: 56, slug: 'Blueshift Plan' }) === 'campaign/56-blueshift-plan', 'campaignBranchFor: campaign/<planId>-<slug>, slugified')
+ok(waveKahunaFor({ planId: 56, waveId: 'W-1' }) === 'kahuna/56-W-1', 'waveKahunaFor: kahuna/<planId>-<waveId> (plan-namespaced — two campaigns cannot collide on kahuna/W-1)')
+// The prefixes MUST differ: git cannot hold a branch that is a directory prefix of another branch
+// (`campaign/56-x` + `campaign/56-x/W-1` → fatal: cannot lock ref … exists). A shared prefix would
+// make every wave branch unrepresentable, so this is a correctness assertion, not cosmetics.
+{
+  const camp = campaignBranchFor({ planId: 56, slug: 'x' })
+  const kah = waveKahunaFor({ planId: 56, waveId: 'W-1' })
+  ok(!kah.startsWith(`${camp}/`) && !camp.startsWith(`${kah}/`), '#1052: wave kahuna is NOT a path-child of the campaign branch (git D/F ref conflict)')
+}
+ok(waveKahunaFor({ waveId: 'W-1' }) === 'kahuna/W-1', 'waveKahunaFor without planId → kahuna/<waveId>')
+// The campaign slug is human-typed (a plan title), so a case-only restatement must NOT resolve to a
+// second campaign branch — git refs are case-sensitive but macOS/Windows checkouts are not, so the
+// two could never coexist anyway. The waveId is engine-generated and stays verbatim (one wave, one
+// spelling, matching resume.js's flight-branch names).
+ok(campaignBranchFor({ planId: 56, slug: 'BlueShift PLAN' }) === campaignBranchFor({ planId: 56, slug: 'blueshift plan' }),
+  '#1052: campaign branch is case-INSENSITIVE in the slug (a retitled plan must not fork a second campaign branch)')
+ok(waveKahunaFor({ planId: 56, waveId: 'W-1' }) !== waveKahunaFor({ planId: 56, waveId: 'w-1' }),
+  '#1052: waveId casing is preserved verbatim (resume.js builds flight branches + its cleanup glob from the same un-lowercased id)')
+
+// ── isIntegrated (the landed predicate, incl. the legacy-record path) ─────────
+ok(isIntegrated({ integrated: true }) === true, 'isIntegrated: integrated:true → landed')
+ok(isIntegrated({ integrated: false, promoted: true }) === false, 'isIntegrated: explicit integrated:false WINS over a stale promoted:true')
+ok(isIntegrated({ promoted: true }) === true, 'isIntegrated: legacy record (promoted only) → landed — a mid-campaign engine upgrade must not stall')
+ok(isIntegrated({ promoted: false }) === false, 'isIntegrated: legacy record, not landed')
+ok(isIntegrated({}) === false && isIntegrated(null) === false, 'isIntegrated: absence → not landed (conservative)')
+
 // ── routeVerdict ──────────────────────────────────────────────────────────────
-ok(routeVerdict({ gate: 'PASS', promoted: true }).advance === true, 'routeVerdict PASS+promoted → advance')
-ok(routeVerdict({ gate: 'PASS', promoted: false }).advance === false, 'routeVerdict PASS+!promoted → HOLD (promoted≠delivered)')
+ok(routeVerdict({ gate: 'PASS', integrated: true }).advance === true, 'routeVerdict PASS+integrated → advance')
+ok(routeVerdict({ gate: 'PASS', integrated: false }).advance === false, 'routeVerdict PASS+!integrated → HOLD (integrated≠delivered)')
+ok(routeVerdict({ gate: 'PASS', promoted: true }).advance === true, 'routeVerdict PASS+promoted (legacy record) → advance')
+ok(routeVerdict({ gate: 'PASS', promoted: false }).advance === false, 'routeVerdict PASS+!promoted → HOLD')
 ok(routeVerdict({ gate: 'HOLD' }).advance === false, 'routeVerdict HOLD → hold')
 ok(routeVerdict({ gate: 'SKIPPED' }).advance === false, 'routeVerdict SKIPPED → hold')
 ok(routeVerdict({}).advance === false, 'routeVerdict {} → hold (conservative)')
+
+// ── #1052 routeRelease — the SINGLE protected-branch write predicate ──────────
+const PLAN = [{ id: 'w1' }, { id: 'w2' }, { id: 'w3' }]
+const MET = { met: true }
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: ['w1', 'w2', 'w3'] }, allWaves: PLAN, dod: MET }).release === true, 'routeRelease: complete plan + DoD met → RELEASE')
+ok(routeRelease({ report: { outcome: 'held', heldAt: 'w2', wavesAdvanced: ['w1'] }, allWaves: PLAN, dod: MET }).release === false, 'routeRelease: campaign held → block (even with a met DoD)')
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: ['w1', 'w2'] }, allWaves: PLAN, dod: MET }).release === false, 'routeRelease: plan INCOMPLETE (w3 missing) → block — completeness is judged against the FULL plan, not this run')
+// The resume case: a run that only advanced w3 still releases, because w1/w2 are durably integrated.
+// Without alreadyIntegrated a resumed campaign could NEVER satisfy completeness and would hold
+// forever with every wave actually integrated.
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: ['w3'], alreadyIntegrated: ['w1', 'w2'] }, allWaves: PLAN, dod: MET }).release === true, 'routeRelease: resumed run + alreadyIntegrated → RELEASE (slice-independent)')
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: ['w1', 'w2', 'w3'] }, allWaves: PLAN, dod: { met: false, unmet: ['AC3'] } }).release === false, 'routeRelease: DoD NOT met → block (this is why one-merge-at-the-end is a gate, not decoration)')
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: ['w1', 'w2', 'w3'] }, allWaves: PLAN, dod: null }).release === false, 'routeRelease: DoD verdict ABSENT → block (an undeterminable DoD is not a met DoD)')
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: ['w1', 'w2', 'w3'] }, allWaves: PLAN, dod: { met: 'yes' } }).release === false, 'routeRelease: malformed DoD (met not === true) → block')
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: [] }, allWaves: [], dod: MET }).release === false, 'routeRelease: empty plan → block (a campaign with no waves is a misconfiguration, not a no-op)')
+ok(routeRelease({}).release === false, 'routeRelease({}) → block (conservative on absence)')
+// A wave id that is not in the plan is not evidence ABOUT the plan. alreadyIntegrated is
+// agent-reported and feeds the completeness half of the ONE trunk-write predicate, so a bogus id
+// must not be able to shrink missing[] into a release. (campaign-workflow.js filters to the plan's
+// id set before this call; this pins that routeRelease does not itself credit unknown ids.)
+ok(routeRelease({ report: { outcome: 'completed', wavesAdvanced: ['w1'], alreadyIntegrated: ['w2', 'nope', 'also-not-a-wave'] }, allWaves: PLAN, dod: MET }).release === false,
+  '#1052: unknown wave ids in alreadyIntegrated do NOT satisfy completeness (w3 still missing)')
+ok(typeof routeRelease({}).reason === 'string' && routeRelease({}).reason.length > 0, 'routeRelease always carries a human-readable reason')
 
 // ── routeJudgment ─────────────────────────────────────────────────────────────
 ok(routeJudgment({ continue: true }).advance === true, 'routeJudgment continue:true → advance')
@@ -170,6 +231,28 @@ async function main() {
   ok(waveOversightPrompt({ intentTier: 'issues-only' }).includes('ISSUES-ONLY tier'), 'lens: issues-only tier calibration')
   ok(/kahuna\/w2/.test(prompt), 'lens: names the kahuna branch for live inspection')
   ok(JUDGMENT_RESULT.required.includes('continue') && JUDGMENT_RESULT.additionalProperties === false, 'JUDGMENT_RESULT schema requires continue, no extra props')
+
+  // ── #1052 the release nodes — DoD verification, then the ONE trunk merge ──
+  const dodP = dodVerificationPrompt({ planId: '56', targetRepo: 'o/r', targetRepoDir: '/tmp/r', campaignBranch: 'campaign/56-x', protectedBranch: 'main', wavesIntegrated: ['w1', 'w2'] })
+  ok(/campaign\/56-x/.test(dodP), 'dod prompt: verifies against the CAMPAIGN branch')
+  ok(/plan_load_dod/.test(dodP), 'dod prompt: loads the plan DoD (the criteria, not an invented list)')
+  // The DoD node must ANSWER, never act — a node that could merge would make routeRelease advisory.
+  ok(!/pr_merge\b/.test(dodP) && !/gh pr merge/.test(dodP), 'dod prompt: NEVER merges — it answers; routing is the pure predicate\'s job')
+  ok(DOD_VERDICT.required.includes('met') && DOD_VERDICT.additionalProperties === false, 'DOD_VERDICT schema requires met, no extra props')
+
+  const relP = releaseMergePrompt({ planId: '56', targetRepo: 'o/r', campaignBranch: 'campaign/56-x', protectedBranch: 'main', wavesIntegrated: ['w1', 'w2'] })
+  ok(/campaign\/56-x/.test(relP) && /main/.test(relP), 'release prompt: names both refs (campaign → protected)')
+  // A wave's pipeline ran against the campaign branch, which drifts from trunk — so the release
+  // needs its OWN merge-result CI run against current trunk. A branch-CI signal is weaker.
+  ok(/require_merge_result/.test(relP), 'release prompt: gates on a MERGE-RESULT CI run (no per-wave pipeline tested this diff against current trunk)')
+  ok(/ci_wait_run/.test(relP), 'release prompt: waits on that CI run before merging')
+  ok(/Refs #/.test(relP), 'release prompt: honors Refs #N (do-not-close) when closing issues (#1046)')
+  ok(RELEASE_RESULT.required.includes('released') && RELEASE_RESULT.additionalProperties === false, 'RELEASE_RESULT schema requires released, no extra props')
+
+  // The oversight lens must know BOTH branches, so a mid-campaign `promoted:false` reads as the
+  // normal state it now is (nothing has shipped yet) rather than as catalog-I evidence.
+  const campPrompt = waveOversightPrompt({ justLanded: { wave: 'w2' }, trajectory: [], remainingPlan: ['w3'], intentTier: 'issues-only', kahunaBranch: 'kahuna/56-w2', campaignBranch: 'campaign/56-x', protectedBranch: 'main' })
+  ok(/campaign\/56-x/.test(campPrompt), 'lens: names the campaign branch (where the wave INTEGRATED)')
 
   console.log('')
   if (failed > 0) {

--- a/tests/regression/gate_signals_roundtrip.mjs
+++ b/tests/regression/gate_signals_roundtrip.mjs
@@ -9,7 +9,7 @@
 //      diff-scoped (the §3.4 refinement: changed-files, never the whole tree).
 //   3. the CI prompt's pass predicate is final_status == "success" and nothing else (#898).
 //   4. the promote prompt is wave_finalize → pr_merge → delete-branch (CODE ONLY), and reports
-//      promoted ONLY once the merge is observable on the protected branch.
+//      promoted ONLY once the merge is observable on the integration base.
 
 import assert from 'node:assert/strict'
 import {
@@ -33,7 +33,11 @@ const bad = (name, e) => { console.log(`  [FAIL] ${name}: ${e?.message || e}`); 
 console.log('test_gate_signals_roundtrip')
 console.log('──────────────────────────────────────────')
 
-const A = { waveId: 'W-7', kahunaBranch: 'kahuna/692-x', protectedBranch: 'main', targetRepo: 'org/repo', targetRepoDir: '/tmp/repo' }
+// #1052: the gate's merge target is `integrationBase`, NOT `protectedBranch`. Inside a campaign the
+// base is the campaign branch and the protected branch is written exactly once, by the campaign's
+// release gate — so the fixture uses a CAMPAIGN branch. A stray `main` in any gate prompt is a real
+// failure: it would mean a wave prompt hard-codes trunk instead of honoring the base it was handed.
+const A = { waveId: 'W-7', kahunaBranch: 'kahuna/692-x', integrationBase: 'campaign/692-x', targetRepo: 'org/repo', targetRepoDir: '/tmp/repo' }
 const PR = 4242 // the draft promotion PR the gate opens (#5); threaded into ci + promote
 
 // ── 1. conservative-fail: an errored signal HOLDs, never PASSes ───────────────────────
@@ -58,7 +62,8 @@ try {
   assert.match(c, /STRONG/); assert.match(c, /MEDIUM/)
   assert.match(c, /PROBE_UNAVAILABLE/) // the conservative-fail verdict is named
   assert.match(c, /ORACLE_REQUIRED/) // #6: gate HOLDs on ORACLE_REQUIRED (named explicitly)
-  assert.match(c, new RegExp(A.protectedBranch)) // base_ref is the protected branch
+  assert.match(c, new RegExp(A.integrationBase.replace('/', '\\/'))) // base_ref is the INTEGRATION BASE (#1052)
+  assert.ok(!/base_ref=undefined/.test(c), 'base_ref must never render undefined (a renamed param silently voids the probe scope)')
   ok('commutativity prompt: commutativity_verify + STRONG/MEDIUM + PROBE_UNAVAILABLE + ORACLE_REQUIRED fail (#6)')
 
   const ci = ciSignalPrompt({ ...A, prNumber: PR })
@@ -69,7 +74,7 @@ try {
   // #476: the gate must REQUIRE a merge-result pipeline. Without this flag the tool
   // will happily grade a branch pipeline — or a SKIPPED one, which GitLab normalizes
   // to "success" — as though it validated the merge. That is a silent false PASS on
-  // the only thing standing between an autonomous wave and the protected branch.
+  // the only thing standing between an autonomous wave and the integration base.
   assert.match(ci, /require_merge_result=true/)
   // #476: the freshness anchor. Without pr_number the tool cannot prove the run it
   // grades belongs to the CURRENT head — a green merge-result run for a PREVIOUS
@@ -81,9 +86,9 @@ try {
   assert.match(ci, /do NOT search for it/i) // #5: deterministic, no race to "find" the PR
   ok('ci prompt: ci_wait_run on the gate-opened PR (#5) + MERGE-RESULT + success-only + diff-scoped (#452, §3.4)')
 
-  // #5 — the gate opens the kahuna→protected DRAFT PR FIRST (before the signals)
+  // #5 — the gate opens the kahuna→base DRAFT PR FIRST (before the signals)
   const op = openPromotionPrPrompt({ ...A, planId: 692 })
-  assert.match(op, /wave_finalize/) // opens the kahuna→protected MR
+  assert.match(op, /wave_finalize/) // opens the kahuna→integrationBase MR
   assert.match(op, /DRAFT/) // as a draft (can't auto-merge before the gate decides)
   assert.match(op, /idempotent/i) // re-open returns the existing PR
   assert.match(op, /do NOT merge/i) // PR-open node never merges
@@ -95,29 +100,29 @@ try {
   assert.equal(OPEN_PR_RESULT.properties.pr_number.type, 'integer')
   ok('open-pr prompt: wave_finalize DRAFT, idempotent, never merges; OPEN_PR_RESULT requires boolean opened (#5)')
 
-  // #847/ENG-5: review is a 2-step stage→review sub-pipeline; diff is origin/<protected>...origin/<kahuna>,
-  // NEVER a hard-coded `main`. Use a release-branch fixture so a stray `origin/main` is a real failure.
+  // #847/ENG-5: review is a 2-step stage→review sub-pipeline; diff is origin/<base>...origin/<kahuna>,
+  // NEVER a hard-coded `main`. Use a non-default base fixture so a stray `origin/main` is a real failure.
   const RVW = {
-    waveId: 'W-7', kahunaBranch: 'kahuna/692-x', protectedBranch: 'release',
+    waveId: 'W-7', kahunaBranch: 'kahuna/692-x', integrationBase: 'release',
     targetRepo: 'org/repo', targetRepoDir: '/tmp/repo',
     workspaceDir: '/tmp/rvw-wt', changedFiles: ['src/a.js', 'src/b.py'],
   }
   const stage = reviewStagePrompt(RVW)
   assert.match(stage, /fetch origin release kahuna\/692-x/) // fetches BOTH refs by name (never assumes main)
-  assert.match(stage, /origin\/release\.\.\.origin\/kahuna\/692-x/) // diffs origin/<protected>...origin/<kahuna>
+  assert.match(stage, /origin\/release\.\.\.origin\/kahuna\/692-x/) // diffs origin/<base>...origin/<kahuna>
   assert.match(stage, /CONSERVATIVE-FAIL/i) // empty/failed stage HOLDs, never silent pass
-  assert.ok(!/origin\/main/.test(stage), 'stage must NOT reference origin/main (protected=release)')
+  assert.ok(!/origin\/main/.test(stage), 'stage must NOT reference origin/main (base=release)')
   assert.equal(REVIEW_STAGE.required[0], 'staged')
   assert.equal(REVIEW_STAGE.properties.staged.type, 'boolean')
-  ok('review STAGE prompt: fetch+diff origin/<protected>...origin/<kahuna>, conservative-fail on empty (ENG-5)')
+  ok('review STAGE prompt: fetch+diff origin/<base>...origin/<kahuna>, conservative-fail on empty (ENG-5)')
 
   const rv = reviewSignalPrompt(RVW)
-  assert.match(rv, /origin\/release\.\.\.origin\/kahuna\/692-x/) // base-ref: origin/<protected>...origin/<kahuna>
-  assert.ok(!/origin\/main/.test(rv), 'review prompt must NEVER reference origin/main (protected=release)')
+  assert.match(rv, /origin\/release\.\.\.origin\/kahuna\/692-x/) // base-ref: origin/<base>...origin/<kahuna>
+  assert.ok(!/origin\/main/.test(rv), 'review prompt must NEVER reference origin/main (base=release)')
   assert.match(rv, /CHANGED FILES/) // diff-scoped (§3.4)
   assert.match(rv, /src\/a\.js/) // scoped to the staged changed-file set
   assert.match(rv, /critical/i); assert.match(rv, /important/i) // pass predicate
-  ok('review prompt: reads staged workspace + origin/<protected>...origin/<kahuna> + diff-scoped (ENG-5, §3.4)')
+  ok('review prompt: reads staged workspace + origin/<base>...origin/<kahuna> + diff-scoped (ENG-5, §3.4)')
 
   const tv = trivySignalPrompt(A)
   assert.match(tv, /trivy fs --scanners vuln --severity HIGH,CRITICAL/)
@@ -137,7 +142,7 @@ try {
   assert.match(p, /pr ready|mark it ready/i) // un-draft the existing PR before merging
   assert.match(p, /pr_merge/)
   assert.doesNotMatch(p, /skip_train/) // #898: queue-less — no train to skip
-  assert.match(p, /pr_merge_wait/) // confirm the merge is observable on the protected branch
+  assert.match(p, /pr_merge_wait/) // confirm the merge is observable on the integration base
   assert.match(p, /delete/i) // kahuna branch deleted after promotion
   // promoted:true ONLY if the merge actually landed (no fabricated success)
   assert.match(p, /promoted \(true ONLY if the merge actually landed/)

--- a/tests/regression/test_campaign_branch_guards.sh
+++ b/tests/regression/test_campaign_branch_guards.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test_campaign_branch_guards.sh — #1052: the campaign engine's fail-loud branch guards.
+#
+# Picked up by scripts/ci/validate.sh's "Regression tests" loop (tests/regression/*.sh).
+#
+# #1052 replaces per-wave merge-backs to the protected branch with ONE campaign branch that is written
+# to trunk exactly once, at the DoD gate. That makes a small set of branch-identity facts load-bearing:
+# get any of them wrong and the engine either writes trunk early (the thing #1052 removes) or authorizes
+# its single trunk write on evidence about a branch it never touched. Each is enforced in
+# campaign-workflow.js as a throw; this asserts those throws exist in BOTH the source and the committed
+# bundle (the bundle is the artifact the Workflow tool actually runs — a guard present only in source is
+# not deployed). Same wiring-guard shape as test_dispatch_ceiling.sh.
+#
+# Guards asserted:
+#   1. node --check on the source + bundle (syntax must hold).
+#   2. campaignBranch === protectedBranch → throw. A campaign whose "integration branch" IS trunk
+#      restores per-wave trunk writes under a name claiming otherwise.
+#   3. An explicitly-passed campaignBranch is lowercased through the same normalization as the derived
+#      name — otherwise a hand-built `campaign/56-Blueshift` and a derived `campaign/56-blueshift` are
+#      two different case-sensitive server refs for one campaign.
+#   4. bootstrap.created && ALREADY_INTEGRATED.length > 0 → throw. A freshly-cut branch cannot already
+#      carry integrated waves; counting them would empty routeRelease's missing[] on the wrong branch.
+#   5. The per-wave kahuna name is always DERIVED — a plan-supplied wave.kahunaBranch is never returned
+#      (it is plan-scoped and trunk-based: shared across waves, so wave 1's promote deletes wave 2's base).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+NW="skills/nextwave"
+
+echo "test_campaign_branch_guards"
+echo "──────────────────────────────────────────"
+
+pass=0
+fail=0
+check() {
+	if [[ -n "$1" ]]; then
+		pass=$((pass + 1))
+		echo "  [PASS] $2"
+	else
+		fail=$((fail + 1))
+		echo "  [FAIL] $2"
+	fi
+}
+
+if ! command -v node &>/dev/null; then
+	echo "  [FAIL] node not found — required for the #1052 campaign branch-guard test"
+	exit 1
+fi
+
+# 1. syntax — source and bundle both parse
+for f in "$NW/campaign-workflow.js" "$NW/campaign-workflow.bundled.js" "$NW/per-wave-workflow.js"; do
+	if node --check "$REPO_DIR/$f" 2>/dev/null; then
+		pass=$((pass + 1))
+		echo "  [PASS] $(basename "$f") syntax (node --check)"
+	else
+		fail=$((fail + 1))
+		echo "  [FAIL] $(basename "$f") syntax (node --check)"
+	fi
+done
+
+# 2-4. the campaign-side guards, in source AND bundle
+for f in "$NW/campaign-workflow.js" "$NW/campaign-workflow.bundled.js"; do
+	src="$(cat "$REPO_DIR/$f")"
+	label="$(basename "$f")"
+
+	check "$(grep -F 'must not equal protectedBranch' <<<"$src" || true)" \
+		"$label: campaignBranch === protectedBranch throws (no campaign integrating onto trunk)"
+
+	# The override must flow through the same lowercasing as the derived name.
+	check "$(grep -F 'params.campaignBranch ?? campaignBranchFor' <<<"$src" | grep -F 'String(' || true)" \
+		"$label: an explicit campaignBranch is normalized (lowercased) like the derived one"
+	check "$(grep -F '})).toLowerCase()' <<<"$src" || true)" \
+		"$label: ... and the normalization is applied to the whole expression, not just the fallback"
+
+	check "$(grep -F 'was just CUT FRESH off' <<<"$src" || true)" \
+		"$label: fresh-cut branch + already-integrated waves throws (integrations on a DIFFERENT branch)"
+
+	# The derived per-wave kahuna wins; a plan-supplied one is ignored.
+	check "$(grep -F 'waveKahunaFor' <<<"$src" || true)" \
+		"$label: the per-wave kahuna name is derived via waveKahunaFor"
+	check "$(grep -F 'ignoring plan-supplied kahunaBranch' <<<"$src" || true)" \
+		"$label: a plan-supplied wave.kahunaBranch is logged and IGNORED (shared + trunk-based)"
+done
+
+# 5. the per-wave half — bootstrap establishes the kahuna off the INTEGRATION BASE, verified, fail-loud
+for f in "$NW/per-wave-workflow.js" "$NW/per-wave-workflow.bundled.js"; do
+	src="$(cat "$REPO_DIR/$f")"
+	label="$(basename "$f")"
+
+	check "$(grep -F 'KAHUNA-BOOTSTRAP' <<<"$src" || true)" \
+		"$label: the wave establishes its own kahuna branch (nothing else creates it)"
+	check "$(grep -F 'branch ${KAHUNA_BRANCH} origin/${INTEGRATION_BASE}' <<<"$src" || true)" \
+		"$label: the kahuna is cut from the INTEGRATION BASE, never the protected branch"
+	check "$(grep -F 'must not equal ${label}' <<<"$src" || true)" \
+		"$label: kahuna === base/trunk throws (else flights land ungated and the gate's diff is empty)"
+	check "$(grep -F 'test(bootstrapSha)' <<<"$src" || true)" \
+		"$label: ready requires an observed sha-shaped head_sha (verified, not merely reported)"
+done
+
+echo ""
+if ((fail > 0)); then
+	echo "  $fail check(s) failed"
+	exit 1
+fi
+echo "  all $pass campaign branch-guard checks passed"

--- a/tests/regression/wave_status_persist_roundtrip.mjs
+++ b/tests/regression/wave_status_persist_roundtrip.mjs
@@ -105,7 +105,7 @@ try {
     //    corrupts durable resume/prune state).
     const promoteArgs = {
       waveId: 'W-7', targetRepo: 'o/r', targetRepoDir: '/clone', kahunaBranch: 'kahuna/1-x',
-      protectedBranch: 'release', disposition: 'promoted', detail: 'gate PASS',
+      integrationBase: 'campaign/1-x', disposition: 'promoted', detail: 'gate PASS',
       blob: toBlob(state), path: '/clone/.claude/status/wave-W-7.json', trajectoryEntry: {},
     }
     const promotePrompt = persistTerminalPrompt(promoteArgs)
@@ -117,6 +117,16 @@ try {
     assert.ok(heldPrompt.includes('wave-status hold-wave W-7'), 'held → wave-status hold-wave <waveId>')
     assert.ok(!/wave-status complete\b/.test(heldPrompt), 'held must NEVER call `complete`')
     ok('persistTerminalPrompt held-branch emits `hold-wave`, never `complete`')
+
+    // #1052: the prompt states WHERE the wave landed, and that ref is `integrationBase` (the campaign
+    // branch inside a campaign), not the protected branch. Asserted because this test previously
+    // passed while rendering `undefined` into both branches of the prompt — it named the base nowhere,
+    // so a renamed parameter was invisible here and only failed in a sibling suite.
+    for (const [label, p] of [['promoted', promotePrompt], ['held', heldPrompt]]) {
+      assert.ok(p.includes('campaign/1-x'), `${label} prompt must name the integration base it landed on (or did not)`)
+      assert.ok(!/undefined/.test(p), `${label} prompt must not render undefined (renamed/missing param)`)
+    }
+    ok('persistTerminalPrompt names the integrationBase in both branches, never `undefined` (#1052)')
   } catch (e) {
     bad('round-trip', e)
   }

--- a/tests/test_gate_contract.py
+++ b/tests/test_gate_contract.py
@@ -77,23 +77,40 @@ class TestPromotionContract:
             "the flag presumes a merge queue/train that no longer exists"
         )
 
-    def test_promotion_targets_kahuna_to_protected(self) -> None:
-        # Flights never merge straight to the protected branch — only kahuna->protected promotes.
+    def test_promotion_targets_kahuna_to_integration_base(self) -> None:
+        # Flights never merge straight to the integration base — only kahuna->base promotes.
         src = _gate_src()
-        assert "kahunaBranch" in src and "protectedBranch" in src, (
-            "promotion must route kahuna_branch -> protected_branch"
+        assert "kahunaBranch" in src and "integrationBase" in src, (
+            "promotion must route kahuna_branch -> integration_base"
         )
+
+    def test_gate_takes_no_protected_branch_target(self) -> None:
+        # #1052: the integration base is NOT necessarily the protected branch — inside a campaign
+        # it is the campaign branch, and the protected branch is written exactly once, by the
+        # campaign's release gate. Asserted NEGATIVELY: a `protectedBranch` PARAMETER on any gate
+        # node is how the next wrong-target merge gets written (a caller passing a campaign branch
+        # into a param named `protectedBranch` reads as authorization to touch trunk). Prose may
+        # name the protected branch; a parameter may not.
+        src = _gate_src()
+        for bad in ("protectedBranch,", "protectedBranch }", "protectedBranch }}", "${protectedBranch}"):
+            assert bad not in src, (
+                f"gate.js must not take a protectedBranch parameter (found {bad!r}) — "
+                "the merge target is integrationBase (#1052)"
+            )
 
 
 class TestPromotionLifecycle:
     """kahuna-branch lifecycle on promotion — relocated from the all-green /
-    any-red kahuna-handling skill assertions (#722 per-plan persistence)."""
+    any-red kahuna-handling skill assertions (#722, retired in-campaign by #1052)."""
 
-    def test_can_preserve_per_plan_kahuna(self) -> None:
-        # #722: a per-plan kahuna shared across waves 1..N must PERSIST, else
-        # deleting it after wave 1 strands the later waves off a diverged base.
+    def test_preserve_kahuna_flag_survives_for_standalone(self) -> None:
+        # #722 gave a per-plan kahuna the ability to PERSIST across waves. #1052 retires that
+        # NEED inside a campaign (the campaign branch carries cross-wave state, so each wave's
+        # kahuna is disposable again — which is what makes a squash merge harmless, #892). The
+        # flag itself must still exist: a STANDALONE /nextwave run has no campaign branch, so
+        # its caller may still ask for a surviving kahuna.
         assert "preserveKahuna" in _gate_src(), (
-            "promotion must support preserveKahuna (#722 per-plan kahuna persistence)"
+            "promotion must still honor preserveKahuna for standalone waves (#722/#1052)"
         )
 
     def test_deletes_disposable_per_wave_kahuna(self) -> None:

--- a/tests/test_per_wave_workflow_contract.py
+++ b/tests/test_per_wave_workflow_contract.py
@@ -161,3 +161,85 @@ class TestPrimePlanningAndReconcile:
         assert "IDEMPOTENT" in src, (
             "reconcile merge must be idempotent (skip already-merged branches)"
         )
+
+
+class TestKahunaBootstrap:
+    """#1052 — the wave's integration branch is established off the INTEGRATION BASE
+    before the flight loop, by this engine.
+
+    Before #1052 nothing in this repo created `origin/<kahuna>`; the only creator was
+    server-side `wave_init`, which cuts ONE plan-scoped branch off trunk. Inside a
+    campaign that is wrong twice over (shared across waves, so wave 1's promote deletes
+    wave 2's base; and trunk-based, so wave 2's flights miss wave 1's integrated work),
+    while every downstream node — worktree setup, the gate's diff, the promote merge —
+    reads `origin/<kahuna>` as a precondition.
+    """
+
+    def test_bootstrap_node_exists(self) -> None:
+        src = _wf_src()
+        assert "KAHUNA-BOOTSTRAP" in src, (
+            "per-wave workflow must establish this wave's kahuna branch (nothing else creates it)"
+        )
+
+    def test_bootstrap_bases_on_integration_base_not_protected(self) -> None:
+        # The whole point: cut from INTEGRATION_BASE. Basing on the protected branch inside a
+        # campaign hands the wave a baseline missing every previously-integrated wave.
+        src = _wf_src()
+        assert "branch ${KAHUNA_BRANCH} origin/${INTEGRATION_BASE}" in src, (
+            "the kahuna branch must be cut from origin/<integrationBase>"
+        )
+
+    def test_bootstrap_reuses_never_recuts(self) -> None:
+        # An existing kahuna carries this wave's already-integrated flights; re-cutting
+        # (or resetting/force-pushing) it silently discards them.
+        src = _wf_src()
+        assert "REUSE it" in src and "Do NOT re-cut" in src, (
+            "bootstrap must reuse an existing kahuna branch, never re-cut it"
+        )
+
+    def test_bootstrap_verifies_then_fails_loud(self) -> None:
+        # Read-back verification, and abort rather than fall back — least of all to trunk.
+        src = _wf_src()
+        assert "rev-parse refs/remotes/origin/${KAHUNA_BRANCH}" in src, (
+            "bootstrap must verify the branch by reading it back from origin"
+        )
+        assert "could not establish the wave's integration branch" in src, (
+            "an unestablished kahuna must abort the wave (throw), not proceed"
+        )
+
+    def test_bootstrap_requires_a_verified_sha(self) -> None:
+        # `head_sha` is optional in the schema, so a schema-valid `{ready: true}` carrying no sha would
+        # pass a bare `ready` check — "reported ready" wearing "verified ready"'s clothes, over a branch
+        # nobody read back. Same defect the promotion-PR node closes by requiring a concrete pr_number.
+        src = _wf_src()
+        assert "/^[0-9a-f]{7,40}$/.test(bootstrapSha)" in src, (
+            "bootstrap must require a sha-shaped head_sha, not merely ready:true"
+        )
+
+    def test_kahuna_may_not_be_the_base_or_trunk(self) -> None:
+        # Flights merge INTO the kahuna and the gate diffs it AGAINST the base. If they are the same ref
+        # every flight lands on the base ungated, and by the time the gate looked its diff would be empty.
+        src = _wf_src()
+        assert "must not equal ${label}" in src, (
+            "bootstrap must reject a kahuna branch equal to the integration base or the protected branch"
+        )
+
+    def test_reuse_log_does_not_assert_unverified_ancestry(self) -> None:
+        # Catalog G: report the observed post-state, not the assumption. Existence != descended-from-base.
+        src = _wf_src()
+        assert "merge-base --is-ancestor" in src, "the reuse path must actually CHECK ancestry"
+        assert "based_on_base" in src, "and report it as a field rather than asserting it in the log"
+        assert "reused (already based on)" not in src, (
+            "the log must not claim an ancestry the node never verified"
+        )
+
+    def test_trajectory_entry_carries_integrated(self) -> None:
+        # #1052: the durable trajectory entry must carry `integrated`, not `promoted` alone.
+        # A record with only `promoted` is indistinguishable from a pre-#1052 one, and the
+        # campaign's (deliberately conservative) rehydrate would decline to count the wave —
+        # re-running an already-integrated wave, whose now-empty diff conservative-fails the
+        # review signal into a HOLD, stalling the campaign short of its release gate.
+        src = _wf_src()
+        assert "integrated: disposition === 'promoted'" in src, (
+            "the trajectory entry must carry `integrated` (current vocabulary), not only `promoted`"
+        )


### PR DESCRIPTION
## Summary

A campaign no longer writes the protected branch per wave. It cuts **one** campaign branch, integrates every wave onto it, and merges to trunk **exactly once** — at the DoD gate, after all waves land. Per-wave `kahuna` branches become genuinely disposable, cut from the campaign branch rather than trunk.

Per-wave merge-backs were removed for a concrete reason: a squash merge makes the integration branch's history un-equal to trunk's, so the post-merge-back equality check could never pass. Deleting the merge-back **dissolves** that incompatibility rather than working around it — and it buys two properties the old shape could not have: a campaign that must roll back reverts nothing from trunk history, and nobody else working from the protected branch is disturbed mid-campaign. A wave is not a real increment to trunk; the campaign is.

## Changes

**Branch topology** — `campaign/<planId>-<slug>` for the campaign, `kahuna/<planId>-<waveId>` per wave. Distinct top-level prefixes are a correctness requirement, not cosmetics: git cannot hold a branch that is a directory prefix of another, so a shared prefix would make every wave branch unrepresentable.

**The wave establishes its own kahuna** (new `KAHUNA-BOOTSTRAP` node) — cut from the integration base, create-or-reuse, verified by read-back. Nothing in this engine created it before: the only creator was server-side `wave_init`, which cuts ONE plan-scoped branch off trunk. Inside a campaign that is wrong twice — shared across waves, so wave 1's promote deletes wave 2's base; and trunk-based, so wave 2's flights build on a baseline missing wave 1's integrated work. A plan-supplied `kahuna_branch` is therefore logged and ignored. On reuse the node runs a real `merge-base --is-ancestor` check and reports what it observed rather than asserting ancestry from mere existence.

**`promoted` splits** into `integrated` (landed on the campaign branch, per wave) and `released` (the campaign landed on trunk, once). `gate.js` takes no `protectedBranch` parameter at all — and a test asserts its absence, because passing a campaign branch in a parameter named `protectedBranch` is how the next wrong-target merge gets written. A wave never decides to write trunk; it writes whatever base it was handed.

**Fail-loud guards**, each replacing a path that would silently write the wrong branch:

- `campaignBranch === protectedBranch` → throw. A campaign whose "integration branch" IS trunk restores per-wave trunk writes under a name claiming otherwise.
- `kahuna === integration base or trunk` → throw. Otherwise every flight lands on the base ungated, and the gate's own diff is empty by the time it looks.
- freshly-cut campaign branch + already-integrated waves → throw. Those integrations landed on a *different* branch; counting them would empty `routeRelease`'s `missing[]` on evidence about a branch this run never touched.
- bootstrap `ready` requires an observed sha-shaped `head_sha`. `head_sha` is optional in the schema, so a schema-valid `{ready:true}` with no sha would otherwise pass the guard over a branch nobody read back — "reported ready" wearing "verified ready"'s clothes.
- rehydrated wave ids are filtered to the plan's own id set. That list is agent-reported and feeds the completeness half of the single trunk-write predicate; an id outside the plan is not evidence about the plan.
- `campaignBranchFor` throws on a missing `planId`/`slug` rather than defaulting two concurrent campaigns onto one `campaign/plan-campaign`.

**Asymmetric ref normalization, deliberately.** The campaign slug is human-typed, so it is lowercased — including when passed explicitly, so a hand-built `campaign/56-Blueshift` and a derived `campaign/56-blueshift` cannot become two case-sensitive server refs for one campaign. The `waveId` is engine-generated and kept verbatim, matching `resume.js`'s flight-branch names and its cleanup glob.

**Docs** — `SEAMS.md` (the base is `integrationBase`, never "the protected branch"), `skills/nextwave/SKILL.md`, `skills/wavemachine/SKILL.md`, `docs/campaign-workflow-design.md`.

## Linked Issues

Closes #1052

## Test Plan

Actually run on this branch:

- `./scripts/ci/validate.sh` → **216 passed, 0 failed**
- `python3 -m pytest tests/` → **1923 passed**, 6 skipped, 64 xfailed, 2 xpassed, 26 subtests
- `tests/regression/test_campaign_loop.sh` → **88/88** (adds: campaign-slug case-insensitivity, waveId case-preservation, unknown ids don't satisfy completeness)
- **New** `tests/regression/test_campaign_branch_guards.sh` → **23/23**. Asserts every guard above in **both** the source and the committed bundle — a guard present only in source is not deployed, since the bundle is what the Workflow tool runs.
- New contract assertions in `tests/test_per_wave_workflow_contract.py` (8) for the bootstrap node and the `integrated` trajectory field.
- Both Workflow bundles regenerated; `bundle.mjs --check` and `campaign-bundle.mjs --check` confirm in-sync.

Signal-prompt suites now assert `!/undefined/`. That closed a real silent hole: two files still passed `protectedBranch:` into a param renamed `integrationBase` — `gate_signals` failed loudly, but `wave_status_persist` passed while rendering the literal text `undefined` into the prompt.

**Dependency scan:** `trivy fs --scanners vuln --severity HIGH,CRITICAL` parsed **zero manifests** at `277b0b1`. That is *no scan*, not a pass — reported here rather than as a green checkmark.

Two review passes ran; 9 findings total, all fixed. The second pass was scoped to the bootstrap code written *in response to* the first pass — code no reviewer had seen — and found 4 real defects in it, including the `{ready:true}`-without-sha hole and the fresh-cut/already-integrated contradiction above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)