### PR TITLE
fix(contained-workflow): run the release's own hooks under aoe

### DIFF
--- a/config/settings.template.json
+++ b/config/settings.template.json
@@ -81,6 +81,16 @@
     ],
     "SessionStart": [
       {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "_comment": "Kit hook-wiring liveness beacon (cc-workflow#1086). Its OWN group, like the context-freshness pair, so merge_settings' group-signature union cannot append-and-duplicate a neighbouring hook. Writes ~/.claude/.kit-hooks-alive by EXECUTING — the one assertion that a settings file cannot fake. Silent (no additionalContext), always exits 0.",
+            "type": "command",
+            "command": "~/.claude/scripts/hooks/workflow/kit-hooks-alive.sh"
+          }
+        ]
+      },
+      {
         "matcher": "compact",
         "hooks": [
           {

--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -3,7 +3,7 @@
 # bootstrap.sh — the container bootstrap (Story 1.4, #964, Plan #959).
 #
 # Runs before the agent (via the aoe-hooks seam — open probe Dev Spec §5.N#5) and
-# performs, in order: env validation, skills symlink-sync, settings.local merge,
+# performs, in order: env validation, skills symlink-sync, kit hook-wiring merge,
 # and secret sourcing + required-secret validation. It is the load-bearing
 # instrument the whole container leans on (SKETCHBOOK D7), so it is written to the
 # **assertion-liveness** discipline from line one:
@@ -42,9 +42,8 @@
 #   OAW_SKILLS_IMAGE                baked skills, image-wins (default: $HOME/.claude/skills)
 #   OAW_SKILLS_HOST                 host skills overlay, fills gaps
 #                                   (default: $HOME/.oaw/.claude/skills)
-#   OAW_SETTINGS_JSON               baked hook wiring (default: $HOME/.claude/settings.json)
-#   OAW_SETTINGS_LOCAL              shared knobs mount
-#                                   (default: $HOME/.claude/settings.local.json)
+#   OAW_SETTINGS_JSON               baked hook wiring, the merge SOURCE
+#                                   (default: $HOME/.claude/settings.json)
 #   OAW_SECRETS_DIR                 ro secrets mount (default: $HOME/.secrets)
 #   OAW_REQUIRED_SECRETS            whitespace-separated required secret names (wins)
 #   OAW_REQUIRED_SECRETS_MANIFEST   values-free manifest file, one name per line,
@@ -91,7 +90,6 @@ fi
 OAW_SKILLS_IMAGE="${OAW_SKILLS_IMAGE:-$OAW_HOME/.claude/skills}"
 OAW_SKILLS_HOST="${OAW_SKILLS_HOST:-$OAW_HOME/.oaw/.claude/skills}"
 OAW_SETTINGS_JSON="${OAW_SETTINGS_JSON:-$OAW_HOME/.claude/settings.json}"
-OAW_SETTINGS_LOCAL="${OAW_SETTINGS_LOCAL:-$OAW_HOME/.claude/settings.local.json}"
 OAW_SECRETS_DIR="${OAW_SECRETS_DIR:-$OAW_HOME/.secrets}"
 OAW_REQUIRED_SECRETS_MANIFEST="${OAW_REQUIRED_SECRETS_MANIFEST:-$OAW_SECRETS_DIR/required.manifest}"
 
@@ -219,30 +217,182 @@ sync_skills() {
 	return 0
 }
 
-# --- Stage 3: settings.local merge --------------------------------------------
-
-# Claude Code itself merges settings.json (baked hook wiring) with the mounted
-# settings.local.json (shared knobs) at runtime (architecture.md §3.3). The
-# bootstrap's job is to make the two silent-skip paths loud: a missing
-# settings.local mount, and a malformed settings.local that CC's merge would
-# silently ignore.
-merge_settings() {
-	if [[ -f "$OAW_SETTINGS_JSON" ]]; then
-		info "settings: image settings.json present"
-	else
-		warn "settings: image settings.json not found ($OAW_SETTINGS_JSON) — expected baked in the image"
-	fi
-
-	if [[ ! -f "$OAW_SETTINGS_LOCAL" ]]; then
-		warn "missing mount: settings.local.json not present ($OAW_SETTINGS_LOCAL); Claude Code will use image settings only"
+# --- Stage 3: the kit's hook wiring, where the CLI reads it (#1086) -----------
+#
+# R-06 says hook wiring is VERSIONED WITH THE RELEASE — the image digest IS the
+# release, so the hooks baked into it are the hooks that run. Under aoe that was
+# false: the CLI reads $CLAUDE_CONFIG_DIR/settings.json (aoe's own config, host-
+# backed and SHARED by every container) and never opens the image's copy.
+#
+# It looked healthy, which is why it survived: that shared file had been seeded
+# from a host carrying the same kit, so an EQUIVALENT hook set was already sitting
+# there and kit hooks did fire. What could not happen was version MOVEMENT. A hook
+# the image added, renamed or repointed stayed on the operator's host timetable
+# instead of the release's, and nothing reported the gap. R-06 held by coincidence,
+# which is not the same as holding — and a coincidence is exactly what a promotion
+# gate must not depend on.
+#
+# MERGE, the same way sync_kit_registrations merges mcpServers, and for the same
+# reason: the destination is SHARED and legitimately carries things that are the
+# operator's — aoe's own AOE_INSTANCE_ID status hooks, theme, model, permissions.
+# So ADD what the image ships and touch nothing else. Image-authoritative for
+# hooks; the operator keeps their preferences. (`./install`'s merge_settings applies
+# this identical rule for a native install; this is that rule reapplied where aoe
+# moved the file out from under it.)
+#
+# What this deliberately does NOT do is delete host-only hooks. The strong reading
+# of "image-authoritative" would clobber aoe's own wiring and break its TUI. Stale
+# host-only entries are already covered by validate_hook_paths, which reports any
+# configured hook that cannot resolve in this namespace.
+#
+# NOTE ON settings.local.json — there is no such thing at user level. The R-03
+# mount that used to land one at ~/.claude/settings.local.json was removed with
+# this change: measured against the real CLI, `localSettings` is PROJECT-scoped
+# (<project>/.claude/settings.local.json) and a settings.local.json beside the user
+# settings.json is never read, aoe or not. The old Stage 3 warned when that mount
+# was missing — an assertion about a file the CLI would have ignored anyway.
+sync_kit_hooks() {
+	if [[ ! -f "$OAW_SETTINGS_JSON" ]]; then
+		warn "hooks: image settings.json not found ($OAW_SETTINGS_JSON) — the release ships no hook wiring to merge"
 		return 0
 	fi
-
-	if python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$OAW_SETTINGS_LOCAL" 2>/dev/null; then
-		info "settings: settings.local.json present and valid JSON (Claude Code merges it)"
-	else
-		warn "settings: settings.local.json is not valid JSON ($OAW_SETTINGS_LOCAL) — Claude Code's merge will ignore/error on it"
+	if [[ "$OAW_SETTINGS_JSON" == "$OAW_EFFECTIVE_SETTINGS" ]]; then
+		info "hooks: the CLI reads the image settings directly — kit wiring already in place"
+		return 0
 	fi
+	command -v python3 >/dev/null 2>&1 || {
+		warn "hooks: python3 unavailable — cannot merge kit hook wiring into $OAW_EFFECTIVE_SETTINGS"
+		return 0
+	}
+	# CREATE rather than bail, for the same reason sync_kit_registrations does: a
+	# fresh aoe profile has a config dir with no settings.json in it, and warning-
+	# and-returning there reproduces the very state this fixes — a container running
+	# none of the release's hooks.
+	if [[ ! -f "$OAW_EFFECTIVE_SETTINGS" ]]; then
+		if mkdir -p "$OAW_CLAUDE_CONFIG_DIR" 2>/dev/null && printf '{}\n' >"$OAW_EFFECTIVE_SETTINGS" 2>/dev/null; then
+			info "hooks: created $OAW_EFFECTIVE_SETTINGS (the CLI had no settings there)"
+		else
+			warn "hooks: $OAW_EFFECTIVE_SETTINGS absent and not creatable — the kit's hooks will not run"
+			return 0
+		fi
+	fi
+
+	local out
+	if ! out="$(
+		OAW_SRC="$OAW_SETTINGS_JSON" OAW_DST="$OAW_EFFECTIVE_SETTINGS" python3 - <<-'PY' 2>&1
+			import fcntl, json, os
+
+			src, dst = os.environ["OAW_SRC"], os.environ["OAW_DST"]
+			with open(src) as fh:
+			    want = json.load(fh).get("hooks", {})
+			if not want:
+			    print("no-kit-hooks")
+			    raise SystemExit(0)
+
+			def key(matcher, cmd):
+			    """Dedup key: two commands that RESOLVE to the same script are one hook.
+
+			    Keying on the raw string is not enough. The image bakes
+			    wtf-post-tool-use.sh under BOTH `~/.local/share/...` (from
+			    settings.template.json) and `/home/ubuntu/.local/share/...` (added at
+			    build time), and the shared settings already carried the absolute form.
+			    A string key called those two different hooks and registered the second,
+			    so the hook fired TWICE on every tool use — a merge that introduces
+			    duplicate execution is not preserving the release's wiring, it is
+			    corrupting it. Measured live before this guard existed.
+
+			    Expansion is for the KEY only; what gets written is always the image's
+			    own string, byte for byte.
+			    """
+			    head, sep, tail = cmd.strip().partition(" ")
+			    return matcher, os.path.expanduser(os.path.expandvars(head)) + sep + tail
+
+			def commands(group):
+			    """(matcher, hook) pairs in one hook group, skipping junk entries."""
+			    if not isinstance(group, dict):
+			        return
+			    matcher = group.get("matcher") or ""
+			    for h in group.get("hooks") or []:
+			        if isinstance(h, dict) and isinstance(h.get("command"), str):
+			            yield matcher, h
+
+			# Locked read-modify-write: this file is shared by every container on the
+			# host, so two agents starting together WILL interleave here.
+			with open(dst, "r+") as fh:
+			    fcntl.flock(fh, fcntl.LOCK_EX)
+			    d = json.loads(fh.read() or "{}")
+			    if not isinstance(d, dict):
+			        raise SystemExit("__ERR__ effective settings is not a JSON object")
+			    before = json.loads(json.dumps(d))  # pre-image for the recovery copy
+			    have = d.setdefault("hooks", {})
+			    if not isinstance(have, dict):
+			        raise SystemExit("__ERR__ effective settings has a non-object 'hooks'")
+
+			    added = []
+			    for event, groups in want.items():
+			        dst_groups = have.setdefault(event, [])
+			        if not isinstance(dst_groups, list):
+			            continue
+			        # Keyed per MATCHER, never by command alone: the kit legitimately
+			        # registers one script under several matchers — context-freshness-warn
+			        # ships under BOTH `startup` and `resume` — and a command-only key
+			        # would silently drop the second registration, which is this bug
+			        # wearing a merge's clothes. See key() for the other half (two
+			        # spellings of one path are one hook).
+			        present = {key(m, h["command"]) for g in dst_groups for m, h in commands(g)}
+			        for g in groups or []:
+			            missing = []
+			            for m, h in commands(g):
+			                k = key(m, h["command"])
+			                if k in present:
+			                    continue
+			                # Add to `present` as we go, so a source group that ships the
+			                # same script twice under one matcher registers it once.
+			                present.add(k)
+			                missing.append(h)
+			            if not missing:
+			                continue
+			            # NOT `k` — `k` is the dedup key three lines up. The comprehension
+			            # has its own scope so reusing it is harmless, and unreadable.
+			            group = {gk: gv for gk, gv in g.items() if gk != "hooks"}
+			            group["hooks"] = missing
+			            dst_groups.append(group)
+			            # (… or ["?"]) — a hook whose command is the empty string is
+			            # junk, but IndexError here would abort the whole merge and
+			            # take every other event's wiring down with it.
+			            added += [f"{event}:{(h['command'].split() or ['?'])[0]}" for h in missing]
+
+			    if added:
+			        # RECOVERY COPY before mutating, and an IN-PLACE write after — both
+			        # inherited from sync_kit_registrations deliberately. A tmp+rename would
+			        # be atomic against a torn write, but it mints a new inode, and this
+			        # config directory is bind-mounted; keeping one inode keeps every view of
+			        # the file the same file. The residual torn-write risk (kill/ENOSPC
+			        # between write and truncate) is what the copy is for, in a file EVERY
+			        # container reads.
+			        try:
+			            with open(dst + ".pre-bootstrap", "w") as bak:
+			                bak.write(json.dumps(before, indent=2))
+			        except Exception:
+			            pass
+			        data = json.dumps(d, indent=2)
+			        fh.seek(0)
+			        fh.write(data)
+			        fh.truncate()
+			print(",".join(added) if added else "already-present")
+		PY
+	)"; then
+		warn "hooks: could not merge kit hook wiring into $OAW_EFFECTIVE_SETTINGS ($out)"
+		return 0
+	fi
+	case "$out" in
+	already-present) info "hooks: kit wiring already present in $OAW_EFFECTIVE_SETTINGS" ;;
+	no-kit-hooks) warn "hooks: image settings.json declares no hooks — nothing to merge" ;;
+	# No __ERR__ arm: `raise SystemExit("__ERR__ …")` exits 1, so those land in the
+	# `if ! out=` branch above with the message already in $out. An arm here would
+	# be unreachable — the kind of handler that reads as coverage and is never run.
+	*) info "hooks: merged kit wiring into the CLI's settings: $out" ;;
+	esac
 	return 0
 }
 
@@ -1000,7 +1150,7 @@ main() {
 	info "starting (home=$OAW_HOME)"
 	validate_env
 	sync_skills
-	merge_settings
+	sync_kit_hooks
 	validate_secrets
 	ensure_ssh_parity
 	ensure_github_auth

--- a/containers/oakandwave-workflow/mounts.d/10-memory.toml
+++ b/containers/oakandwave-workflow/mounts.d/10-memory.toml
@@ -15,13 +15,25 @@ sandbox_scoped = true
 source = "~/.oaw/state/<major>/memory"
 target = "/home/ubuntu/.claude/projects/_sandbox/memory"
 
-# settings.local.json — the genuinely-shared knobs (permissions / env / identity).
-# settings.json (hook wiring) is BAKED in the image (versioned); Claude Code
-# merges the two. This half is host-backed and sandbox-scoped like memory.
-[[mount]]
-name = "settings-local"
-layer = "shared-mutable-rw"
-mode = "rw"
-sandbox_scoped = true
-source = "~/.oaw/state/<major>/settings.local.json"
-target = "/home/ubuntu/.claude/settings.local.json"
+# REMOVED: the "settings-local" mount (#1086). It landed
+# ~/.oaw/state/<major>/settings.local.json at /home/ubuntu/.claude/settings.local.json
+# on the premise that settings.json is SPLIT — image ships hook wiring, this mount
+# supplies the shared knobs, Claude Code merges the two.
+#
+# There is no such file. `localSettings` is PROJECT-scoped: the CLI reads
+# <project>/.claude/settings.local.json and nothing else by that name. Measured
+# against the shipped CLI in one run, three settings.local.json files planted at
+# once — a hook in the project copy FIRED, a hook in the user config dir's copy did
+# NOT, and a hook in the user settings.json did. `claude doctor` names a malformed
+# project settings.local.json and stays silent on a malformed one beside the user
+# settings, so the instrument can see the file class and still reports nothing there.
+#
+# So this mount was never read — not "unread under aoe", unread everywhere,
+# native installs included. It carried `{}` on every profile for its whole life,
+# which is why nothing ever noticed. The shared-knob seam R-03 wanted does exist,
+# but it is the settings.json the CLI actually reads (under aoe: the host-backed,
+# fleet-shared $CLAUDE_CONFIG_DIR copy) — and bootstrap's sync_kit_hooks now merges
+# the image's hook wiring INTO it rather than expecting the CLI to merge two files.
+#
+# Removing the mount changes the resolved volume set, so profile config.toml
+# extra_volumes need regenerating; check-mount-drift.sh is what reports the gap.

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -41,7 +41,7 @@ fragment deterministically. Each file holds one or more `[[mount]]` tables.
 | file | layer | owner story |
 |------|-------|-------------|
 | `05-transcripts.toml` | shared-mutable-rw (session transcripts) | #1064 |
-| `10-memory.toml` | shared-mutable-rw (memory + `settings.local.json`) | 1.3 (#963) |
+| `10-memory.toml` | shared-mutable-rw (memory) | 1.3 (#963), #1086 |
 | `20-secrets.toml` | read-only-secrets (ro named single-file mounts) | 1.5 (#965), #1061 |
 | `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |
 | `40-durable-caches.toml` | durable-cache (cargo, go-mod, uv, ms-playwright) | 1.3 (#963) |

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -34,7 +34,7 @@ flowchart TB
       kit["baked kit: skills / hooks /<br/>scripts / kit MCPs / toolchain"]
     end
     subgraph hoststate["host-backed durable state"]
-      mem["~/.oaw/state/&lt;major&gt;/<br/>memory + settings.local"]
+      mem["~/.oaw/state/&lt;major&gt;/<br/>memory"]
       sec["~/.secrets (ro)"]
       overlay["~/.oaw/overlay, ~/.oaw/toolbox<br/>user MCPs / tools"]
       caches["~/.oaw/cache/&lt;major&gt;/<br/>cargo / go / uv / playwright"]
@@ -114,7 +114,7 @@ flowchart LR
     s1["skills / hook scripts<br/>kit MCP registrations"]
   end
   subgraph rw["2 · shared-mutable-rw"]
-    s2["memory + settings.local<br/>~/.oaw/state/&lt;major&gt;/  (R-03)"]
+    s2["memory<br/>~/.oaw/state/&lt;major&gt;/  (R-03)"]
   end
   subgraph ro["3 · read-only-secrets"]
     s3["~/.secrets (ro)  ·  §3.5"]
@@ -176,13 +176,49 @@ degrades silently (the D7 assertion-liveness discipline):
   The discretionary-tool toolbox (R-11) is a durable, in-container-materialized
   mount decoupled from the kit release.
 
-### 3.3 settings.json split
+### 3.3 settings.json: one file, merged by us (#1086)
 
-`settings.json` straddles versioned and shared, so it is **split** (Dev Spec
-§5.3): the image ships `settings.json` (hook wiring — versioned, because hook
-registrations point at script paths that live in the image), and the
-`10-memory.toml` fragment bind-mounts `settings.local.json` (permissions / env /
-identity — the genuinely shared knobs). Claude Code merges the two.
+`settings.json` straddles versioned and shared. The original design (Dev Spec
+§5.3) **split** it across two files — the image ships `settings.json` (hook
+wiring, versioned, because hook registrations point at script paths that live in
+the image) and `10-memory.toml` bind-mounts `settings.local.json` (permissions /
+env / identity, the genuinely shared knobs) — on the understanding that Claude
+Code merges the two.
+
+**It does not, because the second file does not exist.** `localSettings` is
+*project*-scoped: the CLI reads `<project>/.claude/settings.local.json` and
+nothing else by that name. A `settings.local.json` sitting beside the *user*
+`settings.json` is never read — not "unread under aoe", unread everywhere,
+native installs included. Measured in a single run with three such files planted
+at once: the project copy's hook **fired**, the user config dir's copy's hook did
+**not**, and the user `settings.json`'s hook did. `claude doctor` names a
+malformed *project* `settings.local.json` and stays silent on a malformed one
+beside the user settings, so the instrument can see that file class and still
+reports nothing there. The mount carried `{}` on every profile for its entire
+life, which is why the gap never announced itself.
+
+So the split is gone. There is **one** settings file — the one the CLI actually
+reads — and the kit merges into it:
+
+| | where | who owns it |
+|---|---|---|
+| merge source | image `~/.claude/settings.json` (baked, R-06) | the release |
+| merge target | `$CLAUDE_CONFIG_DIR/settings.json` (under aoe: host-backed `~/.claude/sandbox`, shared by every container) | the operator |
+
+`bootstrap.sh::sync_kit_hooks` merges the image's `hooks` block into the target
+**additively**, keyed on `(matcher, command)` — precisely how `sync_kit_registrations`
+merges `mcpServers`, and for the same reason: the target is shared and legitimately
+carries aoe's own `AOE_INSTANCE_ID` status hooks plus the operator's theme, model
+and permissions. Image-authoritative for hooks; the operator keeps their preferences.
+`./install`'s own `merge_settings` applies this identical rule to a native install;
+this is that rule reapplied where aoe moved the file out from under it.
+
+It deliberately does **not** delete host-only hooks. The strong reading of
+"image-authoritative" would clobber aoe's wiring and break its TUI; stale
+host-only entries are instead reported by `validate_hook_paths` (§3.5.1).
+
+The shared-knob seam R-03 wanted still exists — it is simply this same file,
+rather than a second one beside it.
 
 ### 3.4 PATH precedence
 
@@ -385,27 +421,42 @@ paths that do not exist.
 green and each partially bypassed in production, because every verification used
 `docker run` with the profile's `extra_volumes` — reproducing the **mounts** but
 not the **launcher**. `scripts/ci/aoe-preflight.sh` launches through aoe and
-asserts ten behaviours from inside the container; it was proven able to fail by
+asserts twelve behaviours from inside the container; it was proven able to fail by
 running it against the unfixed image first. **A harness that reproduces the
 inputs but not the invoker is not a rehearsal.**
 
-#### Known, deliberate gap: the settings split does not survive aoe
+#### Closed: the settings split did not survive aoe, and R-06 held by coincidence (#1086)
 
-This fix reconciles `.claude.json` (MCP registrations, onboarding, trust) into the
-effective location. It does **not** reconcile `settings.json`, and the honest
-consequence is that under aoe **the image's baked hook wiring (§3.3, R-06
-"versioned with the release") and the bind-mounted `settings.local.json` (R-03
-shared knobs) are both unread.** The CLI reads the operator's host settings
-instead.
+#1085 reconciled `.claude.json` (MCP registrations, onboarding, trust) into the
+effective location and deliberately left `settings.json` alone, recording the
+consequence here as a known gap: under aoe the image's baked hook wiring was
+unread, because the CLI reads `$CLAUDE_CONFIG_DIR/settings.json` instead.
 
-That contradicts §3.3 and is stated here rather than left to be discovered.
-`aoe-preflight.sh` asserts the effective settings are *readable* and that every
-configured hook *resolves*; nothing yet asserts the kit's own hooks are
-**present**. Resolving it means either merging the image's `hooks` block the way
-`mcpServers` is merged, or accepting that hook wiring is operator-owned under aoe
-and dropping the R-06 claim for it. Deferred deliberately: it is a contract
-change, not a bug fix, and shipping it inside a five-symptom incident fix would
-bury it.
+That was true, and its **stated consequence — that the kit's hooks therefore do
+not run — was not.** They ran. `$CLAUDE_CONFIG_DIR` resolves to
+`~/.claude/sandbox`, a sandbox-dedicated host directory (not the operator's own
+`~/.claude`), and it had been seeded from a host carrying the same kit. So an
+equivalent hook set was already sitting in it, and `~/`-prefixed entries resolve
+in-container because `~` is `/home/ubuntu`. Everything worked.
+
+**The real defect was version skew, and it was invisible by construction.** What
+could not happen was hook wiring MOVING: a hook the image added, renamed or
+repointed stayed on the operator's host timetable rather than the release's, and
+nothing anywhere reported the divergence. R-06 — "versioned with the release" —
+was true by coincidence, which is not the same as true, and a promotion gate must
+not rest on a coincidence.
+
+It is closed by §3.3's merge. Two things follow, and both are the point:
+
+- **No settings-shaped check could have caught this.** A settings file that
+  *mentions* a hook proves nothing about whether that hook ran, and here the file
+  named all the right hooks for the wrong reason. `aoe-preflight.sh` therefore
+  asserts a kit hook **executed**: `kit-hooks-alive.sh` is a SessionStart beacon
+  whose marker exists only as a side effect of running, cleared (and proven
+  cleared) before the assertion.
+- **The beacon is its own red-first proof.** It is new in this release, so it is
+  absent from any host-seeded settings file — run the new preflight against the
+  pre-#1086 image and check 8 fails, for exactly the reason the fix exists.
 
 ### 3.6.1 GitHub credential — file modality, deliberately not env (#1082)
 

--- a/scripts/ci/aoe-preflight.sh
+++ b/scripts/ci/aoe-preflight.sh
@@ -250,6 +250,36 @@ else
 	pass "all configured hook paths resolve ($BOOTLINES bootstrap lines seen)"
 fi
 
+# --- 8. a KIT hook actually EXECUTED (#1086) ----------------------------------
+# Check 7 asks whether configured hooks RESOLVE. That is a different question from
+# whether the RELEASE's hooks are the ones configured, and #1086 is exactly the gap
+# between them: under aoe the CLI reads $CLAUDE_CONFIG_DIR/settings.json — a shared,
+# host-backed file — and never the image's own. It looked healthy because that file
+# had been seeded from a host carrying the same kit, so an equivalent hook set was
+# already there. Every settings-shaped check would have reported R-06 in perfect
+# health while the image's wiring sat unread and version skew went undetected.
+#
+# So do not read settings. kit-hooks-alive.sh writes its marker ONLY by running.
+BEACON=/home/ubuntu/.claude/.kit-hooks-alive
+# Clear it first — and PROVE the clear worked. The marker lives in the image's own
+# $HOME (not the shared config dir), but an earlier `claude` in THIS container has
+# already written one, and a leftover would let this pass on a container running
+# none of the kit's wiring. An undeletable marker is an instrument failure, not a pass.
+x rm -f "$BEACON" >/dev/null 2>&1
+if x test -e "$BEACON"; then
+	fail "could not clear the beacon at $BEACON" \
+		"a stale marker makes the assertion below meaningless — refusing to read it"
+else
+	x claude -p ok >/dev/null 2>&1
+	FIRED="$(x sh -c "cat '$BEACON' 2>/dev/null" | tr -d '\r')"
+	if [[ -n "$FIRED" ]]; then
+		pass "a kit hook EXECUTED (SessionStart beacon: $FIRED)"
+	else
+		fail "no kit hook fired — the release's own hook wiring is not running" \
+			"the CLI reads \$CLAUDE_CONFIG_DIR/settings.json; bootstrap's sync_kit_hooks must merge the image's hooks into it"
+	fi
+fi
+
 echo
 if ((FAILED)); then
 	echo "aoe-preflight: $FAILED check(s) FAILED" >&2

--- a/scripts/hooks/workflow/kit-hooks-alive.sh
+++ b/scripts/hooks/workflow/kit-hooks-alive.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# kit-hooks-alive.sh — SessionStart beacon: proof the KIT'S OWN hook wiring is live.
+#
+# WHY THIS EXISTS (#1086).
+#
+# Hook wiring is supposed to be VERSIONED WITH THE RELEASE (R-06): the image digest
+# IS the release, so the hooks shipped in it are the hooks that run. Under aoe that
+# was not true. The CLI reads $CLAUDE_CONFIG_DIR/settings.json — aoe's own config,
+# host-backed and shared by every container — and never opens the image's copy.
+#
+# It looked healthy, which is exactly why it survived review: that shared file had
+# been seeded from a host carrying the same kit, so an EQUIVALENT hook set was
+# already present and kit hooks did fire. What could not happen was version
+# MOVEMENT. A hook the image added, renamed or repointed stayed on the operator's
+# host timetable rather than the release's, and nothing anywhere reported the gap.
+# R-06 held by coincidence, which is not the same as holding.
+#
+# Reading settings cannot detect that: a settings file that MENTIONS a hook proves
+# nothing about whether the hook RAN. This beacon is the whole difference — it
+# writes its marker only by EXECUTING, so `test -f` on the marker is a statement
+# about behaviour, not about configuration. scripts/ci/aoe-preflight.sh asserts it,
+# and an operator can answer "are my kit hooks live?" with one `ls`.
+#
+# Deliberately trivial, deliberately silent:
+#   * stdout from a SessionStart hook becomes additionalContext in the agent's
+#     window, so this prints NOTHING there — a beacon that spends context would be
+#     a tax on every session for the life of the kit.
+#   * it can never fail a session: every path exits 0.
+set -uo pipefail
+
+# No HOME means no per-user location to claim, and a fixed /tmp path would be a
+# collision (and a squat target) on a multi-user host. Say nothing, do nothing.
+[[ -n "${HOME:-}" ]] || exit 0
+
+# $HOME/.claude, NOT $CLAUDE_CONFIG_DIR. Under aoe the config dir is shared by
+# every container on the host, so a marker written there could not distinguish
+# "this session's hooks fired" from "some other container fired them hours ago" —
+# the beacon would answer a question nobody asked. $HOME/.claude is the image's
+# own directory: per-container, and on a native install it is the config dir anyway.
+marker_dir="$HOME/.claude"
+mkdir -p "$marker_dir" 2>/dev/null || exit 0
+printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$marker_dir/.kit-hooks-alive" 2>/dev/null || true
+
+exit 0

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -15,8 +15,7 @@ Each of the four enumerated silent-skip paths (Dev Spec §5.4 / SKETCHBOOK D7) i
 exercised **red-first** — the broken condition is constructed and the guard's
 logged/failing signal is asserted — before the guard is trusted:
 
-* missing mount   — ``test_missing_host_skills_mount_is_logged_no_dangling``,
-  ``test_missing_settings_local_is_logged`` `[R-14]`
+* missing mount   — ``test_missing_host_skills_mount_is_logged_no_dangling`` `[R-14]`
 * shadowed skill  — ``test_skills_sync_image_wins_and_logs_collision`` `[R-06, R-10]`
 * dangling link   — ``test_dangling_symlink_is_logged`` `[R-14]`
 * missing secret  — ``test_missing_required_secret_fails_loud`` `[R-14]`
@@ -69,7 +68,6 @@ def _make_home(
     image_skills: list[str] | None = None,
     host_skills: list[str] | None = None,
     settings_json: bool = True,
-    settings_local: str | None = None,
     secrets: dict[str, str] | None = None,
     dangling: list[str] | None = None,
 ) -> Path:
@@ -100,9 +98,15 @@ def _make_home(
         (image / name).symlink_to(home / "does-not-exist" / name)
 
     if settings_json:
-        (home / ".claude" / "settings.json").write_text('{"hooks": {}}\n')
-    if settings_local is not None:
-        (home / ".claude" / "settings.local.json").write_text(settings_local)
+        # A REAL hook, not `{"hooks": {}}`. This file is the merge SOURCE for
+        # sync_kit_hooks (#1086), and an empty block would make every cfgdir test
+        # exercise the "nothing to merge" branch — a fixture that cannot detect the
+        # bug it is fixture for. /bin/true is used so validate_hook_paths, which
+        # runs later over the merged result, finds a path that genuinely resolves.
+        (home / ".claude" / "settings.json").write_text(
+            '{"hooks": {"SessionStart": [{"matcher": "startup", "hooks":'
+            ' [{"type": "command", "command": "/bin/true"}]}]}}\n'
+        )
     for fname, content in (secrets or {}).items():
         (secrets_dir / fname).write_text(content)
 
@@ -194,20 +198,15 @@ def test_missing_host_skills_mount_is_logged_no_dangling(tmp_path: Path) -> None
     assert not any(p.is_symlink() and not p.exists() for p in image.iterdir())
 
 
-def test_missing_settings_local_is_logged(tmp_path: Path) -> None:
-    """Absent settings.local mount → logged (silent-skip made loud), non-fatal."""
-    home = _make_home(tmp_path)  # no settings_local
-    proc = _run(home)
-    assert proc.returncode == 0, proc.stderr
-    assert "missing mount: settings.local.json" in proc.stderr
-
-
-def test_malformed_settings_local_is_logged(tmp_path: Path) -> None:
-    """Malformed settings.local → loud warning (CC's merge would silently drop it)."""
-    home = _make_home(tmp_path, settings_local="{ this is not json ]")
-    proc = _run(home)
-    assert proc.returncode == 0, proc.stderr
-    assert "not valid JSON" in proc.stderr
+# NOTE (#1086) — two tests were REMOVED here, not relocated:
+# ``test_missing_settings_local_is_logged`` and
+# ``test_malformed_settings_local_is_logged``. Both asserted that bootstrap warns
+# about ~/.claude/settings.local.json, on the premise that Claude Code merges it
+# with the user settings.json. It does not: ``localSettings`` is PROJECT-scoped
+# and a settings.local.json beside the USER settings is never read, aoe or not.
+# They were well-formed assertions about a file the CLI ignores — green forever,
+# guarding nothing. The mount they policed is gone (mounts.d/10-memory.toml), and
+# what replaced the whole idea is sync_kit_hooks, covered below.
 
 
 # --- dangling link ------------------------------------------------------------
@@ -299,7 +298,6 @@ def test_all_clean_exits_zero(tmp_path: Path) -> None:
         tmp_path,
         image_skills=["alpha"],
         host_skills=["beta"],
-        settings_local='{"permissions": {}}\n',
         secrets={
             ".env": "OAW_REQUIRED_SECRETS=discord-bot-token\n"
                     "DISCORD_TOKEN_PATH=/home/ubuntu/.secrets/discord-bot-token\n",
@@ -400,11 +398,19 @@ def test_bootstrap_failloud(tmp_path: Path) -> None:
         host_skills=["alpha"],
         dangling=["ghost"],
     )
+    # 2) missing mount: the secrets dir. This leg used to be settings.local.json,
+    # until #1086 established the CLI never reads a user-level one and the mount
+    # was removed — an oracle leg that had been asserting a warning about a file
+    # nothing would have opened. The secrets dir is the honest replacement: it is
+    # a real mount, and its absence is the R-14 silent-skip this oracle is for.
+    import shutil
+    shutil.rmtree(home / ".secrets")
+
     logged = _run(home)
     assert logged.returncode == 0, logged.stderr
     assert "skills-sync collision" in logged.stderr  # shadowed skill
     assert "dangling symlink" in logged.stderr  # dangling link
-    assert "missing mount: settings.local.json" in logged.stderr  # 2) missing mount
+    assert "missing mount: secrets dir not present" in logged.stderr  # 2) missing mount
 
     # 4) missing secret FAILS LOUD (the same layout, plus a required secret).
     failed = _run(home, OAW_REQUIRED_SECRETS="MUST_HAVE_TOKEN")
@@ -670,7 +676,6 @@ def test_bootstrap_writes_nothing_to_stdout(tmp_path: Path) -> None:
     home = _make_home(
         tmp_path,
         image_skills=["alpha"],
-        settings_local="{}",
         secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'},
     )
     proc = _run(home)
@@ -1575,3 +1580,252 @@ def test_git_transport_matches_the_host_per_forge() -> None:
         "ensure_ssh_parity is defined but not CALLED from main: gitlab git and "
         "every remote host (blueshift, perkollate, agent-smith-ca) depend on it"
     )
+
+
+# --- kit hook wiring into the settings the CLI reads (#1086) ------------------
+#
+# R-06 says hook wiring is versioned with the release. Under aoe it was not: the
+# CLI reads $CLAUDE_CONFIG_DIR/settings.json and never the image's own copy. That
+# went unnoticed because the shared file had been seeded from a host carrying the
+# same kit, so an equivalent hook set was already sitting in it and hooks DID fire.
+# What could not happen was version movement — and nothing reported that.
+
+
+def _hook_commands(settings: dict, event: str) -> list[tuple[str, str]]:
+    """(matcher, command) pairs registered under one event."""
+    return [
+        (g.get("matcher") or "", h["command"])
+        for g in settings.get("hooks", {}).get(event, [])
+        for h in g.get("hooks", [])
+        if isinstance(h.get("command"), str)
+    ]
+
+
+def test_kit_hooks_merge_into_the_settings_the_cli_reads(tmp_path: Path) -> None:
+    """The image's hooks reach $CLAUDE_CONFIG_DIR/settings.json, additively.
+
+    The destination is SHARED by every container and carries aoe's own status
+    hooks and the operator's preferences, so this must add and never clobber.
+    """
+    import json as J
+
+    home, cfgdir = _home_with_cfgdir(tmp_path)
+    (cfgdir / "settings.json").write_text(J.dumps({
+        "theme": "dark",
+        "hooks": {"SessionStart": [
+            {"matcher": "startup", "hooks": [
+                {"type": "command", "command": "/bin/echo operator-own"}]}]},
+    }))
+    ws = tmp_path / "ws"; ws.mkdir()
+    proc = _run_cfgdir(home, cfgdir, ws)
+    assert proc.returncode == 0, proc.stderr
+
+    got = J.loads((cfgdir / "settings.json").read_text())
+    pairs = _hook_commands(got, "SessionStart")
+    assert ("startup", "/bin/true") in pairs, "the image's hook never arrived"
+    assert ("startup", "/bin/echo operator-own") in pairs, (
+        "the operator's own hook was dropped — the merge must be additive"
+    )
+    assert got["theme"] == "dark", "non-hook operator settings must be untouched"
+
+
+def test_kit_hook_merge_is_idempotent(tmp_path: Path) -> None:
+    """A second boot registers nothing twice — a hook that runs twice per event
+    is its own bug, and every container boots this code path on every launch."""
+    import json as J
+
+    home, cfgdir = _home_with_cfgdir(tmp_path)
+    ws = tmp_path / "ws"; ws.mkdir()
+    assert _run_cfgdir(home, cfgdir, ws).returncode == 0
+    first = _hook_commands(J.loads((cfgdir / "settings.json").read_text()), "SessionStart")
+    proc = _run_cfgdir(home, cfgdir, ws)
+    assert proc.returncode == 0
+    second = _hook_commands(J.loads((cfgdir / "settings.json").read_text()), "SessionStart")
+    assert first == second, f"second boot changed the hook set: {first} -> {second}"
+    assert "already present" in proc.stderr
+
+
+def test_same_command_under_a_different_matcher_is_not_dropped(tmp_path: Path) -> None:
+    """Dedup is on (matcher, command), not command alone.
+
+    The kit legitimately registers one script under several matchers —
+    context-freshness-warn.sh ships under BOTH `startup` and `resume`. A
+    command-only key silently drops the second registration, which is the very
+    bug this merge exists to fix, wearing a merge's clothes.
+    """
+    import json as J
+
+    home, cfgdir = _home_with_cfgdir(tmp_path)
+    (home / ".claude" / "settings.json").write_text(J.dumps({"hooks": {"SessionStart": [
+        {"matcher": "startup", "hooks": [{"type": "command", "command": "/bin/true"}]},
+        {"matcher": "resume", "hooks": [{"type": "command", "command": "/bin/true"}]},
+    ]}}))
+    ws = tmp_path / "ws"; ws.mkdir()
+    assert _run_cfgdir(home, cfgdir, ws).returncode == 0
+    pairs = _hook_commands(J.loads((cfgdir / "settings.json").read_text()), "SessionStart")
+    assert ("startup", "/bin/true") in pairs
+    assert ("resume", "/bin/true") in pairs, (
+        "the resume registration was swallowed by a command-only dedup"
+    )
+
+
+def test_absent_effective_settings_is_created_not_bailed_on(tmp_path: Path) -> None:
+    """A fresh aoe profile has a config dir with no settings.json in it.
+
+    Warning-and-returning there reproduces the exact production state this fixes:
+    a container running none of the release's hooks.
+    """
+    import json as J
+
+    home, cfgdir = _home_with_cfgdir(tmp_path)
+    ws = tmp_path / "ws"; ws.mkdir()
+    assert not (cfgdir / "settings.json").exists()
+    proc = _run_cfgdir(home, cfgdir, ws)
+    assert proc.returncode == 0, proc.stderr
+    assert (cfgdir / "settings.json").is_file(), "bootstrap must create it"
+    pairs = _hook_commands(J.loads((cfgdir / "settings.json").read_text()), "SessionStart")
+    assert ("startup", "/bin/true") in pairs
+
+
+def test_malformed_effective_settings_is_not_clobbered(tmp_path: Path) -> None:
+    """Unparseable destination → warn and leave it ALONE.
+
+    This file is shared by every container on the host. Overwriting one the
+    operator is mid-edit, to 'fix' it, would be a worse failure than the one being
+    reported — and the CLI is already showing them a Settings Error.
+    """
+    home, cfgdir = _home_with_cfgdir(tmp_path)
+    (cfgdir / "settings.json").write_text("{ not json at all")
+    ws = tmp_path / "ws"; ws.mkdir()
+    proc = _run_cfgdir(home, cfgdir, ws)
+    assert proc.returncode == 0, "a malformed shared file must not abort the boot"
+    assert (cfgdir / "settings.json").read_text() == "{ not json at all"
+    # Name the MERGE's own message. A bare "hooks:" match is satisfied by
+    # validate_hook_paths, which also chokes on this file and reports it later —
+    # so the assertion passed under a mutation that removed the merge entirely.
+    # An instrument that reads another function's output is not measuring this one.
+    assert "could not merge kit hook wiring" in proc.stderr, (
+        "the merge must report its own refusal, not leave it to a later stage"
+    )
+
+
+def test_native_install_does_not_merge_a_file_into_itself(tmp_path: Path) -> None:
+    """With no CLAUDE_CONFIG_DIR, source and destination ARE the same file.
+
+    #1085's first cut collapsed the two config locations into one expression and
+    broke every non-aoe path; this is the same hazard one function over.
+    """
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    before = (home / ".claude" / "settings.json").read_text()
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    assert (home / ".claude" / "settings.json").read_text() == before
+    assert "reads the image settings directly" in proc.stderr
+
+
+# --- the beacon that makes "a hook FIRED" assertable (#1086) ------------------
+
+
+BEACON = REPO_ROOT / "scripts" / "hooks" / "workflow" / "kit-hooks-alive.sh"
+
+
+def test_beacon_hook_exists_and_is_executable() -> None:
+    assert BEACON.is_file(), f"missing beacon hook: {BEACON}"
+    assert os.access(BEACON, os.X_OK), f"beacon hook is not executable: {BEACON}"
+
+
+def test_beacon_writes_its_marker_by_running(tmp_path: Path) -> None:
+    """The marker must be a side effect of EXECUTION.
+
+    That is the entire point: a settings file naming a hook proves nothing, and
+    in #1086 the file named every right hook for the wrong reason.
+    """
+    home = tmp_path / "beaconhome"
+    (home / ".claude").mkdir(parents=True)
+    proc = subprocess.run(
+        ["bash", str(BEACON)], capture_output=True, text=True, timeout=30,
+        env={**os.environ, "HOME": str(home)},
+    )
+    assert proc.returncode == 0
+    marker = home / ".claude" / ".kit-hooks-alive"
+    assert marker.is_file(), "the beacon did not write its marker"
+    assert marker.read_text().strip(), "the marker is empty — no timestamp recorded"
+
+
+def test_beacon_is_silent_on_stdout() -> None:
+    """SessionStart stdout becomes additionalContext in the agent's window. A
+    beacon that spends context would tax every session for the life of the kit."""
+    home = os.environ.get("HOME", "/tmp")
+    proc = subprocess.run(
+        ["bash", str(BEACON)], capture_output=True, text=True, timeout=30,
+        env={**os.environ, "HOME": home},
+    )
+    assert proc.stdout == "", f"beacon wrote to stdout: {proc.stdout!r}"
+
+
+def test_beacon_is_wired_into_the_settings_template() -> None:
+    """Shipping the script without registering it is the declared-but-not-wired
+    shape this repo keeps producing (#1076 above all)."""
+    import json as J
+
+    tmpl = J.loads((REPO_ROOT / "config" / "settings.template.json").read_text())
+    cmds = [
+        h.get("command", "")
+        for g in tmpl["hooks"]["SessionStart"]
+        for h in g.get("hooks", [])
+    ]
+    assert any("kit-hooks-alive.sh" in c for c in cmds), (
+        "the beacon is not registered in settings.template.json — it would ship inert"
+    )
+
+
+def test_tilde_and_absolute_forms_of_one_hook_register_once(tmp_path: Path) -> None:
+    """Two commands that RESOLVE to the same script are one hook.
+
+    Not hypothetical — measured live. The image bakes wtf-post-tool-use.sh under
+    BOTH ``~/.local/share/...`` (settings.template.json) and
+    ``/home/ubuntu/.local/share/...`` (added at build time), and the shared
+    settings already carried the absolute form. A string-keyed dedup called those
+    two different hooks and registered the second, so it fired TWICE on every
+    tool use. A merge that introduces duplicate execution is not preserving the
+    release's wiring — it is corrupting it.
+    """
+    import json as J
+
+    home, cfgdir = _home_with_cfgdir(tmp_path)
+    # The image ships both spellings, exactly as the real one does.
+    (home / ".claude" / "settings.json").write_text(J.dumps({"hooks": {"PostToolUse": [
+        {"matcher": "", "hooks": [{"type": "command", "command": "~/hook.sh"}]},
+        {"matcher": "", "hooks": [
+            {"type": "command", "command": str(home) + "/hook.sh"}]},
+    ]}}))
+    (home / "hook.sh").write_text("#!/bin/sh\nexit 0\n")
+    ws = tmp_path / "ws"; ws.mkdir()
+    proc = _run_cfgdir(home, cfgdir, ws, HOME=str(home))
+    assert proc.returncode == 0, proc.stderr
+
+    got = _hook_commands(J.loads((cfgdir / "settings.json").read_text()), "PostToolUse")
+    assert len(got) == 1, f"the same hook registered {len(got)} times: {got}"
+
+
+def test_absolute_form_already_present_blocks_the_tilde_form(tmp_path: Path) -> None:
+    """The destination's spelling wins when both name the same script.
+
+    This is the live case: the shared settings carried the absolute path (a
+    by-hand #1085 fix) and the image ships the tilde form. Adding the tilde form
+    on top is what doubled the hook.
+    """
+    import json as J
+
+    home, cfgdir = _home_with_cfgdir(tmp_path)
+    (home / ".claude" / "settings.json").write_text(J.dumps({"hooks": {"PostToolUse": [
+        {"matcher": "", "hooks": [{"type": "command", "command": "~/hook.sh"}]}]}}))
+    (home / "hook.sh").write_text("#!/bin/sh\nexit 0\n")
+    (cfgdir / "settings.json").write_text(J.dumps({"hooks": {"PostToolUse": [
+        {"matcher": "", "hooks": [
+            {"type": "command", "command": str(home) + "/hook.sh"}]}]}}))
+    ws = tmp_path / "ws"; ws.mkdir()
+    assert _run_cfgdir(home, cfgdir, ws, HOME=str(home)).returncode == 0
+
+    got = _hook_commands(J.loads((cfgdir / "settings.json").read_text()), "PostToolUse")
+    assert got == [("", str(home) + "/hook.sh")], f"tilde form was added on top: {got}"

--- a/tests/contained-workflow/test_mounts.py
+++ b/tests/contained-workflow/test_mounts.py
@@ -87,12 +87,12 @@ def test_sandbox_scoped_flag_applies_guard_to_any_layer() -> None:
     """The R-03 guard fires on any mount flagged ``sandbox_scoped``, not only the
     memory layer — a durable-cache mislabeled into the live tree is still caught."""
     entry = {
-        "name": "settings-local",
+        "name": "stray-shared-file",
         "layer": "shared-mutable-rw",
         "mode": "rw",
         "sandbox_scoped": True,
-        "source": "~/.claude/settings.local.json",
-        "target": "/home/ubuntu/.claude/settings.local.json",
+        "source": "~/.claude/some-shared-file.json",
+        "target": "/home/ubuntu/.claude/some-shared-file.json",
     }
     with pytest.raises(mr.ManifestError, match="R-03"):
         _resolve_one(entry)
@@ -265,6 +265,26 @@ def test_manifest_resolves() -> None:
     # docker -v rendering round-trips (ro suffix only on ro mounts).
     assert mcp.to_docker_volume().endswith(":ro")
     assert not by_name["memory"].to_docker_volume().endswith(":ro")
+
+
+def test_manifest_declares_no_user_level_settings_local(tmp_path: Path) -> None:
+    """No mount may target a user-level ``settings.local.json`` (#1086).
+
+    There is no such file. ``localSettings`` is PROJECT-scoped — the CLI reads
+    ``<project>/.claude/settings.local.json`` — and a settings.local.json beside
+    the USER settings.json is never read, under aoe or natively. The removed
+    mount carried ``{}`` on every profile for its whole life, so nothing noticed.
+
+    Pinned as a test rather than trusted to memory: it resolves cleanly, looks
+    exactly like the memory mount beside it, and would be re-added by anyone
+    reading Dev Spec §5.3's "settings.json is split" in good faith.
+    """
+    resolved = mr.resolve_manifest(MAJOR, home=FAKE_HOME, mounts_dir=MANIFEST_DIR)
+    offenders = [m.name for m in resolved if m.target.endswith("/settings.local.json")]
+    assert not offenders, (
+        f"mount(s) {offenders} target a user-level settings.local.json, which the "
+        f"CLI never reads — dead weight that reads as a working shared-knobs seam"
+    )
 
 
 def test_manifest_dir_exists() -> None:


### PR DESCRIPTION
## Summary

Under aoe the CLI reads `$CLAUDE_CONFIG_DIR/settings.json` and never the image's baked copy, so R-06 — "hook wiring is versioned with the release" — did not hold. bootstrap now merges the image's hooks into the file the CLI actually reads, and `aoe-preflight.sh` asserts a kit hook **executed** rather than merely appearing in a settings file. The R-03 `settings.local.json` mount is removed: there is no user-level file by that name.

## Two corrections to the issue's premise

**The kit's hooks were not silent.** `$CLAUDE_CONFIG_DIR` resolves to `~/.claude/sandbox` — a sandbox-dedicated host directory, not the operator's `~/.claude` — and it had been seeded from a host carrying the same kit. An equivalent hook set was already sitting in it, and `~/` resolves to `/home/ubuntu` in-container, so they fired.

The real defect is **version skew**: a hook the image adds, renames or repoints stays on the operator's host timetable rather than the release's, and nothing reports the divergence. R-06 held *by coincidence*, which is not the same as holding, and a promotion gate must not rest on one.

**`settings.local.json` could not be fixed, only removed.** `localSettings` is project-scoped. Measured against the shipped CLI in one run, with three such files planted at once:

| file | hook fired? |
|---|---|
| `$CLAUDE_CONFIG_DIR/settings.json` | **yes** |
| `<project>/.claude/settings.local.json` | **yes** |
| `$CLAUDE_CONFIG_DIR/settings.local.json` | **no** |

Independently, `claude doctor` names a malformed *project* `settings.local.json` and stays silent on a malformed one beside the user settings — with the instrument proven able to fail first, by malforming `$CLAUDE_CONFIG_DIR/settings.json` and watching it report `Invalid settings`. The mount was never read, aoe or not, and carried `{}` on every profile for its entire life.

## Changes

- **`bootstrap.sh`** — Stage 3 replaced: `sync_kit_hooks()` merges the image's `hooks` into `$CLAUDE_CONFIG_DIR/settings.json`, mirroring `sync_kit_registrations`. Additive and `flock`-guarded (the destination is shared by every container and carries aoe's own `AOE_INSTANCE_ID` status hooks plus the operator's theme/model/permissions), with a `.pre-bootstrap` recovery copy and an in-place write. Host-only hooks are deliberately never deleted — the strong reading of "image-authoritative" would break aoe's TUI; `validate_hook_paths` already reports stale entries.
- **Dedup keys on `(matcher, resolved path)`.** Per-matcher because the kit registers one script under several matchers (`context-freshness-warn.sh` ships under both `startup` and `resume`); resolved-path because the image bakes `wtf-post-tool-use.sh` under *both* `~/.local/share/…` and `/home/ubuntu/.local/share/…`. A raw-string key called those two different hooks and registered the second, making it fire twice per tool use — caught by diffing live shared state, not by a test. The image-side duplicate is filed as #1094.
- **`kit-hooks-alive.sh`** (new) — SessionStart beacon writing `~/.claude/.kit-hooks-alive` by executing. Silent (SessionStart stdout becomes additionalContext), always exits 0, marker in the image's own `$HOME` so it is unambiguously *this* container's.
- **`aoe-preflight.sh`** — check 8 asserts a kit hook fired, clearing the marker first and proving the clear worked.
- **`mounts.d/10-memory.toml`** — `settings-local` mount removed, with the measurement recorded in place.
- **`architecture.md`** — §3.3 rewritten (one file, merged by us); §3.5.1's "known, deliberate gap" closed.

## Linked Issues

Closes #1086
Follow-up filed: #1094

## Test Plan

Everything below was run, not merely available.

- **`./scripts/ci/validate.sh`** — 229 passed, 0 failed.
- **`pytest tests/`** — 2011 passed / 5 skipped / 64 xfailed, plus `test_install.py` 16 passed (471s, single process — it shares state and must not be split), plus 294 in `tests/contained-workflow/`.
- **`aoe-preflight.sh` against the rebuilt image — 12/12 through aoe**, beacon reporting a live timestamp.
- **Red-first: the same preflight against the pre-#1086 image — 11 PASS, check 8 FAIL.** Including `[PASS] all configured hook paths resolve`. Every settings-shaped check reports healthy; only the execution check sees the defect. The beacon is new in this release, so it cannot be present in a host-seeded settings file — that is what makes it its own control.
- **Mutation-tested, both directions.** Removing the `sync_kit_hooks` call from `main` fails all 6 merge tests; reverting the dedup key to the raw command string fails both path-dedup tests. One assertion was found *passing under mutation* (it matched `validate_hook_paths`' output rather than the merge's) and was tightened.
- **Live shared state verified and restored.** The merge writes to `~/.claude/sandbox/settings.json`. Before/after diff confirms all 24 non-hook keys byte-identical, nothing removed, exactly one addition (the beacon). The first run's duplicate was rolled back from the `.pre-bootstrap` copy, verified byte-identical to an independent pre-merge snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS