### PR TITLE
fix(ci): cut image candidates on release, not on every merge

### DIFF
--- a/.github/workflows/oakandwave-workflow-image.yml
+++ b/.github/workflows/oakandwave-workflow-image.yml
@@ -13,14 +13,37 @@
 # All build/sign logic lives in scripts/ci/*.sh (project rule: No Procedural Logic
 # in CI/CD YAML); the steps below only wire installer actions to those scripts.
 #
-# Trigger: merge to main and version tags rebuild the candidate; workflow_dispatch
-# allows a manual rebuild. It does NOT run on the kahuna integration branches, so
-# a wave never triggers a heavy push to ghcr.
+# TRIGGER: a candidate is cut DELIBERATELY, not on every merge (#1063).
+#
+# This used to include `push: branches: [main]`. Every merge — docs-only ones
+# included — ran build -> cosign -> syft -> GHCR push against a ~9.9 GB base.
+# Measured on a markdown-only merge (cc57a75, PR #1060): 1049 s / 17.5 min. Two
+# costs, and the first is the expensive one:
+#
+#   1. THROUGHPUT. /scpmmr waits on the main-branch pipeline, so every agent in
+#      the fleet paid ~17.5 min per merge — the inner loop for every kit change.
+#   2. REGISTRY CLUTTER. Every merge since this workflow landed minted an :edge
+#      that nothing would ever pull.
+#
+# NOT a `paths:` filter, deliberately. The kit is BAKED into the image, so
+# `skills/**` and `scripts/**` genuinely do change it — a filter would either be
+# so broad it saved little, or would silently ship a stale :stable. "Did we
+# decide to release?" is the correct axis, not "which files moved".
+#
+# The bless-and-promote path already existed end to end and is untouched:
+# scripts/ci/promote-oakandwave-image.sh retags the EXACT digest :edge -> :stable
+# with no rebuild (same bytes, R-23), and the mirror workflow only ever mirrors an
+# already-promoted :stable. The only defect was minting candidates on merge rather
+# than on a release decision — which also matches R-05 ("the image digest IS the
+# release") more honestly than minting a release artifact for a typo fix.
+#
+# Merging to main is NOT a release. See docs/operations/image-release-cadence.md.
+# It does NOT run on the kahuna integration branches either, so a wave never
+# triggers a heavy push to ghcr.
 name: oakandwave-workflow image
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
 

--- a/docs/operations/image-release-cadence.md
+++ b/docs/operations/image-release-cadence.md
@@ -1,0 +1,127 @@
+# Image release cadence — a merge is not a release
+
+**A candidate image is cut deliberately.** Merging to `main` does not build one,
+does not sign one, and does not push one to GHCR. Only a version tag or a manual
+dispatch mints a candidate, and only an explicit promote turns a candidate into
+`:stable`.
+
+This page is the operator-facing half of #1063. The trigger's own header comment
+in `.github/workflows/oakandwave-workflow-image.yml` carries the rationale;
+`tests/contained-workflow/test_image_release_cadence.py` pins it.
+
+## Why it changed
+
+Every push to `main` used to run build → cosign sign → syft SBOM → GHCR push
+against a ~9.9 GB base. Measured on a **markdown-only** merge (`cc57a75`,
+PR #1060): **1049 s / 17.5 min**.
+
+Two costs, and the first is the expensive one:
+
+1. **Throughput.** `/scpmmr` waits on the main-branch pipeline, so *every agent*
+   paid ~17.5 min per merge. Post-cutover that is the inner loop for every kit
+   change, multiplied across the fleet.
+2. **Registry clutter.** Every merge since the workflow landed minted an `:edge`
+   that nothing would ever pull.
+
+It also reads better against **R-05 — the image digest *is* the release.**
+Minting a signed, SBOM'd release artifact for a typo fix was never what that
+invariant meant.
+
+### Why not a `paths:` filter
+
+Because the kit is **baked into the image**. `skills/**`, `scripts/**`,
+`config/**` and the container sources genuinely change what ships, so a filter is
+either broad enough to save almost nothing, or narrow enough to **silently ship a
+stale `:stable`** — a correctness bug wearing a performance fix's clothes.
+
+The right axis is *"did we decide to release?"*, not *"which files moved?"*.
+
+## The three steps
+
+| step | what runs | what it produces |
+|---|---|---|
+| **1. Cut a candidate** | push a `v*` tag, or run the workflow via `workflow_dispatch` | `:edge` at a new digest, signed + SBOM'd |
+| **2. Test the candidate** | `scripts/ci/aoe-preflight.sh <profile>` against that digest, plus the throwaway CI ring | a pass/fail on the exact bytes |
+| **3. Promote** | `scripts/ci/promote-oakandwave-image.sh` | `:stable` retagged to the **same digest** |
+
+Step 3 is `docker buildx imagetools create` — a retag, never a rebuild. **The
+digest tested is the digest promoted (R-23).** If promotion ever grows a build
+step, that invariant is gone; the oracle asserts it has not.
+
+## Cutting a candidate by hand
+
+```bash
+gh workflow run "oakandwave-workflow image" --repo Wave-Engineering/claudecode-workflow
+```
+
+Manual dispatch exists so that testing a build does not require pretending to
+release. Use it for anything you want to exercise before a tag.
+
+## What this means day to day
+
+- **Merging kit changes to `main` is cheap again.** Main still runs `validate`;
+  it just no longer builds an image.
+- **`:stable` does not move on its own.** It changes only when someone promotes,
+  which is the point — the fleet's pinned digest stays put until a human decides.
+- **`main` can be ahead of `:stable`.** That is normal and expected now. If you
+  need a container carrying an unreleased change, cut a candidate by hand.
+- **Before pinning a profile to a new digest**, run `aoe-preflight.sh` against it.
+  Verifying through `aoe` rather than around it is the standing rule
+  (`docs/contained-workflow/architecture.md` §3.5.1).
+
+## Registry hygiene — and the trap in it
+
+Accumulated `:edge` digests from the old every-merge behaviour are dead weight:
+each is a full image layer set nothing will pull. Measured 2026-08-01:
+
+| | count |
+|---|---|
+| total versions | **228** |
+| untagged | **143** |
+| cosign `.sig` / `.att` artifacts | 84 |
+| real named tags | **1** (`edge`) |
+
+### DO NOT "prune all untagged versions"
+
+That is the standard GHCR cleanup recipe and **it would have deleted the image
+the live fleet was running.** Measured on the same day:
+
+```
+profile dogfood → ghcr.io/…/oakandwave-workflow@sha256:7e615dd0…
+profile mv05    → ghcr.io/…/oakandwave-workflow@sha256:7e615dd0…
+
+that digest in GHCR:  tags=[]      ← UNTAGGED
+```
+
+A profile pins a **bare digest**. Pinning by digest is correct — it is what makes
+the release immutable (R-05/R-23) — but it leaves no tag behind, so the pinned
+image is indistinguishable from garbage to any tag-based retention rule.
+**Untagged does not mean unused.**
+
+So pruning is deliberately manual and operator-driven. An automated retention
+policy cannot see the operator's profile pins and would eventually delete one out
+from under a running fleet — the failure arriving at the *next container launch*,
+long after the prune, with nothing connecting the two.
+
+**Always enumerate the pins first:**
+
+```bash
+grep -h default_image ~/.config/agent-of-empires/profiles/*/config.toml
+```
+
+Everything in that list must survive, plus the current `:edge`, plus whatever
+`:stable` points at, plus each survivor's `.sig` and `.att` artifacts (a signature
+orphaned from its subject verifies nothing).
+
+### `:stable` does not exist yet
+
+As of 2026-08-01 there is **no `:stable` tag** anywhere in the 228 versions — the
+bless-and-promote path is implemented end to end but has never been run, and the
+profiles pin bare digests instead. Two consequences:
+
+- Nothing is protected by "keep whatever `:stable` points at" today, because it
+  points at nothing. The profile pins are the *only* thing standing between a
+  prune and a broken fleet.
+- The first real promote is also the first exercise of that path. Run it against a
+  candidate you have already preflighted, and verify `:stable` resolves to the
+  digest you expect before pointing any profile at it.

--- a/tests/contained-workflow/test_image_release_cadence.py
+++ b/tests/contained-workflow/test_image_release_cadence.py
@@ -1,0 +1,125 @@
+"""Oracle for the image release cadence (#1063).
+
+A candidate image is cut **deliberately** — on a version tag or a manual
+dispatch — never on every merge to main. Before this, each merge ran
+build → cosign → syft → GHCR push on a ~9.9 GB base: 1049 s / 17.5 min measured
+on a markdown-only merge (cc57a75, PR #1060). `/scpmmr` waits on the main-branch
+pipeline, so the whole fleet paid that per merge.
+
+**These tests PARSE the workflow, they do not grep it.** The trigger's own
+explanatory comment now contains the literal string ``branches: [main]`` —
+describing what was removed and why. A substring or regex check would match that
+prose and report the defect present while the config is correct, which is the
+same instrument-reads-its-own-advice failure this repo keeps producing
+(bootstrap's hook validator matching its own warning text, cc-workflow#925's
+gate matching its own output). Parsing asks the config, not the commentary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip(
+    "yaml",
+    reason="PyYAML is required to parse the workflow — a regex fallback would "
+    "match the trigger's own explanatory comment and assert nothing",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "oakandwave-workflow-image.yml"
+
+
+def _triggers() -> dict:
+    """The workflow's `on:` block, as data.
+
+    YAML 1.1 resolves the bare key ``on`` to the boolean ``True`` (the
+    Norway-problem family), so PyYAML hands it back under ``True`` rather than
+    ``"on"``. Look under both — a lookup for only ``"on"`` returns ``None`` here
+    and every assertion below would then pass over an empty dict, which is the
+    empty-denominator shape rather than a result.
+    """
+    doc = yaml.safe_load(IMAGE_WORKFLOW.read_text())
+    on = doc.get("on", doc.get(True))
+    assert isinstance(on, dict), (
+        f"could not read the workflow's trigger block (got {type(on).__name__}) — "
+        f"refusing to assert against nothing"
+    )
+    return on
+
+
+def test_image_workflow_exists() -> None:
+    assert IMAGE_WORKFLOW.is_file(), f"missing workflow: {IMAGE_WORKFLOW}"
+
+
+def test_merging_to_main_does_not_cut_a_candidate() -> None:
+    """The defect itself: a merge is not a release.
+
+    Docs-only merges minted a signed, SBOM'd release artifact nothing would pull,
+    and blocked every agent's `/scpmmr` for ~17.5 min doing it.
+    """
+    push = _triggers().get("push") or {}
+    assert "branches" not in push, (
+        "the image workflow triggers on a branch push again — every merge to "
+        f"main will mint an :edge and block /scpmmr ~17.5 min (got {push!r})"
+    )
+
+
+def test_a_version_tag_still_cuts_a_candidate() -> None:
+    push = _triggers().get("push") or {}
+    assert push.get("tags") == ["v*"], (
+        f"a version tag must still build a candidate (got tags={push.get('tags')!r})"
+    )
+
+
+def test_a_candidate_can_still_be_cut_by_hand() -> None:
+    """Without this, the only way to get an image is to cut a real version tag —
+    which would make testing a build require pretending to release."""
+    on = _triggers()
+    assert "workflow_dispatch" in on, "manual dispatch must remain available"
+
+
+def test_no_paths_filter_smuggled_in() -> None:
+    """A `paths:` filter is the wrong axis and was rejected on the merits.
+
+    The kit is BAKED into the image, so `skills/**` and `scripts/**` genuinely do
+    change it. A filter would either be broad enough to save little, or would
+    silently ship a stale :stable — a correctness bug wearing a performance fix's
+    clothes. The axis is "did we decide to release", not "which files moved".
+    """
+    push = _triggers().get("push") or {}
+    assert "paths" not in push and "paths-ignore" not in push, (
+        "a paths filter cannot decide whether an image is stale — the kit is "
+        "baked in, so nearly every path changes the image"
+    )
+
+
+def test_the_promote_path_is_untouched() -> None:
+    """#1063 is a TRIGGER change, not a build change.
+
+    `promote-oakandwave-image.sh` retags the exact digest :edge → :stable with no
+    rebuild (same bytes, R-23). If this fix ever grows into "rebuild on promote",
+    the digest tested stops being the digest promoted.
+    """
+    promote = REPO_ROOT / "scripts" / "ci" / "promote-oakandwave-image.sh"
+    assert promote.is_file(), "the promote script must still exist"
+    text = promote.read_text()
+    assert "buildx imagetools create" in text or "imagetools" in text, (
+        "promote must retag by digest, never rebuild"
+    )
+    assert "build-oakandwave-image.sh" not in text, (
+        "promote must not invoke a build — that would break digest-exactness (R-23)"
+    )
+
+
+def test_release_cadence_is_documented() -> None:
+    """The cadence is now a human contract ('a merge is not a release'), and an
+    undocumented contract is one nobody can follow."""
+    runbook = REPO_ROOT / "docs" / "operations" / "image-release-cadence.md"
+    assert runbook.is_file(), f"missing ops runbook: {runbook}"
+    text = runbook.read_text().lower()
+    assert "not a release" in text, "the runbook must state that a merge is not a release"
+    assert "workflow_dispatch" in text or "manual" in text, (
+        "the runbook must say how to cut a candidate deliberately"
+    )


### PR DESCRIPTION
## Summary

The image workflow triggered on every push to `main`, so each merge ran build → cosign → syft → GHCR push against a ~9.9 GB base. Measured on a **markdown-only** merge (`cc57a75`, PR #1060): **1049 s / 17.5 min**. `/scpmmr` waits on the main-branch pipeline, so every agent paid that per merge — the inner loop for every kit change — and every merge minted an `:edge` nothing would pull.

Trigger is now `tags: ["v*"]` + `workflow_dispatch`. **Pure trigger change**; the bless-and-promote path is untouched.

## Changes

- `.github/workflows/oakandwave-workflow-image.yml` — drop the main-push trigger, with the rationale in the header.
- `docs/operations/image-release-cadence.md` (new) — the three steps (cut → test → promote), what changes day to day, and registry hygiene.
- `tests/contained-workflow/test_image_release_cadence.py` (new) — 7 cases pinning the trigger contract.

**Not a `paths:` filter, deliberately.** The kit is baked into the image, so `skills/**` and `scripts/**` genuinely change it — a filter would either save little or **silently ship a stale `:stable`**, a correctness bug wearing a performance fix's clothes. The axis is "did we decide to release", not "which files moved". It also reads better against **R-05**: minting a signed, SBOM'd release artifact for a typo fix was never what "the digest *is* the release" meant.

## The tests parse the workflow; they do not grep it

The trigger's own comment now contains the literal `branches: [main]`, explaining what was removed. A substring or regex assertion would **match its own explanation** and report the defect present while the config is correct — the same instrument-reads-its-own-advice failure as bootstrap's hook validator matching its own warning text, and #925's gate matching its own output.

Verified by mutation in both directions: restoring the main-push trigger turns `test_merging_to_main_does_not_cut_a_candidate` red, and the reverted file still contains that literal exactly once while all 7 pass.

There is also a guard that promotion never grows a build step — if it did, the digest tested would stop being the digest promoted (R-23).

## One AC is deliberately not executed: the GHCR prune

⚠️ **Do not run "prune all untagged versions" on this package.** Enumerating before acting is what caught it:

```
dogfood → …/oakandwave-workflow@sha256:7e615dd0…
mv05    → …/oakandwave-workflow@sha256:7e615dd0…

that digest in GHCR:  tags=[]     ← UNTAGGED
```

143 of 228 versions are untagged, and the fleet's pinned digest is one of them. The standard recipe — and any automated retention policy — **would delete the image the live fleet runs**, with the failure surfacing at the next container launch, disconnected from the prune that caused it. Pinning by digest is correct; it just leaves no tag behind, so a pinned image is indistinguishable from garbage to a tag-based rule. **Untagged does not mean unused.**

Second finding: **no `:stable` tag exists** across all 228 versions. The promote path is implemented end to end but has never been run — profiles pin bare digests instead. So "keep whatever `:stable` points at" protects nothing today, and the first promote will also be the first exercise of that path.

Deleting registry artifacts is irreversible and outward-facing, so it stays with the operator. The runbook documents the safe procedure and the enumeration command; the AC is left unchecked rather than silently dropped.

## Linked Issues

Closes #1063
Supersedes #946 (its premise — "this repo has no main-branch pipeline" — is stale; `validate` still runs on main, only the image build is gone).

## Test Plan

- `./scripts/ci/validate.sh` — **229 passed, 0 failed**.
- `python3 -m pytest tests/ --ignore=tests/test_install.py` — **2018 passed**, 5 skipped, 64 xfailed.

Both lanes deliberately: `validate.sh` does **not** run pytest in this repo, and running only it is how I shipped a red PR earlier today (#1097).

- Mutation-tested as described above.
- `promote-oakandwave-image.sh` inspected: still `docker buildx imagetools create`, digest-exact, no rebuild.
- The behavioural AC — "merge a docs-only change → no image build" — is observable on this PR's own merge, which changes no image inputs. I'll confirm it against the actual main-push after landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS