### PR TITLE
fix(deps): make an empty dependency-scan denominator fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,10 @@ __pycache__/
 
 # Node/Bun dependencies
 node_modules/
-bun.lock
+# bun.lock is COMMITTED, not ignored (#1073). Trivy parses lockfiles rather
+# than manifests, because a manifest carries ranges (`^5.7.0`) and a lockfile
+# carries the resolved version. Ignoring it meant the dependency gate had
+# nothing to scan and said so on every run for eleven days.
 .install-stamp
 .buildinfo
 

--- a/scripts/ci/check-scannable.sh
+++ b/scripts/ci/check-scannable.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# check-scannable.sh — fail when the dependency gate would examine NOTHING (#1073).
+#
+# WHY THIS EXISTS.
+#
+# A scan over zero manifests and a scan finding zero vulnerabilities produce the
+# SAME verdict shape. On 2026-07-19 an agent reported "PASS — zero HIGH or
+# CRITICAL" for a repo where trivy had parsed zero manifests; it had been masking
+# an unscanned tree for months, and the gate's silence and the defect were the
+# same event. cc-workflow itself then reported "0 manifests" on every /precheck
+# for ELEVEN DAYS across FIVE filings (#922, #941, #944, #1053, #1056) — reported
+# accurately every time, and read as noise every time, because an honest report
+# that changes no outcome is indistinguishable from no report at all.
+#
+# So the denominator stops being advisory. If nothing is scannable, this exits 1.
+#
+# WHAT IT CHECKS — shapes, not filenames.
+#
+# The FILES are ecosystem-specific (bun.lock, go.sum, Cargo.lock, poetry.lock…)
+# and pinning one repo's Python does nothing for a Go repo. But two SHAPES
+# generalise, and they are the two that produced every filing above:
+#
+#   1. a package manifest with NO LOCKFILE beside it — the manifest carries
+#      ranges (`^5.7.0`), and a range is not an installed version, so there is
+#      nothing to match a CVE against;
+#   2. a requirements.txt with UNPINNED entries — `flask` resolves to no version,
+#      so the file parses to zero packages. Not a trivy limitation: there is
+#      genuinely nothing to compare against a vulnerability database.
+#
+# ABSENCE MUST BE DECLARED, NOT INFERRED.
+#
+# Some repos legitimately have nothing to scan, and that must not read the same
+# as "nobody pinned anything." A repo with genuinely no scannable dependencies
+# writes .no-scannable-dependencies at its root, containing the reason. Exactly
+# the shape of OAW_REQUIRED_SECRETS="" (#1061): declaring "none" is legitimate,
+# OMITTING the declaration is not.
+#
+# WHAT IT DELIBERATELY DOES NOT DO.
+#
+# It does not run trivy and it does not judge vulnerabilities. It answers one
+# question — "would a scan have anything to look at?" — so that a PASS from the
+# real scanner means something. Keeping the two separate is the point: a gate
+# that both measures and grades can hide an empty denominator inside a pass.
+#
+# Usage:  scripts/ci/check-scannable.sh [repo_root]
+# Exit:   0 something is scannable, or absence is declared
+#         1 nothing scannable and no declaration — the gate would examine nothing
+set -uo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$ROOT" || {
+	echo "check-scannable: cannot enter $ROOT" >&2
+	exit 1
+}
+
+DECLARATION=".no-scannable-dependencies"
+
+# Prune vendored/build trees. A package.json inside node_modules is a
+# DEPENDENCY's manifest, not ours: counting it would let a vendored tree satisfy
+# the gate for a repo that pins nothing of its own, and every one of them reports
+# UNSCANNABLE (they ship no lockfile), burying the repo's real state in noise.
+#
+# -name, NOT -path. The first cut used `-path ./node_modules`, which matches only
+# a node_modules at the REPO ROOT — so ./scripts/wave-watcher/node_modules sailed
+# through and five dependency manifests were judged as if they were ours.
+# Directory NAME matches at any depth; a path pattern has to guess the depth.
+PRUNE=(-name node_modules -o -name .git -o -name dist -o -name build
+	-o -name vendor -o -name .venv -o -name venv -o -name target)
+
+find_files() {
+	find . \( "${PRUNE[@]}" \) -prune -o -type f -name "$1" -print 2>/dev/null
+}
+
+scannable=0
+declare -a REPORT=()
+
+# --- shape 1: a manifest with a lockfile beside it ---------------------------
+# Presence of the lockfile is the test, not its contents. A lockfile whose
+# packages are all devDependencies yields no trivy Results today (measured:
+# scripts/wave-watcher), but the repo is still doing the right thing and the
+# moment a runtime dependency lands it becomes scannable with no further action.
+while IFS= read -r manifest; do
+	[[ -n "$manifest" ]] || continue
+	dir="$(dirname "$manifest")"
+	found_lock=""
+	for lock in bun.lock bun.lockb package-lock.json yarn.lock pnpm-lock.yaml; do
+		[[ -f "$dir/$lock" ]] && {
+			found_lock="$lock"
+			break
+		}
+	done
+	if [[ -n "$found_lock" ]]; then
+		scannable=$((scannable + 1))
+		REPORT+=("  [scannable] $dir/$found_lock")
+	else
+		REPORT+=("  [UNSCANNABLE] $manifest — no lockfile beside it; a manifest carries ranges, not versions")
+	fi
+done < <(find_files 'package.json')
+
+for pair in "go.mod:go.sum" "Cargo.toml:Cargo.lock"; do
+	manifest_name="${pair%%:*}"
+	lock_name="${pair##*:}"
+	while IFS= read -r manifest; do
+		[[ -n "$manifest" ]] || continue
+		dir="$(dirname "$manifest")"
+		if [[ -f "$dir/$lock_name" ]]; then
+			scannable=$((scannable + 1))
+			REPORT+=("  [scannable] $dir/$lock_name")
+		else
+			REPORT+=("  [UNSCANNABLE] $manifest — no $lock_name beside it")
+		fi
+	done < <(find_files "$manifest_name")
+done
+
+# --- shape 2: requirements.txt with pinned entries ---------------------------
+# `==` only. `>=` and `~=` are ranges, and a range is not an installed version,
+# so they parse to nothing for the same reason a bare name does.
+while IFS= read -r req; do
+	[[ -n "$req" ]] || continue
+	pinned="$(grep -cE '^[[:space:]]*[A-Za-z0-9._-]+[[:space:]]*===?[[:space:]]*[0-9]' "$req" 2>/dev/null || true)"
+	entries="$(grep -cE '^[[:space:]]*[A-Za-z0-9._-]+' "$req" 2>/dev/null || true)"
+	if [[ "$pinned" =~ ^[0-9]+$ ]] && ((pinned > 0)); then
+		scannable=$((scannable + 1))
+		REPORT+=("  [scannable] $req — $pinned pinned entr$([[ $pinned -eq 1 ]] && echo y || echo ies)")
+	elif [[ "$entries" =~ ^[0-9]+$ ]] && ((entries > 0)); then
+		REPORT+=("  [UNSCANNABLE] $req — entries present but none pinned with '=='; trivy matches CVEs against versions")
+	fi
+done < <(find_files 'requirements*.txt')
+
+# --- verdict ------------------------------------------------------------------
+# DENOMINATOR FIRST, ALWAYS — before any verdict, and on every path including the
+# passing one. The entire failure this guards against is a verdict printed
+# without the count that qualifies it.
+echo "check-scannable: ${scannable} scannable manifest(s) in $ROOT"
+((${#REPORT[@]})) && printf '%s\n' "${REPORT[@]}"
+
+if ((scannable > 0)); then
+	exit 0
+fi
+
+if [[ -s "$DECLARATION" ]]; then
+	echo "check-scannable: nothing scannable, but absence is DECLARED in $DECLARATION:"
+	sed 's/^/    /' "$DECLARATION"
+	exit 0
+fi
+
+# An EMPTY declaration file is not a declaration. It is the same silence with a
+# filename, and accepting it would rebuild the hole one layer out.
+if [[ -f "$DECLARATION" ]]; then
+	echo "check-scannable: $DECLARATION exists but is EMPTY — a declaration must carry a reason" >&2
+fi
+
+cat >&2 <<EOF
+check-scannable: FAIL — nothing in this repo is scannable, and absence is not declared.
+
+  A dependency scan over zero manifests and a scan finding zero vulnerabilities
+  produce the same verdict shape. Until one of the following is true, a PASS from
+  the scanner means nothing:
+
+    * pin a requirements.txt with '==' (a range is not a version), or
+    * commit the lockfile beside a package manifest, or
+    * declare the absence deliberately:
+
+        echo "why this repo has no scannable dependencies" > $DECLARATION
+
+  Declaring "none" is legitimate. Omitting the declaration is not.
+EOF
+exit 1

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -290,6 +290,29 @@ for test_script in "$REPO_DIR"/tests/regression/*.sh; do
 	fi
 done
 
+# --- Dependency scannability (#1073) ------------------------------------------
+#
+# Asks one question — "would a dependency scan have anything to look at?" — and
+# FAILS if the answer is no. It does not run trivy and does not judge
+# vulnerabilities; keeping measurement separate from grading is the point, because
+# a gate that does both can hide an empty denominator inside a pass.
+#
+# It lives HERE, in the lane CI runs, rather than in /precheck's prose. This repo
+# reported "0 manifests" on every precheck for eleven days across five filings
+# (#922, #941, #944, #1053, #1056) — reported accurately every time, and waved
+# through every time. An honest report that changes no outcome is indistinguishable
+# from no report at all, so the denominator now decides the exit code.
+echo ""
+echo "Dependency scannability"
+echo "──────────────────────────────────────────"
+if bash "$REPO_DIR/scripts/ci/check-scannable.sh" "$REPO_DIR"; then
+	info "scripts/ci/check-scannable.sh"
+	PASS=$((PASS + 1))
+else
+	err "scripts/ci/check-scannable.sh — nothing scannable and absence not declared"
+	FAIL=$((FAIL + 1))
+fi
+
 # --- Summary ------------------------------------------------------------------
 echo ""
 echo "──────────────────────────────────────────"

--- a/scripts/wave-watcher/bun.lock
+++ b/scripts/wave-watcher/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "wave-watcher",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/skills/precheck/SKILL.md
+++ b/skills/precheck/SKILL.md
@@ -72,8 +72,20 @@ prompt: "Run: trivy fs --scanners vuln --severity HIGH,CRITICAL --format json --
 
          THEN return one of:
            PASS — one or more manifests parsed, zero findings
-           NO MANIFESTS — trivy ran and parsed ZERO manifests. This is NOT a pass.
-                          Nothing was scanned. Say so; do not report PASS.
+           NO MANIFESTS — trivy ran and parsed ZERO manifests. This is NOT a pass
+                          and, as of #1073, NOT a deferral either: it FAILS the
+                          checklist item. Nothing was scanned. Say so; do not
+                          report PASS.
+                          The enforcing half lives in scripts/ci/check-scannable.sh
+                          (run by validate.sh), which exits 1 when nothing is
+                          scannable and absence is not declared — because an
+                          honest report that changes no outcome is
+                          indistinguishable from no report at all. cc-workflow
+                          emitted this verdict on every precheck for ELEVEN DAYS
+                          across FIVE filings before anyone acted on it.
+                          A repo with genuinely nothing to scan declares it in
+                          .no-scannable-dependencies with a reason; omitting the
+                          declaration is the failure, not having no dependencies.
            SKIP — trivy not installed
            FINDINGS — list each as: package | CVE | severity | fixed_version (or 'no fix available')
          Do not auto-upgrade anything. Just report."

--- a/tests/regression/test_check_scannable.sh
+++ b/tests/regression/test_check_scannable.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# test_check_scannable.sh — oracle for the dependency-scannability gate (#1073).
+#
+# The gate's whole job is to make an empty denominator FAIL instead of passing
+# quietly, so the cases that matter are the failing ones. Each is built red-first
+# in a throwaway tree — a gate only ever exercised against a healthy repo has not
+# been tested, it has been admired.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$HERE/../.." && pwd)"
+GATE="$REPO_DIR/scripts/ci/check-scannable.sh"
+
+PASS=0
+FAIL=0
+ok() {
+	printf '  [PASS] %s\n' "$1"
+	PASS=$((PASS + 1))
+}
+no() {
+	printf '  [FAIL] %s\n' "$1" >&2
+	FAIL=$((FAIL + 1))
+}
+
+# Run the gate and report ONLY its exit code. Never pipe it here: `cmd | tail`
+# yields tail's status, and an early draft of this file "verified" the failure
+# paths through a pipe and read 0 for a gate that had correctly exited 1.
+run_gate() {
+	bash "$GATE" "$1" >/dev/null 2>&1
+	echo $?
+}
+
+echo "test_check_scannable"
+echo "──────────────────────────────────────────"
+
+[[ -x "$GATE" ]] && ok "gate exists and is executable" || no "gate missing or not executable: $GATE"
+
+T="$(mktemp -d)"
+trap 'rm -rf "$T"' EXIT
+
+# --- the defect itself: nothing to scan, nothing declared --------------------
+rc="$(run_gate "$T")"
+[[ "$rc" == "1" ]] && ok "empty tree with no declaration FAILS (rc=$rc)" ||
+	no "empty tree must fail — an empty denominator is not a pass (rc=$rc)"
+
+# --- unpinned requirements.txt is NOT scannable ------------------------------
+mkdir -p "$T/app"
+printf 'flask\nrequests\n' >"$T/app/requirements.txt"
+rc="$(run_gate "$T")"
+[[ "$rc" == "1" ]] && ok "unpinned requirements.txt FAILS (a name is not a version)" ||
+	no "unpinned requirements.txt must fail (rc=$rc)"
+
+# A RANGE is not a version either — this is the case most likely to look pinned.
+printf 'flask>=3.0\nrequests~=2.0\n' >"$T/app/requirements.txt"
+rc="$(run_gate "$T")"
+[[ "$rc" == "1" ]] && ok "ranged requirements.txt FAILS ('>=' and '~=' are not versions)" ||
+	no "ranged requirements.txt must fail (rc=$rc)"
+
+printf 'flask==3.1.3\n' >"$T/app/requirements.txt"
+rc="$(run_gate "$T")"
+[[ "$rc" == "0" ]] && ok "pinned requirements.txt PASSES" ||
+	no "a pinned requirements.txt must satisfy the gate (rc=$rc)"
+rm -rf "$T/app"
+
+# --- package.json without a lockfile is NOT scannable ------------------------
+mkdir -p "$T/svc"
+printf '{"name":"svc","dependencies":{"left-pad":"^1.0.0"}}\n' >"$T/svc/package.json"
+rc="$(run_gate "$T")"
+[[ "$rc" == "1" ]] && ok "package.json with no lockfile FAILS (a range is not a version)" ||
+	no "package.json without a lockfile must fail (rc=$rc)"
+
+printf '{}\n' >"$T/svc/bun.lock"
+rc="$(run_gate "$T")"
+[[ "$rc" == "0" ]] && ok "package.json WITH a lockfile beside it PASSES" ||
+	no "a lockfile beside the manifest must satisfy the gate (rc=$rc)"
+rm -rf "$T/svc"
+
+# --- vendored trees must not satisfy the gate --------------------------------
+# A dependency's own lockfile is not evidence that WE pinned anything. This also
+# guards the prune bug the first draft shipped: `-path ./node_modules` matches
+# only a root-level node_modules, so a nested one leaked five dependency
+# manifests in and reported them as the repo's own.
+mkdir -p "$T/pkg/node_modules/dep"
+printf '{"name":"dep"}\n' >"$T/pkg/node_modules/dep/package.json"
+printf '{}\n' >"$T/pkg/node_modules/dep/bun.lock"
+rc="$(run_gate "$T")"
+[[ "$rc" == "1" ]] && ok "a lockfile inside a NESTED node_modules does not satisfy the gate" ||
+	no "vendored trees must be pruned at any depth, not just the root (rc=$rc)"
+rm -rf "$T/pkg"
+
+# --- absence must be DECLARED, not inferred ----------------------------------
+echo "pure-shell repo; no package manager in use" >"$T/.no-scannable-dependencies"
+rc="$(run_gate "$T")"
+[[ "$rc" == "0" ]] && ok "a declaration carrying a reason PASSES" ||
+	no "declaring 'none' is legitimate and must pass (rc=$rc)"
+
+: >"$T/.no-scannable-dependencies"
+rc="$(run_gate "$T")"
+[[ "$rc" == "1" ]] && ok "an EMPTY declaration FAILS (silence with a filename is still silence)" ||
+	no "an empty declaration must not satisfy the gate (rc=$rc)"
+
+# --- the denominator is always printed, including on success -----------------
+# The failure this whole gate guards against is a verdict without the count that
+# qualifies it, so the count must appear on the passing path too.
+out="$(bash "$GATE" "$REPO_DIR" 2>&1)"
+grep -qE 'scannable manifest\(s\)' <<<"$out" && ok "prints the denominator on the passing path" ||
+	no "the denominator must be printed before any verdict"
+
+echo ""
+if ((FAIL > 0)); then
+	echo "  $FAIL check(s) failed" >&2
+	exit 1
+fi
+echo "  all checks passed"

--- a/tools/cc-inspector/requirements.txt
+++ b/tools/cc-inspector/requirements.txt
@@ -1,3 +1,10 @@
-mitmproxy
-flask
-requests
+# PINNED, not ranged (#1073). Trivy matches CVEs against VERSIONS — an unpinned
+# entry resolves to no version, so the file parses to zero packages and the whole
+# repo reports "0 manifests scanned". That is not a trivy limitation: there is
+# genuinely nothing to compare against a vulnerability database.
+#
+# `==` specifically. `>=` and `~=` are ranges, and a range is not an installed
+# version, so they parse to nothing for the same reason.
+mitmproxy==12.2.3
+flask==3.1.3
+requests==2.34.2


### PR DESCRIPTION
## Summary

trivy has parsed **0 manifests** in this repo on every `/precheck` for eleven days across five filings (#922, #941, #944, #1053, #1056) — reported accurately every time, and waved through every time. **An honest report that changes no outcome is indistinguishable from no report at all**, so the denominator now decides the exit code.

trivy on this branch: **`scanned: 1 manifest — PASS`**. First non-zero denominator this repo has ever produced.

## Changes

**Per-project** — not generalisable; manifests are ecosystem-specific and pinning this repo's Python does nothing for a Go repo:

- `tools/cc-inspector/requirements.txt` pinned with `==`. A bare name resolves to no version, and a range is not a version, so both parse to zero packages.
- `scripts/wave-watcher/bun.lock` committed, and `bun.lock` un-ignored repo-wide. Trivy parses lockfiles rather than manifests precisely because a manifest carries ranges (`^5.7.0`) and a lockfile carries the resolved version.

**Fleetwide** — one fix, lands everywhere `/precheck` installs:

- `scripts/ci/check-scannable.sh` detects the two shapes that generalise even though the files do not — *a manifest with no lockfile beside it*, and *a requirements.txt with no pinned entries* — and exits 1 when nothing is scannable. **Wired into `validate.sh`, so it enforces rather than suggests.**
- Absence must be **declared**: `.no-scannable-dependencies` carrying a reason. Same shape as `OAW_REQUIRED_SECRETS=""` (#1061) — declaring "none" is legitimate, *omitting* the declaration is not. An empty file is rejected; silence with a filename is still silence.
- `/precheck` Job C updated: `NO MANIFESTS` is now a **failure**, not a deferral.

The gate deliberately **does not run trivy and does not judge vulnerabilities**. It answers one question — "would a scan have anything to look at?" — so that a PASS from the real scanner means something. Keeping measurement separate from grading is the point: a gate that does both can hide an empty denominator inside a pass.

## Two defects in my own work, found while building it

**The prune matched only the repo root.** `-path ./node_modules` does not match `./scripts/wave-watcher/node_modules`, so five *dependency* manifests leaked in and were judged as ours. It is `-name` now — directory name matches at any depth, a path pattern has to guess the depth. This is the identical too-literal-path trap `skills/precheck/SKILL.md` documents; there is now a regression case that plants a nested vendored lockfile and asserts it does **not** satisfy the gate.

**My first verification measured `tail`.** I piped the gate through `tail` and read the pipeline's exit status, reporting `0` for a gate that had correctly exited `1`. Re-measured without the pipe; the oracle carries a comment telling the next person not to.

## A measurement worth recording

**Committing `bun.lock` does not make wave-watcher scannable** — trivy returns zero results for it. That is *not* a trivy gap: it scanned `mcp-server-sdlc`'s `bun.lock` as `Type: bun` the same day. wave-watcher has **only devDependencies and no runtime deps**, which trivy excludes by default. It is genuinely dependency-free today. The lockfile is committed anyway so that the moment a real dependency lands, it becomes scannable with no further action.

## Linked Issues

Closes #1073

Consolidates #922, #941, #944, #1053, #1056 — those close against this.

## Test Plan

- `./scripts/ci/validate.sh` — **233 passed, 0 failed** (up from 229: the new gate plus its oracle).
- `python3 -m pytest tests/ --ignore=tests/test_install.py` — **2011 passed**, 5 skipped, 64 xfailed. Both lanes deliberately; `validate.sh` does not run pytest in this repo.
- `tests/regression/test_check_scannable.sh` — **11 cases**, every failure path built red-first in a throwaway tree: empty tree, unpinned requirements, *ranged* requirements (the case most likely to look pinned), manifest-without-lockfile, nested vendored lockfile, empty declaration. A gate only ever exercised against a healthy repo has not been tested.
- Exit codes re-measured without pipelines after the `tail` bug: 1 / 0 / 1 / 0 as intended.

## Note on a separate consequence of #1063

`validate.yml` is `pull_request`-only, so the image build was the **only** workflow running on main push. With #1063 merged, this repo now has **no main-branch pipeline at all** — which makes **#946 live again**, the issue #1063's body claimed to supersede. Flagged, not fixed here; it is a separate changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS