### PR TITLE
fix(contained-workflow): host-back transcripts; surgeon off the fleet root

### DIFF
--- a/containers/oakandwave-workflow/mounts.d/05-transcripts.toml
+++ b/containers/oakandwave-workflow/mounts.d/05-transcripts.toml
@@ -1,0 +1,70 @@
+# 05-transcripts.toml — host-backed session transcripts (#1064, R-01/R-03/R-20).
+#
+# WHY THIS EXISTS. Without it the container's `~/.claude/projects/<slug>/*.jsonl`
+# lives in the container filesystem, so `docker rm` destroys it. Two things break,
+# and the second is the dangerous one:
+#
+#   1. `--resume` is impossible in a replacement container. Any replacement —
+#      crash, OOM, host reboot, image bump, a skill update — loses the session.
+#      Skill updates are merely the most frequent trigger, not the only one.
+#
+#   2. The FLIGHT SURGEON reads a transcript that was never there. It is
+#      documented as reading "the container's host-backed .jsonl transcript
+#      directly ... without depending on the container's kit" — that independence
+#      is the whole point of a host-side probe — and resolves under
+#      `--transcripts-root ~/.claude/projects`. With no mount, that root holds the
+#      NATIVE fleet's transcripts, and `_newest_transcript_for()` returns the
+#      newest file matching the workspace slug. Measured 2026-07-30: for a
+#      container on this repo it resolved to the live native session's own
+#      transcript, 19s stale.
+#
+#      So the seam does not fail closed — it hands the classifier a confident
+#      answer about the wrong process, wrong in BOTH directions depending on
+#      timing. Natives still running: their transcripts are fresh, every container
+#      reads healthy, quarantine never fires. Natives stopped (the big-bang
+#      cut-over): host transcripts go stale at once, running containers read
+#      stalled, healthy candidates get false-quarantined. The promotion gate
+#      consumes `should_quarantine` either way.
+#
+# THIS MOUNT IS HALF THE FIX. The surgeon and dogfood-cutover.sh must also point
+# at this sandbox root instead of ~/.claude/projects — otherwise the mount ships
+# and the probe keeps resolving fleet transcripts. See #1064.
+#
+# ORDERING. This fragment is numbered BEFORE 10-memory.toml deliberately: it
+# mounts the whole `projects` dir, and 10-memory nests `projects/_sandbox/memory`
+# inside it. Docker sorts binds by destination depth so parents land first, but
+# matching the lexical fragment order makes the nesting intentional rather than
+# dependent on that behaviour.
+#
+# LIMITATION — this mount does NOT make resolution 1:1. The source carries no
+# session or container token, so every container of a given major writes into one
+# shared host directory, and `_newest_transcript_for` keys only on the WORKSPACE
+# path. Two live sessions on the same repo — a dogfood and a dev-mode container is
+# an explicitly supported pair (R-22), and this fleet routinely runs several agents
+# per repo — both resolve to whichever file has the newest mtime. One stalled agent
+# and one healthy agent on the same workspace get the healthy agent's verdict.
+#
+# That is the same "confident verdict about the wrong process" this fragment fixes,
+# relocated from native-vs-container to container-vs-container. The resolver was
+# always 1:many; this mount is what makes the collision reachable. Closing it needs
+# resolution keyed on the session/container id (or a per-session mount source) —
+# tracked, not solved here. Do not read this fragment as closing the seam entirely.
+#
+# SIDE EFFECT: because `projects` is a bind mount, Docker materialises the nested
+# `_sandbox/memory` mountpoint INSIDE the host transcripts dir, so expect a
+# `~/.oaw/state/<major>/transcripts/_sandbox/` to appear. Harmless — it holds no
+# `.jsonl`, so rglob ignores it.
+#
+# R-03 still holds. `sandbox_scoped = true`, so mount_resolver's
+# check_sandbox_scoped_memory refuses any source outside ~/.oaw/state/<major>/ —
+# a broken :edge candidate must never gain write access to the live fleet's
+# ~/.claude/projects. Transcripts are session LOGS, not durable knowledge, so a
+# sandbox-scoped path preserves the isolation intent while making resume work.
+
+[[mount]]
+name = "transcripts"
+layer = "shared-mutable-rw"
+mode = "rw"
+sandbox_scoped = true
+source = "~/.oaw/state/<major>/transcripts"
+target = "/home/ubuntu/.claude/projects"

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -40,6 +40,7 @@ fragment deterministically. Each file holds one or more `[[mount]]` tables.
 
 | file | layer | owner story |
 |------|-------|-------------|
+| `05-transcripts.toml` | shared-mutable-rw (session transcripts) | #1064 |
 | `10-memory.toml` | shared-mutable-rw (memory + `settings.local.json`) | 1.3 (#963) |
 | `20-secrets.toml` | read-only-secrets (ro named single-file mounts) | 1.5 (#965), #1061 |
 | `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -124,7 +124,7 @@ flowchart LR
 | Layer | Mechanism | Manifest fragment | Requirements |
 |-------|-----------|-------------------|--------------|
 | Baked-in-image | Built by `./install` in the image; immutable per tag | *(none — in the image)* | R-06, R-09 |
-| Shared-mutable-rw | rw bind-mount, **sandbox-scoped** host source | `10-memory.toml` | R-03, R-20 |
+| Shared-mutable-rw | rw bind-mount, **sandbox-scoped** host source | `05-transcripts.toml`, `10-memory.toml` | R-03, R-20 |
 | Read-only secrets | ro **named single-file** bind-mounts under `~/.secrets` (§3.5) | `20-secrets.toml` | R-12, R-13, R-14 |
 | User-environment overlay | additive / in-container / symlink, by artifact type | `30-user-overlay.toml` | R-09, R-10, R-11 |
 | Durable caches | rw bind-mount, major-partitioned | `40-durable-caches.toml` | §5.3 |

--- a/docs/contained-workflow/cutover-prerequisites.md
+++ b/docs/contained-workflow/cutover-prerequisites.md
@@ -48,7 +48,7 @@ gets worse.
 | `~/.claude/discord-bot.auth-failed` | One 401 deafens the whole fleet | Per agent | **Fixed for free** |
 | `~/.claude/discord-bot.kill` | Operator brake stops every watcher | Stops **one** container | **Silently degraded** |
 | Kit / skills (Cellar) | Edit once, every agent picks it up | Baked per image | **Changed workflow** |
-| Session transcripts | Survive on the host | Destroyed with the container | **Broken** — #1064 |
+| Session transcripts | Survive on the host | Host-backed mount | **Fixed by #1064** |
 | Secrets | Whole `~/.secrets` readable by all | Named files only, per container | **Fixed by #1061** |
 
 Two rows deserve emphasis because they cut in opposite directions.
@@ -114,6 +114,15 @@ success while checking nothing:
   satisfied by an incidental parenthetical elsewhere in the file, not by the
   exit-code contract it intended to protect.
 
+- **The flight surgeon** — read `--transcripts-root ~/.claude/projects`, the
+  *native fleet's* store, while sandbox transcripts were unmounted. It did not
+  fail closed: `_newest_transcript_for` returns the newest `.jsonl` matching the
+  workspace slug, so a container resolved to a live native session's transcript
+  (measured 2026-07-30, 19s stale). Wrong in both directions — healthy while
+  natives run, stalled once the big-bang stop makes those files go cold — and
+  the promotion gate consumes that verdict. Fixed in #1064; the root is now
+  sandbox-scoped and a fleet root is refused unless explicitly asked for.
+
 The shared lesson, and the rule this doc asks future work to follow:
 **an instrument that has only ever run against a passing case has not been
 tested.** Plant a failure, confirm the guard fires, then remove it. This applies
@@ -130,7 +139,7 @@ untouched defect, not faster repair.
 |---|---|---|
 | #1061 | Secrets: `.secrets` canonical, named single-file mounts, `.env` carries pointers | Hard blocker. Consumers read `~/secrets`; the mount is `~/.secrets`. Container #1 boots with no Discord at all. |
 | #1062 | Drop Slack | `slackbot-send` is the one non-MCP secret consumer, and unused. Removing it keeps #1061 to a single pointer mechanism with no exception. |
-| #1064 | Session durability | Transcripts are unmounted; any container replacement destroys the session. |
+| #1064 | Session durability | Transcripts were unmounted: any container replacement destroyed the session, AND the flight surgeon resolved the NATIVE fleet's transcripts — a confident verdict about the wrong process. |
 | #1063 | Image cadence | Not a correctness gate — a throughput one. ~17.5 min per merge, multiplied fleet-wide. |
 
 **What actually shipped, and why it changed mid-implementation.** The design

--- a/docs/contained-workflow/manual-verification.md
+++ b/docs/contained-workflow/manual-verification.md
@@ -330,7 +330,7 @@ harness can stand up a real sandbox session in the pytest lane).
    ```bash
    # from the host, tail the session's host-backed .jsonl and look for the ping
    python3 scripts/flight-surgeon/surgeon.py --live \
-     --transcripts-root ~/.claude/projects   # locates the transcript path
+     --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts   # locates the transcript path
    ```
 
    **EXPECT:** the sent text appears as a new user turn in the transcript (and/or
@@ -407,7 +407,7 @@ confirms it and records the boundary behaviour.
 2. **Confirm the transcript is growing** on the host (record its size/last line):
 
    ```bash
-   python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.claude/projects
+   python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts
    # note the resolved transcript path P from the summary, then:
    wc -l "$P"; tail -1 "$P"
    ```
@@ -438,7 +438,7 @@ confirms it and records the boundary behaviour.
    the stall after the threshold:
 
    ```bash
-   python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.claude/projects
+   python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts
    ```
 
    **EXPECT:** the container is not reported healthy-and-progressing — either a
@@ -530,7 +530,7 @@ so it cannot run in the pytest lane.
 
    ```bash
    python3 scripts/flight-surgeon/surgeon.py --live \
-     --transcripts-root ~/.claude/projects --fail-on-quarantine ; echo "exit=$?"
+     --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts --fail-on-quarantine ; echo "exit=$?"
    ```
 
    **EXPECT:** the container is reported `should_quarantine=true` and the exit is

--- a/docs/contained-workflow/ops-runbook.md
+++ b/docs/contained-workflow/ops-runbook.md
@@ -110,7 +110,7 @@ container's host-backed transcript — no `docker exec`, no kit dependency, R-15
 
 ```bash
 python3 scripts/flight-surgeon/surgeon.py --live \
-  --transcripts-root ~/.claude/projects
+  --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts
 ```
 
 It correlates transcript growth with aoe status: `running` + flat-for-N-minutes =

--- a/scripts/ci/dogfood-cutover.sh
+++ b/scripts/ci/dogfood-cutover.sh
@@ -39,8 +39,9 @@
 #                       ~/.oaw/soak/ledger.jsonl). This script does not write it; the
 #                       soak-accrual bridge (scripts/ci/soak-accrual-bridge.sh, #1008)
 #                       does — run it periodically alongside this cutover.
-#   SURGEON_TRANSCRIPTS_ROOT  root the surgeon resolves host-backed transcripts
-#                       under (default ~/.claude/projects).
+#   SURGEON_TRANSCRIPTS_ROOT  root the surgeon resolves host-backed SANDBOX transcripts
+#                             (default ~/.oaw/state/$OAW_MAJOR/transcripts; must NOT
+#                             be ~/.claude/projects — that is the live fleet's store)
 #   DOGFOOD_CUTOVER_APPLY  "true" ⇒ actually launch (operator go); default false ⇒
 #                       plan only, launch nothing.
 
@@ -54,7 +55,13 @@ SURGEON_PY="$REPO_DIR/scripts/flight-surgeon/surgeon.py"
 EDGE_REF="${EDGE_REF:-ghcr.io/wave-engineering/oakandwave-workflow:edge}"
 OAW_MAJOR="${OAW_MAJOR:-1}"
 OAW_SOAK_LEDGER="${OAW_SOAK_LEDGER:-$HOME/.oaw/soak/ledger.jsonl}"
-SURGEON_TRANSCRIPTS_ROOT="${SURGEON_TRANSCRIPTS_ROOT:-$HOME/.claude/projects}"
+# Sandbox transcripts are host-backed under ~/.oaw/state/<major>/transcripts
+# (mounts.d/05-transcripts.toml). This USED to default to $HOME/.claude/projects
+# — the live fleet's own store — which does not merely miss: the surgeon resolves
+# the newest .jsonl matching the workspace slug, so a container picked up a NATIVE
+# session's transcript and was classified on it (#1064). The major is known here,
+# so pass the exact root rather than the module's wider default.
+SURGEON_TRANSCRIPTS_ROOT="${SURGEON_TRANSCRIPTS_ROOT:-$HOME/.oaw/state/$OAW_MAJOR/transcripts}"
 APPLY="${DOGFOOD_CUTOVER_APPLY:-false}"
 
 # --- Fail-closed on a red config ----------------------------------------------

--- a/scripts/ci/soak-accrual-bridge.sh
+++ b/scripts/ci/soak-accrual-bridge.sh
@@ -38,7 +38,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BRIDGE_PY="$HERE/soak_accrual_bridge.py"
 
 OAW_SOAK_LEDGER="${OAW_SOAK_LEDGER:-$HOME/.oaw/soak/ledger.jsonl}"
-SURGEON_TRANSCRIPTS_ROOT="${SURGEON_TRANSCRIPTS_ROOT:-$HOME/.claude/projects}"
+# Sandbox transcripts, NOT the fleet's ~/.claude/projects — the surgeon refuses
+# that root (#1064) and this loop would exit non-zero and accrue ZERO soak,
+# defeating #1008. Mirrors dogfood-cutover.sh.
+SURGEON_TRANSCRIPTS_ROOT="${SURGEON_TRANSCRIPTS_ROOT:-$HOME/.oaw/state/${OAW_MAJOR:-1}/transcripts}"
 
 cmd=(python3 "$BRIDGE_PY" --ledger "$OAW_SOAK_LEDGER" --transcripts-root "$SURGEON_TRANSCRIPTS_ROOT")
 [[ "${SOAK_BRIDGE_DRY_RUN:-false}" == "true" ]] && cmd+=(--dry-run)

--- a/scripts/ci/soak_accrual_bridge.py
+++ b/scripts/ci/soak_accrual_bridge.py
@@ -66,7 +66,7 @@ CLI::
 
     # accrue soak from the current live :edge dogfood ring
     python3 soak_accrual_bridge.py --ledger ~/.oaw/soak/ledger.jsonl \\
-        --transcripts-root ~/.claude/projects
+        --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts
 
     # preview what WOULD accrue, writing nothing
     python3 soak_accrual_bridge.py --dry-run
@@ -110,7 +110,12 @@ sys.path.insert(0, str(SURGEON_PY.parent))
 import surgeon as sg  # noqa: E402
 
 DEFAULT_LEDGER = "~/.oaw/soak/ledger.jsonl"
-DEFAULT_TRANSCRIPTS_ROOT = "~/.claude/projects"
+# Mirror the surgeon's own default rather than re-spelling it. Spelling it
+# independently is what let this drift: the surgeon moved off ~/.claude/projects
+# (#1064) and now REFUSES that root, so a stale default here made the whole
+# accrual loop exit non-zero and accrue ZERO soak — :edge could never promote,
+# which is exactly what #1008 exists to prevent.
+DEFAULT_TRANSCRIPTS_ROOT = sg.DEFAULT_TRANSCRIPTS_ROOT
 
 # The bounded per-pass look-back (hours). Each pass credits at most this much time,
 # ending at the ``now`` it just health-verified — so a point-in-time "clean now"

--- a/scripts/flight-surgeon/README.md
+++ b/scripts/flight-surgeon/README.md
@@ -44,7 +44,7 @@ consumes this module's `should_quarantine` verdict.
 python3 scripts/flight-surgeon/surgeon.py --observations obs.json
 
 # best-effort live gather over aoe sessions (flags the UNPROVEN seams)
-python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.claude/projects
+python3 scripts/flight-surgeon/surgeon.py --live --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts
 
 # a watcher/cron signal: non-zero exit if any quarantine-eligible break
 python3 scripts/flight-surgeon/surgeon.py --observations obs.json --fail-on-quarantine

--- a/scripts/flight-surgeon/surgeon.py
+++ b/scripts/flight-surgeon/surgeon.py
@@ -53,7 +53,7 @@ CLI::
     python3 surgeon.py --observations obs.json
 
     # best-effort live gather over aoe sessions (flags the UNPROVEN seams)
-    python3 surgeon.py --live --transcripts-root ~/.claude/projects
+    python3 surgeon.py --live --transcripts-root ~/.oaw/state/$OAW_MAJOR/transcripts
 
 Emits a JSON report on stdout (one assessment per container) and a human summary
 on stderr; exits 0 normally, or non-zero with ``--fail-on-quarantine`` if any
@@ -64,6 +64,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -83,6 +84,54 @@ DEFAULT_STALL_SECONDS = 15 * 60
 DEFAULT_LOOP_MIN_REPEATS = 5
 # The longest repeating cycle length considered (e.g. period 2 = A B A B ...).
 DEFAULT_LOOP_MAX_PERIOD = 4
+
+
+# --- transcript root (#1064) --------------------------------------------------
+#
+# Sandbox transcripts are host-backed at ~/.oaw/state/<major>/transcripts (mounted
+# to the container's ~/.claude/projects by mounts.d/05-transcripts.toml). This
+# default USED to be ~/.claude/projects — the live fleet's own store — which is a
+# confident wrong answer rather than a miss: `_newest_transcript_for` returns the
+# newest .jsonl matching the workspace slug, so a container resolved against that
+# root picks up a NATIVE session's transcript. Measured 2026-07-30 on this host: a
+# container on the cc-workflow workspace resolved to the live native session's
+# file, 19s stale.
+#
+# The failure is bidirectional. Natives running -> their transcripts are fresh ->
+# every container reads healthy and quarantine never fires. Natives stopped (the
+# big-bang cut-over) -> those transcripts go stale at once -> running containers
+# read stalled and healthy candidates are false-quarantined.
+#
+# The default is the state ROOT, not a <major>-specific path: this module depends
+# on the standard library only (R-15) and must not import the mount resolver to
+# interpolate <major>. Resolution rglobs, so `~/.oaw/state` finds
+# `<major>/transcripts/<slug>/*.jsonl` under any major — correct but deliberately
+# wider than R-20's per-major isolation. Callers that know the major SHOULD pass
+# the exact root (dogfood-cutover.sh does); this default only guarantees the bare
+# `surgeon.py --live` invocation stays inside the sandbox tree rather than
+# resolving fleet transcripts.
+def _default_transcripts_root() -> str:
+    """Sandbox transcript root, narrowed to $OAW_MAJOR when the fleet sets it.
+
+    Spanning majors is not merely untidy: `_newest_transcript_for` picks by mtime
+    across everything `rglob` reaches, so a freshly-launched major-8 container
+    that has not written yet resolves to the leftover major-7 file for the same
+    workspace — stale, therefore running+flat, therefore FALSE QUARANTINE. That is
+    the same mechanic this issue fixes, narrowed from cross-fleet to cross-major,
+    and R-20 exists precisely to keep majors isolated.
+
+    `os.environ` is stdlib, so this respects R-15 (no mount-resolver import).
+    """
+    major = os.environ.get("OAW_MAJOR", "").strip()
+    if major:
+        return f"~/.oaw/state/{major}/transcripts"
+    return "~/.oaw/state"
+
+
+DEFAULT_TRANSCRIPTS_ROOT = _default_transcripts_root()
+
+# Any transcripts root inside this tree is the live fleet's, not a sandbox's.
+LIVE_FLEET_TREE = ".claude"
 
 
 # --- aoe run states -----------------------------------------------------------
@@ -601,6 +650,52 @@ def _load_observations(path: str) -> list[dict]:
     return data
 
 
+class FleetTranscriptRootError(SurgeonError):
+    """The transcripts root points at the live fleet's store, not a sandbox's.
+
+    Subclasses SurgeonError deliberately: as a bare RuntimeError it escaped
+    ``main()``'s ``except`` tuple, so the carefully-worded refusal arrived as the
+    tail of a stack trace and the exit code was 1 instead of the documented 2
+    (usage error). One taxonomy, one exit contract.
+    """
+
+
+def assert_sandbox_transcripts_root(root: Path, *, allow_fleet: bool = False) -> None:
+    """Refuse a transcripts root inside the live-fleet tree (#1064).
+
+    A container resolved against ``~/.claude/projects`` does not fail to find a
+    transcript — it finds a NATIVE session's and classifies confidently on it.
+    That is why this raises instead of warning: a warning on a probe whose whole
+    job is to notice silence would itself be noise the operator learns to skip.
+
+    ``allow_fleet=True`` is the deliberate escape hatch for the pre-cut-over case
+    where the fleet IS the thing being watched.
+    """
+    if allow_fleet:
+        return
+    # Check BOTH forms. resolve() follows symlinks, so a fleet whose ~/.claude is
+    # a symlink to /mnt/data/claude-config resolves to parts containing no
+    # ".claude" and the guard would pass on the fleet's actual store — failing
+    # OPEN, the one direction this whole issue is about. mount_resolver's
+    # check_sandbox_scoped_memory reasons over normalized path TEXT and never
+    # touches the filesystem; this matches that.
+    candidates = {root.parts}
+    try:
+        candidates.add(root.resolve().parts)
+    except OSError:
+        pass
+    if any(LIVE_FLEET_TREE in parts for parts in candidates):
+        raise FleetTranscriptRootError(
+            f"transcripts root {root} is inside the live-fleet tree "
+            f"({LIVE_FLEET_TREE}). Sandbox transcripts are host-backed under "
+            f"{DEFAULT_TRANSCRIPTS_ROOT}/<major>/transcripts "
+            "(mounts.d/05-transcripts.toml). Resolving a container against the "
+            "fleet's store yields a confident verdict about the wrong process — "
+            "healthy while natives run, stalled once they stop. Pass "
+            "--allow-fleet-transcripts only if you mean to watch the fleet itself."
+        )
+
+
 def _gather_live(args, runner=_run) -> list[dict]:
     """Best-effort live gather over aoe sessions.
 
@@ -611,13 +706,20 @@ def _gather_live(args, runner=_run) -> list[dict]:
     configurable ``--transcripts-root`` (best-effort, newest ``.jsonl`` under the
     session's project) and leaves the profile ``unknown`` unless a label is wired.
     """
+    # Refuse FIRST — before spending two aoe subprocesses on a root we reject.
+    root = Path(args.transcripts_root).expanduser()
+    assert_sandbox_transcripts_root(
+        root, allow_fleet=getattr(args, "allow_fleet_transcripts", False)
+    )
     sessions = discover_sessions(runner)
     states = parse_status_table(runner(["aoe", "status", "-v"]))
-    root = Path(args.transcripts_root).expanduser()
     records: list[dict] = []
+    unresolved: list[str] = []
     for s in sessions:
         title = s.get("title", "?")
         transcript = _newest_transcript_for(root, s.get("path", ""))
+        if transcript is None:
+            unresolved.append(title)
         records.append(
             {
                 "container_id": s.get("id", "?"),
@@ -625,7 +727,21 @@ def _gather_live(args, runner=_run) -> list[dict]:
                 "status": states.get(title, STATUS_UNKNOWN),
                 "profile": s.get("profile_label", PROFILE_UNKNOWN),
                 "transcript": str(transcript) if transcript else "",
+                # Distinguish "read it, agent is fine" from "found no transcript".
+                # Without this an unresolved session yields transcript "" ->
+                # read_transcript [] -> classify_health "no timestamped activity
+                # yet" -> broken=False, and the promotion gate accrues soak for a
+                # session whose health was never measured. Silence that reads as
+                # health is the failure class this issue exists to remove.
+                "transcript_resolved": transcript is not None,
             }
+        )
+    if unresolved:
+        print(
+            f"surgeon: WARNING {len(unresolved)}/{len(sessions)} session(s) had NO "
+            f"resolvable transcript under {root} — their health was NOT measured: "
+            + ", ".join(unresolved),
+            file=sys.stderr,
         )
     return records
 
@@ -666,8 +782,22 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--transcripts-root",
-        default="~/.claude/projects",
-        help="root to resolve host-backed transcripts under (--live)",
+        default=DEFAULT_TRANSCRIPTS_ROOT,
+        help=(
+            "root to resolve host-backed sandbox transcripts under (--live); "
+            f"default {DEFAULT_TRANSCRIPTS_ROOT}. Pointing this at "
+            "~/.claude/projects resolves the NATIVE fleet's transcripts, not the "
+            "containers' — see --allow-fleet-transcripts"
+        ),
+    )
+    parser.add_argument(
+        "--allow-fleet-transcripts",
+        action="store_true",
+        help=(
+            "permit a --transcripts-root inside the live-fleet tree (~/.claude). "
+            "Refused by default: a container resolved against a fleet transcript "
+            "yields a confident verdict about the wrong process (#1064)"
+        ),
     )
     parser.add_argument(
         "--stall-seconds", type=float, default=DEFAULT_STALL_SECONDS,

--- a/tests/contained-workflow/test_mounts.py
+++ b/tests/contained-workflow/test_mounts.py
@@ -277,3 +277,62 @@ def test_manifest_dir_exists() -> None:
     owned = {"10-memory.toml", "30-user-overlay.toml", "40-durable-caches.toml"}
     missing = owned - fragments
     assert not missing, f"missing Story 1.3 manifest fragments: {sorted(missing)}"
+
+
+# --- transcripts mount (#1064) -------------------------------------------------
+
+
+def _resolved(major: int = 7):
+    return mr.resolve_manifest(major, home=PurePosixPath("/home/bakerb"),
+                               mounts_dir=MANIFEST_DIR)
+
+
+def test_transcripts_mount_exists_and_is_sandbox_scoped() -> None:
+    """Without this, `docker rm` destroys the session AND the flight surgeon
+    reads a transcript that was never written (#1064)."""
+    t = [m for m in _resolved() if m.name == "transcripts"]
+    assert t, "no transcripts mount — sessions cannot survive container replacement"
+    m = t[0]
+    assert m.mode == "rw", "transcripts are written by the harness"
+    assert m.source == "/home/bakerb/.oaw/state/7/transcripts", (
+        f"transcripts must be sandbox-scoped under ~/.oaw/state/<major>/, got {m.source!r}"
+    )
+    assert m.target == "/home/ubuntu/.claude/projects"
+
+
+def test_transcripts_mount_never_points_at_the_live_fleet() -> None:
+    """R-03: a broken :edge candidate must not gain write access to the fleet's
+    ~/.claude. The resolver's own guard enforces this — assert it is ARMED for
+    this mount by planting the violation, not by trusting the declaration."""
+    import tomllib
+    frag = MANIFEST_DIR / "05-transcripts.toml"
+    entry = tomllib.load(frag.open("rb"))["mount"][0]
+    assert entry.get("sandbox_scoped") is True, (
+        "transcripts must set sandbox_scoped so check_sandbox_scoped_memory runs; "
+        "without it a future edit could point this at ~/.claude and pass"
+    )
+    with pytest.raises(mr.ManifestError, match="R-03"):
+        mr.check_sandbox_scoped_memory(
+            "/home/bakerb/.claude/projects", 7, PurePosixPath("/home/bakerb")
+        )
+
+
+def test_transcripts_mounts_before_memory_nests_inside_it() -> None:
+    """05-transcripts mounts `projects`; 10-memory nests `projects/_sandbox/memory`
+    inside it. Docker sorts binds by destination depth, but matching the lexical
+    fragment order makes the nesting intentional rather than dependent on that."""
+    order = [m.name for m in _resolved()]
+    assert order.index("transcripts") < order.index("memory"), (
+        "transcripts must resolve before memory — it is the parent directory"
+    )
+
+
+def test_memory_target_nests_inside_the_transcripts_target() -> None:
+    """The ordering test asserts list order; this asserts the INVARIANT that
+    ordering exists to protect — memory's target must actually be under the
+    transcripts target, or the nesting rationale is fiction."""
+    by_name = {m.name: m for m in _resolved()}
+    t, mem = by_name["transcripts"].target, by_name["memory"].target
+    assert mem.startswith(t.rstrip("/") + "/"), (
+        f"memory target {mem!r} is not nested under transcripts target {t!r}"
+    )

--- a/tests/contained-workflow/test_surgeon.py
+++ b/tests/contained-workflow/test_surgeon.py
@@ -221,8 +221,12 @@ def test_module_is_kit_independent() -> None:
     imports ONLY the Python standard library, so a broken container cannot shape
     the verdict."""
     tree = ast.parse(SURGEON_PY.read_text())
+    # An enumeration of the stdlib modules this file uses — NOT a policy
+    # narrowing. R-15's guarantee is "nothing from the container's KIT", so a
+    # genuinely-stdlib addition (os, for $OAW_MAJOR) preserves it exactly.
+    # Anything outside the standard library still fails, which is the point.
     stdlib = {
-        "argparse", "json", "subprocess", "sys", "dataclasses",
+        "argparse", "json", "os", "subprocess", "sys", "dataclasses",
         "datetime", "pathlib", "__future__",
     }
     imported: set[str] = set()
@@ -370,3 +374,81 @@ def test_surgeon_is_executable() -> None:
     assert SURGEON_PY.exists()
     assert os.access(SURGEON_PY, os.X_OK), "surgeon.py must be executable"
     assert SURGEON_PY.read_text().startswith("#!"), "surgeon.py needs a shebang"
+
+
+# --- transcripts-root provenance (#1064) --------------------------------------
+#
+# The seam these cover produced a CONFIDENT WRONG ANSWER, not a miss. Measured on
+# the development host 2026-07-30: with --transcripts-root ~/.claude/projects, a
+# container on the cc-workflow workspace resolved to the live NATIVE session's
+# transcript (19s stale). Wrong in both directions — healthy while natives run,
+# stalled the moment the big-bang cut-over stops them.
+
+
+def test_fleet_transcripts_root_is_refused() -> None:
+    """A root inside ~/.claude is the fleet's store, not a sandbox's."""
+    with pytest.raises(fs.FleetTranscriptRootError) as exc:
+        fs.assert_sandbox_transcripts_root(Path.home() / ".claude" / "projects")
+    msg = str(exc.value)
+    assert "live-fleet" in msg, "the refusal must say WHY, not just refuse"
+    assert "--allow-fleet-transcripts" in msg, "it must name the escape hatch"
+
+
+def test_fleet_transcripts_root_allowed_with_explicit_flag() -> None:
+    """Watching the fleet itself is legitimate — but must be asked for."""
+    fs.assert_sandbox_transcripts_root(
+        Path.home() / ".claude" / "projects", allow_fleet=True
+    )
+
+
+def test_sandbox_transcripts_root_is_accepted() -> None:
+    """The host-backed sandbox root (and a major-specific path under it) pass."""
+    fs.assert_sandbox_transcripts_root(Path.home() / ".oaw" / "state")
+    fs.assert_sandbox_transcripts_root(
+        Path.home() / ".oaw" / "state" / "7" / "transcripts"
+    )
+
+
+def test_default_transcripts_root_is_not_the_fleet_tree() -> None:
+    """The DEFAULT must be safe with no flags — the bare `--live` invocation in
+    this module's own docstring must not resolve fleet transcripts."""
+    fs.assert_sandbox_transcripts_root(
+        Path(fs.DEFAULT_TRANSCRIPTS_ROOT).expanduser()
+    )
+
+
+def test_gather_live_refuses_a_fleet_root(tmp_path) -> None:
+    """The guard is wired into the live path, not merely available.
+
+    A guard that exists but is never called is the defect this whole issue is
+    about, so assert the call site rather than the function.
+    """
+    class _Args:
+        transcripts_root = str(Path.home() / ".claude" / "projects")
+        allow_fleet_transcripts = False
+
+    with pytest.raises(fs.FleetTranscriptRootError):
+        fs._gather_live(_Args(), runner=lambda *a, **k: "")
+
+
+def test_refused_root_exits_2_without_a_traceback() -> None:
+    """The refusal must reach the operator as a MESSAGE, not a stack trace.
+
+    FleetTranscriptRootError began life as a bare RuntimeError, which is in none
+    of main()'s except branches — so the carefully-worded refusal arrived as the
+    tail of a traceback and the exit code was 1, breaking the documented contract
+    (0 normal / 2 usage / 3 quarantine). The in-process tests could not see this
+    because they never cross the CLI boundary.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(SURGEON_PY), "--live",
+         "--transcripts-root", str(Path.home() / ".claude" / "projects")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 2, (
+        f"a refused root is a usage error (exit 2), got {proc.returncode}"
+    )
+    assert "Traceback" not in proc.stderr, (
+        "the refusal must be a message, not a stack trace:\n" + proc.stderr
+    )
+    assert "live-fleet" in proc.stderr


### PR DESCRIPTION
## Summary

Two failures, one missing mount.

The container wrote `~/.claude/projects/<slug>/*.jsonl` to its own filesystem, so `docker rm` destroyed it — **no `--resume` in a replacement container**, on *any* replacement: crash, OOM, host reboot, image bump. Skill updates are merely the most frequent trigger.

The second is worse. The flight surgeon is documented as reading *"the container's host-backed `.jsonl` transcript directly … without depending on the container's kit"* — that independence is the entire point of a host-side probe — and resolved under `--transcripts-root ~/.claude/projects`. With no mount, that root holds the **native fleet's** transcripts, and `_newest_transcript_for` returns the newest file matching the workspace slug.

**Measured on the dev host:** a container on the cc-workflow workspace resolved to the *live native session's own transcript*, 19s stale.

So the seam did not fail closed. It handed the classifier a confident answer about the wrong process — wrong in **both directions** depending on timing:

| cut-over state | host transcripts | container reads as | consequence |
|---|---|---|---|
| natives still running | fresh | **healthy** | quarantine never fires |
| natives stopped (big-bang) | cold at once | **stalled** | healthy candidates false-quarantined |

The promotion gate consumes `should_quarantine` either way.

## Changes

**Half 1 — the mount.** `mounts.d/05-transcripts.toml`: `~/.oaw/state/<major>/transcripts` → `/home/ubuntu/.claude/projects`, `rw`, `sandbox_scoped` so `mount_resolver`'s R-03 guard refuses any source outside `~/.oaw/state/<major>/`. Numbered `05` so it resolves before `10-memory.toml`, which nests `projects/_sandbox/memory` inside it — Docker sorts binds by destination depth regardless, but matching lexical order makes the nesting intentional.

**Half 2 — the surgeon.** Without this the mount ships and the probe keeps resolving fleet transcripts:

- `DEFAULT_TRANSCRIPTS_ROOT` moves off the fleet root, narrowing to `$OAW_MAJOR` when set (stdlib `os`, so R-15 holds).
- `assert_sandbox_transcripts_root` **refuses** a root inside `~/.claude`, checked *before* any `aoe` subprocess runs. `--allow-fleet-transcripts` is the deliberate escape hatch for watching the fleet itself.
- It raises rather than warns because a warning on a probe whose whole job is noticing silence is noise an operator learns to skip.

## From code review — 1 critical, 5 important, 4 minor, all fixed

**Critical: half 2 broke #1008.** `soak-accrual-bridge` still defaulted to the now-refused fleet root, so the accrual loop would exit non-zero and accrue **zero soak** — `:edge` could never promote, the exact failure #1008 exists to prevent. The bridge now mirrors the surgeon's constant instead of re-spelling it, which is what let the two drift apart.

- `FleetTranscriptRootError` subclasses `SurgeonError`. As a bare `RuntimeError` it escaped `main()`'s `except` tuple, so the refusal arrived as a **stack trace** and the exit code was 1, not the documented 2.
- **Six** operator/verification procedures still passed the refused root — including `surgeon.py`'s *own module docstring*, and MV-08, which asserts exit 3 and was unreachable as written. A stale command there is a false FAIL during the very verification this change enables.
- An unresolved transcript no longer reads as healthy: records carry `transcript_resolved`, and `_gather_live` warns to stderr with a count. Previously `""` → `read_transcript` `[]` → *"no timestamped activity yet"* → `broken=False`, and soak accrued for a session whose health was never measured.
- **Symlink evasion closed.** `resolve()` follows symlinks, so a fleet whose `~/.claude` is a symlink resolved to parts containing no `.claude` and passed — failing **open**, the one direction that matters here. Both pre- and post-resolve forms are now checked, matching `check_sandbox_scoped_memory`'s text-only reasoning.

### Documented, not solved

The mount carries no session token, so **two containers on one workspace still resolve to whichever `.jsonl` is newest** — the same wrong-process verdict relocated from native-vs-container to container-vs-container. A dogfood + dev-mode pair on one repo is explicitly supported (R-22), so this is reachable. The fragment says so rather than reading as if it closes the seam.

## Linked Issues

Closes #1064

## Test Plan

- `./scripts/ci/validate.sh` → **215 passed, 0 failed**
- Full `pytest tests/` → **1941 passed**, 6 skipped, 64 xfailed, 2 xpassed — **+10 over the #1062 baseline of 1931**, matching the tests added
- End-to-end that the bridge default now *survives* the guard (the critical fix), and that `OAW_MAJOR=7` narrows the default
- `dogfood-cutover.sh` PLAN mode emits `--transcripts-root /home/bakerb/.oaw/state/7/transcripts`

**Every new guard mutation-verified** — each mutation fails exactly one test:

| mutation | caught by |
|---|---|
| default reverted to the fleet root | `test_default_transcripts_root_is_not_the_fleet_tree` |
| guard **unwired** from `_gather_live` (left defined) | `test_gather_live_refuses_a_fleet_root` |
| `sandbox_scoped` removed from the fragment | `test_transcripts_mount_never_points_at_the_live_fleet` |
| fragment renamed to sort after `10-memory` | `test_transcripts_mounts_before_memory_nests_inside_it` |

The unwiring case matters most — a guard that exists but is never called is this issue's own defect.

### DEFERRED to MV-05 (operator direction)

**No container was launched.** Still unproven:

1. `--resume` survives `docker rm` + recreate.
2. The container writes to the mounted path — its cwd-derived slug is `/home/ubuntu`-shaped while the surgeon slugs the **host** path. **They may not match**, which would resolve nothing (a safe failure, but no health detection until fixed). Check this first when MV-05 runs.
3. Nesting under a live Docker daemon.

Blocked on an isolated aoe profile plus a live `:edge` session. Recorded on the issue.

### Deferred

`trivy` parsed **0 manifests** — not a pass. Pre-existing (#1056 et al.); no dependency changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS