### PR TITLE
fix(secrets): scope the container secrets mount to named files

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ These authenticate automatically through Claude Code's OAuth flow. No manual tok
 The `/ping` skill uses `slackbot-send`, which requires a Slack bot token:
 
 ```bash
-mkdir -p ~/secrets
+mkdir -p ~/.secrets
 echo "xoxb-your-token" > ~/secrets/slack-bot-token
 chmod 600 ~/secrets/slack-bot-token
 ```
@@ -298,9 +298,9 @@ The `/disc` skill and discord-watcher channel server require a Discord bot token
 ### 1. Bot Token
 
 ```bash
-mkdir -p ~/secrets
-echo "your-bot-token" > ~/secrets/discord-bot-token
-chmod 600 ~/secrets/discord-bot-token
+mkdir -p ~/.secrets
+echo "your-bot-token" > ~/.secrets/discord-bot-token
+chmod 600 ~/.secrets/discord-bot-token
 ```
 
 The bot needs these permissions in your Discord server:

--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -25,11 +25,14 @@
 # Skills are symlink-safe artifacts (scripts/markdown, not compiled binaries), so
 # symlinking them across the host/container boundary is R-10-correct.
 #
-# Secrets (SKETCHBOOK D6, R-12/R-14): the whole ~/.secrets dir is a read-only
-# bind-mount. `.env` is the env modality (sourced here); loose files are the path
-# modality (NEVER auto-exported to env — that re-leaks via /proc/<pid>/environ).
-# A values-free manifest declares which secrets are required; any required secret
-# missing at boot fails loud.
+# Secrets (SKETCHBOOK D6 as amended by #1061, R-12/R-14): NAMED single-file
+# read-only bind-mounts under ~/.secrets — not the whole dir, which handed every
+# container both sides of the OaW/Analogic IP boundary. `.env` is the env modality
+# (sourced here) and carries POINTERS, never token values; loose files are the
+# path modality (NEVER auto-exported to env — that re-leaks via
+# /proc/<pid>/environ AND into every child process). The required-secret set is
+# declared by OAW_REQUIRED_SECRETS in that .env; any required secret missing at
+# boot fails loud. See ../secrets-env.example.
 #
 # Every path is env-injectable (defaults derived from $HOME) so the oracle
 # (tests/contained-workflow/test_bootstrap.py) drives this for real with fake
@@ -213,16 +216,57 @@ validate_secrets() {
 			. "$dir/.env"
 			set +a
 			info "secrets: sourced $dir/.env (env modality)"
+		else
+			# MUST NOT be a silent skip (#1061). Since the whole-dir mount was
+			# replaced by named file mounts, the `else` below is now unreachable —
+			# a file bind FORCES $dir into existence — so this is the only place a
+			# missing secrets provision can still be reported. It is also where
+			# Docker's create-if-missing bites: a bind whose source is absent
+			# appears as an empty DIRECTORY, which `-f` correctly rejects.
+			if [[ -e "$dir/.env" ]]; then
+				warn "secrets: $dir/.env exists but is not a regular file"
+				warn "  Docker creates a DIRECTORY when a bind-mount source is missing on the host."
+				warn "  Create ~/.secrets/.env on the HOST (see containers/oakandwave-workflow/secrets-env.example)."
+			else
+				warn "secrets: no $dir/.env — no pointers, no required-secret declaration"
+				warn "  Consumers will fall back to defaults and may find no token at all."
+				warn "  See containers/oakandwave-workflow/secrets-env.example."
+			fi
 		fi
 	else
 		warn "missing mount: secrets dir not present ($dir)"
 	fi
 
 	# Required-secrets list: the env override wins; else the values-free manifest.
+	#
+	# R-14 IS INERT WHEN BOTH ARE ABSENT (#1061). Before this guard, neither source
+	# being present left `required` empty, the validation loop ran zero times, and
+	# `validate_secrets` returned success — so the check designed to catch a missing
+	# secret at boot reported a clean run while examining nothing. That is the same
+	# empty-denominator failure as a scanner that parses zero manifests: a pass over
+	# nothing is indistinguishable from a pass over everything.
+	#
+	# Declaring "this container needs no secrets" is legitimate (the throwaway-CI
+	# ring builds without a secrets mount at all), so this WARNS rather than aborts.
+	# Set OAW_REQUIRED_SECRETS="" to declare it deliberately and silence the warning.
+	# Branch on SET-ness, not emptiness, so the documented precedence actually
+	# holds: `OAW_REQUIRED_SECRETS=""` means "deliberately none" and must beat a
+	# manifest, rather than falling through to it. `${VAR+set}` expands only when
+	# VAR is set (empty included) and is `set -u`-safe.
 	local -a required=()
-	if [[ -n "${OAW_REQUIRED_SECRETS:-}" ]]; then
-		IFS=' ' read -r -a required <<<"$OAW_REQUIRED_SECRETS"
-	elif [[ -f "$OAW_REQUIRED_SECRETS_MANIFEST" ]]; then
+	if [[ -n "${OAW_REQUIRED_SECRETS+set}" ]]; then
+		if [[ -n "$OAW_REQUIRED_SECRETS" ]]; then
+			IFS=' ' read -r -a required <<<"$OAW_REQUIRED_SECRETS"
+		else
+			info "secrets: no required secrets declared (OAW_REQUIRED_SECRETS is empty)"
+		fi
+	elif [[ ! -f "$OAW_REQUIRED_SECRETS_MANIFEST" ]]; then
+		warn "secrets: R-14 check is INERT — no \$OAW_REQUIRED_SECRETS and no manifest at $OAW_REQUIRED_SECRETS_MANIFEST"
+		warn "  Nothing was validated. A missing token will NOT fail this boot; it will"
+		warn "  surface later as an agent that polls normally and delivers nothing."
+		warn "  Declare the required set in ~/.secrets/.env (OAW_REQUIRED_SECRETS=...),"
+		warn "  or set it to \"\" if none are needed. See secrets-env.example."
+	else
 		local line
 		while IFS= read -r line || [[ -n "$line" ]]; do
 			line="${line%%#*}"         # strip comment

--- a/containers/oakandwave-workflow/mounts.d/20-secrets.toml
+++ b/containers/oakandwave-workflow/mounts.d/20-secrets.toml
@@ -1,36 +1,75 @@
 # 20-secrets.toml — read-only secrets (Dev Spec §5.5, Story 1.5 #965, R-12/R-13).
 #
-# The whole ~/.secrets dir enters as ONE read-only bind-mount. Secrets are NEVER
+# Secrets enter as NAMED, read-only, single-FILE bind-mounts — never the whole
+# ~/.secrets dir (changed in #1061; see the rationale block below). They are NEVER
 # baked into an image layer (R-12) — the image is the release and ships to every
-# ring/registry; a baked secret would leak with the digest. They are provided
-# only at runtime, via this mount. mount_resolver.py fails LOUD if a future edit
-# flips this to mode = "rw" (check: read-only-secrets + mode != ro -> R-12).
+# ring/registry; a baked secret would leak with the digest. They are provided only
+# at runtime, via these mounts. mount_resolver.py fails LOUD if a future edit
+# flips one to mode = "rw" (check: read-only-secrets + mode != ro -> R-12).
 #
-# Liveness (R-13): a bind-mount is the host dir, so a file the host adds to
-# ~/.secrets mid-session is visible to the running container with no restart.
-# That liveness is REAL for file-path consumers (they re-read the file); it is
-# NOT retroactive for env-var consumers — bootstrap.sh sources ~/.secrets/.env
-# once at boot (env modality), so a value added after boot reaches only path
-# consumers until the next process re-source. Hence the consumer split below:
+# Liveness (R-13), by modality:
 #
-#   .env         -> env modality  : sourced once at boot; env-var consumers.
-#   loose files  -> path modality : read on demand; FULLY live (R-13). PREFER.
+#   .env         -> env modality  : sourced ONCE at boot by bootstrap.sh. A value
+#                                   changed afterwards does not reach the running
+#                                   container.
+#   loose files  -> path modality : re-read on demand, so an IN-PLACE rewrite is
+#                                   live. An atomic replace is NOT — see the
+#                                   ROTATION note below. PREFER these.
 #
-# Blast-radius tradeoff (open item, §5.N / architecture.md §3.5): mounting the
-# WHOLE dir means every ring — and every process in the container, across the
-# GitLab/GitHub IP boundary — sees every secret. Least-privilege per-secret
-# scoping is a deliberate open design item; this whole-dir layer is where a
-# future scoped mechanism slots in. The mount stays ro so no ring can mutate a
-# shared secret.
+# Targets land under bootstrap.sh's OAW_SECRETS_DIR default ($HOME/.secrets), so
+# secret sourcing and required-secret validation (R-14) find them with no extra
+# env wiring. The R-14 required-secret list is declared via OAW_REQUIRED_SECRETS
+# in `.env` — NOT a `required.manifest` file, which would sit unmounted in
+# ~/.secrets now that the whole-dir mount is gone, leaving R-14 validating
+# nothing while appearing configured. Template: ../secrets-env.example.
+
+# --- Scoped mounts, NOT the whole dir (#1061) ---------------------------------
 #
-# The target matches bootstrap.sh's OAW_SECRETS_DIR default ($HOME/.secrets), so
-# secret sourcing + required-secret validation (R-14) find the dir with no extra
-# env wiring. A values-free required.manifest lives inside the dir (mounted with
-# it) and drives the fail-loud missing-secret check.
+# The blast-radius tradeoff described above is now closed for the default case.
+# The host's ~/.secrets holds ~80 credentials spanning BOTH sides of the OaW /
+# Analogic IP boundary; the kit needs exactly one of them. Mounting the whole dir
+# put every ANALOGICAL-*-KEY and gitlab-* token inside a GitHub/OaW container (and
+# vice versa) for no benefit. We therefore mount named files, not the directory.
+#
+# `.env` is the SINGLE configuration input (R-13 env modality). It carries
+# POINTERS, never secret values:
+#
+#     DISCORD_TOKEN_PATH=/home/ubuntu/.secrets/discord-bot-token   # watcher
+#     DISCORD_TOKEN_FILE=/home/ubuntu/.secrets/discord-bot-token   # disc-server
+#
+# Why a pointer instead of DISCORD_BOT_TOKEN=<value>: environment variables are
+# inherited by EVERY child process, while a file must be deliberately opened. With
+# session transcripts now host-durable (#1064), one stray `env` dump would write a
+# live bot token into permanent storage. The pointer keeps the single-input
+# property without ever putting the credential in the environment.
+#
+# ROTATION — read this before rotating a token on a running container. A Docker
+# FILE bind binds the INODE, not the path. Rewriting the file **in place**
+# (`printf > file`) is visible inside the container; an **atomic replace** (`mv`,
+# `install`, `sops`, and most editors' save-by-rename) leaves the container bound
+# to the old inode — silently, permanently, until it is recreated. That is the
+# "polls forever and delivers nothing" failure class, so it is worth saying twice:
+#
+#     rotate:  printf '%s' "$NEW" > ~/.secrets/discord-bot-token     # seen live
+#     do NOT:  mv new-token ~/.secrets/discord-bot-token             # NOT seen
+#
+# An env-modality value would need a restart unconditionally, so the pointer is
+# still strictly better — but "full R-13 liveness" would overstate it.
+#
+# Adding a secret here is a deliberate two-line act: mount it, and point at it
+# from .env. That is the intended friction — it is what keeps an unrelated
+# credential from silently entering a container's reach.
 
 [[mount]]
-name = "secrets"
+name = "secrets-env"
 layer = "read-only-secrets"
 mode = "ro"
-source = "~/.secrets"
-target = "/home/ubuntu/.secrets"
+source = "~/.secrets/.env"
+target = "/home/ubuntu/.secrets/.env"
+
+[[mount]]
+name = "secret:discord-bot-token"
+layer = "read-only-secrets"
+mode = "ro"
+source = "~/.secrets/discord-bot-token"
+target = "/home/ubuntu/.secrets/discord-bot-token"

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -41,12 +41,13 @@ fragment deterministically. Each file holds one or more `[[mount]]` tables.
 | file | layer | owner story |
 |------|-------|-------------|
 | `10-memory.toml` | shared-mutable-rw (memory + `settings.local.json`) | 1.3 (#963) |
-| `20-secrets.toml` | read-only-secrets (ro `~/.secrets` dir mount) | 1.5 (#965) |
+| `20-secrets.toml` | read-only-secrets (ro named single-file mounts) | 1.5 (#965), #1061 |
 | `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |
 | `40-durable-caches.toml` | durable-cache (cargo, go-mod, uv, ms-playwright) | 1.3 (#963) |
 
 `20-secrets.toml` was a drop-in for Story 1.3's resolver: the
 `read-only-secrets` layer and its `mode = "ro"` enforcement (R-12) already
-existed, so Story 1.5 added only the fragment (no resolver change). The whole
-`~/.secrets` dir mounts ro; a host-added file is live mid-session (R-13) — see
-`architecture.md` §3.5 for the consumer split and blast-radius tradeoff.
+existed, so Story 1.5 added only the fragment (no resolver change). #1061 then
+replaced the whole-dir mount with **named single-file** mounts, so a container
+sees only the secrets it declares; an in-place rewrite is live mid-session, an
+atomic replace is not (inode binding) — see `architecture.md` §3.5.

--- a/containers/oakandwave-workflow/secrets-env.example
+++ b/containers/oakandwave-workflow/secrets-env.example
@@ -1,0 +1,42 @@
+# secrets .env — the SINGLE configuration input for the contained workflow (#1061).
+#
+# COPY THIS TO THE HOST, NOT THE IMAGE: `~/.secrets/.env`, mode 600. It is
+# mounted read-only into the container by `mounts.d/20-secrets.toml`; it never
+# ships in an image layer (R-12), because the image is the release and goes to
+# every ring.
+#
+# ── POINTERS, NOT VALUES ──────────────────────────────────────────────────────
+#
+# Do NOT put `DISCORD_BOT_TOKEN=<value>` here. An environment variable is
+# inherited by every child process, while a file must be deliberately opened —
+# so a literal token would be handed to every build script, test harness, and
+# fetched tool the agent runs. With session transcripts host-durable (#1064),
+# one stray `env` dump writes it to permanent storage. Point at the file
+# instead; both consumers support it with no code change.
+
+DISCORD_TOKEN_PATH=/home/ubuntu/.secrets/discord-bot-token   # discord-watcher
+DISCORD_TOKEN_FILE=/home/ubuntu/.secrets/discord-bot-token   # disc-server
+
+# ── THE REQUIRED-SECRET DECLARATION (R-14) ────────────────────────────────────
+#
+# Space-separated secret NAMES that must be present for this container to be
+# useful. bootstrap.sh aborts the boot when a named secret is absent from both
+# $OAW_SECRETS_DIR and the environment.
+#
+# It is declared HERE rather than in a `required.manifest` file because the
+# whole-dir secrets mount is gone: a manifest sitting in `~/.secrets` would no
+# longer be mounted, so following that instruction would leave R-14 validating
+# nothing while appearing configured. `.env` is sourced before the required list
+# is computed, so this key is the route that actually works.
+#
+# Set it to the empty string to declare "this container needs no secrets"
+# deliberately (the throwaway-CI ring). Omitting it entirely is NOT the same
+# thing — that leaves R-14 inert, and bootstrap warns loudly about it.
+#
+# WHY IT EARNS ITS KEEP: a bind-mount whose SOURCE does not exist is created by
+# Docker as an empty DIRECTORY at the target. Consumers then fail with a
+# confusing read error rather than "your token is missing". bootstrap's
+# `[[ -f ... ]]` test fails on that directory, so the boot aborts with the
+# secret named — which is the entire point.
+
+OAW_REQUIRED_SECRETS=discord-bot-token

--- a/deps.json
+++ b/deps.json
@@ -25,6 +25,6 @@
   ],
   "secrets": [
     { "path": "~/secrets/slack-bot-token",   "required_by": "/ping skill" },
-    { "path": "~/secrets/discord-bot-token", "required_by": "disc-server and discord-watcher MCPs" }
+    { "path": "~/.secrets/discord-bot-token", "required_by": "disc-server and discord-watcher MCPs" }
   ]
 }

--- a/docs/contained-workflow-SKETCHBOOK.md
+++ b/docs/contained-workflow-SKETCHBOOK.md
@@ -141,7 +141,7 @@ target path (bare basename self-references); **log every collision** (a silently
 shadowed host skill is the night's own "did nothing, said nothing" defect);
 tolerate an absent mount without dangling links.
 
-**D6 — Secrets: ro bind-mount of the whole `~/.secrets` DIR (not just `.env`).**
+**D6 — Secrets: ro bind-mount of the whole `~/.secrets` DIR (not just `.env`).** *(SUPERSEDED by #1061: named single-file mounts. The reasoning below still holds for why `.env` alone is insufficient — path-modality consumers need their files — but the whole-dir scope was replaced once it was clear the kit consumes one secret of ~80 across an IP boundary.)*
 *Proven (tested):* a directory bind-mount is **live** — a file the host adds mid-run
 appears in the running container immediately, readable, no restart; ro blocks the
 container from writing while the host keeps rw. *Asserted (correct Docker behavior,

--- a/docs/contained-workflow-devspec.md
+++ b/docs/contained-workflow-devspec.md
@@ -212,7 +212,7 @@ Five layers, each with a fixed mechanism:
 Runs before the agent (via the `aoe-hooks` seam — open probe §5.N). Performs: skills symlink-sync (image-wins, host-fills, collision-logged), `settings.local` merge, secret sourcing, env validation. **Assertion-liveness:** every silent-skip path (missing mount, missing secret, shadowed skill, dangling link) becomes a logged or failing condition (R-14).
 
 ### 5.5 Secrets
-Read-only bind-mount of the whole `~/.secrets` dir (R-12). Live mid-session adds (R-13, proven). Prefer file-path consumers (fully live) over env-var consumers. `.env` = env modality, loose files = path modality. Fail loud at boot on a missing required secret (R-14). Whole-dir blast-radius (every ring sees every secret) is flagged; least-privilege scoping is an open item (§5.N).
+Read-only **named single-file** bind-mounts under `~/.secrets` (R-12; whole-dir superseded by #1061 — the host dir spans the OaW/Analogic IP boundary and the kit consumes one entry). Live mid-session adds (R-13, proven). Prefer file-path consumers (fully live) over env-var consumers. `.env` = env modality, loose files = path modality. Fail loud at boot on a missing required secret (R-14). Whole-dir blast-radius (every ring sees every secret) is flagged; least-privilege scoping is an open item (§5.N).
 
 ### 5.6 Promotion & rings
 Two rings: **dogfood** (persistent, real-workload) + **throwaway-CI** (install-from-nothing smoke). The promotion gate is a mechanical conjunction queried over FlightDeck + CI (R-07); adoption is rolling per-agent at container-recreate (R-08).

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -125,7 +125,7 @@ flowchart LR
 |-------|-----------|-------------------|--------------|
 | Baked-in-image | Built by `./install` in the image; immutable per tag | *(none — in the image)* | R-06, R-09 |
 | Shared-mutable-rw | rw bind-mount, **sandbox-scoped** host source | `10-memory.toml` | R-03, R-20 |
-| Read-only secrets | ro bind-mount of the `~/.secrets` dir (§3.5) | `20-secrets.toml` | R-12, R-13, R-14 |
+| Read-only secrets | ro **named single-file** bind-mounts under `~/.secrets` (§3.5) | `20-secrets.toml` | R-12, R-13, R-14 |
 | User-environment overlay | additive / in-container / symlink, by artifact type | `30-user-overlay.toml` | R-09, R-10, R-11 |
 | Durable caches | rw bind-mount, major-partitioned | `40-durable-caches.toml` | §5.3 |
 
@@ -184,10 +184,12 @@ gate depends on (Dev Spec §5.3).
 
 ### 3.5 Secrets: the read-only mount (Story 1.5)
 
-The whole `~/.secrets` dir enters as **one read-only bind-mount**
+Secrets enter as **named, read-only, single-file bind-mounts**
 ([`20-secrets.toml`](../../containers/oakandwave-workflow/mounts.d/20-secrets.toml))
-targeting `/home/ubuntu/.secrets` — the default the bootstrap's `OAW_SECRETS_DIR`
-already resolves (Dev Spec §5.5).
+landing under `/home/ubuntu/.secrets` — the default the bootstrap's
+`OAW_SECRETS_DIR` already resolves (Dev Spec §5.5). Story 1.5 mounted the *whole*
+dir; #1061 replaced that with named files, because the host dir spans both sides
+of the OaW/Analogic IP boundary and the kit consumes one entry of ~80.
 
 - **Never baked (R-12).** The image *is* the release: it ships to every ring and
   registry, so a secret baked into any layer would leak with the digest. Secrets
@@ -195,12 +197,19 @@ already resolves (Dev Spec §5.5).
   tolerates `check-deps`' missing-token advisory rather than baking the tokens
   (Dockerfile §"Bake the kit"). The resolver enforces the ro half — a fragment
   fat-fingered to `mode = "rw"` raises `R-12 VIOLATION` (`test_secrets_rw_fragment_is_rejected`).
-- **Live mid-session (R-13).** A bind-mount *is* the host dir, so a file the host
-  adds to `~/.secrets` after the container started is visible inside the running
-  container with no restart — proven by `test_secrets_readonly` (IT-02) and MV-07.
-- **Fail-loud on a missing required secret (R-14).** A values-free
-  `required.manifest` inside the dir (mounted with it) drives the bootstrap's
-  required-secret check (Story 1.4); a missing required secret aborts the boot.
+- **Live mid-session (R-13), with one sharp limit.** A bind *is* the host file, so
+  an **in-place** rewrite is visible inside the running container with no restart.
+  An **atomic replace** (`mv`, `sops`, most editors' save-by-rename) is NOT: a file
+  bind binds the *inode*, so the container stays pinned to the old one, silently,
+  until it is recreated. Rotate in place, or recreate. Adding a *new* secret also
+  needs a new mount — deliberately, since that is what keeps an unrelated
+  credential from entering a container's reach.
+- **Fail-loud on a missing required secret (R-14).** The required set is declared
+  via `OAW_REQUIRED_SECRETS` in the mounted `.env` (template:
+  [`secrets-env.example`](../../containers/oakandwave-workflow/secrets-env.example)),
+  **not** a `required.manifest` file — with the whole-dir mount gone, a manifest in
+  `~/.secrets` would be unmounted, leaving R-14 validating nothing while appearing
+  configured. bootstrap warns loudly when neither is declared.
 
 **Consumer split (the load-bearing nuance).** The mount is live, but *how* live
 depends on how a consumer reads a secret:
@@ -214,10 +223,16 @@ So **prefer file-path consumers** where liveness matters: `.env` is convenient
 but its values are frozen at the boot source. Loose files stay path-modality and
 are **never auto-exported** (SKETCHBOOK D6), which is also why they stay live.
 
-**Blast-radius tradeoff (open item).** Mounting the *whole* dir means every ring
-— and every process in the container, across the GitLab/GitHub IP boundary — sees
-*every* secret. That is a deliberate, flagged tradeoff for the foundation: it is
-one mount, ro, with no per-secret plumbing. **Least-privilege per-secret scoping
+**Blast-radius tradeoff — CLOSED for the default case (#1061).** The whole-dir
+mount was replaced by named single-file mounts: `.env` (pointers only) plus the
+one secret the kit actually consumes. The host's `~/.secrets` holds ~80
+credentials spanning both sides of the OaW/Analogic IP boundary and the kit needs
+exactly one, so the whole-dir mount was paying full exposure for no benefit.
+`.env` carries `DISCORD_TOKEN_PATH` / `DISCORD_TOKEN_FILE` — **pointers, never
+values** — because an environment variable is inherited by every child process
+while a file must be deliberately opened, and host-durable transcripts (#1064)
+would make one stray `env` dump permanent. The historical rationale for the
+whole-dir approach is retained below. **Least-privilege per-secret scoping
 is an open design item** (Dev Spec §5.5, §5.N); the `read-only-secrets` layer is
 exactly where a future scoped-secrets mechanism slots in without disturbing the
 rest of the taxonomy. See §5 for the carried open item.
@@ -254,11 +269,13 @@ rest of the taxonomy. See §5 for the carried open item.
   observation; it is confirmed against the full manifest in MV-02 (closing story
   4.3). The resolver's R-03 guard is the *static* half of that assurance; MV-02
   is the runtime half.
-- **Secrets blast-radius** (Dev Spec §5.5, §5.N; documented in §3.5): the
-  whole-`~/.secrets`-dir mount means every ring sees every secret, including
-  across the GitLab/GitHub IP boundary. Least-privilege per-secret scoping is an
-  open design item; the manifest's `read-only-secrets` layer is where a future
-  scoped-secrets mechanism slots in without disturbing the taxonomy.
+- **Secrets blast-radius** (Dev Spec §5.5, §5.N; documented in §3.5) — **closed
+  by #1061.** The whole-dir mount is gone; the `read-only-secrets` layer now
+  carries named single-file mounts, so a container sees only the secrets it
+  declares. This was the slot the taxonomy reserved for a scoped mechanism, and
+  it needed no new machinery — with the kit consuming one secret of ~80, naming
+  it was cheaper than building a scoping engine. Revisit only if the
+  container-required set grows beyond a handful.
 - **AoE bootstrap seam** (Dev Spec §5.N#5): whether aoe respects the image
   `ENTRYPOINT` or `docker exec`s the agent directly determines where the
   bootstrap (Story 1.4) hooks the resolver in. The resolver is seam-agnostic — it

--- a/docs/contained-workflow/cutover-prerequisites.md
+++ b/docs/contained-workflow/cutover-prerequisites.md
@@ -1,0 +1,192 @@
+# Cut-over prerequisites — why these, in this order
+
+Companion to [`architecture.md`](architecture.md) and the Dev Spec. That pair
+describes **what** the contained workflow is. This describes **why the
+prerequisites to cutting the fleet over are the ones we picked**, and what we
+deliberately chose not to fix first.
+
+It exists because the cut-over is big-bang — stop every agent, bring them back
+one at a time — and the first container replaces the agent that derived this
+reasoning. A plan that lives only in a session transcript does not survive its
+own canary.
+
+Derived 2026-07-30. Tracking issues: #1061 (secrets), #1062 (drop Slack),
+#1063 (image cadence), #1064 (session durability),
+`mcp-server-wtf`#29 (`.wtf/` relocation).
+
+---
+
+## 1. The failure class that connects all of them
+
+Every prerequisite here traces to one pattern: **a component that fails in a way
+indistinguishable from having nothing to report.**
+
+A watcher with a revoked token does not exit — it polls forever and delivers
+nothing. An agent with unresolved identity fails *closed* and delivers nothing.
+A dependency scanner that parses zero manifests reports a clean run. In all
+three, "no output" is both the healthy state and the broken state.
+
+That is tolerable at fleet-of-one-box scale because a human notices the silence.
+It is **not** tolerable during a staged cut-over, where every agent is expected
+to be quiet while it waits its turn. The signal we would rely on to detect a
+broken container is the same signal a correctly-idle container produces.
+
+So the bar for a cut-over prerequisite is not "is this bug severe." It is:
+**would this failure be visible during the cut-over, or would it look like
+progress?**
+
+## 2. What containerisation structurally changes
+
+One container per session means `$HOME` goes from *shared by ~12 agents* to
+*private per agent*. Every known defect should be filtered through that before
+being called a prerequisite — several fix themselves, and at least one silently
+gets worse.
+
+| Behaviour | Today (shared `$HOME`) | After cut-over | Verdict |
+|---|---|---|---|
+| `~/.claude/discord-forward.json` | One rule, every watcher obeys it | Per agent | **Fixed for free** |
+| `~/.claude/discord-bot.auth-failed` | One 401 deafens the whole fleet | Per agent | **Fixed for free** |
+| `~/.claude/discord-bot.kill` | Operator brake stops every watcher | Stops **one** container | **Silently degraded** |
+| Kit / skills (Cellar) | Edit once, every agent picks it up | Baked per image | **Changed workflow** |
+| Session transcripts | Survive on the host | Destroyed with the container | **Broken** — #1064 |
+| Secrets | Whole `~/.secrets` readable by all | Named files only, per container | **Fixed by #1061** |
+
+Two rows deserve emphasis because they cut in opposite directions.
+
+**The kill switch descopes with no error.** `touch ~/.claude/discord-bot.kill` is
+today a fleet-wide emergency brake (`discord-watcher` `index.ts:256`). After
+cut-over the same command pauses exactly one container and reports success. If
+anyone reaches for it during an incident they will believe the fleet is stopped
+when it is not. This is not a bug to fix so much as a **behaviour change to
+document loudly** in the ops runbook.
+
+**Kit distribution inverts.** A skill fix is currently a file copy into the
+shared Cellar. Afterwards it is an image rebuild plus an agent restart. That
+makes cc-workflow#937 (deliver rule changes to *live* sessions via hooks)
+materially more important than its priority suggests: it becomes the only
+channel that reaches a running agent between releases.
+
+## 3. `Monitor` is gated, not missing
+
+Recorded here because it cost a full session to establish and the surface
+symptom is misleading.
+
+`Monitor.isEnabled()` resolves the server-side feature flag
+`tengu_amber_sentinel`, which **defaults to false**. Both local override paths
+are compiled out of the shipped bundle — the settings override returns
+unconditionally, and the `CLAUDE_INTERNAL_FC_OVERRIDES` read sits after an
+unconditional `return`, making it unreachable. The flag can only arrive from the
+feature service, and that lookup **short-circuits to false before consulting the
+cache** when any of the following hold:
+
+- the provider is not first-party (Bedrock, Vertex / Google Cloud Agent
+  Platform, Microsoft Foundry) — overridden by `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`
+- gateway auth is in use
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, or
+  `DO_NOT_TRACK` is set
+- `DISABLE_GROWTHBOOK` is set
+
+Read out of CLI 2.1.220 on 2026-07-30. Minified identifiers are regenerated per
+build, so match on behaviour, not symbol names.
+
+Two consequences for the cut-over. An **Anthropic-authenticated** container with
+telemetry disabled still has no `Monitor` — the auth path is not the whole
+story. And `--channels` is *correlated but separately gated* (it is
+admin-enabled on Team/Enterprise plans), so the two must be diagnosed
+independently rather than inferred from one another.
+
+Full operator-facing detail: `skills/disc/SKILL.md`, "Arming the channels-free
+doorbell".
+
+## 4. Verify the instruments before trusting them
+
+Three guards were found inert on a single day, each of which would have reported
+success while checking nothing:
+
+- **R-14 (fail loud on a missing required secret)** — specified, implemented in `validate_secrets()`, and **inert**: it reads a `required.manifest` that does
+  not exist, so the required list is empty and the validation loop never runs.
+  It would have waved the #1061 secrets mismatch straight through.
+- **The dependency gate** — `trivy` parses **zero** manifests in this repo, and
+  a pass over an empty denominator is indistinguishable from a clean scan. Filed
+  five separate times (#922, #941, #944, #1053, #1056) over eleven days by five
+  agents; never fixed, only re-discovered.
+- **A regression assertion** — the doorbell test's `grep -q 'exit 4'` was
+  satisfied by an incidental parenthetical elsewhere in the file, not by the
+  exit-code contract it intended to protect.
+
+The shared lesson, and the rule this doc asks future work to follow:
+**an instrument that has only ever run against a passing case has not been
+tested.** Plant a failure, confirm the guard fires, then remove it. This applies
+with particular force to the cut-over, because the container bootstrap's guards
+are what stand between a misconfiguration and a fleet of silently deaf agents.
+
+Note also the five-way duplicate filing. That pattern gets *worse* with more
+agents, not better — more capacity means faster re-discovery of the same
+untouched defect, not faster repair.
+
+## 5. The prerequisites, and the one real dependency
+
+| # | Prerequisite | Why it gates the cut-over |
+|---|---|---|
+| #1061 | Secrets: `.secrets` canonical, named single-file mounts, `.env` carries pointers | Hard blocker. Consumers read `~/secrets`; the mount is `~/.secrets`. Container #1 boots with no Discord at all. |
+| #1062 | Drop Slack | `slackbot-send` is the one non-MCP secret consumer, and unused. Removing it keeps #1061 to a single pointer mechanism with no exception. |
+| #1064 | Session durability | Transcripts are unmounted; any container replacement destroys the session. |
+| #1063 | Image cadence | Not a correctness gate — a throughput one. ~17.5 min per merge, multiplied fleet-wide. |
+
+**What actually shipped, and why it changed mid-implementation.** The design
+reviewed here started as "put the token in the environment," with per-MCP-server
+`env` as the mitigation for inheritance. Implementation killed that: scoping a
+token to an MCP server requires the **literal value inside `mcp.json`**, which is
+a worse artifact than the secret file it replaced. Both consumers turned out to
+already accept a token *path* env var (`DISCORD_TOKEN_PATH` for the watcher,
+`DISCORD_TOKEN_FILE` for disc-server), so `.env` carries **pointers, never
+values** and the credential never enters the environment at all.
+
+That keeps the single-input property, removes the inheritance exposure entirely
+— nothing for a stray `env` dump to capture into a host-durable transcript
+(#1064) — and leaves rotation working without a restart, with one sharp caveat.
+
+**The caveat, because it is a silent failure.** A Docker file bind binds the
+**inode**. An in-place rewrite (`printf > file`) is seen by the container; an
+atomic replace (`mv`, `sops`, most editors' save) is **not**, permanently and
+without any error, until the container is recreated. Rotate in place, or plan on
+a restart. This does not undo the #1064 dependency so much as narrow it: #1064
+is what makes the restart cheap when a rotation is done the other way.
+
+## 6. Deliberately deferred
+
+- **`parseForwardArgs` accepts any token.** `discord-watcher forward …` (a
+  literal ellipsis) wrote a healthy-looking rule that silently misrouted every
+  addressed doorbell on the box for ~11 hours. Real, and *not* a prerequisite:
+  the fleet-wide blast radius comes from the shared `$HOME`, which the cut-over
+  removes. Big-bang means no mixed-mode window in which it stays fleet-global.
+  Fix it after.
+- **Per-secret scoping across the IP boundary.** The whole-dir mount put every
+  Analogic and OaW credential in every container. #1061 closes this incidentally
+  by mounting a single `.env`, so no scoping engine is needed today. Revisit if
+  the set of container-required secrets ever grows beyond a handful.
+- **Mattermost + chat-backend abstraction.** Post-cut-over. Two constraints
+  worth carrying forward: abstract at the **MCP-server layer**, not in skill
+  prose (servers enforce, skills suggest); and derive backend selection from the
+  existing forge rule (GitLab/Analogic → Mattermost, GitHub/OaW → Discord), so
+  the abstraction *enforces* the IP boundary rather than merely enabling a
+  second chat system.
+
+## 7. Still unverified
+
+Recorded as open questions rather than assumptions:
+
+- **Is the session project directory already bind-mounted by aoe?** If it is,
+  `<repo>/.claude/` survives container replacement for free and #1064 only needs
+  a transcripts fragment. The `[sandbox]` config carries `volume_ignores` /
+  `volume_ignores_strategy = "anonymous"`, and masking subpaths only makes sense
+  over a bind-mount — but aoe is a compiled binary and this was inferred from
+  config shape, not read from its mount code. One container launch and a
+  `mount | grep <repo>` settles it.
+- **Where the image build's ~17.5 minutes actually goes** — pull, build, sign,
+  SBOM, or push. #1063 removes most builds rather than optimising them, so this
+  is only worth measuring if the remaining release-time builds are painful.
+- **The `Monitor` gate chain has been read statically, not exercised.** No one
+  has flipped `DISABLE_TELEMETRY` and watched the tool disappear. The static
+  read is unambiguous; the behavioural confirmation is a five-minute test on a
+  throwaway session.

--- a/docs/discord-config.md
+++ b/docs/discord-config.md
@@ -13,7 +13,7 @@ their agents at their own Discord server without modifying source.
 ```json
 {
   "guild_id": "1234567890",
-  "token_path": "~/secrets/discord-bot-token",
+  "token_path": "~/.secrets/discord-bot-token",
   "scream_hole_url": "http://scream-hole:3000",
   "default_channel_id": "1487288523638837268",
   "roll_call_channel_id": "1487382005036617851",
@@ -30,7 +30,7 @@ their agents at their own Discord server without modifying source.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `guild_id` | string | Yes | Discord server (guild) ID |
-| `token_path` | string | No | Path to bot token file (default: `~/secrets/discord-bot-token`) |
+| `token_path` | string | No | Path to bot token file (default: `~/.secrets/discord-bot-token`) |
 | `scream_hole_url` | string | No | Base URL of a [scream-hole](https://github.com/Wave-Engineering/scream-hole) proxy (e.g., `http://scream-hole:3000`). When set, `disc-server` MCP and `discord-watcher` route Discord REST API calls through the proxy instead of hitting Discord directly. Omit to use direct Discord API. |
 | `default_channel_id` | string | Yes | Snowflake ID of the channel playing the **default** role |
 | `roll_call_channel_id` | string | Yes | Snowflake ID of the channel playing the **roll-call** role |
@@ -60,7 +60,7 @@ Every component reads configuration using a three-level fallback:
 | `DISCORD_DEFAULT_CHANNEL` | `default_channel_id` | `1487288523638837268` |
 | `DISCORD_ROLL_CALL_CHANNEL` | `roll_call_channel_id` | `1487382005036617851` |
 | `DISCORD_WAVE_STATUS_CHANNEL` | `channels["wave-status"]` | `1487386934094462986` |
-| `DISCORD_TOKEN_PATH` | `token_path` | `~/secrets/discord-bot-token` |
+| `DISCORD_TOKEN_PATH` | `token_path` | `~/.secrets/discord-bot-token` |
 | `SCREAM_HOLE_URL` | `scream_hole_url` | *(disabled)* |
 
 ## Scream-Hole Proxy

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,7 +132,7 @@ The identity file lives at `<project_root>/.claude/agent-identity.json` — rebo
 
 Common causes:
 
-- **Token file missing or empty.** The default path is `~/secrets/discord-bot-token`. If the file does not exist or is empty, all API calls fail.
+- **Token file missing or empty.** The default path is `~/.secrets/discord-bot-token`. If the file does not exist or is empty, all API calls fail.
 - **Token is invalid.** The token may have been regenerated in the Discord Developer Portal, invalidating the old one.
 - **Bot not in the server.** The bot must be invited to your Discord server with the correct permissions.
 - **Missing Message Content Intent.** Discord requires bots to enable the "Message Content Intent" in the Developer Portal (Settings -> Bot -> Privileged Gateway Intents) to read message content.
@@ -140,7 +140,7 @@ Common causes:
 
 **Fix:**
 
-1. Verify the token file exists and is not empty: `cat ~/secrets/discord-bot-token | head -c 20` (check the first 20 characters -- do not print the full token).
+1. Verify the token file exists and is not empty: `cat ~/.secrets/discord-bot-token | head -c 20` (check the first 20 characters -- do not print the full token).
 2. Test a simple read: call `mcp__disc-server__disc_read` with a known `channel_id` and `limit: 1`.
 3. In the [Discord Developer Portal](https://discord.com/developers/applications), verify the bot's token, that Message Content Intent is enabled, and that the bot has been added to your server.
 4. Check the bot's permissions in the server: it needs Send Messages and Read Message History at minimum.

--- a/scripts/discord-status-post
+++ b/scripts/discord-status-post
@@ -12,7 +12,8 @@ Usage:
     discord-status-post [--channel-id ID] [--state-dir DIR] [--dev-team NAME]
 
 Environment:
-    DISCORD_BOT_TOKEN   Bot token (fallback: ~/secrets/discord-bot-token)
+    DISCORD_BOT_TOKEN   Bot token (fallback: ~/.secrets/discord-bot-token,
+                        then the deprecated ~/secrets/discord-bot-token)
 
 Requires Python 3.10+ stdlib only — no external dependencies [CT-01].
 """
@@ -37,7 +38,11 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 _DEFAULT_WAVE_STATUS_CHANNEL_ID = "1487386934094462986"
-_DEFAULT_TOKEN_PATH = "~/secrets/discord-bot-token"
+# ~/.secrets is canonical (#1061). The undotted ~/secrets is deprecating and is
+# NOT mounted into the contained workflow, so a container resolving it finds
+# nothing. Kept only as a trailing fallback for un-migrated hosts.
+_DEFAULT_TOKEN_PATH = "~/.secrets/discord-bot-token"
+_LEGACY_TOKEN_PATH = "~/secrets/discord-bot-token"
 API_BASE = "https://discord.com/api/v10"
 
 
@@ -149,10 +154,16 @@ def get_token() -> str:
         or _DEFAULT_TOKEN_PATH
     )
     token_file = Path(os.path.expanduser(token_path_str))
-    if token_file.exists():
+    if token_file.is_file():
         return token_file.read_text().strip()
+    # Trailing fallback for un-migrated hosts only. Never reached in a container:
+    # ~/secrets is not mounted, so this resolves to nothing there by design.
+    legacy = Path(os.path.expanduser(_LEGACY_TOKEN_PATH))
+    if legacy.is_file():
+        return legacy.read_text().strip()
     raise RuntimeError(
-        f"DISCORD_BOT_TOKEN not set and {token_file} not found"
+        f"DISCORD_BOT_TOKEN not set and {token_file} not found "
+        f"(legacy {legacy} also absent)"
     )
 
 

--- a/scripts/godspeed-lookback.sh
+++ b/scripts/godspeed-lookback.sh
@@ -867,13 +867,34 @@ _godspeed_notify() {
 	fi
 
 	# Discord via stdlib python3 (no external deps).
-	local token_file="$HOME/secrets/discord-bot-token"
-	if [[ -f "$token_file" ]]; then
+	# ~/.secrets is canonical (#1061); the undotted ~/secrets is deprecating and is
+	# not mounted into the contained workflow. Env wins, then canonical, then legacy.
+	# An EXPLICIT DISCORD_TOKEN_PATH is honored as given — never silently swapped
+	# for the deprecated path, which would hide a bad pointer behind a stale token.
+	local token_file
+	if [[ -n "${DISCORD_TOKEN_PATH:-}" ]]; then
+		token_file="$DISCORD_TOKEN_PATH"
+	else
+		token_file="$HOME/.secrets/discord-bot-token"
+		[[ -f "$token_file" ]] || token_file="$HOME/secrets/discord-bot-token"
+	fi
+	if [[ -n "${DISCORD_BOT_TOKEN:-}" ]] || [[ -f "$token_file" ]]; then
 		local token
-		token=$(tr -d '[:space:]' <"$token_file")
-		python3 -c "
+		# Env wins and must NOT fall through to a file read — the file may not exist
+		# at all in that case (it does not in a container, by design).
+		if [[ -n "${DISCORD_BOT_TOKEN:-}" ]]; then
+			token=$(tr -d '[:space:]' <<<"$DISCORD_BOT_TOKEN")
+		else
+			token=$(tr -d '[:space:]' <"$token_file")
+		fi
+		# Token arrives on STDIN, never argv. /proc/<pid>/cmdline is world-readable
+		# (0444) while /proc/<pid>/environ is owner-only (0400) — so an argv-passed
+		# secret is MORE exposed than the env-passing this design already rejects.
+		# The message stays in argv: it is not a credential.
+		printf '%s' "$token" | python3 -c "
 import urllib.request, json, sys
-token, channel_id, msg = sys.argv[1], '1518536836673310800', sys.argv[2]
+token = sys.stdin.read().strip()
+channel_id, msg = '1518536836673310800', sys.argv[1]
 req = urllib.request.Request(
     f'https://discord.com/api/v10/channels/{channel_id}/messages',
     data=json.dumps({'content': msg}).encode(),
@@ -881,7 +902,12 @@ req = urllib.request.Request(
     method='POST'
 )
 urllib.request.urlopen(req, timeout=5)
-" "$token" "$discord_msg" 2>/dev/null || true
+" "$discord_msg" 2>/dev/null || true
+	else
+		# Not a silent skip: with no token source the Discord half of this notify
+		# simply does not happen, and silence here is indistinguishable from a
+		# delivered message. One line, stderr, no secret material.
+		echo "godspeed: no Discord token source (\$DISCORD_BOT_TOKEN unset, $token_file absent) — skipping Discord notify" >&2
 	fi
 }
 

--- a/skills/ccwork/SKILL.md
+++ b/skills/ccwork/SKILL.md
@@ -417,14 +417,14 @@ If the file exists, show the current configuration and ask if the user wants to 
 Check that the bot token file exists before proceeding:
 
 ```bash
-TOKEN_PATH="${DISCORD_TOKEN_PATH:-~/secrets/discord-bot-token}"
+TOKEN_PATH="${DISCORD_TOKEN_PATH:-~/.secrets/discord-bot-token}"
 ls -la "$TOKEN_PATH" 2>/dev/null
 ```
 
 - **If the file exists:** Confirm to the user and move on. Ask if they want to use this path or specify a different one.
 - **If the file does NOT exist:** Guide the user through setup:
   1. "You need a Discord bot token. If you haven't created a bot yet, visit: https://discord.com/developers/applications"
-  2. "Create the token file: `mkdir -p ~/secrets && echo 'YOUR_TOKEN' > ~/secrets/discord-bot-token && chmod 600 ~/secrets/discord-bot-token`"
+  2. "Create the token file: `mkdir -p ~/.secrets && echo 'YOUR_TOKEN' > ~/.secrets/discord-bot-token && chmod 600 ~/.secrets/discord-bot-token`"
   3. Wait for the user to confirm the file is in place before continuing.
 
 Record the token path for the final config.

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -258,17 +258,95 @@ def test_missing_required_env_fails_loud(tmp_path: Path) -> None:
 
 
 def test_all_clean_exits_zero(tmp_path: Path) -> None:
-    """Fully-provisioned boot: no warnings, no fatals, exit 0."""
+    """Fully-provisioned boot: no fatals, exit 0.
+
+    A fully-provisioned boot declares its required set — otherwise R-14 is inert
+    and the boot is not, in fact, fully provisioned. `.env` carries POINTERS and
+    the declaration; the token is a loose file (#1061).
+    """
     home = _make_home(
         tmp_path,
         image_skills=["alpha"],
         host_skills=["beta"],
         settings_local='{"permissions": {}}\n',
+        secrets={
+            ".env": "OAW_REQUIRED_SECRETS=discord-bot-token\n"
+                    "DISCORD_TOKEN_PATH=/home/ubuntu/.secrets/discord-bot-token\n",
+            "discord-bot-token": "not-a-real-token\n",
+        },
     )
     proc = _run(home)
     assert proc.returncode == 0, proc.stderr
     assert "0 fatal(s)" in proc.stdout
     assert "complete" in proc.stderr
+    assert "INERT" not in proc.stderr, (
+        "a fully-provisioned boot must not report R-14 as inert"
+    )
+
+
+# --- R-14 inert-guard (#1061) --------------------------------------------------
+#
+# The guard these cover was, until #1061, a pass over an empty denominator: with
+# neither OAW_REQUIRED_SECRETS nor a manifest, `required` was empty, the loop ran
+# zero times, and validate_secrets returned success while examining nothing.
+
+
+def test_r14_inert_when_nothing_declared(tmp_path: Path) -> None:
+    """No declaration at all -> loud INERT warning (not a silent pass)."""
+    home = _make_home(tmp_path, secrets={"discord-bot-token": "tok\n"})
+    proc = _run(home)
+    assert proc.returncode == 0, "an undeclared set is tolerated, not fatal"
+    assert "INERT" in proc.stderr, (
+        "R-14 validating nothing must announce itself; a silent pass here is "
+        "indistinguishable from a real check"
+    )
+
+
+def test_r14_empty_declaration_is_deliberate_and_quiet(tmp_path: Path) -> None:
+    """OAW_REQUIRED_SECRETS="" declares 'none needed' -> no INERT warning."""
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert "INERT" not in proc.stderr, (
+        "an explicit empty declaration is deliberate and must not warn"
+    )
+
+
+def test_r14_declared_but_missing_secret_is_fatal(tmp_path: Path) -> None:
+    """A declared secret that is absent aborts the boot, naming the secret."""
+    home = _make_home(
+        tmp_path, secrets={".env": "OAW_REQUIRED_SECRETS=discord-bot-token\n"}
+    )
+    proc = _run(home)
+    assert proc.returncode != 0, "a missing required secret must fail the boot"
+    assert "discord-bot-token" in proc.stderr, "the fatal must name the secret"
+
+
+def test_r14_declared_secret_as_directory_is_fatal(tmp_path: Path) -> None:
+    """Docker's create-if-missing footgun: a bind whose host source is absent
+    appears as an empty DIRECTORY at the target. `-f` must reject it, or the
+    consumer fails later with a confusing read error instead of a named secret."""
+    home = _make_home(
+        tmp_path, secrets={".env": "OAW_REQUIRED_SECRETS=discord-bot-token\n"}
+    )
+    (home / ".secrets" / "discord-bot-token").mkdir()
+    proc = _run(home)
+    assert proc.returncode != 0, (
+        "a directory standing in for a secret file must fail the boot"
+    )
+    assert "discord-bot-token" in proc.stderr
+
+
+def test_missing_env_file_is_announced(tmp_path: Path) -> None:
+    """No .env -> warn. Since #1061 replaced the whole-dir mount with file
+    mounts, a file bind forces the secrets dir into existence, so the older
+    'missing mount: secrets dir not present' warning is unreachable — this is
+    the only remaining report of an unprovisioned secrets layer."""
+    home = _make_home(tmp_path, secrets={"discord-bot-token": "tok\n"})
+    proc = _run(home)
+    assert "no " in proc.stderr and ".env" in proc.stderr, (
+        "a missing .env must not be a silent skip"
+    )
 
 
 # --- the devspec-named aggregate oracle ---------------------------------------

--- a/tests/contained-workflow/test_secrets.py
+++ b/tests/contained-workflow/test_secrets.py
@@ -52,32 +52,87 @@ SECRETS_TARGET = "/home/ubuntu/.secrets"
 # --- Static R-12 oracles (pure; run in the stock lane) ------------------------
 
 
-def _secrets_mount() -> mr.ResolvedMount:
-    """Resolve the checked-in secrets fragment (and only it) for assertions."""
+def _secrets_mounts() -> list[mr.ResolvedMount]:
+    """Resolve the checked-in secrets fragment's mounts for assertions.
+
+    Returns a LIST, not a single mount. #1061 replaced the whole-`~/.secrets`-dir
+    mount with named single-file mounts, so the count is a design variable now —
+    every added secret is one more entry. This helper deliberately asserts nothing
+    about how many there are: pinning the count made the previous version of this
+    test fail on a change that strictly *narrowed* exposure, which is backwards
+    for a guard whose subject is blast radius.
+    """
     assert SECRETS_FRAGMENT.is_file(), f"missing secrets fragment: {SECRETS_FRAGMENT}"
     resolved = mr.resolve_manifest(MAJOR, home=FAKE_HOME, mounts_dir=MANIFEST_DIR)
     secrets = [m for m in resolved if m.layer == "read-only-secrets"]
     assert secrets, "no read-only-secrets mount in the resolved manifest"
-    assert len(secrets) == 1, f"expected one secrets mount, got {len(secrets)}"
-    return secrets[0]
+    return secrets
 
 
 def test_secrets_mount_is_readonly() -> None:
-    """R-12: secrets are provided ONLY via the ro mount — the checked-in fragment
-    resolves read-only, sourced from ~/.secrets, targeting the bootstrap's dir."""
-    m = _secrets_mount()
-    assert m.mode == "ro", f"secrets mount must be ro (R-12), got {m.mode!r}"
-    assert m.source == "/home/bakerb/.secrets", (
-        f"secrets source must be ~/.secrets, got {m.source!r}"
-    )
-    assert m.target == SECRETS_TARGET, (
-        f"secrets target must match bootstrap OAW_SECRETS_DIR default "
-        f"({SECRETS_TARGET}), got {m.target!r}"
-    )
-    # The docker -v rendering carries the :ro suffix — the mount is ro at runtime.
-    assert m.to_docker_volume().endswith(":ro"), (
-        f"docker volume spec must end :ro, got {m.to_docker_volume()!r}"
-    )
+    """R-12: secrets are provided ONLY via ro mounts — EVERY resolved
+    read-only-secrets mount is ro, sourced from ~/.secrets, and lands under the
+    bootstrap's OAW_SECRETS_DIR."""
+    mounts = _secrets_mounts()
+    for m in mounts:
+        assert m.mode == "ro", f"{m.name}: secrets mount must be ro (R-12), got {m.mode!r}"
+        # Compare against the path WITH its separator: a bare prefix test would
+        # also accept ~/.secrets-analogic/..., which is precisely the blast-radius
+        # this guard exists to bound.
+        assert m.source.startswith("/home/bakerb/.secrets/"), (
+            f"{m.name}: source must be a file under ~/.secrets/, got {m.source!r}"
+        )
+        assert m.target.startswith(SECRETS_TARGET + "/"), (
+            f"{m.name}: target must be under the bootstrap OAW_SECRETS_DIR "
+            f"({SECRETS_TARGET}/), got {m.target!r}"
+        )
+        # The docker -v rendering carries the :ro suffix — ro at runtime.
+        assert m.to_docker_volume().endswith(":ro"), (
+            f"{m.name}: docker volume spec must end :ro, got {m.to_docker_volume()!r}"
+        )
+
+
+def test_secrets_mounts_are_scoped_not_whole_dir() -> None:
+    """#1061: no mount may be the whole ~/.secrets directory.
+
+    The host dir spans both sides of the OaW/Analogic IP boundary (~80 entries);
+    the kit consumes one. A whole-dir mount hands every container every credential
+    on both sides of that line. This is the guard that keeps a future edit from
+    quietly restoring it — the failure it prevents is silent, since a wider mount
+    breaks nothing and looks like it works.
+    """
+    whole_dir = "/home/bakerb/.secrets"
+    for m in _secrets_mounts():
+        assert m.source != whole_dir, (
+            f"{m.name}: mounts the WHOLE secrets dir ({whole_dir}). Mount named "
+            f"files instead — see mounts.d/20-secrets.toml and #1061."
+        )
+
+
+def test_secrets_env_declares_no_literal_token() -> None:
+    """#1061: no manifest-declared env may carry a literal credential.
+
+    An environment variable is inherited by every child process; a file must be
+    deliberately opened. With transcripts host-durable (#1064), a literal token in
+    the environment is one `env` dump away from permanent storage.
+
+    SCOPE, stated honestly: this examines the *manifest's* `env` metadata, which is
+    the only surface reachable from CI — the host's `~/.secrets/.env` is not in the
+    repo and cannot be inspected here. An earlier version of this test looped over
+    that metadata without asserting it had any subject at all; since no fragment
+    declares `env`, the loop body never ran and the test passed over an empty
+    denominator — the very shape `cutover-prerequisites.md` §4 catalogues. The
+    guard below therefore asserts the *invariant that is actually checkable*: the
+    secrets layer declares no env at all, so the pointer-vs-value question cannot
+    be answered wrongly here. If a future fragment adds `env`, this fails and
+    forces the author to re-derive the rule rather than inherit a silent pass.
+    """
+    for m in _secrets_mounts():
+        assert not (m.env or {}), (
+            f"{m.name} declares manifest env {sorted((m.env or {}))!r}. The secrets "
+            f"layer passes POINTERS via the mounted .env file, not manifest env "
+            f"metadata — re-read #1061 before adding one."
+        )
 
 
 def test_secrets_rw_fragment_is_rejected() -> None:
@@ -162,6 +217,21 @@ def test_secrets_readonly() -> None:
          with no restart (R-13: liveness).
     Self-skips without docker/the image; OAKANDWAVE_REQUIRE_IMAGE makes absence a
     hard failure so CI proves the contract.
+
+    KNOWN SCOPE GAP (#1061), stated rather than hidden: this mounts a whole
+    tempdir, which is **no longer the shipped mount shape** — `20-secrets.toml`
+    now declares named single-FILE binds. The R-12 half generalises (ro is ro);
+    the R-13 half does NOT, and the difference matters:
+
+      - dir bind  : a file the host ADDS afterwards appears  (what this proves)
+      - file bind : the inode is bound, so an ADD is invisible and an atomic
+                    replace (`mv`/`sops`/editor save) silently pins the container
+                    to the old content until it is recreated
+
+    So a green run here does not license the claim "rotation is live" for the
+    shape we actually ship — only "in-place rewrite of a bound file is live".
+    Extending this oracle to the two file mounts is tracked in #1061's follow-up;
+    until then, treat the liveness assertion as scoped to the dir shape.
     """
     docker, ref = _docker_and_image_or_skip()
 


### PR DESCRIPTION
## Summary

**Hard blocker on container #1.** The contained workflow mounts `~/.secrets`; every kit consumer read `~/secrets` (no dot). Nothing bridged them — `discord.json` sets no `token_path` and there was no `.env` — so `loadToken()` throws and neither `disc-server` nor `discord-watcher` starts. The first container would have come up with no channels, no doorbell, and no `/disc`.

The guard that exists to catch this was **inert**: bootstrap's R-14 check builds its required list from `OAW_REQUIRED_SECRETS` or a manifest, and with neither present the list is empty, the loop runs zero times, and `validate_secrets` reports success while examining nothing — the same empty-denominator failure as a scanner that parses zero manifests.

## Changes

Rather than repoint the whole-dir mount, **drop it**. The host `~/.secrets` holds ~80 credentials spanning both sides of the OaW/Analogic IP boundary and the kit consumes **one**, so an OaW/GitHub container was carrying `ANALOGICAL-*-KEY`, `analogic-bao-token` and `gitlab-full-send` for no benefit. Named single-file mounts close that structurally: a container cannot read what is not mounted.

- **`mounts.d/20-secrets.toml`** — whole-dir mount → named single-file mounts (`.env` + `discord-bot-token`).
- **`.env` carries pointers, never values** — `DISCORD_TOKEN_PATH` / `DISCORD_TOKEN_FILE`, both already supported by their consumers with **no code change**. A literal token in the environment is inherited by every child process (a file must be deliberately opened), and with transcripts becoming host-durable (#1064) one stray `env` dump writes it to permanent storage.
- **R-14's required set moves to `OAW_REQUIRED_SECRETS` in that `.env`.** A `required.manifest` in `~/.secrets` would no longer be mounted, so the documented route would leave R-14 validating nothing while appearing configured. Template: `containers/oakandwave-workflow/secrets-env.example` (no credential values — paths and one secret *name*).
- **`bootstrap.sh`** — warns loudly when nothing is declared; distinguishes an absent `.env` from Docker's create-if-missing *directory*; branches on set-ness so `OAW_REQUIRED_SECRETS=""` beats a manifest as documented.
- **`deps.json`, `README.md`, `docs/discord-config.md`, `docs/troubleshooting.md`, `skills/ccwork/SKILL.md`** repointed. `check-deps.sh` read the legacy path and its whitelist matches by **basename**, so that guard could not distinguish "provisioned correctly" from this bug recurring.
- **`scripts/godspeed-lookback.sh`** — honors an explicit `DISCORD_TOKEN_PATH` instead of silently substituting the deprecated path; announces when no token source resolves; passes the token on **stdin** (`/proc/<pid>/cmdline` is world-readable, `environ` is owner-only — argv was the wider of the two exposures this change argues against).
- **`docs/contained-workflow/cutover-prerequisites.md`** (new) — why the cut-over prerequisites are the ones we picked, what containerisation fixes for free, what it *silently degrades* (the operator kill switch descopes from fleet-wide to one container), and what we deliberately deferred.

### Rejected alternative

Scoping the token per-MCP-server was the original plan and was rejected during implementation: it requires the literal value inside `mcp.json`, a worse artifact than the file it replaces.

### Rotation caveat — the failure is silent

A Docker **file** bind binds the **inode**. An in-place rewrite is live; an atomic replace (`mv`, `sops`, most editors' save-by-rename) leaves the container pinned to the old content until it is recreated.

```
rotate:  printf '%s' "$NEW" > ~/.secrets/discord-bot-token   # seen live
do NOT:  mv new-token ~/.secrets/discord-bot-token           # NOT seen
```

## Linked Issues

Closes #1061

## Test Plan

Run on the final tree:

- `./scripts/ci/validate.sh` → **219 passed, 0 failed**
- Full `pytest tests/` → **1930 passed**, 6 skipped, 64 xfailed, 2 xpassed (the 2 xpassed match the pre-change baseline)
- `tests/contained-workflow/` → **198 passed** (up from 193 — five new R-14 guards)
- The three godspeed-touching suites re-run after the final edit → 111 + 51 + 18 passed
- Behavioural check that the token reaches Python via **stdin** and argv carries only the message

**Mutation-tested, not just green** — the rule this PR's own doc sets out:

| mutation | result |
|---|---|
| silence the INERT warning | `test_r14_inert_when_nothing_declared` **fails**, nothing else |
| restore the whole-dir mount | `test_secrets_mounts_are_scoped_not_whole_dir` **fails**, nothing else |

New guards also cover: an empty declaration is deliberate and quiet; a declared-but-absent secret is fatal and names the secret; Docker's create-as-**directory** footgun is fatal (`-f` rejects it); a missing `.env` is announced rather than silently skipped.

### Not verified

- No container was launched. The mount fragment is asserted through the resolver, not by running `docker`.
- `test_secrets_readonly` (IT-02) still mounts a whole tempdir, so its R-13 liveness half proves the **dir** shape, not the file shape now shipped. Documented in the test rather than left implicit; extending it is follow-up work.

### Deferred

`trivy` parsed **0 manifests** — not a pass, nothing was scanned. Pre-existing (#1056/#944/#941/#1053/#922); this changeset touches no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS