### PR TITLE
fix(surgeon): resolve transcripts by the CONTAINER workspace path

### DIFF
--- a/docs/contained-workflow/manual-verification.md
+++ b/docs/contained-workflow/manual-verification.md
@@ -512,7 +512,31 @@ so it cannot run in the pytest lane.
    aoe -p meful-test add --sandbox --sandbox-image oaw-mv05:edge --launch /tmp/mv05-ws
    ```
 
-2. **Do real work that lands on the host-backed mount** — write a durable artifact
+2. **Pin the container workspace path** (#1075). aoe mounts a workspace at
+   `/workspace/<name>`, **not** at its host path. This repo does not own that
+   convention and `surgeon.py` hardcodes it as `CONTAINER_WORKSPACE_ROOT`, so it
+   must be re-observed here rather than believed. A silent change means **no**
+   containerised transcript resolves: soak then fails safe (nothing accrues) but
+   quarantine fails **open** (`broken=False` forever).
+
+   Resolve the container from **this session**, not `head -1` over every sandbox —
+   picking an arbitrary container compares its `WorkingDir` against the derivation
+   for a different workspace and produces a spurious FAIL:
+
+   ```bash
+   sid=$(aoe -p meful-test list | awk '/mv05-ws/ {print $NF}')
+   cid=$(docker ps --filter "name=$sid" --format '{{.ID}}')   # aoe names it aoe-sandbox-<id-prefix>
+   docker inspect "$cid" --format '{{.Config.WorkingDir}}'
+   docker exec "$cid" sh -c 'readlink /proc/$(pgrep -n claude)/cwd'
+   python3 -c "import sys;sys.path.insert(0,'scripts/flight-surgeon');import surgeon
+   print(surgeon.container_workspace_path('/tmp/mv05-ws'))"
+   ```
+
+   **EXPECT:** all three agree. Verified 2026-07-31: `/tmp/mv05-ws` →
+   `/workspace/mv05-ws` from `WorkingDir`, from `/proc/<pid>/cwd`, and from the
+   derivation. A disagreement is a **FAIL** — fix `CONTAINER_WORKSPACE_ROOT`.
+
+3. **Do real work that lands on the host-backed mount** — write a durable artifact
    from inside the session (this is the "work" that must survive):
 
    ```bash
@@ -521,11 +545,11 @@ so it cannot run in the pytest lane.
 
    Confirm on the **host**: `cat /tmp/mv05-ws/durable-work.txt` → `zero-work-lost`.
 
-3. **Plant the break.** Wedge the agent so the surgeon classifies it broken — e.g.
+4. **Plant the break.** Wedge the agent so the surgeon classifies it broken — e.g.
    drive it into a tool loop, or hard-kill `claude` inside the container while aoe
    still reports `running` (as MV-06 step 3). The transcript stops progressing.
 
-4. **Confirm the surgeon flags it** (host-side, reading the host-backed transcript —
+5. **Confirm the surgeon flags it** (host-side, reading the host-backed transcript —
    no container access):
 
    ```bash
@@ -536,7 +560,7 @@ so it cannot run in the pytest lane.
    **EXPECT:** the container is reported `should_quarantine=true` and the exit is
    `3`. A dogfood breakage must flag; a `dev-mode` one would not (R-22).
 
-5. **Note the container id** and **run the quarantine** on the surgeon's verdict:
+6. **Note the container id** and **run the quarantine** on the surgeon's verdict:
 
    ```bash
    cid=$(docker ps --filter name=<session> --format '{{.ID}}')
@@ -549,7 +573,7 @@ so it cannot run in the pytest lane.
    stops + `docker rm`s the broken container and recreates on `:stable`. It appends
    a quarantine record to `~/.oaw/quarantine/ledger.jsonl`.
 
-6. **Confirm zero work lost** on the **host** — the durable artifact survived the
+7. **Confirm zero work lost** on the **host** — the durable artifact survived the
    `docker rm` + recreate:
 
    ```bash
@@ -559,7 +583,7 @@ so it cannot run in the pytest lane.
    **EXPECT:** `zero-work-lost` — unchanged. A missing/empty file is a **FAIL**
    (R-02 violated — the rollback was not lossless).
 
-7. **Confirm the recreate is on `:stable`** and re-attached the host source:
+8. **Confirm the recreate is on `:stable`** and re-attached the host source:
 
    ```bash
    new=$(docker ps --filter name=<session> --format '{{.ID}}')
@@ -567,7 +591,7 @@ so it cannot run in the pytest lane.
    docker inspect --format '{{json .Mounts}}' "$new"       # /tmp/mv05-ws still bind-mounted
    ```
 
-8. **Confirm the bad `:edge` digest is held from promotion** — the ledger carries
+9. **Confirm the bad `:edge` digest is held from promotion** — the ledger carries
    the quarantine so the gate's zero-quarantines condition (R-07) trips:
 
    ```bash

--- a/scripts/ci/soak_accrual_bridge.py
+++ b/scripts/ci/soak_accrual_bridge.py
@@ -280,6 +280,19 @@ def build_observations(
             )
             continue
 
+        if not a.get("transcript_resolved", True):
+            skipped.append(
+                (
+                    sid,
+                    "transcript unresolved — health was never measured, so no soak "
+                    "is credited. NOT a break: an unresolved session classifies "
+                    "'running, no timestamped activity yet' -> broken=False, i.e. it "
+                    "reads HEALTHY, which is why crediting it would accrue toward "
+                    "promotion on evidence that does not exist (#1075).",
+                )
+            )
+            continue
+
         # Session-start signal: created_at (primary), transcript-earliest (fallback).
         start = sl.parse_ts(created_at.get(sid))
         if start is None:

--- a/scripts/flight-surgeon/README.md
+++ b/scripts/flight-surgeon/README.md
@@ -9,6 +9,21 @@ so the probe is **fate-independent** (R-15): a wedged, looping, or OOM-killed
 agent cannot corrupt the signal, and the probe needs **nothing from inside the
 container** — no `docker exec`, no kit import, no MCP call.
 
+## `transcript_resolved` (input and output)
+
+Both an accepted observation key and an emitted report field. `false` means **no
+transcript could be resolved for this session — its health was never measured**.
+
+It matters because an unresolved session is not a neutral one: it classifies
+`running` with no timestamps, which takes the "no timestamped activity yet"
+branch and yields `broken=false`. Without this field it is indistinguishable from
+a healthy session, and `soak_accrual_bridge` would credit soak toward promotion on
+evidence that does not exist (#1075). Absent in an observation file, it defaults
+to `true` — a hand-authored observation supplies its entries directly.
+
+The live seam that produces it is pinned by **MV-05 step 2**, which re-observes
+aoe's `/workspace/<name>` mount against a running container.
+
 ## What it detects (R-16)
 
 While a container's aoe status is **`running`**:

--- a/scripts/flight-surgeon/surgeon.py
+++ b/scripts/flight-surgeon/surgeon.py
@@ -67,9 +67,9 @@ import json
 import os
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 # --- tunable thresholds (all overridable at the CLI) --------------------------
 
@@ -475,6 +475,13 @@ class Assessment:
     quarantine_eligible: bool
     should_quarantine: bool
     reasons: tuple[str, ...]
+    # False when no transcript could be resolved for this session. A container with
+    # no transcript classifies "running, no timestamped activity yet" -> broken=False,
+    # i.e. it reads HEALTHY. The promotion gate consumes this JSON (not the stderr
+    # warning), so the distinction between "measured and fine" and "never measured"
+    # has to travel with the verdict (#1075). Defaults True so the observation-file
+    # path — where the caller supplied entries directly — is unaffected.
+    transcript_resolved: bool = True
 
     def as_dict(self) -> dict:
         return {
@@ -483,6 +490,7 @@ class Assessment:
             "profile": self.profile,
             "quarantine_eligible": self.quarantine_eligible,
             "should_quarantine": self.should_quarantine,
+            "transcript_resolved": self.transcript_resolved,
             "health": self.health.as_dict(),
             "reasons": list(self.reasons),
         }
@@ -545,7 +553,7 @@ def assess_record(rec: dict, *, now: datetime | None = None, **params) -> Assess
         entries = rec["entries"] if isinstance(rec["entries"], list) else []
     else:
         entries = read_transcript(rec.get("transcript", ""))
-    return assess(
+    a = assess(
         container_id=rec.get("container_id", rec.get("id", "?")),
         title=rec.get("title", "?"),
         status=rec.get("status"),
@@ -555,6 +563,9 @@ def assess_record(rec: dict, *, now: datetime | None = None, **params) -> Assess
         last_growth=parse_timestamp(rec.get("last_growth")),
         **params,
     )
+    # _gather_live stamps this; an observation file that omits it is treated as
+    # resolved, preserving the pre-#1075 contract for hand-authored observations.
+    return replace(a, transcript_resolved=bool(rec.get("transcript_resolved", True)))
 
 
 class SurgeonError(ValueError):
@@ -628,7 +639,18 @@ def discover_sessions(runner=_run) -> list[dict]:
 def report_summary(assessments: list[Assessment]) -> str:
     lines = ["flight surgeon — health report:"]
     for a in assessments:
-        mark = "QUARANTINE" if a.should_quarantine else ("BROKEN(excluded)" if a.health.broken else "ok")
+        # UNMEASURED outranks "ok": a session with no resolvable transcript
+        # classifies broken=False and would print [ok], which is the human summary
+        # disagreeing with the machine verdict about the one thing that matters —
+        # whether anything was actually checked (#1075).
+        if a.should_quarantine:
+            mark = "QUARANTINE"
+        elif a.health.broken:
+            mark = "BROKEN(excluded)"
+        elif not a.transcript_resolved:
+            mark = "UNMEASURED"
+        else:
+            mark = "ok"
         lines.append(
             f"  [{mark}] {a.title} ({a.container_id}) "
             f"status={a.health.status} profile={a.profile} state={a.health.state}"
@@ -636,7 +658,11 @@ def report_summary(assessments: list[Assessment]) -> str:
         for r in a.reasons:
             lines.append(f"      - {r}")
     n_q = sum(1 for a in assessments if a.should_quarantine)
-    lines.append(f"  => {len(assessments)} watched, {n_q} quarantine-eligible break(s)")
+    n_u = sum(1 for a in assessments if not a.transcript_resolved)
+    tail = f", {n_u} UNMEASURED (no transcript resolved)" if n_u else ""
+    lines.append(
+        f"  => {len(assessments)} watched, {n_q} quarantine-eligible break(s){tail}"
+    )
     return "\n".join(lines)
 
 
@@ -717,7 +743,10 @@ def _gather_live(args, runner=_run) -> list[dict]:
     unresolved: list[str] = []
     for s in sessions:
         title = s.get("title", "?")
-        transcript = _newest_transcript_for(root, s.get("path", ""))
+        transcript = _newest_transcript_for(
+            root, s.get("path", ""),
+            allow_fleet=getattr(args, "allow_fleet_transcripts", False),
+        )
         if transcript is None:
             unresolved.append(title)
         records.append(
@@ -746,17 +775,82 @@ def _gather_live(args, runner=_run) -> list[dict]:
     return records
 
 
-def _newest_transcript_for(root: Path, project_path: str) -> Path | None:
-    """Best-effort: the newest ``.jsonl`` under ``root`` whose name encodes
-    ``project_path`` (Claude Code escapes the project path into the dir name).
-    Returns None if nothing matches — the seam MV-04/MV-06 nail down."""
+# aoe mounts a session's workspace at /workspace/<name> inside the sandbox, NOT at
+# its host path. Measured from a live container during MV-05 (2026-07-31):
+#
+#   docker inspect  ->  /tmp/mv05-ws -> /workspace/mv05-ws,  WorkingDir /workspace/mv05-ws
+#   /proc/<claude>/cwd (in-container)  ->  /workspace/mv05-ws
+#
+# Claude Code derives its transcript dir from CWD, so a containerised agent writes
+# under `-workspace-<name>` while `aoe list` reports the HOST path (`/tmp/mv05-ws`).
+# Slugging the host path yields `-tmp-mv05-ws`, which can never match — so before
+# #1075 the surgeon resolved NOTHING for any containerised session, every container
+# read healthy, quarantine never fired, and soak accrued on unmeasured sessions.
+#
+# Nothing in the repo documents this mapping (mounts.d targets /home/ubuntu/..., the
+# docs say "host-backed" without a container-side path, and aoe is a compiled
+# binary), which is why static verification could not catch it and MV-05 did.
+CONTAINER_WORKSPACE_ROOT = "/workspace"
+
+
+def container_workspace_path(host_path: str) -> str:
+    """The in-container path aoe mounts ``host_path`` at.
+
+    Convention, not contract — this repo does not own aoe's mount layout, so it is
+    pinned by MV-05 reading a real container rather than by belief. If aoe changes
+    it, the manual-verification cross-check is what catches it; a silent mismatch
+    here is exactly the failure #1075 fixes.
+    """
+    name = PurePosixPath(host_path.rstrip("/")).name
+    # No basename ("/", "", ".") -> return empty so the caller treats it as
+    # unresolved. Falling back to host_path would be the one path this function
+    # exists to avoid.
+    return f"{CONTAINER_WORKSPACE_ROOT}/{name}" if name else ""
+
+
+def _slug(path: str) -> str:
+    """The inner part of Claude Code's project-dir name: `/` -> `-`, ends stripped.
+
+    NOT the full directory name — CC keeps a LEADING dash (`/workspace/x` ->
+    `-workspace-x`). Callers add it. An earlier docstring claimed this produced the
+    whole name, which was only harmless because the match was a loose substring.
+    """
+    return path.strip("/").replace("/", "-")
+
+
+def _newest_transcript_for(
+    root: Path, project_path: str, *, allow_fleet: bool = False
+) -> Path | None:
+    """The newest ``.jsonl`` under ``root`` for ``project_path``.
+
+    ``project_path`` is the HOST path (what ``aoe list`` reports). The transcript is
+    written by the agent INSIDE the container, so the lookup slugs the *container*
+    workspace path — see CONTAINER_WORKSPACE_ROOT above. Returns None if nothing
+    matches, which callers must surface (``transcript_resolved``) rather than treat
+    as health.
+    """
     if not root.is_dir() or not project_path:
         return None
-    slug = project_path.strip("/").replace("/", "-")
+    # Fleet mode watches NATIVE sessions, whose cwd IS the host path — converting
+    # to /workspace/<name> would match nothing and report every fleet session
+    # unmeasured. That is the pre-cut-over configuration, i.e. the one usable
+    # today, so the escape hatch has to reach here and not stop at _gather_live.
+    lookup = project_path if allow_fleet else container_workspace_path(project_path)
+    slug = _slug(lookup)
+    if not slug or slug == ".":
+        # An empty slug would disable filtering entirely (`if slug and ...` below),
+        # returning the newest .jsonl ANYWHERE under the root and calling it
+        # resolved — precisely the confident-wrong-verdict this issue removes.
+        return None
     best: Path | None = None
     best_mtime = -1.0
+    # EXACT parent-directory match, not a substring of the full path. Claude Code
+    # names the dir with a LEADING dash (`-workspace-mv05-ws`), and a substring test
+    # let `workspace-app` match `-workspace-app-2/...` — a wedged agent inheriting a
+    # neighbour's transcript is the same wrong-process verdict, one level down.
+    want = f"-{slug}"
     for jsonl in root.rglob("*.jsonl"):
-        if slug and slug not in str(jsonl):
+        if jsonl.parent.name != want:
             continue
         try:
             m = jsonl.stat().st_mtime

--- a/tests/contained-workflow/test_soak_bridge.py
+++ b/tests/contained-workflow/test_soak_bridge.py
@@ -180,12 +180,17 @@ def test_active_since_falls_back_to_transcript_earliest(tmp_path):
     entry timestamp (≈ session start), resolved with the surgeon's own transcript
     resolver under --transcripts-root."""
     # surgeon's _newest_transcript_for matches a .jsonl whose path contains the slug
-    # of the session path ("/work/agent-x" -> "work-agent-x").
+    # of the CONTAINER workspace path, not the host one (#1075): aoe mounts
+    # /work/agent-x at /workspace/agent-x, so the agent writes under
+    # "workspace-agent-x". The old fixture used the host slug ("work-agent-x") and
+    # therefore encoded the bug — it passed only because the resolver was wrong in
+    # the same direction.
     root = tmp_path / "projects"
     root.mkdir()
     earliest = (NOW - timedelta(hours=12)).replace(microsecond=0)
     later = (NOW - timedelta(hours=1)).replace(microsecond=0)
-    transcript = root / "work-agent-x.jsonl"
+    transcript = root / "-workspace-agent-x" / "sess.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
     transcript.write_text(
         json.dumps({"timestamp": later.isoformat()})
         + "\n"
@@ -455,3 +460,37 @@ def test_bridge_wrapper_is_executable():
     (repo convention, cf. #948/#953)."""
     assert BRIDGE_WRAPPER.exists(), f"wrapper missing: {BRIDGE_WRAPPER}"
     assert os.access(BRIDGE_WRAPPER, os.X_OK), "soak-accrual-bridge.sh must be executable"
+
+
+def test_unresolved_transcript_is_skipped_not_credited(tmp_path):
+    """#1075: a session whose transcript never resolved was never health-checked.
+
+    It classifies `running` with no timestamps -> broken=False -> it reads HEALTHY,
+    so crediting it accrues soak toward promotion on evidence that does not exist.
+    This is the half of #1075 that protects the gate, and it shipped untested —
+    deleting the guard left the whole suite green.
+    """
+    a = _assessment("u", "dogfood", "running")
+    a["transcript_resolved"] = False
+    obs, skipped = bridge.build_observations(
+        [a], [_session("u", path="/work/agent-u")],
+        now=NOW, transcripts_root=tmp_path, lookback_hours=10,
+    )
+    assert obs == [], "an unmeasured session must not produce a creditable observation"
+    reasons = " ".join(r for _, r in skipped)
+    assert "never measured" in reasons, "the skip must say WHY, not drop silently"
+    assert "NOT a break" in reasons, (
+        "it must not assert a break that was never observed — soak_ledger's "
+        "broken-path reason would claim the surgeon found one"
+    )
+
+
+def test_resolved_transcript_is_still_credited(tmp_path):
+    """The guard must not swallow healthy measured sessions."""
+    a = _assessment("r", "dogfood", "running")
+    a["transcript_resolved"] = True
+    obs, _ = bridge.build_observations(
+        [a], [_session("r", path="/work/agent-r")],
+        now=NOW, transcripts_root=tmp_path, lookback_hours=10,
+    )
+    assert len(obs) == 1 and obs[0]["broken"] is False

--- a/tests/contained-workflow/test_surgeon.py
+++ b/tests/contained-workflow/test_surgeon.py
@@ -452,3 +452,99 @@ def test_refused_root_exits_2_without_a_traceback() -> None:
         "the refusal must be a message, not a stack trace:\n" + proc.stderr
     )
     assert "live-fleet" in proc.stderr
+
+
+# --- container workspace slug (#1075) ------------------------------------------
+#
+# Found by MV-05, the first cut-over step that launches a container. aoe mounts a
+# workspace at /workspace/<name>, NOT at its host path — measured from a live
+# container: `docker inspect` gave `/tmp/mv05-ws -> /workspace/mv05-ws` with
+# WorkingDir `/workspace/mv05-ws`, and the agent's own /proc/<pid>/cwd agreed.
+# Claude Code derives its transcript dir from cwd, so the agent writes under
+# `-workspace-mv05-ws` while `aoe list` reports the HOST path. Slugging the host
+# path could never match, so NO containerised session resolved — every container
+# read healthy, quarantine never fired, and soak accrued unmeasured.
+
+
+def test_container_workspace_path_derivation() -> None:
+    assert fs.container_workspace_path("/tmp/mv05-ws") == "/workspace/mv05-ws"
+    assert fs.container_workspace_path("/home/bakerb/sandbox/github/x") == "/workspace/x"
+    assert fs.container_workspace_path("/tmp/trailing/") == "/workspace/trailing"
+
+
+def test_resolves_the_container_written_slug(tmp_path) -> None:
+    """The transcript is written INSIDE the container, so the lookup must slug the
+    container path even though aoe reports the host one."""
+    d = tmp_path / "-workspace-mv05-ws"
+    d.mkdir()
+    (d / "96304b8d-c729-4fd1-b971-90176cb53cf5.jsonl").write_text("{}\n")
+    got = fs._newest_transcript_for(tmp_path, "/tmp/mv05-ws")
+    assert got is not None, "a containerised session's transcript must resolve"
+    assert got.parent.name == "-workspace-mv05-ws"
+
+
+def test_host_slug_alone_does_not_resolve(tmp_path) -> None:
+    """Regression guard for the pre-#1075 behaviour: a transcript sitting under the
+    HOST-path slug must NOT satisfy the lookup, or the bug is back."""
+    d = tmp_path / "-tmp-mv05-ws"
+    d.mkdir()
+    (d / "s.jsonl").write_text("{}\n")
+    assert fs._newest_transcript_for(tmp_path, "/tmp/mv05-ws") is None
+
+
+def test_unresolved_transcript_is_visible_in_the_json_report() -> None:
+    """The promotion gate reads the JSON, not the stderr warning — so 'never
+    measured' has to travel with the verdict. Note broken stays False: an
+    unresolved transcript is not evidence of a break, which is exactly why it
+    would otherwise read as health."""
+    a = fs.assess_record(
+        {"container_id": "c1", "title": "t", "status": "running",
+         "profile": "dogfood", "entries": [], "transcript_resolved": False}
+    )
+    d = a.as_dict()
+    assert d["transcript_resolved"] is False
+    assert d["health"]["broken"] is False
+
+
+def test_observation_files_default_to_resolved() -> None:
+    """Hand-authored observations supply entries directly, so the pre-#1075
+    contract must be unchanged for them."""
+    a = fs.assess_record(
+        {"container_id": "c2", "title": "t", "status": "running",
+         "profile": "dogfood", "entries": []}
+    )
+    assert a.as_dict()["transcript_resolved"] is True
+
+
+def test_fleet_mode_resolves_native_host_slug(tmp_path) -> None:
+    """--allow-fleet-transcripts watches NATIVE sessions, whose cwd IS the host
+    path. Converting to /workspace/<name> there matches nothing and reports every
+    fleet session unmeasured — and fleet mode is the PRE-cut-over configuration,
+    the one usable today. #1075's fix silently killed it until this test."""
+    d = tmp_path / "-home-bakerb-sandbox-github-claudecode-workflow"
+    d.mkdir()
+    (d / "s.jsonl").write_text("{}\n")
+    host = "/home/bakerb/sandbox/github/claudecode-workflow"
+    assert fs._newest_transcript_for(tmp_path, host, allow_fleet=True) is not None
+    # …and without the flag the container derivation still applies.
+    assert fs._newest_transcript_for(tmp_path, host) is None
+
+
+def test_prefix_collision_does_not_match(tmp_path) -> None:
+    """Exact parent-dir match, not substring. `-workspace-app-2` must not satisfy
+    a lookup for `app`, or a wedged agent inherits a neighbour's transcript."""
+    d = tmp_path / "-workspace-app-2"
+    d.mkdir()
+    (d / "s.jsonl").write_text("{}\n")
+    assert fs._newest_transcript_for(tmp_path, "/x/app") is None
+
+
+def test_degenerate_path_is_unresolved_not_wildcard(tmp_path) -> None:
+    """An empty slug would disable filtering and return the newest .jsonl anywhere,
+    reported as RESOLVED — the confident-wrong-verdict this issue removes."""
+    d = tmp_path / "-workspace-anything"
+    d.mkdir()
+    (d / "s.jsonl").write_text("{}\n")
+    for degenerate in ("/", ".", ""):
+        assert fs._newest_transcript_for(tmp_path, degenerate) is None, degenerate
+    assert fs.container_workspace_path("/") == ""


### PR DESCRIPTION
## Summary

**Found by MV-05** — the first cut-over step that launches a real container.

aoe mounts a workspace at **`/workspace/<name>`**, not at its host path. Measured from a live sandbox:

```
docker inspect        /tmp/mv05-ws -> /workspace/mv05-ws,  WorkingDir /workspace/mv05-ws
/proc/<claude>/cwd    /workspace/mv05-ws
```

Claude Code derives its transcript dir from **cwd**, so a containerised agent writes under `-workspace-mv05-ws` while `aoe list` reports the **host** path. The surgeon slugged the host path → `-tmp-mv05-ws` → **could never match**.

So **no containerised session's transcript resolved.** An unresolved session classifies `running` with no timestamps → `broken=False` → it reads **healthy**: every container looked fine, quarantine never fired, and the bridge accrued soak toward promotion on sessions whose health was never measured.

**Static verification could not catch this.** Nothing in the repo documents aoe's `/workspace` mount — `mounts.d/` targets `/home/ubuntu/…`, the docs say "host-backed" without a container-side path, and aoe is a compiled binary. It only exists in a running container's config.

## Changes

- **`container_workspace_path()`** + exact-match resolution in `_newest_transcript_for`.
- **Provenance travels to where decisions are made**: `transcript_resolved` in the JSON (the promotion gate reads the JSON, not the stderr warning), `UNMEASURED` rather than `[ok]` in the human summary, and the bridge **skips** such sessions with an accurate reason instead of crediting them.
- **MV-05 step 2** re-observes the `/workspace` convention against a running container, since `CONTAINER_WORKSPACE_ROOT` is a constant this repo does not own.

## From code review — 3 important, 3 minor, all fixed

**The first was self-inflicted: the fix killed `--allow-fleet-transcripts`.** Fleet mode watches **native** sessions whose cwd *is* the host path, so converting them to `/workspace/<name>` reported every fleet session unmeasured — and that's the **pre**-cut-over configuration, the one usable today. I replaced one wrong assumption with a right one applied universally.

- **The bridge's unmeasured-is-not-creditable rule shipped untested** — deleting it left the whole suite green. It also set `broken=true`, asserting a break the surgeon never observed; `soak_ledger` is built on *"every exclusion is a reason, never a silent drop"*, so a **wrong** reason is worse than a vague one. Now skips with the real one.
- **MV-05's pin step could not be run as written** — it resolved the container *before* the step that launches it, and `head -1` over all sandboxes could compare an unrelated container's `WorkingDir` and point the operator at a spurious `CONTAINER_WORKSPACE_ROOT` fix.
- **Matching was a substring test** against the full path, so `workspace-app` matched `-workspace-app-2`; with basename collapse (`/a/api` and `/b/api` share a slug) a wedged agent could inherit a neighbour's transcript — the same wrong-process verdict, one level down.
- **A degenerate path** (`/`, `.`, `""`) produced an empty slug, which **disabled filtering entirely** and returned the newest `.jsonl` anywhere under the root, reported as *resolved*.
- `_slug`'s docstring claimed it produced the whole directory name; CC keeps a leading dash. Only harmless because the match was loose.

## One pre-existing test changed

`test_active_since_falls_back_to_transcript_earliest` wrote its fixture at the **host** slug and the resolver read the **host** slug — both wrong, mutually consistent, and **green for its entire life**. A test that agrees with a bug is indistinguishable from one that agrees with the spec, and no amount of mutation-testing *new* code finds it.

## Linked Issues

Closes #1075

## Test Plan

- `./scripts/ci/validate.sh` → **221 passed, 0 failed**
- Full `pytest tests/` → **1956 passed**, 6 skipped, 64 xfailed, 2 xpassed
- Derivation cross-checked against the **live container**: `WorkingDir`, `/proc/<pid>/cwd`, and `container_workspace_path()` all agree on `/workspace/mv05-ws`

Mutation-verified, each caught by exactly one test:

| mutation | caught by |
|---|---|
| revert to slugging the host path | `test_resolves_the_container_written_slug` + `test_host_slug_alone_does_not_resolve` |
| drop `transcript_resolved` from the JSON | 2 assessment tests |
| kill fleet mode again | `test_fleet_mode_resolves_native_host_slug` |
| delete the bridge's unresolved guard | `test_unresolved_transcript_is_skipped_not_credited` |

### Follow-up worth taking

An aoe-side change to the mount root fails **safe** for soak (nothing accrues) but fails **open** for quarantine (`broken=False` forever). R-15 forbids depending on the *container's* kit, not host-side subprocesses — the surgeon already shells to `aoe list` — so a host-side `docker inspect --format '{{.Config.WorkingDir}}'` could derive it at runtime and retire the constant.

### Deferred

`trivy` parsed **0 manifests** — deferred pending #1073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS