### PR TITLE
fix(contained-workflow): derive the kit major, guard the skills overlay

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Tags are REQUIRED: scripts/ci/oaw-major.sh derives the kit major from
+          # `git describe --tags` (#1067), and the default shallow checkout fetches
+          # with --no-tags. Without this the derivation cannot resolve in CI while
+          # passing locally — the classic green-here/red-there split.
+          fetch-depth: 0
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,14 @@ jobs:
 
       - name: Compat-guard — block a silent same-major schema break (#1002)
         run: |
-          git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
+          # NO --depth=1 and NO --no-tags. A shallow fetch does not merely fetch
+          # less — it marks the whole repository shallow (.git/shallow), and that
+          # persists for every LATER step in the job. It silently un-did checkout's
+          # fetch-depth: 0 + fetch-tags: true, so `git describe --tags` in the test
+          # step could no longer walk history and scripts/ci/oaw-major.sh refused
+          # (#1067). checkout already fetched full history here, so this costs
+          # nothing extra and leaves the repo intact for what runs after it.
+          git fetch origin main:refs/remotes/origin/main
           COMPAT_GUARD_BASE_REF=origin/main ./scripts/ci/compat-guard.sh
 
       - name: Set up Python

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,10 +11,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # Tags are REQUIRED: scripts/ci/oaw-major.sh derives the kit major from
-          # `git describe --tags` (#1067), and the default shallow checkout fetches
-          # with --no-tags. Without this the derivation cannot resolve in CI while
-          # passing locally — the classic green-here/red-there split.
+          # `git describe --tags` (#1067). Without them the derivation cannot resolve
+          # in CI while passing locally — the classic green-here/red-there split.
+          #
+          # BOTH inputs are needed. fetch-depth: 0 does NOT imply tags in
+          # actions/checkout@v4: fetch-tags is a separate input defaulting to false,
+          # and the action fetches with --no-tags unless it is set. Verified from the
+          # run log, which printed `fetch-tags: false` alongside `fetch-depth: 0`
+          # while the derivation still failed.
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck

--- a/containers/oakandwave-workflow/profiles.py
+++ b/containers/oakandwave-workflow/profiles.py
@@ -56,7 +56,7 @@ CLI — the gate-signal emitter plugs straight into ``promote-oakandwave-image.s
     # -> SOAK_HOURS=<candidate soak sum>
     #    QUARANTINE_COUNT=<candidate quarantine count>
 
-    python3 profiles.py --emit launch --profile dev-mode
+    python3 profiles.py --emit launch --profile dev-mode --major "$(scripts/ci/oaw-major.sh)"
     # -> the docker/aoe launch args: the oaw.profile label + the skills overlay -v
 """
 
@@ -202,11 +202,49 @@ def skills_overlay_mount(
     return f"{src}:{IMAGE_SKILLS_TARGET}{suffix}"
 
 
+class EmptySkillsOverlayError(ProfileError):
+    """dev-mode's overlay source is empty — binding it would BLANK the skills."""
+
+
+def assert_overlay_populated(mount: str) -> None:
+    """Refuse a dev-mode launch whose overlay source is empty or absent (#1067).
+
+    The overlay is a WHOLE-DIRECTORY bind over the image's skills dir, so the
+    container sees exactly what the host source contains — it REPLACES, it does not
+    merge. `architecture.md` calls it "the developer's working skills bind over the
+    baked skills", which reads as an overlay; a whole-dir bind is a replacement.
+
+    The source is empty by default (nothing populates it), so an unguarded dev-mode
+    launch comes up with NO SKILLS AT ALL rather than with the developer's layered
+    over the baked ones. That is silent — the container starts fine and the agent
+    simply has no skills — which is why this raises rather than warns.
+    """
+    src = Path(mount.split(":", 1)[0]).expanduser()
+    try:
+        empty = not src.is_dir() or not any(src.iterdir())
+    except OSError as exc:
+        # An unreadable dir is "not usable as an overlay" just as surely as an
+        # empty one — surface it as the same legible refusal rather than letting a
+        # raw PermissionError escape as a traceback.
+        raise EmptySkillsOverlayError(
+            f"dev-mode skills overlay source {src} is not readable: {exc}"
+        ) from exc
+    if empty:
+        raise EmptySkillsOverlayError(
+            f"dev-mode skills overlay source {src} is empty or absent. The overlay "
+            f"is a whole-directory bind over {IMAGE_SKILLS_TARGET}, so launching "
+            "would leave the container with NO skills, not with yours layered over "
+            "the baked ones. Populate it (e.g. symlink your working skills into it) "
+            "or use the dogfood profile, which is image-only by design."
+        )
+
+
 def launch_spec(
     profile: object,
     *,
     major: int | str,
     skills_overlay_source: str = DEFAULT_SKILLS_OVERLAY_SOURCE,
+    require_populated_overlay: bool = True,
 ) -> list[str]:
     """Render the concrete launch args for a profile (R-21).
 
@@ -219,6 +257,10 @@ def launch_spec(
     args = ["--label", f"{PROFILE_LABEL_KEY}={prof.label}"]
     mount = skills_overlay_mount(prof.name, major=major, source=skills_overlay_source)
     if mount is not None:
+        # Guarded by default: an empty overlay blanks the skill surface silently.
+        # Callers rendering a spec for inspection (tests, docs) pass False.
+        if require_populated_overlay:
+            assert_overlay_populated(mount)
         args += ["-v", mount]
     return args
 
@@ -347,12 +389,28 @@ def main(argv: list[str] | None = None) -> int:
         "--profile", default=None, help="profile name for --emit launch (dev-mode|dogfood)"
     )
     parser.add_argument(
-        "--major", default="1", help="the state/image major for <major> substitution"
+        # NO literal default. A default here is the #1067 defect relocated from
+        # shell to the CLI — it resolves silently to the wrong state namespace.
+        # Not argparse-`required` though: --major is only consumed where <major> is
+        # actually substituted (a dev-mode overlay), so demanding it for
+        # --emit gate-signals or a dogfood launch would be noise. Enforced below,
+        # where it is used.
+        "--major", default=None,
+        help="the state/image major for <major> substitution (derive: scripts/ci/oaw-major.sh)",
     )
     parser.add_argument(
         "--skills-overlay-source",
         default=DEFAULT_SKILLS_OVERLAY_SOURCE,
         help="host source for the dev-mode skills overlay (--emit launch)",
+    )
+    parser.add_argument(
+        "--allow-empty-overlay",
+        action="store_true",
+        help=(
+            "render a dev-mode spec even when the overlay source is empty. For "
+            "INSPECTION only — launching with an empty overlay leaves the "
+            "container with no skills at all (#1067)"
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -368,11 +426,30 @@ def main(argv: list[str] | None = None) -> int:
     if not args.profile:
         print("--profile is required for --emit launch", file=sys.stderr)
         return 2
+    # Demand --major only when the rendered spec actually substitutes <major> —
+    # i.e. an overlay-ON profile. Guessing a literal is the #1067 defect.
+    if args.major is None and "<major>" in args.skills_overlay_source:
+        if skills_overlay_on(args.profile):
+            print(
+                "--major is required for an overlay-ON profile (its source contains "
+                "<major>). Derive it: --major \"$(scripts/ci/oaw-major.sh)\". There is "
+                "no default on purpose — a literal silently picks the wrong state "
+                "namespace (#1067).",
+                file=sys.stderr,
+            )
+            return 2
+        args.major = ""  # unused: overlay OFF renders no <major>
     try:
         args_out = launch_spec(
-            args.profile, major=args.major, skills_overlay_source=args.skills_overlay_source
+            args.profile,
+            major=args.major,
+            skills_overlay_source=args.skills_overlay_source,
+            require_populated_overlay=not args.allow_empty_overlay,
         )
     except ProfileError as exc:
+        print(f"profile error: {exc}", file=sys.stderr)
+        return 2
+    except EmptySkillsOverlayError as exc:
         print(f"profile error: {exc}", file=sys.stderr)
         return 2
     print(" ".join(args_out))

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -73,7 +73,15 @@ docker label the surgeon and the promotion gate both read:
 | Profile | Skills overlay | `oaw.profile` | Candidate? | Role |
 |---------|----------------|---------------|------------|------|
 | **dogfood** | OFF — image-only | `dogfood` | yes | The real dogfood ring: its runs accrue soak and its breakages trip quarantine — it is what the gate measures. |
-| **dev-mode** | ON — the developer's working skills bind over the baked skills (the R-06 non-promotable exception) | `dev-mode` | **no** | Skill iteration without a rebuild. **Excluded from promotion telemetry** — dev-mode runs/breakages never count toward soak nor trip quarantine. |
+| **dev-mode** | ON — a whole-directory bind of the developer's working skills **over** the image skills dir (the R-06 non-promotable exception) | `dev-mode` | **no** | Skill iteration without a rebuild. **Excluded from promotion telemetry** — dev-mode runs/breakages never count toward soak nor trip quarantine. |
+
+> **The overlay REPLACES, it does not merge (#1067).** The bind covers the whole
+> image skills dir, so the container sees exactly what the host source contains.
+> An empty source therefore yields a container with **no skills at all**, silently —
+> `profiles.py` refuses that launch rather than rendering it. Note this is a
+> *different* mechanism from `bootstrap.sh`'s skills-sync, which is **image-wins /
+> host-fills** from `~/.oaw/.claude/skills`. Two overlay paths with two semantics;
+> reconciling them is open work.
 
 `containers/oakandwave-workflow/profiles.py` is the canonical owner of the label
 and the candidacy rule. It renders each profile's launch (`launch_spec` — the

--- a/scripts/ci/dogfood-cutover.sh
+++ b/scripts/ci/dogfood-cutover.sh
@@ -33,8 +33,11 @@
 #                       ghcr.io/wave-engineering/oakandwave-workflow:edge).
 #   CUTOVER_WORKSPACES  whitespace/newline-separated workspace paths to cut over
 #                       (required — the OaW dev team's working trees).
-#   OAW_MAJOR           the kit major for the dogfood profile's <major> mounts
-#                       (default 1).
+#   OAW_MAJOR           the kit major for the dogfood profile's <major> mounts.
+#                       DERIVED from the repo tag via scripts/ci/oaw-major.sh; set
+#                       explicitly to override. There is no literal default — a
+#                       hardcoded major is the #1067 defect, and it fails silently
+#                       as empty state rather than loudly.
 #   OAW_SOAK_LEDGER     the FlightDeck soak ledger the gate reads (default
 #                       ~/.oaw/soak/ledger.jsonl). This script does not write it; the
 #                       soak-accrual bridge (scripts/ci/soak-accrual-bridge.sh, #1008)
@@ -53,7 +56,11 @@ PROFILES_PY="$REPO_DIR/containers/oakandwave-workflow/profiles.py"
 SURGEON_PY="$REPO_DIR/scripts/flight-surgeon/surgeon.py"
 
 EDGE_REF="${EDGE_REF:-ghcr.io/wave-engineering/oakandwave-workflow:edge}"
-OAW_MAJOR="${OAW_MAJOR:-1}"
+# Derived, never a literal (#1067). A hardcoded major shares one state namespace
+# across kit generations (defeating R-20) and, when wrong, fails SILENTLY as
+# empty state rather than loudly. --check also refuses an unprovisioned major.
+OAW_MAJOR="$("$HERE/oaw-major.sh")"
+export OAW_MAJOR # surgeon.py narrows its default transcripts root from this
 OAW_SOAK_LEDGER="${OAW_SOAK_LEDGER:-$HOME/.oaw/soak/ledger.jsonl}"
 # Sandbox transcripts are host-backed under ~/.oaw/state/<major>/transcripts
 # (mounts.d/05-transcripts.toml). This USED to default to $HOME/.claude/projects
@@ -78,6 +85,15 @@ echo "    dogfood launch args (from profiles.py): $dogfood_args"
 # Each workspace becomes one dogfood-profile sandbox on :edge. `aoe add --sandbox`
 # is the one-container-per-session seam (TC-1); the profile args stamp
 # oaw.profile=dogfood so the surgeon and the gate both filter on it (R-22).
+# Refuse an unprovisioned major before the FIRST real launch — not on the plan
+# path. A wrong/absent major is silent (docker materialises each missing bind
+# source as an empty dir, so memory and caches come up blank), so the guard has to
+# fire; but gating the documented dry run on host provisioning would break its
+# "launches NOTHING" contract and make it fail on any checkout without ~/.oaw.
+if [[ "$APPLY" == "true" ]]; then
+	"$HERE/oaw-major.sh" --check >/dev/null
+fi
+
 launched=0
 for ws in $CUTOVER_WORKSPACES; do
 	launch_cmd=(aoe add --sandbox --sandbox-image "$EDGE_REF")

--- a/scripts/ci/oaw-major.sh
+++ b/scripts/ci/oaw-major.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# oaw-major.sh — resolve the kit MAJOR that partitions sandbox state (#1067, R-20).
+#
+# WHY THIS EXISTS. `dogfood-cutover.sh` and `soak-accrual-bridge.sh` each carried
+# `OAW_MAJOR="${OAW_MAJOR:-1}"` — a hardcoded literal, sitting under a comment
+# calling it "the kit major", while the kit was at 7.3.0. So every kit generation
+# shared namespace `1` and R-20's guarantee ("the major partitions the namespace
+# so mixing majors is isolated") did not hold in practice.
+#
+# WHY A WRONG MAJOR IS DANGEROUS RATHER THAN UNTIDY. It does not error. Docker's
+# create-if-missing turns an absent bind source into an empty DIRECTORY, so
+# ~/.oaw/state/<major>/memory and every cache come up BLANK — no warning, no
+# failed mount, just an agent with no memory and cold caches. Identical shape to
+# the missing ~/.secrets/.env in #1061.
+#
+# DERIVATION mirrors scripts/ci/oakandwave-oci-labels.sh rather than inventing a
+# second mechanism: $OAW_MAJOR wins, else the major of `git describe --tags`.
+# There is deliberately NO literal fallback — a constant is the defect this
+# replaces, and guessing silently is worse than refusing.
+#
+# Usage:
+#   OAW_MAJOR="$(scripts/ci/oaw-major.sh)"            # resolve, or fail loud
+#   scripts/ci/oaw-major.sh --check                   # also verify the dirs exist
+#
+# Exit: 0 resolved; 2 cannot resolve; 3 resolved but --check found missing dirs.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECK=false
+[[ "${1:-}" == "--check" ]] && CHECK=true
+
+resolve_major() {
+	if [[ -n "${OAW_MAJOR:-}" ]]; then
+		printf '%s' "$OAW_MAJOR"
+		return 0
+	fi
+	local tag
+	tag="$(git -C "$REPO_DIR" describe --tags --abbrev=0 2>/dev/null)" || tag=""
+	[[ -n "$tag" ]] || return 1
+	tag="${tag#v}" # tags are vX.Y.Z
+	local major="${tag%%.*}"
+	[[ "$major" =~ ^[0-9]+$ ]] || return 1
+	printf '%s' "$major"
+}
+
+# Validate the OVERRIDE here, not inside resolve_major: that runs in a command
+# substitution, where `exit` leaves only the subshell and the caller then reports
+# "cannot resolve" — two messages, one of them wrong.
+#
+# mount_resolver coerces a full semver to its major int while profiles.py
+# substitutes <major> as a raw string, so OAW_MAJOR=7.3.0 silently SPLITS the
+# namespace: mounts land at ~/.oaw/state/7 and the skills overlay at
+# ~/.oaw/overlay/7.3.0.
+if [[ -n "${OAW_MAJOR:-}" && ! "$OAW_MAJOR" =~ ^[0-9]+$ ]]; then
+	echo "oaw-major: \$OAW_MAJOR must be a bare major integer, got '$OAW_MAJOR'." >&2
+	echo "  A semver like 7.3.0 splits the namespace: mount_resolver coerces it to 7" >&2
+	echo "  while profiles.py substitutes it verbatim. Pass just the major." >&2
+	exit 2
+fi
+
+if ! MAJOR="$(resolve_major)"; then
+	echo "oaw-major: cannot resolve the kit major." >&2
+	echo "  Set \$OAW_MAJOR explicitly, or run inside a checkout with a vX.Y.Z tag." >&2
+	echo "  There is no literal fallback on purpose: a hardcoded major is the defect" >&2
+	echo "  this replaces (#1067), and it fails SILENTLY as empty state rather than loudly." >&2
+	exit 2
+fi
+
+printf '%s\n' "$MAJOR"
+
+if [[ "$CHECK" == true ]]; then
+	# The state namespace must already exist. Docker would otherwise materialise
+	# each missing source as an empty dir and the agent boots with blank memory
+	# and cold caches — the silent failure this whole guard is for.
+	missing=()
+	# All FOUR major-partitioned host roots. toolbox is declared at
+	# mounts.d/30-user-overlay.toml (source = ~/.oaw/toolbox/<major>, rw) and is the
+	# same failure class: absent -> docker makes an empty dir -> the discretionary
+	# toolbox comes up bare, silently.
+	for d in "$HOME/.oaw/state/$MAJOR" "$HOME/.oaw/cache/$MAJOR" \
+		"$HOME/.oaw/overlay/$MAJOR" "$HOME/.oaw/toolbox/$MAJOR"; do
+		[[ -d "$d" ]] || missing+=("$d")
+	done
+	if ((${#missing[@]} > 0)); then
+		echo "oaw-major: major $MAJOR is NOT provisioned — missing:" >&2
+		printf '  %s\n' "${missing[@]}" >&2
+		echo "" >&2
+		echo "  Docker would create these as EMPTY directories at launch, so the agent" >&2
+		echo "  would come up with no memory and cold caches, silently." >&2
+		echo "" >&2
+		echo "  A major bump RE-NAMESPACES state (R-20) — it is a migration, not a" >&2
+		echo "  reset. To carry state forward from the previous major <PREV>:" >&2
+		echo "    cp -a ~/.oaw/state/<PREV>   ~/.oaw/state/$MAJOR" >&2
+		echo "    cp -a ~/.oaw/cache/<PREV>   ~/.oaw/cache/$MAJOR" >&2
+		echo "    cp -a ~/.oaw/overlay/<PREV> ~/.oaw/overlay/$MAJOR" >&2
+		echo "    cp -a ~/.oaw/toolbox/<PREV> ~/.oaw/toolbox/$MAJOR" >&2
+		echo "  Or provision empty deliberately if a clean namespace is intended." >&2
+		exit 3
+	fi
+fi

--- a/scripts/ci/soak-accrual-bridge.sh
+++ b/scripts/ci/soak-accrual-bridge.sh
@@ -22,8 +22,13 @@
 #
 # Inputs (env):
 #   OAW_SOAK_LEDGER           soak .jsonl ledger to append (default ~/.oaw/soak/ledger.jsonl).
-#   SURGEON_TRANSCRIPTS_ROOT  root the surgeon resolves host-backed transcripts under
-#                             (default ~/.claude/projects).
+#   OAW_MAJOR                 kit major partitioning sandbox state. DERIVED from the
+#                             repo tag via scripts/ci/oaw-major.sh (#1067); no literal
+#                             default — a hardcoded major fails silently as empty state.
+#   SURGEON_TRANSCRIPTS_ROOT  root the surgeon resolves host-backed SANDBOX transcripts
+#                             under (default ~/.oaw/state/$OAW_MAJOR/transcripts). It
+#                             must NOT be ~/.claude/projects — that is the live fleet's
+#                             store, and the surgeon refuses it (#1064).
 #   OAW_SOAK_LOOKBACK_HOURS   bounded per-pass look-back in hours (default 1). SET THIS
 #                             TO YOUR CRON CADENCE: it must be >= the interval between
 #                             runs (else clean time between passes is under-credited),
@@ -41,7 +46,9 @@ OAW_SOAK_LEDGER="${OAW_SOAK_LEDGER:-$HOME/.oaw/soak/ledger.jsonl}"
 # Sandbox transcripts, NOT the fleet's ~/.claude/projects — the surgeon refuses
 # that root (#1064) and this loop would exit non-zero and accrue ZERO soak,
 # defeating #1008. Mirrors dogfood-cutover.sh.
-SURGEON_TRANSCRIPTS_ROOT="${SURGEON_TRANSCRIPTS_ROOT:-$HOME/.oaw/state/${OAW_MAJOR:-1}/transcripts}"
+OAW_MAJOR="${OAW_MAJOR:-$("$(dirname "${BASH_SOURCE[0]}")/oaw-major.sh")}"
+export OAW_MAJOR # surgeon.py narrows DEFAULT_TRANSCRIPTS_ROOT from this
+SURGEON_TRANSCRIPTS_ROOT="${SURGEON_TRANSCRIPTS_ROOT:-$HOME/.oaw/state/$OAW_MAJOR/transcripts}"
 
 cmd=(python3 "$BRIDGE_PY" --ledger "$OAW_SOAK_LEDGER" --transcripts-root "$SURGEON_TRANSCRIPTS_ROOT")
 [[ "${SOAK_BRIDGE_DRY_RUN:-false}" == "true" ]] && cmd+=(--dry-run)

--- a/tests/contained-workflow/test_profiles.py
+++ b/tests/contained-workflow/test_profiles.py
@@ -72,7 +72,9 @@ def test_launch_spec_labels_and_overlay():
     assert dog == ["--label", "oaw.profile=dogfood"]
     assert "-v" not in dog  # image-only
 
-    dev = pf.launch_spec("dev-mode", major=1)
+    # Rendering, not launch safety — the overlay-populated guard (#1067) is a
+    # separate question, covered by test_dev_mode_refuses_an_empty_overlay.
+    dev = pf.launch_spec("dev-mode", major=1, require_populated_overlay=False)
     assert dev[:2] == ["--label", "oaw.profile=dev-mode"]
     assert "-v" in dev
     mount = dev[dev.index("-v") + 1]
@@ -225,7 +227,10 @@ def test_cli_gate_signals(tmp_path):
 def test_cli_launch_emit():
     """The --emit launch CLI renders a profile's docker/aoe args."""
     dev = subprocess.run(
-        [sys.executable, str(PROFILES_PY), "--emit", "launch", "--profile", "dev-mode", "--major", "1"],
+        # --allow-empty-overlay: this asserts RENDERING. Production callers get
+        # the guard by default; see test_cli_refuses_empty_overlay.
+        [sys.executable, str(PROFILES_PY), "--emit", "launch", "--profile", "dev-mode",
+         "--major", "1", "--allow-empty-overlay"],
         capture_output=True,
         text=True,
         check=True,
@@ -240,3 +245,60 @@ def test_cli_launch_emit():
         check=True,
     ).stdout.strip()
     assert dog == "--label oaw.profile=dogfood"
+
+
+# --- dev-mode overlay must not blank the skill surface (#1067) ----------------
+
+
+def test_dev_mode_refuses_an_empty_overlay(tmp_path) -> None:
+    """The overlay is a whole-dir bind over the image skills dir — it REPLACES.
+    An empty source therefore yields a container with NO skills, silently, rather
+    than the developer's layered over the baked ones."""
+    empty = tmp_path / "skills"
+    empty.mkdir()
+    with pytest.raises(pf.EmptySkillsOverlayError) as exc:
+        pf.launch_spec("dev-mode", major=7, skills_overlay_source=str(empty))
+    msg = str(exc.value)
+    assert "NO skills" in msg, "the refusal must say what would actually happen"
+    assert "dogfood" in msg, "it must name the image-only alternative"
+
+
+def test_dev_mode_accepts_a_populated_overlay(tmp_path) -> None:
+    populated = tmp_path / "skills"
+    (populated / "myskill").mkdir(parents=True)
+    (populated / "myskill" / "SKILL.md").write_text("---\nname: myskill\n---\n")
+    args = pf.launch_spec("dev-mode", major=7, skills_overlay_source=str(populated))
+    assert "-v" in args and str(populated) in " ".join(args)
+
+
+def test_dogfood_is_unaffected_by_the_overlay_guard(tmp_path) -> None:
+    """dogfood is image-only: no overlay, so an empty source is irrelevant."""
+    empty = tmp_path / "nothing"
+    empty.mkdir()
+    assert pf.launch_spec("dogfood", major=7, skills_overlay_source=str(empty)) == [
+        "--label", "oaw.profile=dogfood",
+    ]
+
+
+def test_spec_still_renderable_for_inspection(tmp_path) -> None:
+    """Docs/tests must be able to render the spec without a populated host dir."""
+    args = pf.launch_spec(
+        "dev-mode", major=7, skills_overlay_source=str(tmp_path / "absent"),
+        require_populated_overlay=False,
+    )
+    assert "-v" in args
+
+
+def test_cli_refuses_empty_overlay_by_default(tmp_path) -> None:
+    """Production callers are guarded without opting in — the inspection escape
+    must be explicit, or the guard is one forgotten flag from being inert."""
+    empty = tmp_path / "skills"
+    empty.mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(PROFILES_PY), "--emit", "launch", "--profile", "dev-mode",
+         "--major", "7", "--skills-overlay-source", str(empty)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 2, f"expected refusal (exit 2), got {proc.returncode}"
+    assert "no skills" in proc.stderr.lower()
+    assert "Traceback" not in proc.stderr, "must be a message, not a stack trace"

--- a/tests/regression/test_oaw_major.sh
+++ b/tests/regression/test_oaw_major.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test_oaw_major.sh — #1067: the kit major is DERIVED, never a literal.
+#
+# The defect this guards: `OAW_MAJOR="${OAW_MAJOR:-1}"` sat in two scripts under a
+# comment calling it "the kit major", while the kit was at 7.3.0. Every generation
+# therefore shared namespace `1` and R-20's isolation did not hold. A wrong major
+# does not error — Docker's create-if-missing turns an absent bind source into an
+# empty DIRECTORY, so memory and caches come up blank with no warning.
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_DIR/scripts/ci/oaw-major.sh"
+FAILS=0
+pass() { echo "  [PASS] $1"; }
+fail() {
+	echo "  [FAIL] $1" >&2
+	FAILS=$((FAILS + 1))
+}
+
+[[ -x "$SCRIPT" ]] || fail "oaw-major.sh is not executable (it is invoked directly)"
+bash -n "$SCRIPT" || fail "bash -n failed on oaw-major.sh"
+pass "syntax + executable"
+
+# Derives from the git tag, and is NOT the old literal.
+# Derivation needs a reachable tag. CI checks out shallow+--no-tags by default
+# (validate.yml now sets fetch-depth: 0), but a contributor's shallow clone still
+# will not have one — SKIP rather than hard-fail, and never inherit an ambient
+# $OAW_MAJOR, which would silently turn this into an override test.
+tag_major="$(git -C "$REPO_DIR" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
+if [[ -n "$tag_major" ]]; then
+	got="$(env -u OAW_MAJOR "$SCRIPT" 2>/dev/null)"
+	[[ "$got" =~ ^[0-9]+$ ]] || fail "did not emit a numeric major, got: '$got'"
+	[[ "$got" == "$tag_major" ]] ||
+		fail "major '$got' does not match the repo tag major '$tag_major'"
+	pass "derives the major from the repo tag (got $got)"
+else
+	echo "  [SKIP] no reachable tag (shallow clone) — derivation case not exercised"
+fi
+
+# The env override wins.
+got="$(OAW_MAJOR=42 "$SCRIPT" 2>/dev/null)"
+[[ "$got" == "42" ]] || fail "OAW_MAJOR override ignored, got '$got'"
+pass "\$OAW_MAJOR overrides the derivation"
+
+# NO literal fallback: outside a tagged checkout it must REFUSE, not guess.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+git -C "$tmp" init -q 2>/dev/null
+mkdir -p "$tmp/scripts/ci" && cp "$SCRIPT" "$tmp/scripts/ci/"
+(cd "$tmp" && env -u OAW_MAJOR ./scripts/ci/oaw-major.sh >/dev/null 2>&1)
+rc=$?
+[[ "$rc" -eq 2 ]] ||
+	fail "an untagged checkout must REFUSE (exit 2), got $rc — a silent guess is the defect"
+pass "no literal fallback: untagged checkout refuses (exit 2)"
+
+# --check refuses an unprovisioned major, and says how to migrate.
+err="$(OAW_MAJOR=99999 "$SCRIPT" --check 2>&1 >/dev/null)"
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "--check on an unprovisioned major must exit 3, got $rc"
+grep -q 'NOT provisioned' <<<"$err" || fail "--check must say the major is unprovisioned"
+grep -q 'EMPTY directories' <<<"$err" ||
+	fail "--check must explain the SILENT failure (docker creates empty dirs)"
+grep -q 'cp -a' <<<"$err" || fail "--check must give the migration recipe, not just refuse"
+pass "--check refuses an unprovisioned major with the migration recipe"
+
+# Consumers must not carry a hardcoded major.
+for f in "$REPO_DIR/scripts/ci/dogfood-cutover.sh" "$REPO_DIR/scripts/ci/soak-accrual-bridge.sh"; do
+	# Positive: it must DERIVE. A negative-only guard passes if someone re-hardcodes
+	# to a different literal (${OAW_MAJOR:-7}, or a bare OAW_MAJOR=7), which is the
+	# same defect wearing a new number.
+	grep -q 'oaw-major.sh' "$f" ||
+		fail "$(basename "$f") does not derive the major via oaw-major.sh"
+	grep -qE 'OAW_MAJOR:-[0-9]' "$f" &&
+		fail "$(basename "$f") hardcodes a major literal — derive via oaw-major.sh"
+	grep -qE '^[[:space:]]*OAW_MAJOR=[0-9]' "$f" &&
+		fail "$(basename "$f") assigns a bare major literal — derive via oaw-major.sh"
+done
+pass "every consumer derives the major; no literal fallback"
+
+# The override must be validated, not passed through: a semver splits the namespace
+# (mount_resolver coerces to the major int, profiles.py substitutes verbatim).
+OAW_MAJOR=7.3.0 "$SCRIPT" >/dev/null 2>&1
+[[ "$?" -eq 2 ]] || fail "a semver \$OAW_MAJOR must be refused (exit 2)"
+pass "semver override refused (namespace-split guard)"
+
+echo ""
+if ((FAILS > 0)); then
+	echo "  $FAILS oaw-major check(s) FAILED"
+	exit 1
+fi
+echo "  all oaw-major checks passed"

--- a/tests/regression/test_oaw_major.sh
+++ b/tests/regression/test_oaw_major.sh
@@ -83,6 +83,18 @@ OAW_MAJOR=7.3.0 "$SCRIPT" >/dev/null 2>&1
 [[ "$?" -eq 2 ]] || fail "a semver \$OAW_MAJOR must be refused (exit 2)"
 pass "semver override refused (namespace-split guard)"
 
+# CI must actually FETCH tags, or the derivation resolves locally and refuses in CI.
+# `fetch-depth: 0` is NOT enough: in actions/checkout@v4 `fetch-tags` is a separate
+# input defaulting to false, and the action fetches with --no-tags without it. This
+# shipped once exactly that way — depth set, tags absent, run log printing
+# `fetch-tags: false` while the derivation failed.
+WF="$REPO_DIR/.github/workflows/validate.yml"
+if [[ -f "$WF" ]]; then
+	grep -q 'fetch-tags: true' "$WF" ||
+		fail "validate.yml must set fetch-tags: true — oaw-major.sh derives from git tags, and fetch-depth alone does not fetch them"
+	pass "CI checkout fetches tags (fetch-depth alone does not)"
+fi
+
 echo ""
 if ((FAILS > 0)); then
 	echo "  $FAILS oaw-major check(s) FAILED"


### PR DESCRIPTION
## Summary

Two defects, both silent.

**`OAW_MAJOR` was `${OAW_MAJOR:-1}`** in `dogfood-cutover.sh` and `soak-accrual-bridge.sh`, sitting under a comment calling it *"the kit major"*, while the kit was at **7.3.0**. Every generation therefore shared namespace `1`, and R-20's isolation never held in practice.

A wrong major does not error. Docker's create-if-missing turns an absent bind source into an empty **directory**, so `~/.oaw/state/<major>/memory` and every cache come up **blank** — no warning, no failed mount. Same shape as the missing `~/.secrets/.env` in #1061.

**dev-mode's skills overlay is a whole-directory bind** over the image skills dir — it **replaces**, it does not merge. The source is empty by default, so a dev-mode container came up with **no skills at all** rather than the developer's layered over the baked ones.

## Changes

- **`scripts/ci/oaw-major.sh`** (new) — derives from `git describe --tags`, mirroring `oakandwave-oci-labels.sh` rather than inventing a second mechanism. **No literal fallback**: an untagged checkout exits 2. `--check` refuses an unprovisioned major (exit 3) *and prints the migration recipe*, because a major bump **re-namespaces** state rather than resetting it.
- **Both consumers rewired**; neither carries a literal.
- **`profiles.py`** — `assert_overlay_populated` refuses a launch whose overlay source is empty. Raises rather than warns: the container starts fine and simply has no skills.
- **`architecture.md` §2.1** — states plainly that the overlay replaces rather than merges, and that it is a *different* mechanism from `bootstrap.sh`'s image-wins/host-fills sync. Two overlay paths, two semantics; reconciling them is open.

## From code review — 2 critical, 5 important, 4 minor, all fixed

Both criticals were the same root cause: **verified on a box that has git tags and provisioned `~/.oaw` dirs, without asking what CI has.**

- **`actions/checkout@v4` defaults to `fetch-depth: 1` with `--no-tags`**, so the derivation resolved locally and would have **refused in CI**. `validate.yml` now sets `fetch-depth: 0`, and the tag-dependent assertion SKIPs on a shallow clone while the tag-*independent* cases — the ones that actually guard the defect — stay unconditional.
- **`--check` ran unconditionally in the cutover**, including on the plan path whose own header promises *"launches NOTHING"*. That broke two pre-existing `test_promotion_cycle.py` tests, which strip `OAW_MAJOR` and drive the real script against the real `$HOME`. It now runs only before the first real launch.

Important:

- **`--check` omitted `~/.oaw/toolbox/<major>`** — the fourth major-partitioned root (`mounts.d/30-user-overlay.toml`), same failure class.
- **The env override skipped validation.** `OAW_MAJOR=7.3.0` splits the namespace: `mount_resolver` coerces to `7`, `profiles.py` substitutes verbatim → `~/.oaw/overlay/7.3.0`. Now refused — and hoisted out of the command substitution, where `exit` leaves only the subshell and the caller printed a second, contradictory message.
- **`profiles.py --major` still defaulted to literal `1`** — the same defect relocated to the CLI. Now demanded **only where `<major>` is actually substituted**; requiring it outright broke `gate-signals` and dogfood launches, which never substitute.
- **`EmptySkillsOverlayError` subclasses `ProfileError`** so one `except` covers the taxonomy, and an unreadable overlay dir surfaces as the same legible refusal instead of a raw `PermissionError` traceback.
- **The hardcode guard only matched the original byte sequence** — re-hardcoding to `${OAW_MAJOR:-7}` or a bare `OAW_MAJOR=7` passed it. Now asserts the **positive** (each consumer must derive) plus a negative on any digit.

Minor: duplicate import; `soak-accrual-bridge.sh`'s env doc still claimed the `~/.claude/projects` default #1064 removed; both wrappers now `export OAW_MAJOR` (surgeon.py narrows its default transcripts root from the environment and neither exported it); test hygiene.

## Linked Issues

Closes #1067

## Test Plan

- `./scripts/ci/validate.sh` → **218 passed, 0 failed**
- Full `pytest tests/` → **1946 passed**, 6 skipped, 64 xfailed, 2 xpassed — unchanged across the review rework, so eleven fixes over six files altered no covered behaviour
- **`test_promotion_cycle.py` → 10 passed, 1 skipped** — the exact CI-red case review predicted
- PLAN mode against an **unprovisioned `$HOME`** → exit 0 (it must not require host provisioning)
- Behavioural: derivation → `7`; `OAW_MAJOR=42` → `42`; `OAW_MAJOR=7.3.0` → refused, **one** accurate message with no contradictory second; unprovisioned major → exit 3 naming `toolbox`

Mutation-verified, each caught by exactly one test:

| mutation | caught by |
|---|---|
| unwire the guard from `launch_spec` (left defined) | `test_dev_mode_refuses_an_empty_overlay` |
| flip the CLI default to opt-**in** | `test_cli_refuses_empty_overlay_by_default` |

### Not verified

No container launched — the overlay guard is proven at the `launch_spec`/CLI boundary, not against a running dev-mode container. That is MV-05 territory.

### Deferred

`trivy` parsed **0 manifests**. Root cause now understood rather than restated: `tools/cc-inspector/requirements.txt` is **completely unpinned** (`mitmproxy`, `flask`, `requests` — no versions to match CVEs against), and `scripts/wave-watcher/package.json` has **no lockfile beside it** and `bun.lock` is in `.gitignore:30`. So the repo genuinely presents nothing scannable. Filed five times (#922/#941/#944/#1053/#1056) and never fixed. Worth closing before the release turns this repo into a distributed, signed artifact — a signature attests provenance, not dependency safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS