### PR TITLE
fix(contained-workflow): guard mounts.d against the profile that copies it

### DIFF
--- a/containers/oakandwave-workflow/mount_resolver.py
+++ b/containers/oakandwave-workflow/mount_resolver.py
@@ -354,7 +354,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--home", default=None, help="override $HOME (test/dry-run)")
     parser.add_argument(
         "--format",
-        choices=("docker", "aoe", "json"),
+        choices=("docker", "aoe", "aoe-toml", "json"),
         default="docker",
         help="output shape (default: docker -v args)",
     )
@@ -391,6 +391,18 @@ def main(argv: list[str] | None = None) -> int:
     elif args.format == "aoe":
         for m in resolved:
             print(m.to_aoe_extra_volume())
+    elif args.format == "aoe-toml":
+        # Paste-ready. `aoe` emits bare lines that a human then has to wrap in TOML
+        # by hand — and that hand-copy is precisely what #1069 exists to catch, so
+        # making the REMEDY a hand-copy would leave the loop open.
+        print("# Generated: mount_resolver.py --format aoe-toml")
+        print("# Paste into the AoE profile's config.toml under [sandbox].")
+        print("# mounts.d/ is the source of truth; verify with")
+        print("#   scripts/ci/check-mount-drift.sh <profile>")
+        print("extra_volumes = [")
+        for m in resolved:
+            print(f'    "{m.to_aoe_extra_volume()}",')
+        print("]")
     else:  # docker
         for m in resolved:
             print(f"-v {m.to_docker_volume()}")

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -46,6 +46,14 @@ fragment deterministically. Each file holds one or more `[[mount]]` tables.
 | `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |
 | `40-durable-caches.toml` | durable-cache (cargo, go-mod, uv, ms-playwright) | 1.3 (#963) |
 
+> **These fragments are INERT until copied into an AoE profile.** `extra_volumes`
+> is a manual copy of `mount_resolver.py --format aoe`, so the container runs on
+> whatever was last pasted — a fresh profile has `[0 items]` and every mount here
+> applies to nothing, silently. `scripts/ci/check-mount-drift.sh <profile>` diffs
+> the two and also stats every host source (an absent one is materialised by
+> Docker as an empty directory rather than erroring). It runs from
+> `dogfood-cutover.sh` — advisory on the plan path, fatal on apply (#1069).
+
 `20-secrets.toml` was a drop-in for Story 1.3's resolver: the
 `read-only-secrets` layer and its `mode = "ro"` enforcement (R-12) already
 existed, so Story 1.5 added only the fragment (no resolver change). #1061 then

--- a/containers/oakandwave-workflow/sandbox-profile.toml
+++ b/containers/oakandwave-workflow/sandbox-profile.toml
@@ -54,3 +54,27 @@ container_runtime = "docker"
 uid = 1000
 user = "ubuntu"
 home_dir = "/home/ubuntu"
+
+# --- extra_volumes: REQUIRED, and NOT shipped here (#1069) --------------------
+#
+# This template deliberately carries no extra_volumes. The value is host-specific
+# (absolute paths, and the kit <major>), so a literal here would be wrong on every
+# machine but the one it was written on.
+#
+# It is also the single most important key in this file. mounts.d/ declares the
+# container's mounts, but AoE only applies what extra_volumes lists — so a profile
+# installed from this template as-is has NO memory, NO secrets and cold caches, and
+# nothing anywhere reports it. That silent [0 items] state is the whole reason
+# #1069 exists.
+#
+# Generate the block (paste-ready, already TOML):
+#
+#   python3 containers/oakandwave-workflow/mount_resolver.py \
+#       --major "$(scripts/ci/oaw-major.sh)" --format aoe-toml
+#
+# Then verify the profile against the manifest — do not trust the paste:
+#
+#   scripts/ci/check-mount-drift.sh <profile-name>
+#
+# dogfood-cutover.sh runs that check itself: advisory on the plan path, FATAL
+# before a real launch.

--- a/docs/contained-workflow/cutover-prerequisites.md
+++ b/docs/contained-workflow/cutover-prerequisites.md
@@ -123,6 +123,11 @@ success while checking nothing:
   the promotion gate consumes that verdict. Fixed in #1064; the root is now
   sandbox-scoped and a fleet root is refused unless explicitly asked for.
 
+- **The mount manifest itself** — `mounts.d/` is the declared source of truth, but
+  `extra_volumes` is a hand-copy of it. A freshly created profile carried
+  `[0 items]`, so memory, secrets and caches were all declared and applied to
+  nothing. Nothing compared the two until #1069.
+
 The shared lesson, and the rule this doc asks future work to follow:
 **an instrument that has only ever run against a passing case has not been
 tested.** Plant a failure, confirm the guard fires, then remove it. This applies

--- a/docs/contained-workflow/ops-runbook.md
+++ b/docs/contained-workflow/ops-runbook.md
@@ -88,6 +88,16 @@ image-only — the profile the gate trusts, R-21) with the flight surgeon watchi
 Clean work accrues soak **automatically**: the soak-accrual bridge (`scripts/ci/soak-accrual-bridge.sh`, #1008) drives the flight surgeon over the live ring and feeds each running dogfood session's clean span to `soak_ledger`, so the promotion gate's `SOAK_HOURS` fills over time (run it periodically / from a cron during the cutover). A broken candidate is caught and held.
 
 ```bash
+# 0) The profile must carry the declared mounts. mounts.d/ is the source of truth,
+#    but AoE only applies what extra_volumes lists — a profile missing them comes up
+#    with no memory, no secrets and cold caches, silently (#1069). Generate + verify:
+#      python3 containers/oakandwave-workflow/mount_resolver.py \
+#          --major "$(scripts/ci/oaw-major.sh)" --format aoe-toml   # paste-ready
+#      scripts/ci/check-mount-drift.sh dogfood
+#    The cutover runs this itself: ADVISORY on plan, FATAL before a real launch.
+#    CUTOVER_CHECK_PROFILES names the profiles to check ("dogfood" by default);
+#    set it EMPTY to skip. AOE_PROFILE_ROOT relocates the profile dir (test seam).
+
 # 1) PLAN (default): prints the exact `aoe add` line per workspace + the surgeon
 #    watch command, launches NOTHING.
 EDGE_REF=oakandwave-workflow:edge \

--- a/scripts/ci/check-mount-drift.sh
+++ b/scripts/ci/check-mount-drift.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# check-mount-drift.sh — mounts.d/ is the source of truth; a profile is a COPY (#1069).
+#
+# WHY THIS EXISTS. `mount_resolver.py --format aoe` emits `host:container[:ro]`
+# lines and AoE's `sandbox.extra_volumes` consumes exactly that shape — but the
+# copy between them is MANUAL, per-profile, and nothing checked it. So mounts.d/
+# is the declared truth while the container actually runs on whatever a human last
+# pasted.
+#
+# Observed 2026-07-30 during cut-over prep: `extra_volumes` was `[0 items]` on a
+# freshly created profile. Every fragment — memory, secrets, caches — was declared
+# and applied to NOTHING. A container launched then would have come up with no
+# memory, no secrets and cold caches, and nothing anywhere would have said so.
+#
+# That is the defect shape this cut-over keeps producing: the manifest declares it,
+# the runtime does not have it, and the gap is silent. Same family as the inert
+# R-14 check (#1061), trivy scanning zero manifests (#1056), the surgeon reading
+# the wrong transcript root (#1064), and a --depth=1 fetch quietly shallowing the
+# repo. It is also load-bearing: #1061's secrets mounts and #1064's transcript
+# mount are only REAL if they reach extra_volumes.
+#
+# WHY IT ALSO STATS EVERY SOURCE. mount_resolver deliberately never touches the
+# filesystem (sources may not exist yet — see its module docstring), so nothing
+# else catches a path that is declared, copied, and simply absent. Docker's
+# create-if-missing then materialises it as an empty DIRECTORY, which is how a
+# wrong path becomes empty state instead of an error.
+#
+# WHY IT READS THE PROFILE FILE, NOT `aoe settings`. `aoe settings explain` does
+# not resolve profile-scoped overrides — it reports `schema default` for values the
+# TUI shows as `(override, inherits: …)`. The TUI is authoritative; the CLI is not
+# a usable verification path today.
+#
+# Usage:
+#   scripts/ci/check-mount-drift.sh <profile> [--major N]
+#   scripts/ci/check-mount-drift.sh dogfood dev-mode      # several at once
+#
+# Exit: 0 in sync; 2 usage/unreadable; 3 drift or a missing host source.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+RESOLVER="$REPO_DIR/containers/oakandwave-workflow/mount_resolver.py"
+PROFILE_ROOT="${AOE_PROFILE_ROOT:-$HOME/.config/agent-of-empires/profiles}"
+
+MAJOR=""
+profiles=()
+while (($# > 0)); do
+	case "$1" in
+	--major)
+		MAJOR="${2:-}"
+		shift 2
+		;;
+	--major=*)
+		MAJOR="${1#*=}"
+		shift
+		;;
+	-h | --help)
+		sed -n '2,36p' "${BASH_SOURCE[0]}"
+		exit 0
+		;;
+	*)
+		profiles+=("$1")
+		shift
+		;;
+	esac
+done
+
+if ((${#profiles[@]} == 0)); then
+	echo "usage: check-mount-drift.sh <profile> [<profile>...] [--major N]" >&2
+	exit 2
+fi
+
+[[ -n "$MAJOR" ]] || MAJOR="$("$HERE/oaw-major.sh")"
+
+expected="$(python3 "$RESOLVER" --major "$MAJOR" --format aoe)" || {
+	echo "check-mount-drift: mount_resolver failed for major $MAJOR" >&2
+	exit 2
+}
+
+fails=0
+
+# --- every declared host source must EXIST -----------------------------------
+# Checked once, independent of any profile: a manifest entry pointing at nothing
+# is broken whether or not a profile has copied it yet.
+while IFS= read -r line; do
+	[[ -n "$line" ]] || continue
+	src="${line%%:*}"
+	if [[ ! -e "$src" ]]; then
+		echo "  [MISSING SOURCE] $src" >&2
+		echo "      declared in mounts.d/ but absent on this host. Docker would" >&2
+		echo "      create it as an EMPTY DIRECTORY at launch, so the container" >&2
+		echo "      comes up with that state blank and no error anywhere." >&2
+		# Remediation must match the KIND. Four declared sources are FILES, and
+		# mkdir -p on those creates a directory where a file belongs — reproducing
+		# exactly the failure this message warns about.
+		case "$src" in
+		*.json | */.env | */discord-bot-token)
+			echo "      fix (this one is a FILE):  install -D /dev/null $src" >&2
+			;;
+		*)
+			echo "      fix (this one is a DIR):   mkdir -p $src" >&2
+			;;
+		esac
+		fails=$((fails + 1))
+	fi
+done <<<"$expected"
+
+# --- each named profile must match the manifest exactly ----------------------
+for prof in "${profiles[@]}"; do
+	cfg="$PROFILE_ROOT/$prof/config.toml"
+	if [[ ! -f "$cfg" ]]; then
+		echo "  [NO CONFIG] profile '$prof' has no config.toml at $cfg" >&2
+		echo "      An AoE profile with no config inherits the GLOBAL sandbox" >&2
+		echo "      settings, so extra_volumes is empty and every mount is inert." >&2
+		fails=$((fails + 1))
+		continue
+	fi
+
+	actual="$(
+		python3 - "$cfg" <<-'PY'
+			import sys, tomllib
+			try:
+			    d = tomllib.load(open(sys.argv[1], "rb"))
+			except Exception as exc:            # unreadable/invalid TOML is drift too
+			    print(f"__ERROR__ {exc}")
+			    raise SystemExit(0)
+			for v in d.get("sandbox", {}).get("extra_volumes", []):
+			    print(v)
+		PY
+	)"
+
+	if [[ "$actual" == __ERROR__* ]]; then
+		echo "  [UNREADABLE] $cfg: ${actual#__ERROR__ }" >&2
+		fails=$((fails + 1))
+		continue
+	fi
+
+	# Compare as SETS: order is not semantically meaningful to docker, and failing
+	# on order would train people to ignore this check.
+	missing="$(comm -23 <(sort <<<"$expected") <(sort <<<"$actual") | sed '/^$/d')"
+	extra="$(comm -13 <(sort <<<"$expected") <(sort <<<"$actual") | sed '/^$/d')"
+
+	# A profile-rendered mount is not mounts.d drift. Ask profiles.py what it
+	# renders for this profile rather than spelling its target here — profiles.py
+	# owns IMAGE_SKILLS_TARGET, and duplicating it would be exactly the drift this
+	# script exists to catch, one layer up.
+	profile_mount="$(python3 "$REPO_DIR/containers/oakandwave-workflow/profiles.py" \
+		--emit launch --profile "$prof" --major "$MAJOR" --allow-empty-overlay 2>/dev/null |
+		tr ' ' '\n' | grep ':/home/ubuntu/' || true)"
+	# profiles.py emits the host side with an unexpanded ~; extra_volumes stores it
+	# expanded. Normalise before comparing, or the exclusion silently never matches
+	# and dev-mode reports permanent false drift.
+	# Per-LINE expansion: ${var/#~} anchors to the start of the whole string, so a
+	# multi-line emit would leave every line after the first unexpanded and the
+	# exclusion would silently stop matching.
+	_expanded=""
+	while IFS= read -r _pm; do
+		[[ -n "$_pm" ]] || continue
+		_expanded+="${_pm/#\~/$HOME}"$'\n'
+	done <<<"$profile_mount"
+	profile_mount="${_expanded%$'\n'}"
+	if [[ -n "$profile_mount" && -n "$extra" ]]; then
+		extra="$(grep -vxF "$profile_mount" <<<"$extra" || true)"
+	fi
+
+	if [[ -n "$missing" || -n "$extra" ]]; then
+		echo "  [DRIFT] profile '$prof' does not match mounts.d/ at major $MAJOR" >&2
+		[[ -n "$missing" ]] && {
+			echo "    declared but NOT in the profile (these mounts do not happen):" >&2
+			while IFS= read -r l; do echo "      - $l" >&2; done <<<"$missing"
+		}
+		[[ -n "$extra" ]] && {
+			echo "    in the profile but NOT declared (unreviewed mounts):" >&2
+			while IFS= read -r l; do echo "      + $l" >&2; done <<<"$extra"
+		}
+		echo "    fix — regenerate the paste-ready block and replace [sandbox].extra_volumes in" >&2
+		echo "         $cfg :" >&2
+		echo "      python3 containers/oakandwave-workflow/mount_resolver.py --major $MAJOR --format aoe-toml" >&2
+		fails=$((fails + 1))
+	else
+		echo "  [OK] profile '$prof' matches mounts.d/ ($(wc -l <<<"$expected") mounts, major $MAJOR)"
+	fi
+done
+
+if ((fails > 0)); then
+	echo "check-mount-drift: $fails problem(s) — mounts.d/ is the source of truth." >&2
+	exit 3
+fi
+echo "check-mount-drift: in sync (major $MAJOR)"

--- a/scripts/ci/dogfood-cutover.sh
+++ b/scripts/ci/dogfood-cutover.sh
@@ -38,6 +38,8 @@
 #                       explicitly to override. There is no literal default — a
 #                       hardcoded major is the #1067 defect, and it fails silently
 #                       as empty state rather than loudly.
+#   CUTOVER_CHECK_PROFILES  space-separated AoE profiles whose extra_volumes must
+#                       match mounts.d/ (default "dogfood"). Set empty to skip.
 #   OAW_SOAK_LEDGER     the FlightDeck soak ledger the gate reads (default
 #                       ~/.oaw/soak/ledger.jsonl). This script does not write it; the
 #                       soak-accrual bridge (scripts/ci/soak-accrual-bridge.sh, #1008)
@@ -85,6 +87,28 @@ echo "    dogfood launch args (from profiles.py): $dogfood_args"
 # Each workspace becomes one dogfood-profile sandbox on :edge. `aoe add --sandbox`
 # is the one-container-per-session seam (TC-1); the profile args stamp
 # oaw.profile=dogfood so the surgeon and the gate both filter on it (R-22).
+# mounts.d/ is the source of truth, but a profile's extra_volumes is a MANUAL copy
+# of it — and an out-of-sync profile means the declared mounts simply do not happen.
+# Checked on the PLAN path deliberately: catching it during a dry run is the whole
+# point, and unlike --check it needs no host provisioning. Non-fatal so a plan on a
+# box with no AoE profiles still renders; APPLY re-runs it fatally below.
+# NOTE the colon-less ${VAR-default}: with ${VAR:-default}, set-but-EMPTY is
+# treated as unset, so the documented "set empty to skip" escape hatch did nothing
+# and an operator whose profile is named otherwise had no way past the fatal APPLY
+# check below.
+if [[ -n "${CUTOVER_CHECK_PROFILES-dogfood}" ]]; then
+	# shellcheck disable=SC2086  # intentional split: a space-separated profile list
+	"$HERE/check-mount-drift.sh" ${CUTOVER_CHECK_PROFILES-dogfood} --major "$OAW_MAJOR"
+	drift_rc=$?
+	# Only exit 3 is drift. Exit 2 is usage / an unreadable resolver — calling that
+	# "drift" sends the operator to fix the wrong thing.
+	if ((drift_rc == 3)); then
+		echo "  [!] profile/manifest drift above — the mounts you think are declared may not happen" >&2
+	elif ((drift_rc != 0)); then
+		echo "  [!] mount-drift check could not run (exit $drift_rc) — this is NOT a drift verdict" >&2
+	fi
+fi
+
 # Refuse an unprovisioned major before the FIRST real launch — not on the plan
 # path. A wrong/absent major is silent (docker materialises each missing bind
 # source as an empty dir, so memory and caches come up blank), so the guard has to
@@ -92,6 +116,11 @@ echo "    dogfood launch args (from profiles.py): $dogfood_args"
 # "launches NOTHING" contract and make it fail on any checkout without ~/.oaw.
 if [[ "$APPLY" == "true" ]]; then
 	"$HERE/oaw-major.sh" --check >/dev/null
+	# FATAL on a real launch: cutting the ring over onto a profile that does not
+	# carry the declared mounts is how an agent comes up with no memory or secrets.
+	# shellcheck disable=SC2086  # intentional split: a space-separated profile list
+	[[ -n "${CUTOVER_CHECK_PROFILES-dogfood}" ]] &&
+		"$HERE/check-mount-drift.sh" ${CUTOVER_CHECK_PROFILES-dogfood} --major "$OAW_MAJOR"
 fi
 
 launched=0

--- a/scripts/ci/dogfood-cutover.sh
+++ b/scripts/ci/dogfood-cutover.sh
@@ -97,9 +97,14 @@ echo "    dogfood launch args (from profiles.py): $dogfood_args"
 # and an operator whose profile is named otherwise had no way past the fatal APPLY
 # check below.
 if [[ -n "${CUTOVER_CHECK_PROFILES-dogfood}" ]]; then
+	# `cmd; rc=$?` is WRONG under `set -e`: the non-zero exit kills the script before
+	# the assignment runs, which silently turned this advisory check FATAL and broke
+	# the plan path's "launches NOTHING" contract on any box without ~/.oaw.
+	# `cmd || rc=$?` is the idiom that actually captures it.
+	drift_rc=0
 	# shellcheck disable=SC2086  # intentional split: a space-separated profile list
-	"$HERE/check-mount-drift.sh" ${CUTOVER_CHECK_PROFILES-dogfood} --major "$OAW_MAJOR"
-	drift_rc=$?
+	"$HERE/check-mount-drift.sh" ${CUTOVER_CHECK_PROFILES-dogfood} --major "$OAW_MAJOR" ||
+		drift_rc=$?
 	# Only exit 3 is drift. Exit 2 is usage / an unreadable resolver — calling that
 	# "drift" sends the operator to fix the wrong thing.
 	if ((drift_rc == 3)); then

--- a/tests/regression/test_mount_drift.sh
+++ b/tests/regression/test_mount_drift.sh
@@ -168,6 +168,22 @@ python3 - "$MAJOR" <<-PYEOF || fail "aoe-toml output does not parse or does not 
 PYEOF
 pass "aoe-toml remedy parses as TOML and matches the manifest exactly"
 
+# --- the plan path stays ADVISORY when drift is actually present -------------
+# This is the case that shipped broken. "Advisory" was only ever exercised with a
+# CLEAN check (rc 0) or with the check skipped, so nothing proved the non-zero
+# branch was survivable — and `cmd; rc=$?` under `set -e` killed the script before
+# the capture, silently making it fatal. A dry run that aborts on drift breaks its
+# own "launches NOTHING" contract and fails on any box without ~/.oaw.
+CUT="$REPO_DIR/scripts/ci/dogfood-cutover.sh"
+if [[ -x "$CUT" ]]; then
+	HOME="$SANDBOX/nohome" EDGE_REF=x CUTOVER_WORKSPACES=/tmp/ws \
+		timeout 120 "$CUT" >/dev/null 2>&1
+	rc=$?
+	[[ "$rc" -eq 0 ]] ||
+		fail "PLAN must stay advisory when drift IS present (no ~/.oaw), got $rc — 'cmd; rc=\$?' under set -e is the trap"
+	pass "plan path is advisory with drift present (the case that shipped broken)"
+fi
+
 echo ""
 if ((FAILS > 0)); then
 	echo "  $FAILS mount-drift check(s) FAILED"

--- a/tests/regression/test_mount_drift.sh
+++ b/tests/regression/test_mount_drift.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# test_mount_drift.sh — #1069: mounts.d/ is the source of truth; a profile is a COPY.
+#
+# The defect: mount_resolver emits `host:container[:ro]` and AoE's extra_volumes
+# consumes exactly that, but the copy is MANUAL and nothing checked it. Observed
+# 2026-07-30 — `extra_volumes` was [0 items] on a fresh profile, so every fragment
+# (memory, secrets, caches) was declared and applied to NOTHING, silently.
+#
+# Every case below PLANTS the failure. A drift check that has only ever run against
+# a matching pair has not been tested.
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_DIR/scripts/ci/check-mount-drift.sh"
+FAILS=0
+pass() { echo "  [PASS] $1"; }
+fail() {
+	echo "  [FAIL] $1" >&2
+	FAILS=$((FAILS + 1))
+}
+
+[[ -x "$SCRIPT" ]] || fail "check-mount-drift.sh is not executable"
+bash -n "$SCRIPT" || fail "bash -n failed"
+pass "syntax + executable"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# Hermetic on BOTH sides. AOE_PROFILE_ROOT isolates only the PROFILE; the MANIFEST
+# side resolves through the process $HOME (mount_resolver -> expanduser). Reading the
+# operator's real ~/.oaw made the positive cases pass or fail on host provisioning —
+# green here, red on a runner where none of the sources exist. Same green-here/
+# red-there split #1067 hit; injecting HOME is what actually closes it.
+FAKE_HOME="$SANDBOX/home"
+mkdir -p "$FAKE_HOME"
+MAJOR=7
+
+# A fake profile root so we never read or mutate the operator's real profiles.
+mk_profile() { # <name> <volumes-toml-body>
+	mkdir -p "$SANDBOX/profiles/$1"
+	{
+		echo "[sandbox]"
+		echo "extra_volumes = ["
+		printf '%s\n' "$2"
+		echo "]"
+	} >"$SANDBOX/profiles/$1/config.toml"
+}
+
+expected="$(HOME="$FAKE_HOME" python3 "$REPO_DIR/containers/oakandwave-workflow/mount_resolver.py" \
+	--major "$MAJOR" --format aoe 2>/dev/null)"
+
+# Materialise every declared source so the positive cases test ONE variable (drift)
+# rather than tripping the missing-source check at the same time. Kind matters: four
+# of these are FILES, and creating a directory in their place reproduces the very
+# failure the check warns about.
+while IFS= read -r l; do
+	[[ -n "$l" ]] || continue
+	src="${l%%:*}"
+	case "$src" in
+	*.json | */.env | */discord-bot-token) install -D /dev/null "$src" 2>/dev/null ;;
+	*) mkdir -p "$src" 2>/dev/null ;;
+	esac
+done <<<"$expected"
+[[ -n "$expected" ]] || fail "mount_resolver emitted nothing for major $MAJOR"
+
+all_vols="$(while IFS= read -r l; do [[ -n "$l" ]] && echo "    \"$l\","; done <<<"$expected")"
+
+run() { HOME="$FAKE_HOME" AOE_PROFILE_ROOT="$SANDBOX/profiles" "$SCRIPT" "$@" --major "$MAJOR" 2>&1; }
+
+# --- the real-world case: a profile that copied NOTHING ----------------------
+mk_profile empty ""
+out="$(run empty)"
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "an empty extra_volumes must fail (exit 3), got $rc"
+grep -q 'DRIFT' <<<"$out" || fail "an empty profile must be reported as drift"
+grep -q 'these mounts do not happen' <<<"$out" ||
+	fail "the report must say what the drift MEANS, not just that it differs"
+pass "empty extra_volumes -> drift (the observed real case)"
+
+# --- a profile missing exactly one entry -------------------------------------
+mk_profile partial "$(sed '1d' <<<"$all_vols")"
+out="$(run partial)"
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "a missing entry must fail (exit 3), got $rc"
+first_src="$(head -1 <<<"$expected")"
+grep -qF "$first_src" <<<"$out" || fail "the report must NAME the missing mount"
+pass "one missing entry -> drift, named"
+
+# --- a profile carrying an UNDECLARED entry ----------------------------------
+mk_profile extra "$all_vols"$'\n    "/tmp/rogue:/home/ubuntu/rogue",'
+out="$(run extra)"
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "an undeclared entry must fail (exit 3), got $rc"
+grep -q '/tmp/rogue' <<<"$out" || fail "the report must NAME the undeclared mount"
+grep -q 'unreviewed' <<<"$out" || fail "an undeclared mount must be called out as unreviewed"
+pass "undeclared entry -> drift, named"
+
+# --- a profile with no config at all ------------------------------------------
+out="$(run nonexistent)"
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "a profile with no config.toml must fail (exit 3), got $rc"
+grep -q 'inherits the GLOBAL' <<<"$out" ||
+	fail "it must explain WHY a missing config means inert mounts"
+pass "no config.toml -> failure, with the reason"
+
+# --- ORDER must not matter ----------------------------------------------------
+mk_profile reordered "$(sort -r <<<"$all_vols")"
+run reordered >/dev/null 2>&1
+rc=$?
+[[ "$rc" -eq 0 ]] || fail "reordering must NOT be reported as drift (docker ignores order), got $rc"
+pass "reordered volumes are in sync (order is not semantic)"
+
+# --- an exact copy passes -----------------------------------------------------
+mk_profile exact "$all_vols"
+run exact >/dev/null 2>&1
+rc=$?
+[[ "$rc" -eq 0 ]] || fail "an exact copy must pass, got $rc"
+pass "exact copy -> in sync"
+
+# --- a declared source that does not exist ------------------------------------
+# Docker create-if-missing makes this an empty dir rather than an error, which is
+# the whole reason the check stats sources at all.
+out="$(HOME="$SANDBOX/nohome" AOE_PROFILE_ROOT="$SANDBOX/profiles" "$SCRIPT" exact --major "$MAJOR" 2>&1)"
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "absent host sources must fail (exit 3), got $rc"
+grep -q 'MISSING SOURCE' <<<"$out" || fail "an absent source must be reported"
+grep -q 'EMPTY DIRECTORY' <<<"$out" ||
+	fail "it must explain the SILENT consequence, not just report absence"
+pass "absent host source -> failure, with the silent-failure explanation"
+
+# --- the dev-mode overlay exclusion (the most fragile logic here) -------------
+# It was previously untested: no case used a profile name that resolves to a real
+# container profile, so profiles.py exited 2, the emit was swallowed, and the parse
+# / grep / tilde-expansion never ran at all. Both failure modes are bad — a changed
+# emit shape gives PERMANENT false drift (which trains people to ignore the check),
+# and an over-broad grep silently excludes real undeclared mounts.
+overlay="$FAKE_HOME/.oaw/overlay/$MAJOR/skills:/home/ubuntu/.claude/skills"
+mk_profile dev-mode "$all_vols"$'\n    "'"$overlay"'",'
+run dev-mode >/dev/null 2>&1
+rc=$?
+[[ "$rc" -eq 0 ]] ||
+	fail "dev-mode's own skills overlay must NOT read as drift (it is profile-rendered), got $rc"
+pass "dev-mode skills overlay excluded (derived from profiles.py, not hardcoded)"
+
+# …and the exclusion must not be a blanket pass for anything under /home/ubuntu.
+mk_profile dev-mode "$all_vols"$'\n    "'"$overlay"$'",\n    "/tmp/rogue:/home/ubuntu/rogue",'
+out="$(run dev-mode)"
+rc=$?
+[[ "$rc" -eq 3 ]] || fail "an unrelated undeclared mount must still be drift on dev-mode, got $rc"
+grep -q '/tmp/rogue' <<<"$out" || fail "the undeclared mount must be named"
+pass "dev-mode exclusion is not over-broad (rogue mount still caught)"
+
+# --- the paste-ready remedy must be real TOML that matches the manifest -------
+toml="$(HOME="$FAKE_HOME" python3 "$REPO_DIR/containers/oakandwave-workflow/mount_resolver.py" \
+	--major "$MAJOR" --format aoe-toml 2>/dev/null)"
+python3 - "$MAJOR" <<-PYEOF || fail "aoe-toml output does not parse or does not match --format aoe"
+	import subprocess, sys, tomllib, os
+	major = sys.argv[1]
+	env = dict(os.environ)
+	out = subprocess.run(["python3", "$REPO_DIR/containers/oakandwave-workflow/mount_resolver.py",
+	                      "--major", major, "--format", "aoe-toml"],
+	                     capture_output=True, text=True, env=env).stdout
+	gen = tomllib.loads("[sandbox]\n" + out)["sandbox"]["extra_volumes"]
+	aoe = subprocess.run(["python3", "$REPO_DIR/containers/oakandwave-workflow/mount_resolver.py",
+	                      "--major", major, "--format", "aoe"],
+	                     capture_output=True, text=True, env=env).stdout.strip().split("\n")
+	raise SystemExit(0 if gen == aoe else 1)
+PYEOF
+pass "aoe-toml remedy parses as TOML and matches the manifest exactly"
+
+echo ""
+if ((FAILS > 0)); then
+	echo "  $FAILS mount-drift check(s) FAILED"
+	exit 1
+fi
+echo "  all mount-drift checks passed"


### PR DESCRIPTION
## Summary

`mounts.d/` declares the container's mounts, but AoE only applies what a profile's `extra_volumes` lists — and that list is a **manual copy** of `mount_resolver.py --format aoe`. Nothing compared the two.

Observed during cut-over prep: `extra_volumes` was **`[0 items]`** on a freshly created profile. Memory, secrets and every cache were declared and applied to **nothing**. A container launched then would have come up with no memory, no secrets and cold caches, and nothing anywhere would have said so.

It's also load-bearing for work already merged: **#1061's secrets mounts and #1064's transcript mount are only real if they reach `extra_volumes`.**

## Changes

**`scripts/ci/check-mount-drift.sh`** diffs resolver output against a profile's `extra_volumes` and stats every declared host source.

Three design calls:

- **Sets, not sequences.** Docker ignores volume order; failing on it would train people to ignore the check — the fastest way to make a guard worthless.
- **Stats every source.** `mount_resolver` deliberately never touches the filesystem, so nothing else catches a path that is declared, copied, and simply absent. Docker's create-if-missing then makes it an empty dir rather than an error.
- **Reads `config.toml`, not `aoe settings`.** The CLI does not resolve profile-scoped overrides — it reports `schema default` for values the TUI shows as `(override, inherits: …)`. Using it would have made the check confidently wrong.

Wired into `dogfood-cutover.sh`: **advisory on PLAN** (a dry run must not require host provisioning — verified with `HOME=/tmp/nohome`, rc 0) and **fatal before the first real launch**.

The dev-mode overlay exclusion is **derived** from `profiles.py` rather than hardcoding `IMAGE_SKILLS_TARGET` — duplicating a path another module owns would be the same drift this script exists to catch, one layer up. It paid immediately: `profiles.py` emits an unexpanded `~` while `extra_volumes` stores expanded paths, so the exclusion silently never matched and dev-mode showed permanent false drift.

## From code review — 1 critical, 3 important, 3 minor, all fixed

**Critical, and a repeat:** the tests were hermetic on the **profile** side only. `AOE_PROFILE_ROOT` isolates profiles; `mount_resolver` still expands `~` from the process `$HOME`, so two cases read the operator's real `~/.oaw` and would have gone **red on a runner** where none of the twelve sources exist.

That's the third time in this queue I verified on a box carrying state CI doesn't have — git tags for #1067, `~/.oaw`/`~/.secrets` here. Now injects `HOME` and materialises sources **by kind**, verified under a fake `HOME`.

- **The escape hatch was dead on arrival.** `CUTOVER_CHECK_PROFILES` documented "set empty to skip" but used `${VAR:-default}`, where set-but-empty reads as *unset*. With the APPLY check fatal, an operator whose profile is named otherwise had **no way to proceed**.
- **Nothing in the repo could produce a passing profile.** `sandbox-profile.toml` ships no `extra_volumes` at all, so the documented install lands exactly in the `[0 items]` state this issue is about — and the drift message named the resolver but not the target file, the TOML shape, or the array wrapper, making the remedy *the same hand-copy that caused the problem*. `mount_resolver` grows **`--format aoe-toml`** (paste-ready, round-trip verified to match `--format aoe` exactly) and the message points at it.
- **The dev-mode exclusion had zero coverage** — no case used a profile name resolving to a real container profile, so the parse, grep and tilde expansion never executed.
- Tilde expansion was string-anchored, so a multi-line emit would leave every line after the first unexpanded.
- `[MISSING SOURCE]` said Docker would create an empty **directory**; four of the twelve sources are **files**, so the natural `mkdir -p` reply reproduces the failure the message warns about. Remediation is now kind-aware.
- The plan advisory called every non-zero exit "drift", including exit 2 (usage / unreadable resolver).

## Linked Issues

Closes #1069

## Test Plan

- `./scripts/ci/validate.sh` → **221 passed, 0 failed** (+3 from the new suite)
- Full `pytest tests/` → **1946 passed**, 6 skipped, 64 xfailed, 2 xpassed
- **Suite re-run under a fake `HOME`** — the actual CI condition — all green
- PLAN with no AoE profiles at all → rc 0
- `CUTOVER_CHECK_PROFILES=""` → check genuinely skipped
- `--format aoe-toml` round-trip: parses as TOML, 12 entries, byte-identical to `--format aoe`

11 regression cases, each planting a real failure — including the observed `[0 items]` case, a rogue undeclared mount, and reordering (which must **not** fail).

Mutation-verified, both failure directions of the previously-untested exclusion:

| mutation | result |
|---|---|
| break the dev-mode exclusion (permanent false drift) | 1 test fails |
| blanket the exclusion (swallows real mounts) | 2 tests fail |

### Deferred

`trivy` parsed **0 manifests** — deferred pending **#1073**, which now consolidates the five prior filings (#922/#941/#944/#1053/#1056, all closed) and establishes the root cause: `requirements.txt` completely unpinned, `package.json` with no adjacent lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS