### PR TITLE
docs(disc): name the four conditions that gate Monitor off

### DIFF
--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -420,6 +420,7 @@ Unified Discord integration for the Oak and Wave server. Handles sending message
 - To read what other agents or team members have posted
 - To create new channels or threads for coordination
 - To route your doorbells to another agent while you are away, or to reach one whose doorbells are forwarded
+- To arm the **channels-free doorbell** when the session has no `--channels` sink — the only way to hear Discord at all when `Monitor` is gated off (third-party provider, gateway auth, or telemetry disabled)
 
 **Examples:**
 
@@ -436,6 +437,8 @@ Unified Discord integration for the Oak and Wave server. Handles sending message
 /disc forward babelfish --exclude dev,ci # ...except doorbells from #dev or #ci
 /disc forward off                        # Clear the rule
 /disc dm treebeard "PR #12 is red"       # Direct message, bypasses forwarding
+
+/disc doorbell                           # Arm the channels-free doorbell (no --channels)
 ```
 
 **`<agent>` is an agent, never a channel** — a Dev-Name or Dev-Team token. Passing a channel silently "succeeds" and then fails at every delivery. `--exclude` names channels/authors whose doorbells **stay local**, not recipients to omit.

--- a/scripts/doorbell-oneshot.sh
+++ b/scripts/doorbell-oneshot.sh
@@ -11,11 +11,35 @@
 #
 #     Monitor({ command: "discord-watcher doorbell", persistent: true })
 #
-# That primitive is NOT present in every client. Where it is missing, the only
-# background-process mechanism available notifies the agent when a task **exits** —
-# and `discord-watcher doorbell` is a persistent poll loop that never exits. Armed
-# that way the doorbell line lands in a file nobody reads and the agent is never
-# woken: silent deafness, the exact failure the doorbell exists to prevent.
+# That primitive is gated OFF under several common conditions. All of the following
+# were read out of the 2.1.220 bundle (2026-07-27); minified symbol names are
+# regenerated per build, so this records the behavior, not the identifiers.
+#
+# `Monitor.isEnabled()` resolves the server-side feature flag `tengu_amber_sentinel`,
+# which DEFAULTS TO FALSE, and both local override paths are compiled out: the
+# settings override returns unconditionally, and the CLAUDE_INTERNAL_FC_OVERRIDES env
+# read sits after an unconditional `return` — unreachable dead code. The flag can only
+# come from the feature service, and that lookup SHORT-CIRCUITS TO FALSE before it
+# consults the cache when any of these hold:
+#
+#     - provider is not first-party (Bedrock, Vertex / Google Cloud Agent Platform,
+#       Microsoft Foundry) — unless CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST is set
+#     - gateway auth is in use
+#     - CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC / DISABLE_TELEMETRY / DO_NOT_TRACK
+#     - DISABLE_GROWTHBOOK
+#
+# So an Anthropic-authenticated session with telemetry disabled ALSO has no Monitor —
+# the auth path is not the whole story. On a third-party provider `--channels` is
+# unavailable too, which is why a Bedrock-backed session is exactly the case this
+# wrapper exists for: no Monitor to fall back to, and no channels either. The two are
+# separately gated, though (Channels is admin-enabled on Team/Enterprise plans), so
+# diagnose them independently rather than inferring one from the other.
+#
+# Where Monitor is missing, the only background-process mechanism available notifies
+# the agent when a task **exits** — and `discord-watcher doorbell` is a persistent
+# poll loop that never exits. Armed that way the doorbell line lands in a file nobody
+# reads and the agent is never woken: silent deafness, the exact failure the doorbell
+# exists to prevent.
 #
 # So this wrapper inverts it: make the EXIT be the doorbell. One batch of messages,
 # one exit, one task-completion notification, one agent turn. Re-arm for the next.

--- a/skills/disc/SKILL.md
+++ b/skills/disc/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: disc
-description: Discord integration — /disc routes to disc-server MCP tools, plus discord-watcher CLI subcommands for forward/directmsg.
+description: Discord integration — /disc routes to disc-server MCP tools, plus discord-watcher CLI subcommands for forward/directmsg/doorbell. Includes the channels-free doorbell transport for sessions started WITHOUT --channels, where no MCP notification sink is wired and the agent is otherwise deaf.
 usage: |
   /disc send #ch "msg"  /disc read #ch  /disc list  /disc create #ch  /disc thread "name" in #ch
   /disc forward <agent> [--exclude a,b]  /disc forward off  /disc dm <agent> "msg"
+  /disc doorbell  — arm the channels-free doorbell (no --channels required)
 ---
 
 <!-- introduction-gate: If introduction.md exists in this skill's directory AND
@@ -74,7 +75,22 @@ For sessions started **without** `--channels`: the MCP notification sink is neve
 Monitor({ command: "discord-watcher doorbell", persistent: true })
 ```
 
-`Monitor` is **absent from some clients' tool surface** — check before relying on it. Where it is missing, the only background-process mechanism available notifies the agent when a task **exits**, and `doorbell` is a persistent loop that never exits. Armed that way the line is written to a file nobody reads and the agent is never woken: *silent* deafness, the exact failure the doorbell exists to prevent.
+`Monitor` is **absent under several common conditions** — see the list below; a non-Anthropic provider is only one of them. Where it is missing, the only background-process mechanism available notifies the agent when a task **exits**, and `doorbell` is a persistent loop that never exits. Armed that way the line is written to a file nobody reads and the agent is never woken: *silent* deafness, the exact failure the doorbell exists to prevent.
+
+**When `Monitor` is missing, and why.** `Monitor.isEnabled()` resolves the server-side feature flag `tengu_amber_sentinel`, which **defaults to false**, and both local override paths are compiled out of the shipped bundle — the settings override returns unconditionally, and the `process.env.CLAUDE_INTERNAL_FC_OVERRIDES` read sits *after* an unconditional `return`, so it is unreachable dead code. The flag can therefore arrive only from the feature service — and the lookup **short-circuits to `false` before it ever consults the cache** unless *all* of the following hold:
+
+| condition | `Monitor` absent when… |
+|---|---|
+| provider | the resolved provider is **not first-party** — Bedrock, Vertex / Google Cloud Agent Platform, Microsoft Foundry (overridden by `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`) |
+| gateway | gateway auth is in use |
+| telemetry | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, or `DO_NOT_TRACK` is set |
+| flag service | `DISABLE_GROWTHBOOK` is set |
+
+So an **Anthropic-authenticated session still loses `Monitor`** if it has telemetry disabled — do not stop at the auth path. Verified by reading the 2.1.220 bundle (2026-07-27); the minified symbol names are regenerated per build, so match on this behavior rather than on identifiers.
+
+**Relationship to `--channels` — correlation, not a shared switch.** On a third-party provider both are unavailable, so a Bedrock-backed session is precisely the case this wrapper exists for: no `Monitor` to fall back to *and* no channels. But they are **separately gated** and do not always fail together — Channels is admin-enabled on claude.ai Team/Enterprise plans and can be off while `Monitor` is fine. Diagnose them independently; do not infer one from the other.
+
+Do not patch the vendor bundle to force the flag — it self-updates and the change reverts silently.
 
 **Use the one-shot wrapper instead** — it makes the exit BE the doorbell, so the task-completion notification wakes the agent. Invoke it by **bare name** (`./install` symlinks every `scripts/*` file onto PATH); a relative `scripts/…` path only resolves inside the cc-workflow source tree, which is never where you want to be — the wrapper must run from the *target project's* root so identity resolves:
 
@@ -87,7 +103,7 @@ DEBUG=1 doorbell-oneshot.sh         # also forward the watcher's stderr
 
 Run it as a **background** task, then re-arm after handling the messages it printed (one batch → one turn). Cellar copy, for reference: `~/.claude/scripts/doorbell-oneshot.sh`.
 
-**Read the exit code — it is the whole signal.** `0` = one or more `[doorbell]` lines on stdout; `2` = precondition failure (bash < 4, watcher missing, **watcher older than v1.6.0**, malformed `TIMEOUT`/`DRAIN_SECONDS`); `3` = `TIMEOUT` elapsed with nothing delivered; `4` = the `doorbell` subcommand exists but the watcher died without emitting a valid line — bad token, baseline-init failure, crash — with its stderr printed for you. Never treat a bare exit 0 with empty stdout as a message: re-arming on that is a hot loop, and the wrapper is built so it cannot happen.
+**Read the exit code — it is the whole signal.** exit 0 = one or more `[doorbell]` lines on stdout; exit 2 = precondition failure (bash < 4, watcher missing, **watcher older than v1.6.0**, malformed `TIMEOUT`/`DRAIN_SECONDS`, temp-dir/fifo setup); exit 3 = `TIMEOUT` elapsed with nothing delivered; exit 4 = the `doorbell` subcommand exists but the watcher died without emitting a valid line — bad token, baseline-init failure, crash — with its stderr printed for you. Never treat a bare exit 0 with empty stdout as a message: re-arming on that is a hot loop, and the wrapper is built so it cannot happen.
 
 A **pre-v1.6.0 watcher does not error** — it has no unknown-subcommand handler, so `doorbell` falls through to the MCP server and the process never exits. That would hang the wrapper forever at the default `TIMEOUT=0`, so the wrapper probes `doorbell --help` up front and fails with exit 2 instead. If you see that, the fix is a watcher upgrade, not a retry.
 


### PR DESCRIPTION
## Summary

The doorbell section of `/disc` said `Monitor` is *"absent from some clients' tool surface — check before relying on it."* That is unfalsifiable, and it cost a full session to rediscover: the reader is sent decompiling the CLI bundle instead of looking something up. This replaces it with the four verified gate conditions, and fixes the frontmatter that never advertised the doorbell at all.

## Changes

- **`skills/disc/SKILL.md` frontmatter** — `description` and `usage` now advertise the doorbell. #1055 shipped the 45-line body section but left the frontmatter untouched, and skill selection reads frontmatter. So an agent that is *already deaf* — the exact reader this feature exists for — would scan the skill list, see no mention of "doorbell", and conclude `/disc` was not the answer. Same defect class as #945.
- **`skills/disc/SKILL.md` body** — replaced the vague sentence with the gate chain. `Monitor.isEnabled()` resolves the server-side flag `tengu_amber_sentinel`, which defaults to **false**; both local override paths are compiled out of the shipped bundle (the settings override returns unconditionally; the `CLAUDE_INTERNAL_FC_OVERRIDES` read sits after an unconditional `return`). The flag can only come from the feature service, and that lookup **short-circuits to `false` before consulting the cache** when any of:

  | gate | `Monitor` absent when… |
  |---|---|
  | provider | not first-party — Bedrock, Vertex / Google Cloud Agent Platform, Microsoft Foundry (overridden by `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`) |
  | gateway | gateway auth in use |
  | telemetry | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` / `DISABLE_TELEMETRY` / `DO_NOT_TRACK` |
  | flag service | `DISABLE_GROWTHBOOK` |

- **Channels is documented as correlated, not co-gated.** Both are unavailable on third-party providers, but Channels is separately admin-enabled on Team/Enterprise plans and can be off while `Monitor` is healthy. The doc now says to diagnose them independently.
- **Exit-code contract writes `exit N` literally** — the regression guard `grep -q 'exit 4'` was passing only via an incidental parenthetical in the identity bullet. Rewording that unrelated aside would have turned the guard red while the contract paragraph sat untouched, and vice versa.
- **Exit 2 list** gains the temp-dir/fifo setup path it always had.
- **`scripts/doorbell-oneshot.sh` header** carries the same corrected condition at the same epistemic status as the skill (it previously stated the causal chain with no hedge while the skill hedged).
- **`docs/skill-reference.md`** lists the doorbell verb the frontmatter now advertises.

## Why the auth-only framing was wrong

The first draft of this change said `Monitor` is absent "whenever the client authenticates somewhere other than Anthropic." Code review flagged that the telemetry env vars also kill it — chasing that resolved the *whole* chain out of the bundle, which is why the hedge present in the first draft is gone: it is no longer inferred.

The practical consequence: **an Anthropic-authenticated session with telemetry disabled also has no `Monitor`.** The auth-only version would have sent that reader down the one path that was fine.

## Linked Issues

Closes #1059

## Test Plan

Actually run on the final tree:

- `./scripts/ci/validate.sh` → **219 passed, 0 failed**
- All 17 `SKILL.md`-reading pytest files → **378 passed, 1 skipped, 64 xfailed, 2 xpassed** (the 2 xpassed are pre-existing — identical count to the full-suite baseline)
- `tests/regression/test_doorbell_oneshot.sh` → 24/24, run before *and* after the review rework
- `bash -n scripts/doorbell-oneshot.sh` → clean
- **Mutation-tested the exit-4 guard**: deleted the incidental parenthetical it had been binding to and confirmed the assertion still passes, i.e. it is now bound to the contract paragraph

Full pytest (**1923 passed, 6 skipped, 64 xfailed**) was run by the precheck batch, but on a tree that predates the review rework — hence the targeted re-run above rather than claiming that result covers this commit.

**Not verified:** the `Monitor` gate chain is read out of CLI 2.1.220 statically. It has not been exercised by flipping each env var and observing the tool surface. Minified symbol names are regenerated per build, so the docs record behavior rather than identifiers.

### Deferred

`trivy` parsed **0 manifests** — not a pass, nothing was scanned. Pre-existing and tracked as #1056 (`bun.lock` gitignored, `requirements.txt` unpinned). This changeset touches no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS