### PR TITLE
feat(disc): arm the channels-free doorbell for clients with no Monitor primitive

### DIFF
--- a/scripts/doorbell-oneshot.sh
+++ b/scripts/doorbell-oneshot.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# doorbell-oneshot.sh — one-shot arming wrapper for `discord-watcher doorbell` (#1055)
+#
+# Blocks until at least one deliverable Discord message arrives, prints every
+# `[doorbell] ...` line the watcher has produced by that moment, and exits.
+#
+# WHY THIS EXISTS
+# ---------------
+# The watcher's README and its own `--help` both tell you to arm the doorbell with
+# Claude Code's `Monitor` primitive:
+#
+#     Monitor({ command: "discord-watcher doorbell", persistent: true })
+#
+# That primitive is NOT present in every client. Where it is missing, the only
+# background-process mechanism available notifies the agent when a task **exits** —
+# and `discord-watcher doorbell` is a persistent poll loop that never exits. Armed
+# that way the doorbell line lands in a file nobody reads and the agent is never
+# woken: silent deafness, the exact failure the doorbell exists to prevent.
+#
+# So this wrapper inverts it: make the EXIT be the doorbell. One batch of messages,
+# one exit, one task-completion notification, one agent turn. Re-arm for the next.
+#
+# THE EXIT CODE IS THE SIGNAL — so it must never lie
+# --------------------------------------------------
+# Because the whole design rests on "process exited ⇒ a message arrived", an exit 0
+# that carries no message is worse than a crash: the agent re-arms immediately and
+# spins. Every non-message way the read can end therefore gets its OWN code, and a
+# dead watcher (bad token, baseline-init failure) is reported loudly with its
+# captured stderr as exit 4.
+#
+# A watcher older than v1.6.0 is NOT that case, and must be caught before we ever
+# read. It has no unknown-subcommand handler — `argv[2] === "doorbell"` simply fails
+# and control falls through to `main()`, the full MCP stdio server, which installs a
+# poll interval and never exits. So an old binary invoked as `doorbell` HANGS rather
+# than failing; with the default TIMEOUT=0 that is an unbounded silent wait, the very
+# deafness this script exists to prevent. Hence the capability probe below, which
+# needs its own `timeout` because `doorbell --help` hangs on an old binary too.
+#
+# WHY NOT `discord-watcher doorbell | head -1`
+# -------------------------------------------
+# Because it leaks an orphaned poller. Bun ignores SIGPIPE and swallows the write
+# error, so closing the read end does NOT terminate the child — verified still
+# alive 20s after `head` exited, polling Discord forever. Re-arming that way would
+# accumulate a poller per message. We therefore read through a fifo and kill the
+# child by PID.
+#
+# WHY IT DRAINS INSTEAD OF READING EXACTLY ONE LINE
+# -------------------------------------------------
+# A single poll can yield several deliverable messages. Reading one line and killing
+# the watcher would discard the rest — and they are NOT recoverable: the re-armed
+# instance seeds its cursor to the latest message per channel AND marks it delivered,
+# so it starts *past* them. One line per exit would therefore silently lose messages,
+# which is the same class of failure this script exists to prevent. So once the first
+# line lands we drain whatever else is already buffered before exiting.
+#
+# KNOWN LIMIT — the drain covers one channel, not a whole cycle.
+# The watcher emits a channel's messages back-to-back with no awaits between them, so
+# a same-channel burst lands well inside the drain window. Between channels it sleeps
+# 50-150ms of jitter and then makes an HTTP round trip, so messages in DIFFERENT
+# channels in the same cycle usually fall outside the window; and because cleanup
+# kills the watcher mid-cycle, channels it had not yet polled are never fetched at
+# all. Those are lost the same unrecoverable way. DRAIN_SECONDS widens the window to
+# trade wall-clock for coverage, but it cannot close the gap — only a cycle-boundary
+# signal from the watcher could. Raise it if you are addressed across many channels.
+#
+# PREREQUISITE — must be launched from the project root
+# ----------------------------------------------------
+# The watcher resolves agent identity from `CLAUDE_PROJECT_DIR ?? process.cwd()`
+# and reads `<root>/.claude/agent-identity.json`. With identity unresolved,
+# `shouldDeliverMessage` FAILS CLOSED: the loop polls normally and delivers
+# nothing. Run from the project root, or export CLAUDE_PROJECT_DIR.
+#
+# Usage:
+#   doorbell-oneshot.sh                 # block until a message, print it, exit
+#   TIMEOUT=1800 doorbell-oneshot.sh    # give up after N seconds (exit 3)
+#   DRAIN_SECONDS=2 doorbell-oneshot.sh # widen the post-first-line drain window
+#   DEBUG=1 doorbell-oneshot.sh         # also forward the watcher's stderr (identity
+#                                       # confirmation, poll diagnostics)
+#
+# Exit codes: 0 = one or more doorbell lines emitted; 2 = precondition failure
+#             (bash too old, watcher missing or pre-v1.6.0, bad TIMEOUT/DRAIN_SECONDS,
+#             temp-dir setup); 3 = TIMEOUT elapsed with no message; 4 = watcher exited
+#             without emitting a line.
+set -uo pipefail
+
+# bash 4.0 is a hard requirement, and both features it provides fail SILENTLY on 3.2
+# (stock /usr/bin/bash on macOS): fractional `read -t` is rejected outright, so the
+# drain would no-op and quietly truncate multi-message polls; and a timed-out read
+# returns 1 instead of >128, so every timeout would be misreported as a dead watcher.
+# Two silent wrong answers — so refuse loudly instead.
+if ((BASH_VERSINFO[0] < 4)); then
+	echo "doorbell-oneshot: needs bash >= 4 (this is $BASH_VERSION)." >&2
+	echo "  Fractional 'read -t' and the >128 timeout status are 4.0+ features;" >&2
+	echo "  on 3.2 the drain and the timeout both fail silently. macOS: brew install bash." >&2
+	exit 2
+fi
+
+WATCHER="${WATCHER:-$HOME/.local/bin/discord-watcher}"
+TIMEOUT="${TIMEOUT:-0}"
+DRAIN_SECONDS="${DRAIN_SECONDS:-0.2}"
+DEBUG="${DEBUG:-0}"
+
+if [[ ! -x "$WATCHER" ]]; then
+	echo "doorbell-oneshot: watcher not found or not executable: $WATCHER" >&2
+	exit 2
+fi
+
+# Probe the capability rather than inferring it from a read that fails. An old watcher
+# does not reject `doorbell` — it falls through to the MCP server and never exits, so
+# without this the script would simply hang. `timeout` is load-bearing: `--help` hangs
+# on an old binary too, for the same reason.
+if ! timeout 5 "$WATCHER" doorbell --help 2>/dev/null | grep -q 'doorbell'; then
+	echo "doorbell-oneshot: $WATCHER does not implement the 'doorbell' subcommand." >&2
+	echo "  It needs discord-watcher v1.6.0 or newer. An older binary silently falls" >&2
+	echo "  through to the MCP server and hangs instead of failing, so this is checked" >&2
+	echo "  up front rather than diagnosed from a stalled read." >&2
+	exit 2
+fi
+
+# Validate TIMEOUT before use. `[[ "$TIMEOUT" -gt 0 ]]` evaluates arithmetically, so
+# a plausible typo like TIMEOUT=30s is a syntax error that makes the test FALSE and
+# silently selects the unbounded branch — the caller asks for a bound and gets an
+# infinite block, the very failure the bound was for.
+if [[ ! "$TIMEOUT" =~ ^[0-9]+$ ]]; then
+	echo "doorbell-oneshot: TIMEOUT must be a whole number of seconds, got: $TIMEOUT" >&2
+	exit 2
+fi
+
+# DRAIN_SECONDS goes straight to `read -t`, which rejects a malformed value and returns
+# non-zero — indistinguishable from "nothing left to drain", i.e. a silently skipped
+# drain. Fractional is allowed here (unlike TIMEOUT) because that is the useful range.
+if [[ ! "$DRAIN_SECONDS" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+	echo "doorbell-oneshot: DRAIN_SECONDS must be a number of seconds, got: $DRAIN_SECONDS" >&2
+	exit 2
+fi
+
+# Warn (do not fail) when identity is unresolvable — the watcher would fail closed
+# and this script would just hang, which reads as "no messages" rather than "deaf".
+IDENTITY_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+if [[ ! -f "$IDENTITY_ROOT/.claude/agent-identity.json" ]]; then
+	echo "doorbell-oneshot: WARNING no $IDENTITY_ROOT/.claude/agent-identity.json —" >&2
+	echo "  the delivery gate fails closed on unresolved identity, so NOTHING will" >&2
+	echo "  be delivered. Run from the project root or set CLAUDE_PROJECT_DIR." >&2
+fi
+
+# A private directory rather than `mktemp -u` + mkfifo: no TOCTOU window on the
+# name, and `rm -rf` cleans the fifo and the stderr capture together.
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/doorbell.XXXXXX") || {
+	echo "doorbell-oneshot: could not create a temp directory" >&2
+	exit 2
+}
+FIFO="$WORKDIR/doorbell-fifo"
+ERRLOG="$WORKDIR/watcher-stderr"
+mkfifo "$FIFO" || {
+	rm -rf "$WORKDIR"
+	echo "doorbell-oneshot: could not create the fifo at $FIFO" >&2
+	exit 2
+}
+
+# Capture the watcher's stderr rather than discarding it: it is where a dead-watcher
+# diagnosis lives, and where the identity state_change line the skill tells you to
+# check appears.
+"$WATCHER" doorbell >"$FIFO" 2>"$ERRLOG" &
+CHILD=$!
+
+cleanup() {
+	# shellcheck disable=SC2317  # invoked indirectly via `trap cleanup EXIT` below
+	kill "$CHILD" 2>/dev/null
+	# shellcheck disable=SC2317  # ditto — reap the killed child before removing its fifo
+	wait "$CHILD" 2>/dev/null
+	# shellcheck disable=SC2317  # ditto
+	rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+# Signal handlers must EXIT. A bare `trap cleanup TERM` runs the handler, returns,
+# and lets the interrupted `read` fall through to the success path — making task
+# cancellation indistinguishable from a delivered message.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+dump_watcher_stderr() {
+	[[ -s "$ERRLOG" ]] || return 0
+	echo "doorbell-oneshot: --- watcher stderr ---" >&2
+	cat "$ERRLOG" >&2
+	echo "doorbell-oneshot: --- end watcher stderr ---" >&2
+}
+
+# Open the fifo ONCE on fd 3. Reopening per read would race the writer and could
+# lose buffered lines between the first read and the drain.
+exec 3<"$FIFO"
+
+LINE=""
+rc=0
+if [[ "$TIMEOUT" -gt 0 ]]; then
+	IFS= read -r -t "$TIMEOUT" LINE <&3 || rc=$?
+else
+	IFS= read -r LINE <&3 || rc=$?
+fi
+
+# read distinguishes its two failure modes by code: >128 means the -t deadline
+# elapsed, anything else non-zero means EOF — the watcher closed the pipe.
+if ((rc > 128)); then
+	echo "doorbell-oneshot: no message within ${TIMEOUT}s" >&2
+	exit 3
+elif ((rc != 0)) || [[ -z "$LINE" ]]; then
+	echo "doorbell-oneshot: watcher exited without emitting a doorbell line." >&2
+	echo "  The 'doorbell' subcommand is present, so this is a genuinely failed watcher" >&2
+	echo "  (bad token, baseline init, crash) rather than an old binary." >&2
+	dump_watcher_stderr
+	exit 4
+fi
+
+# Validate the shape before calling it a doorbell. The watcher's other mode writes
+# JSON-RPC frames to stdout, and reporting one of those as a delivered message would
+# be a false doorbell — the failure this script's exit contract exists to rule out.
+if [[ "$LINE" != '[doorbell] '* ]]; then
+	echo "doorbell-oneshot: stdout did not carry a doorbell line. Got:" >&2
+	printf '  %s\n' "$LINE" >&2
+	dump_watcher_stderr
+	exit 4
+fi
+
+printf '%s\n' "$LINE"
+
+# Drain what this channel's poll already produced. A short deadline, not a blocking
+# read: the point is "what is buffered now", not "wait for the next message". See the
+# KNOWN LIMIT note in the header — this does not span channels within a cycle.
+while IFS= read -r -t "$DRAIN_SECONDS" LINE <&3; do
+	[[ "$LINE" == '[doorbell] '* ]] && printf '%s\n' "$LINE"
+done
+
+exec 3<&-
+
+[[ "$DEBUG" == "1" ]] && dump_watcher_stderr
+
+exit 0

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -37,11 +37,13 @@ Last-resort fallbacks only if `discord.json` is missing the key: default `148728
 - forward → `discord-watcher forward <agent> [--exclude a,b,c]` — routes this agent's doorbells to another **agent**. Confirms with `disc forward: forwarding doorbells to <label>`.
 - forward off / stop → `discord-watcher forward --off` — confirms `rule cleared`, or `no rule to clear` if none was set.
 - directmsg / dm → `discord-watcher directmsg <agent> <content...>` (`dm` is an accepted alias) — bypasses the forward rule and rides the deliver-router.
+- doorbell → `discord-watcher doorbell` — the **channels-free** doorbell transport, for sessions started without `--channels`. Arm it with `doorbell-oneshot.sh`, never bare: see "Arming the channels-free doorbell" below.
 
 Exact usage, read from the installed binary:
 ```
 usage: discord-watcher forward <target> [--exclude a,b,c] | forward --off
 usage: discord-watcher directmsg <target> <content...>
+usage: discord-watcher doorbell
 ```
 
 ⚠️ **`<target>` is an AGENT, never a channel.** It becomes the aoe session name (`rule.target = {label, session}`), so it must be a **Dev-Name or Dev-Team token** (`babelfish`, `oaw`) — leading `@`/`#` are stripped. **This fails silently if you get it wrong:** any non-`--` token is accepted, so `forward #agent-ops` exits 0 and prints `forwarding doorbells to #agent-ops`. The rule is written and looks healthy; every doorbell then fails at delivery. Do not pattern-match off `#ch` used elsewhere in this skill.
@@ -57,6 +59,49 @@ usage: discord-watcher directmsg <target> <content...>
 `parseDirectMsg` matches `/^(\S+)\s+([\s\S]+)$/`, so a target token **and** a non-empty body are mandatory. `//dm help` returns null; `//dm need you now` silently parses `need` as the target, matches no agent, and the message is **forwarded away** — the exact failure the direct lane exists to prevent. The `@<target>` mention is also what routes the doorbell to that watcher at all.
 
 The override is **scoped**, not global: it fires only when the target matches the *receiving* agent's own dev-name or dev-team (`isDirectMsgForLocal`), overriding **that agent's** forward rule. Relay this form to users verbatim when they ask how to reach an agent whose doorbells are forwarded; it is not something `/disc` invokes.
+
+## Arming the channels-free doorbell (`doorbell`)
+
+For sessions started **without** `--channels`: the MCP notification sink is never wired up, so no doorbell reaches the agent. `discord-watcher doorbell` (watcher **v1.6.0+**) is the alternate transport — same poll loop, same fail-closed delivery gate, but each deliverable message is emitted as one stdout line:
+
+```
+[doorbell] #<channel> channel_id=<id> msg_id=<id> from <author>: <preview>
+```
+
+⚠️ **Do NOT arm it the way the watcher's README and `--help` say to.** Both print:
+
+```
+Monitor({ command: "discord-watcher doorbell", persistent: true })
+```
+
+`Monitor` is **absent from some clients' tool surface** — check before relying on it. Where it is missing, the only background-process mechanism available notifies the agent when a task **exits**, and `doorbell` is a persistent loop that never exits. Armed that way the line is written to a file nobody reads and the agent is never woken: *silent* deafness, the exact failure the doorbell exists to prevent.
+
+**Use the one-shot wrapper instead** — it makes the exit BE the doorbell, so the task-completion notification wakes the agent. Invoke it by **bare name** (`./install` symlinks every `scripts/*` file onto PATH); a relative `scripts/…` path only resolves inside the cc-workflow source tree, which is never where you want to be — the wrapper must run from the *target project's* root so identity resolves:
+
+```bash
+doorbell-oneshot.sh                 # blocks until a message arrives, prints it, exits
+TIMEOUT=1800 doorbell-oneshot.sh    # bounded wait; exit 3 if nothing arrives
+DRAIN_SECONDS=2 doorbell-oneshot.sh # widen the drain window (see the limit below)
+DEBUG=1 doorbell-oneshot.sh         # also forward the watcher's stderr
+```
+
+Run it as a **background** task, then re-arm after handling the messages it printed (one batch → one turn). Cellar copy, for reference: `~/.claude/scripts/doorbell-oneshot.sh`.
+
+**Read the exit code — it is the whole signal.** `0` = one or more `[doorbell]` lines on stdout; `2` = precondition failure (bash < 4, watcher missing, **watcher older than v1.6.0**, malformed `TIMEOUT`/`DRAIN_SECONDS`); `3` = `TIMEOUT` elapsed with nothing delivered; `4` = the `doorbell` subcommand exists but the watcher died without emitting a valid line — bad token, baseline-init failure, crash — with its stderr printed for you. Never treat a bare exit 0 with empty stdout as a message: re-arming on that is a hot loop, and the wrapper is built so it cannot happen.
+
+A **pre-v1.6.0 watcher does not error** — it has no unknown-subcommand handler, so `doorbell` falls through to the MCP server and the process never exits. That would hang the wrapper forever at the default `TIMEOUT=0`, so the wrapper probes `doorbell --help` up front and fails with exit 2 instead. If you see that, the fix is a watcher upgrade, not a retry.
+
+**It prints a batch, not one line** — and the batch is one channel's worth. After the first line the wrapper drains for `DRAIN_SECONDS` (default `0.2`) and prints everything already buffered. Handle **every** line before re-arming: the re-armed instance seeds its cursor past them and marks them delivered (see "Cold start does not replay" below), so a line you ignore is gone for good.
+
+⚠️ **Known gap — the drain does not span channels.** Within one poll cycle the watcher waits 50–150ms of jitter plus an HTTP round trip between channels, and the wrapper kills it once the drain window closes, so channels it had not reached yet are never polled. Messages addressed to you in a *second* channel during the same cycle can therefore be missed, unrecoverably. If you are routinely addressed across several channels, raise `DRAIN_SECONDS` (2 covers the jitter and a round trip) — it narrows the gap without closing it. Closing it properly needs a cycle-boundary signal from the watcher.
+
+**Three ways this goes silently deaf.** Every one of them polls normally and delivers nothing, so "no doorbells" never distinguishes healthy-and-quiet from broken:
+
+1. **Wrong cwd → unresolved identity → fail closed.** Identity comes from `CLAUDE_PROJECT_DIR ?? process.cwd()` and is read from `<root>/.claude/agent-identity.json`; with either field unresolved, `shouldDeliverMessage` returns false for everything (deaf > over-broad). **Launch from the project root, or export `CLAUDE_PROJECT_DIR`.** Confirm via stderr: `state_change ... "what":"identity","from":"null/null","to":"<name>/<team>"` — the wrapper captures the watcher's stderr and replays it under `DEBUG=1` (and always on exit 4). It also warns when the identity file is missing.
+2. **Never pipe to `head -1`** — it leaks an orphaned poller. Bun ignores `SIGPIPE` and swallows the write error, so closing the read end does **not** kill the child; it keeps polling Discord forever, and re-arming that way accumulates one poller per message. The wrapper reads through a fifo and kills the child by PID.
+3. **Your own signature is filtered.** The self-echo gate drops any message containing `— **<dev-name>**`. A test message signed the normal way tests nothing — send it unsigned, from another account, or it will be correctly discarded.
+
+**Cold start does not replay.** The cursor is seeded to the latest message per channel at startup, so pre-existing history is never re-delivered — same as the MCP watcher. A message landing in the exact instant of a `--channels`→`doorbell` cutover is not bridged. Forward-rule routing is intentionally **not** applied in doorbell mode: it always delivers this agent's own doorbells.
 
 **Why the split matters:** these are different binaries. `disc-server` is the MCP server this skill mostly drives; `discord-watcher` is the notification daemon. A `disc_forward` tool does not exist and never has — attempting one fails. If a future intent has no `disc_*` tool, that is the expected shape for watcher-owned features, not a bug to route around.
 

--- a/tests/regression/test_doorbell_oneshot.sh
+++ b/tests/regression/test_doorbell_oneshot.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# test_doorbell_oneshot.sh — #1055: the one-shot doorbell wrapper's contract.
+#
+# Picked up by scripts/ci/validate.sh's "Regression tests" loop (tests/regression/*.sh).
+#
+# scripts/doorbell-oneshot.sh exists because the arming instruction printed by the watcher's own
+# README and --help (`Monitor({command: "discord-watcher doorbell", persistent: true})`) does not
+# work in clients that have no `Monitor` primitive: their background-task mechanism notifies only
+# on process EXIT, and `doorbell` is a loop that never exits. The wrapper inverts that — one batch
+# of messages, one exit, one notification.
+#
+# Every failure mode this guards is SILENT: the watcher polls normally and delivers nothing, so a
+# regression reads as "no messages" rather than as breakage. Hence asserting on the script text
+# where a live Discord round-trip would be needed — that is not hermetic and cannot run in CI.
+# Everything that CAN be exercised with a stub watcher is exercised behaviorally.
+#
+# Guards asserted:
+#   1. bash -n on the wrapper (syntax must hold) + the executable bit (it is invoked directly).
+#   2. The child is killed by PID. Bun ignores SIGPIPE and swallows the write error, so a
+#      `| head -1` shape leaves an orphaned poller alive — verified still polling 20s after the
+#      reader exited. Re-arming that way accumulates one leaked poller per message.
+#   3. No `| head -` pipeline in the wrapper — the specific shape trap #2 describes.
+#   4. A cleanup trap removes the working dir, so re-arming does not litter $TMPDIR.
+#   5. The identity precondition is checked and WARNED about. Identity resolves from
+#      CLAUDE_PROJECT_DIR ?? cwd; unresolved → the delivery gate fails closed → total silence.
+#   6. TIMEOUT is honored with a distinct non-zero exit, and a non-numeric TIMEOUT is REJECTED
+#      rather than silently selecting the unbounded branch ([[ -gt ]] is arithmetic, so
+#      TIMEOUT=30s makes the test false and blocks forever — the opposite of what was asked).
+#   7. A watcher that exits without emitting a line yields exit 4, never a blank exit 0. The whole
+#      design rests on "exited ⇒ a message arrived"; a false exit 0 makes the agent re-arm
+#      instantly and spin.
+#   8. The fifo is opened ONCE on a fd and drained, so a multi-message poll is not truncated to
+#      its first line. Dropped lines are unrecoverable — the re-armed watcher seeds its cursor
+#      past them and marks them delivered. Drain width is configurable (DRAIN_SECONDS) because
+#      the default cannot span a cross-channel burst; that residual gap is documented, not fixed.
+#  10. A pre-v1.6.0 watcher is caught by an up-front capability probe. It does NOT error on an
+#      unknown subcommand — `doorbell` falls through to the MCP server and never exits — so the
+#      un-probed shape is an unbounded silent hang, not an exit-4. The probe itself must be
+#      `timeout`-bounded because `--help` hangs on such a binary too.
+#  11. Only a line with the `[doorbell] ` prefix counts as a message. The watcher's other mode
+#      writes JSON-RPC frames to stdout, and reporting one as delivered is a false doorbell.
+#   9. skills/disc/SKILL.md routes `doorbell`, warns that Monitor may be unavailable, and invokes
+#      the wrapper by BARE NAME. A relative `scripts/...` path only resolves inside the
+#      cc-workflow source tree and breaks the skill everywhere else — the #569 regression class
+#      (see test_skill_uses_installed_binaries.sh); it also contradicts the wrapper's own
+#      requirement to run from the target project's root.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+WRAPPER="$REPO_DIR/scripts/doorbell-oneshot.sh"
+SKILL="$REPO_DIR/skills/disc/SKILL.md"
+
+FAILS=0
+# `pass` closes the assertion group above it, so it must not print when that group already
+# failed — several groups make multiple assertions before their single verdict line, and an
+# unconditional pass would print [FAIL] and [PASS] for the SAME check. Comparing against the
+# failure count at the previous verdict keeps the two mutually exclusive with no bookkeeping at
+# the ~20 call sites.
+LAST_FAILS=0
+pass() {
+	((FAILS == LAST_FAILS)) && echo "  [PASS] $1"
+	LAST_FAILS=$FAILS
+}
+fail() {
+	echo "  [FAIL] $1" >&2
+	FAILS=$((FAILS + 1))
+}
+
+# A private TMPDIR for every stub run. The litter check must scan only what THIS test created:
+# globbing shared /tmp would fail whenever another agent legitimately holds a live doorbell, which
+# is the wrapper's intended production use on a box that routinely runs several agents.
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# --- 1. syntax + executable ---------------------------------------------------
+if [[ ! -f "$WRAPPER" ]]; then
+	echo "  [FAIL] missing $WRAPPER" >&2
+	exit 1
+fi
+bash -n "$WRAPPER" || fail "bash -n failed on doorbell-oneshot.sh"
+pass "doorbell-oneshot.sh syntax (bash -n)"
+[[ -x "$WRAPPER" ]] || fail "doorbell-oneshot.sh is not executable (it is invoked directly)"
+pass "doorbell-oneshot.sh is executable"
+
+# --- 2/3. the child is killed by PID, never left to SIGPIPE -------------------
+# Strip comments before asserting on CODE: the wrapper's own header explains the `| head -1`
+# trap in prose, and matching that prose would pass (or fail) on documentation rather than
+# behavior. Every grep below therefore reads $WRAPPER_CODE, not $WRAPPER.
+WRAPPER_CODE="$(grep -vE '^[[:space:]]*#' "$WRAPPER")"
+
+grep -Eq "kill[[:space:]]+\"\\\$CHILD\"" <<<"$WRAPPER_CODE" ||
+	fail "wrapper must kill its child by PID — Bun ignores SIGPIPE, so a closed pipe leaks a poller"
+pass "child poller is killed by PID (not left to SIGPIPE)"
+
+grep -Eq '\|[[:space:]]*head[[:space:]]+-' <<<"$WRAPPER_CODE" &&
+	fail "wrapper pipes to 'head -' — that shape leaks an orphaned poller (Bun ignores SIGPIPE)"
+pass "no '| head -' pipeline (the leak shape) in the wrapper"
+
+# --- 4. temp state is cleaned up on every exit path ---------------------------
+grep -Eq 'trap[[:space:]]+cleanup[[:space:]]+EXIT' <<<"$WRAPPER_CODE" ||
+	fail "wrapper must trap cleanup on EXIT so the fifo/workdir are removed"
+grep -Eq "rm[[:space:]]+-rf[[:space:]]+\"\\\$WORKDIR\"" <<<"$WRAPPER_CODE" ||
+	fail "cleanup must rm the working directory (fifo + stderr capture)"
+pass "workdir removed via cleanup trap (re-arming leaves no litter)"
+
+# Signal handlers must terminate. A bare `trap cleanup TERM` runs the handler, returns, and lets
+# the interrupted read fall through to the success path — cancellation would look like delivery.
+grep -Eq "trap[[:space:]]+'exit[[:space:]]+[0-9]+'[[:space:]]+INT" <<<"$WRAPPER_CODE" ||
+	fail "INT handler must exit, or a cancelled task falls through to the success path"
+grep -Eq "trap[[:space:]]+'exit[[:space:]]+[0-9]+'[[:space:]]+TERM" <<<"$WRAPPER_CODE" ||
+	fail "TERM handler must exit, or a cancelled task falls through to the success path"
+pass "INT/TERM handlers exit (cancellation is not mistaken for delivery)"
+
+# --- 5. the fail-closed identity precondition is surfaced --------------------
+grep -q 'agent-identity.json' <<<"$WRAPPER_CODE" ||
+	fail "wrapper must check for .claude/agent-identity.json — unresolved identity fails CLOSED (silent)"
+grep -q 'CLAUDE_PROJECT_DIR' <<<"$WRAPPER_CODE" ||
+	fail "wrapper must honor CLAUDE_PROJECT_DIR (identity root, immune to cwd drift)"
+grep -q 'WARNING' <<<"$WRAPPER_CODE" ||
+	fail "the deaf case must announce itself — silent hang is indistinguishable from 'no messages'"
+pass "identity precondition checked + warned (deaf case is not silent)"
+
+# The watcher's stderr must be captured, not discarded: it carries the identity state_change line
+# the skill tells operators to check, and the dead-watcher diagnosis.
+# shellcheck disable=SC2016  # matching the literal text `2>"$ERRLOG"` in the wrapper — no expansion
+grep -Eq '2>"\$ERRLOG"' <<<"$WRAPPER_CODE" ||
+	fail "watcher stderr must be captured (identity confirmation + dead-watcher diagnosis)"
+# Scope this to the line that STARTS THE POLLER (the one redirecting into the fifo). The wrapper
+# legitimately discards stderr elsewhere — on kill/wait, and on the capability probe, whose stderr
+# is noise by design — so a bare `WATCHER + 2>/dev/null` match would flag correct code.
+#
+# NOTE the first grep must NOT be -q: -q writes nothing, so piping it into a second grep feeds an
+# always-empty stream and the fail becomes unreachable. That vacuous form shipped here once — the
+# one assertion class mutation testing cannot catch, since deleting it changes nothing.
+# shellcheck disable=SC2016  # matching the literal text `>"$FIFO"` in the wrapper — no expansion
+if grep -E '>"\$FIFO"' <<<"$WRAPPER_CODE" | grep -qE '2>[[:space:]]*/dev/null'; then
+	fail "the doorbell poller's stderr must not be discarded (it carries identity + diagnosis)"
+fi
+pass "watcher stderr is captured, not discarded"
+
+# --- 6. TIMEOUT: distinct exit code, and non-numeric input rejected -----------
+# shellcheck disable=SC2016  # matching the literal text `read -r -t "$TIMEOUT"` — no expansion
+grep -Eq 'read -r -t "\$TIMEOUT"' <<<"$WRAPPER_CODE" || fail "TIMEOUT must bound the read"
+grep -Eq 'exit 3' <<<"$WRAPPER_CODE" || fail "timeout must exit with a distinct non-zero code (3)"
+grep -Eq '\^\[0-9\]\+\$' <<<"$WRAPPER_CODE" ||
+	fail "TIMEOUT must be validated as an integer — [[ -gt ]] is arithmetic, so 'TIMEOUT=30s' would silently block forever"
+pass "TIMEOUT bounds the wait, with a distinct exit code and integer validation"
+
+# bash 3.2 (stock macOS) breaks BOTH mechanisms silently: fractional `read -t` is rejected, so
+# the drain no-ops and truncates multi-message polls; and a timed-out read returns 1 instead of
+# >128, so every timeout is misreported as a dead watcher. Two silent wrong answers — refuse.
+grep -Eq 'BASH_VERSINFO\[0\][[:space:]]*<[[:space:]]*4' <<<"$WRAPPER_CODE" ||
+	fail "wrapper must refuse bash < 4 — fractional read -t and the >128 timeout status are 4.0+"
+pass "bash >= 4 enforced (3.2 would break the drain and the timeout, both silently)"
+
+# DRAIN_SECONDS feeds `read -t` directly; a malformed value returns non-zero, which is
+# indistinguishable from "nothing left to drain" — a silently skipped drain.
+grep -q 'DRAIN_SECONDS' <<<"$WRAPPER_CODE" ||
+	fail "the drain window must be configurable — the default cannot span cross-channel bursts"
+grep -Eq '\^\[0-9\]\+\(\\\.\[0-9\]\+\)\?\$' <<<"$WRAPPER_CODE" ||
+	fail "DRAIN_SECONDS must be validated as a number, or a typo silently skips the drain"
+pass "DRAIN_SECONDS is configurable and validated"
+
+# Behavioral: a stub watcher that emits nothing and stays alive → exit 3.
+# `exec sleep` so the PID the wrapper kills IS the sleep; a plain `sleep` would be orphaned for
+# ten minutes after every validate.sh run.
+QUIET_DIR="$SANDBOX/quiet"
+mkdir -p "$QUIET_DIR/.claude"
+echo '{"dev_name":"stub","dev_team":"test"}' >"$QUIET_DIR/.claude/agent-identity.json"
+cat >"$QUIET_DIR/discord-watcher" <<'STUB'
+#!/usr/bin/env bash
+# Emits nothing, exits only when killed — stands in for a quiet poll loop.
+# Answers the capability probe so it reads as a v1.6.0+ binary.
+if [[ "${2:-}" == "--help" ]]; then
+	echo "usage: discord-watcher doorbell"
+	exit 0
+fi
+exec sleep 600
+STUB
+chmod +x "$QUIET_DIR/discord-watcher"
+(cd "$QUIET_DIR" && TMPDIR="$QUIET_DIR" WATCHER="$QUIET_DIR/discord-watcher" TIMEOUT=2 "$WRAPPER" >/dev/null 2>&1)
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "expected exit 3 on TIMEOUT with no message, got $rc"
+pass "quiet watcher + TIMEOUT → exit 3 (behavioral)"
+
+# The stub run must not leave its fifo/workdir behind — scanning only ITS TMPDIR.
+if compgen -G "$QUIET_DIR/doorbell.*" >/dev/null; then
+	fail "a doorbell workdir survived the timeout path"
+fi
+pass "no workdir survives the timeout path (behavioral)"
+
+# Behavioral: non-numeric TIMEOUT is rejected up front (exit 2), not silently unbounded.
+(cd "$QUIET_DIR" && TMPDIR="$QUIET_DIR" WATCHER="$QUIET_DIR/discord-watcher" TIMEOUT=30s timeout 10 "$WRAPPER" >/dev/null 2>&1)
+rc=$?
+[[ "$rc" -eq 2 ]] || fail "expected exit 2 on non-numeric TIMEOUT, got $rc (124 = it blocked, the bug)"
+pass "non-numeric TIMEOUT → exit 2, never an unbounded wait (behavioral)"
+
+# --- 7. a watcher that dies without emitting → exit 4, never a blank exit 0 ---
+DEAD_DIR="$SANDBOX/dead"
+mkdir -p "$DEAD_DIR/.claude"
+echo '{"dev_name":"stub","dev_team":"test"}' >"$DEAD_DIR/.claude/agent-identity.json"
+cat >"$DEAD_DIR/discord-watcher" <<'STUB'
+#!/usr/bin/env bash
+# A v1.6.0+ binary (answers the probe) that then dies without emitting — bad token,
+# baseline-init failure, crash. NOT the old-version case: an old binary hangs instead,
+# which is why the wrapper probes capability separately (see guard 10).
+if [[ "${2:-}" == "--help" ]]; then
+	echo "usage: discord-watcher doorbell"
+	exit 0
+fi
+echo "doorbell: Fatal: baseline init failed (401 Unauthorized)" >&2
+exit 1
+STUB
+chmod +x "$DEAD_DIR/discord-watcher"
+out="$(cd "$DEAD_DIR" && TMPDIR="$DEAD_DIR" WATCHER="$DEAD_DIR/discord-watcher" timeout 10 "$WRAPPER" 2>/dev/null)"
+rc=$?
+[[ "$rc" -eq 4 ]] || fail "dead watcher must exit 4, got $rc (0 = the false-doorbell hot-loop bug)"
+[[ -z "$out" ]] || fail "dead watcher must emit no stdout line, got: $out"
+pass "watcher exits without a line → exit 4, empty stdout (behavioral)"
+
+# And its stderr must be surfaced — that is the only diagnosis the caller gets.
+err="$(cd "$DEAD_DIR" && TMPDIR="$DEAD_DIR" WATCHER="$DEAD_DIR/discord-watcher" timeout 10 "$WRAPPER" 2>&1 >/dev/null)"
+grep -q '401 Unauthorized' <<<"$err" ||
+	fail "the dead watcher's own stderr must be replayed to the caller"
+pass "dead watcher's stderr is replayed (diagnosable, not silent)"
+
+# --- 10. a pre-v1.6.0 watcher is caught by the probe, not by hanging -----------
+# The real old binary has no unknown-subcommand handler: `doorbell` falls through to the
+# MCP server, which never exits. So `doorbell --help` hangs too, and the wrapper's probe
+# must bound it. Without the probe this case is an unbounded silent wait at TIMEOUT=0 —
+# the exact deafness the feature exists to prevent. exit 124 here would mean the wrapper
+# hung and `timeout` killed it: the bug.
+OLD_DIR="$SANDBOX/old"
+mkdir -p "$OLD_DIR/.claude"
+echo '{"dev_name":"stub","dev_team":"test"}' >"$OLD_DIR/.claude/agent-identity.json"
+cat >"$OLD_DIR/discord-watcher" <<'STUB'
+#!/usr/bin/env bash
+# Pre-v1.6.0 shape: every argv falls through to the MCP server and never exits —
+# including `doorbell --help`.
+exec sleep 600
+STUB
+chmod +x "$OLD_DIR/discord-watcher"
+(cd "$OLD_DIR" && TMPDIR="$OLD_DIR" WATCHER="$OLD_DIR/discord-watcher" timeout 20 "$WRAPPER" >/dev/null 2>&1)
+rc=$?
+[[ "$rc" -eq 2 ]] || fail "pre-v1.6.0 watcher must fail the probe with exit 2, got $rc (124 = it hung, the bug)"
+pass "pre-v1.6.0 watcher → exit 2 from the capability probe, never a hang (behavioral)"
+
+# shellcheck disable=SC2016  # matching the literal text `timeout 5 "$WATCHER" …` — no expansion
+grep -Eq 'timeout 5 "\$WATCHER" doorbell --help' <<<"$WRAPPER_CODE" ||
+	fail "the capability probe must bound --help with timeout — it hangs on an old binary too"
+pass "capability probe bounds --help with timeout"
+
+# --- 11. a non-doorbell stdout line is not reported as a message --------------
+# The watcher's other mode writes JSON-RPC frames to stdout. Printing one of those as a
+# doorbell and exiting 0 would be a false doorbell.
+JUNK_DIR="$SANDBOX/junk"
+mkdir -p "$JUNK_DIR/.claude"
+echo '{"dev_name":"stub","dev_team":"test"}' >"$JUNK_DIR/.claude/agent-identity.json"
+cat >"$JUNK_DIR/discord-watcher" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "--help" ]]; then
+	echo "usage: discord-watcher doorbell"
+	exit 0
+fi
+echo '{"jsonrpc":"2.0","method":"notifications/claude/channel","params":{}}'
+exec sleep 600
+STUB
+chmod +x "$JUNK_DIR/discord-watcher"
+out="$(cd "$JUNK_DIR" && TMPDIR="$JUNK_DIR" WATCHER="$JUNK_DIR/discord-watcher" timeout 20 "$WRAPPER" 2>/dev/null)"
+rc=$?
+[[ "$rc" -eq 4 ]] || fail "a non-doorbell stdout line must not be reported as a message (exit 4), got $rc"
+[[ -z "$out" ]] || fail "a non-doorbell line must not be printed to stdout, got: $out"
+pass "non-doorbell stdout → exit 4, nothing printed (behavioral)"
+
+# --- 8. a multi-message poll is drained, not truncated to one line ------------
+# shellcheck disable=SC2016  # matching the literal text `exec 3<"$FIFO"` — no expansion
+grep -Eq 'exec 3<"\$FIFO"' <<<"$WRAPPER_CODE" ||
+	fail "the fifo must be opened once on a fd — reopening races the writer and can lose buffered lines"
+pass "fifo opened once on a fd (drain reads the same stream)"
+
+BURST_DIR="$SANDBOX/burst"
+mkdir -p "$BURST_DIR/.claude"
+echo '{"dev_name":"stub","dev_team":"test"}' >"$BURST_DIR/.claude/agent-identity.json"
+cat >"$BURST_DIR/discord-watcher" <<'STUB'
+#!/usr/bin/env bash
+# Three deliverable messages in one poll, then keep polling like the real thing.
+if [[ "${2:-}" == "--help" ]]; then
+	echo "usage: discord-watcher doorbell"
+	exit 0
+fi
+echo "[doorbell] #a channel_id=1 msg_id=1 from X: first"
+echo "[doorbell] #a channel_id=1 msg_id=2 from X: second"
+echo "[doorbell] #a channel_id=1 msg_id=3 from X: third"
+exec sleep 600
+STUB
+chmod +x "$BURST_DIR/discord-watcher"
+out="$(cd "$BURST_DIR" && TMPDIR="$BURST_DIR" WATCHER="$BURST_DIR/discord-watcher" timeout 20 "$WRAPPER" 2>/dev/null)"
+rc=$?
+[[ "$rc" -eq 0 ]] || fail "a delivered burst must exit 0, got $rc"
+lines="$(grep -c '^\[doorbell\]' <<<"$out")"
+[[ "$lines" -eq 3 ]] || fail "expected all 3 buffered doorbell lines, got $lines — the rest are unrecoverable"
+pass "multi-message poll drained: all 3 lines emitted, exit 0 (behavioral)"
+
+# --- 9. the skill routes doorbell, flags the Monitor trap, uses a bare name ---
+if [[ ! -f "$SKILL" ]]; then
+	echo "  [FAIL] missing $SKILL" >&2
+	exit 1
+fi
+grep -q 'doorbell' "$SKILL" || fail "skills/disc/SKILL.md must route the doorbell subcommand"
+grep -q 'Monitor' "$SKILL" ||
+	fail "SKILL.md must warn that Monitor (the README's arming instruction) may be unavailable"
+grep -q 'doorbell-oneshot.sh' "$SKILL" || fail "SKILL.md must point at the one-shot wrapper"
+pass "skills/disc/SKILL.md routes doorbell + flags the Monitor trap"
+
+# #569 class: a relative scripts/ path only resolves in the cc-workflow source tree. ./install
+# symlinks scripts/* onto PATH, so the invocation must be the bare name.
+#
+# Anchor on a path BOUNDARY (line start, whitespace, or backtick). Matching `scripts/…` anywhere
+# would also flag the legitimate absolute Cellar path `~/.claude/scripts/doorbell-oneshot.sh`,
+# failing the skill for documenting where the file lives — a false positive that would train the
+# next author to delete the guard rather than the defect.
+grep -Eq '(^|[[:space:]`])(\./)?scripts/doorbell-oneshot\.sh' "$SKILL" &&
+	fail "SKILL.md must invoke doorbell-oneshot.sh by bare name, not a relative scripts/ path (#569 class)"
+pass "SKILL.md invokes the wrapper by bare name (works outside cc-workflow)"
+
+grep -q 'exit 4' "$SKILL" ||
+	fail "SKILL.md must document exit 4 — a pre-v1.6.0 watcher is the reachable case"
+pass "SKILL.md documents the exit-code contract including exit 4"
+
+echo ""
+if ((FAILS > 0)); then
+	echo "  $FAILS doorbell one-shot wrapper check(s) FAILED"
+	exit 1
+fi
+echo "  all doorbell one-shot wrapper checks passed"


### PR DESCRIPTION
## Summary

Watcher v1.6.0 shipped the `doorbell` subcommand, but the skill↔tool seam was never wired: `skills/disc/SKILL.md` had **zero** mention of it. Worse, the arming instruction printed by the watcher's own README and `--help` — `Monitor({command: "discord-watcher doorbell", persistent: true})` — names a primitive that is **absent from some clients' tool surface**. Where it is missing, the only background mechanism available notifies on process **EXIT**, and `doorbell` is a poll loop that never exits: the line lands in a file nobody reads and the agent is never woken. That is *silent* deafness — the exact failure the doorbell exists to prevent.

`scripts/doorbell-oneshot.sh` inverts it: **make the exit BE the doorbell.** One batch of messages, one exit, one task-completion notification, one agent turn. Re-arm for the next.

No drain-and-restart required — `doorbell` is a separate subcommand in its own process, so a running `--channels` watcher is untouched.

## Changes

- **`scripts/doorbell-oneshot.sh`** (new) — one-shot arming wrapper.
  - **The exit code is the whole signal, so it must never lie.** Because the design rests on "exited ⇒ a message arrived", an exit 0 carrying no message is worse than a crash: the agent re-arms instantly and spins. Every non-message way the read can end gets its own code — `2` precondition, `3` timeout, `4` watcher died (with its stderr replayed).
  - **A pre-v1.6.0 watcher HANGS, it does not error.** `index.ts:1983-1999` has no unknown-subcommand handler, so `doorbell` falls through to `main()` — the MCP stdio server — which installs a poll interval and never exits. So it is caught by an up-front capability probe, not diagnosed from a stalled read. The probe needs its own `timeout` because `doorbell --help` hangs on such a binary too.
  - **Reads through a fifo and kills the child by PID.** Bun ignores `SIGPIPE` and swallows the write error, so `| head -1` does *not* terminate the child — verified still polling 20s after the reader exited. Re-arming that way accumulates one leaked poller per message.
  - **Drains after the first line.** A single poll can yield several messages, and dropped ones are *unrecoverable*: a re-armed instance seeds its cursor to the newest message per channel **and** marks it delivered, so it starts past them.
  - Validates `TIMEOUT`/`DRAIN_SECONDS` as numbers — `[[ "$TIMEOUT" -gt 0 ]]` evaluates arithmetically, so a plausible typo like `TIMEOUT=30s` makes the test **false** and silently selects the *unbounded* branch: the caller asks for a bound and gets an infinite block.
  - Refuses bash < 4 (stock macOS 3.2), where fractional `read -t` is rejected *and* a timed-out read returns 1 instead of >128 — two silent wrong answers (skipped drain, timeout misreported as a dead watcher).
  - Warns when `<root>/.claude/agent-identity.json` is unresolvable: `shouldDeliverMessage` fails **closed**, so the watcher polls normally and delivers nothing.
- **`tests/regression/test_doorbell_oneshot.sh`** (new) — 24 assertions, behavioral wherever a stub can carry it. Four stub watchers: quiet → `3`, dead (`401 Unauthorized`) → `4` + stderr replay, pre-v1.6.0 → `2` from the probe (`124` would mean the real hang), non-doorbell JSON-RPC stdout → `4`, 3-message burst → all 3 lines + `0`. Asserts on **comment-stripped** code so the wrapper's own prose about a trap cannot satisfy a guard.
- **`skills/disc/SKILL.md`** — route `doorbell`, flag the `Monitor` trap, document the exit-code contract, the batch semantics, the cross-channel known gap, and the three silent-deafness modes. Invoked by **bare name** (`./install` symlinks `scripts/*` onto PATH); a relative `scripts/…` path only resolves inside this source tree — the #569 regression class.

### Known limit, documented rather than claimed fixed

**The drain covers one channel, not a whole cycle.** The watcher emits a channel's messages back-to-back, so a same-channel burst lands inside the window. Between channels it sleeps 50–150ms of jitter plus an HTTP round trip, and `cleanup` kills it mid-cycle, so channels it had not yet polled are never fetched. `DRAIN_SECONDS` trades wall-clock for coverage but cannot close the gap — only a cycle-boundary signal from the watcher could.

## Linked Issues

Closes #1055

Deferred, filed separately: #1056 — trivy parses **0 manifests** in this repo (`bun.lock` gitignored at `.gitignore:30`; `tools/cc-inspector/requirements.txt` unpinned). Pre-existing; this changeset adds no dependencies.

## Test Plan

Actually run, not aspirational:

- `./scripts/ci/validate.sh` → **219 passed, 0 failed** (includes the new suite via the `tests/regression/*.sh` loop). shellcheck `-x` + shfmt clean on both new files.
- `python3 -m pytest tests/` → **1923 passed, 6 skipped, 64 xfailed, 2 xpassed, 26 subtests** (553s).
- `tests/regression/test_doorbell_oneshot.sh` → **24/24**, ~7s.
- **Live-fired end-to-end twice against real Discord**: exact `[doorbell] #<channel> channel_id=… msg_id=… from <author>: <preview>` line shape, exit 0, background-task notification fired, zero orphaned pollers, zero stray workdirs.
- **Mutation-tested the guards**, because an assertion is a claim and claims get tested: removing the capability probe yields `124` (the real hang) rather than a pass; `/bin/false >"$FIFO"` reproduced the original critical exit-0-with-no-message; the first version of the stderr assertion was **vacuous** (`grep -q | grep -q` feeds an always-empty stream, making its `fail` unreachable) and was rewritten, then confirmed to fire on real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)