### PR TITLE
feat(contained-workflow): materialise R-11 toolchains into containers

### DIFF
--- a/containers/oakandwave-workflow/Dockerfile
+++ b/containers/oakandwave-workflow/Dockerfile
@@ -29,6 +29,11 @@ ARG GLAB_VERSION=1.53.0
 ARG TRIVY_VERSION=0.72.0
 ARG BAO_VERSION=2.6.0
 ARG AWSCLI_VERSION=2.24.0
+ARG MISE_VERSION=2026.8.0
+# mise publishes `linux-x64`, NOT Go's `amd64`. Reusing ${GOARCH} here 404'd the
+# build (curl exit 22) — the naming conventions genuinely differ per project, so
+# this gets its own arg rather than an assumption that they agree.
+ARG MISE_ARCH=x64
 # The base is linux/amd64; the fetch URLs below are arch-specific. Rebuild with
 # matching ARGs if a multi-arch base is ever introduced.
 ARG GOARCH=amd64
@@ -50,6 +55,23 @@ RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" -o /tm
 	&& ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt \
 	&& rm -f /tmp/go.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
+
+# --- mise (R-11 toolbox installer) --------------------------------------------
+# THE INSTALLER IS BAKED; THE TOOLCHAINS ARE NOT. That distinction is the whole
+# of R-11 (#1092). Baking a JDK would put a Java toolchain in every agent whether
+# or not it touches Java, and would make bumping Maven a KIT RELEASE. mise is one
+# ~30 MB static binary that can materialise JDK / Maven / Node / Go / Python on
+# demand into the durable toolbox mount, where they survive container recreation
+# and are decoupled from the kit's release cadence.
+#
+# Pinned tarball, not the piped installer script (`curl … | sh`) — same rule as
+# trivy and bao above: a build step that executes whatever a URL serves today is
+# not reproducible, and it is the supply-chain surface we are here to avoid.
+RUN curl -fsSL "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-${MISE_ARCH}.tar.gz" -o /tmp/mise.tar.gz \
+	&& tar -C /tmp -xzf /tmp/mise.tar.gz \
+	&& install -m 0755 /tmp/mise/bin/mise /usr/local/bin/mise \
+	&& rm -rf /tmp/mise.tar.gz /tmp/mise \
+	&& mise --version
 
 # --- shellcheck ---------------------------------------------------------------
 RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" -o /tmp/shellcheck.tar.xz \
@@ -139,7 +161,27 @@ ENV HOME=/home/ubuntu
 # The operator's own ~/.local/bin is mounted at .oaw/overlay/local-bin (#1089)
 # and APPENDED — never prepended. The kit's own bin holds the claude wrapper
 # (#1076) and the MCP binaries; a host utility must never shadow those.
-ENV PATH="/home/ubuntu/.local/bin:/usr/local/go/bin:${PATH}:/home/ubuntu/.oaw/overlay/local-bin"
+# mise keeps its installs on the DURABLE toolbox mount, so a materialised
+# toolchain survives container recreation instead of being re-downloaded (R-11).
+ENV MISE_DATA_DIR=/home/ubuntu/.oaw/toolbox/mise
+# The operator manifest IS mise's global config. Without this the shims are on
+# PATH but cannot resolve a version — measured: `command -v java` returned the
+# shim while `java -version` said "No version is set for shim: java". A shim that
+# exists and cannot run is not a toolchain; it is a more confusing absence.
+# bootstrap re-exports this to whatever manifest it actually finds, which also
+# covers a non-default toolbox path; this ENV is the floor for a bare docker exec.
+ENV MISE_GLOBAL_CONFIG_FILE=/home/ubuntu/.oaw/toolbox/mise.toml
+
+# Toolbox shims sit AFTER the kit's own bin dir and BEFORE the system dirs:
+#   * after ~/.local/bin so a toolchain can never shadow a kit binary — §3.4's
+#     "kit wins over the overlay" keeps the RTE authoritative;
+#   * before ${PATH} so a mise-managed JDK does beat a stray system one.
+#
+# It goes in the IMAGE's ENV deliberately. `docker exec` resolves against the
+# image's configured PATH, not a shell's — non-interactive shells never read
+# ~/.bashrc, which is exactly why bifrost had to hand-source an env file. A hook
+# or an agent-run command must find `mvn` with no shell cooperation at all.
+ENV PATH="/home/ubuntu/.local/bin:/usr/local/go/bin:/home/ubuntu/.oaw/toolbox/mise/shims:${PATH}:/home/ubuntu/.oaw/overlay/local-bin"
 WORKDIR ${KIT_SRC}
 # install's final step is a runtime-readiness advisory (check-deps.sh) whose exit
 # code is the count of missing deps. `bun` (and node/claude) are now on PATH (the

--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -4,8 +4,8 @@
 #
 # Runs before the agent (via the aoe-hooks seam — open probe Dev Spec §5.N#5) and
 # performs, in order: env validation, skills symlink-sync, kit hook-wiring merge,
-# and secret sourcing + required-secret validation. It is the load-bearing
-# instrument the whole container leans on (SKETCHBOOK D7), so it is written to the
+# R-11 toolbox materialisation, and secret sourcing + required-secret validation.
+# It is the load-bearing instrument the whole container leans on (SKETCHBOOK D7), so it is written to the
 # **assertion-liveness** discipline from line one:
 #
 #   Every silent-skip path becomes a LOGGED or FAILING condition — never a check
@@ -44,6 +44,9 @@
 #                                   (default: $HOME/.oaw/.claude/skills)
 #   OAW_SETTINGS_JSON               baked hook wiring, the merge SOURCE
 #                                   (default: $HOME/.claude/settings.json)
+#   OAW_TOOLBOX_DIR                 R-11 durable toolbox mount, where mise
+#                                   materialises declared toolchains
+#                                   (default: $HOME/.oaw/toolbox)
 #   OAW_SECRETS_DIR                 ro secrets mount (default: $HOME/.secrets)
 #   OAW_REQUIRED_SECRETS            whitespace-separated required secret names (wins)
 #   OAW_REQUIRED_SECRETS_MANIFEST   values-free manifest file, one name per line,
@@ -393,6 +396,101 @@ sync_kit_hooks() {
 	# be unreachable — the kind of handler that reads as coverage and is never run.
 	*) info "hooks: merged kit wiring into the CLI's settings: $out" ;;
 	esac
+	return 0
+}
+
+# --- Stage 3b: R-11 toolbox — materialise declared toolchains (#1092) ---------
+#
+# THE MECHANISM WAS DECLARED AND INERT. mounts.d/30-user-overlay.toml has wired
+# the toolbox mount since Story 1.3 and described exactly this behaviour; nothing
+# ever materialised anything into it. bifrost hit it head-on: `java`, `mvn`,
+# `docker` all command-not-found on a Java repo, so every session began by
+# bootstrapping the world. Same shape as #1076 (bootstrap never invoked), #1061
+# (inert R-14) and #1056 (trivy parsing zero manifests) — the manifest promises
+# it, the runtime does not have it, and nothing says so.
+#
+# The image bakes `mise` (the INSTALLER) and never a toolchain: a baked JDK would
+# ride along in every agent that never touches Java, and bumping Maven would
+# become a kit release. R-11 exists precisely to avoid that.
+#
+# Two manifest sources, both honoured, because they answer different questions:
+#
+#   operator-level  $TOOLBOX/mise.toml     "every agent on this profile needs X"
+#   per-repo        <workspace>/mise.toml  "this project needs Java 17 + Maven"
+#
+# The per-repo case needs nothing from us at boot — mise's shims resolve the
+# version from the cwd's config at exec time, which is why shims are on the
+# image PATH rather than a toolchain being pinned into it.
+#
+# NEVER FATAL. The wrapper sources this and then execs the agent, so a fatal here
+# means no agent at all: a container with no Maven is bad, a container with no
+# agent is worse. Offline, unreadable manifest, mise itself missing — all warn.
+sync_toolbox() {
+	local toolbox="${OAW_TOOLBOX_DIR:-$OAW_HOME/.oaw/toolbox}"
+
+	if [[ ! -d "$toolbox" ]]; then
+		warn "missing mount: toolbox dir not present ($toolbox); declared toolchains cannot be materialised"
+		return 0
+	fi
+
+	# A manifest is OPTIONAL and its absence is the common case — most agents
+	# never touch a toolchain. info, not warn: a warning that fires on every
+	# healthy boot is how a fleet learns to stop reading warnings.
+	local manifest=""
+	local candidate
+	for candidate in "$toolbox/mise.toml" "$toolbox/.mise.toml" "$toolbox/config.toml"; do
+		[[ -f "$candidate" ]] && {
+			manifest="$candidate"
+			break
+		}
+	done
+	if [[ -z "$manifest" ]]; then
+		info "toolbox: no manifest in $toolbox — per-repo mise.toml still resolves via shims"
+		return 0
+	fi
+
+	if ! command -v mise >/dev/null 2>&1; then
+		warn "toolbox: $manifest declares toolchains but mise is not installed — expected baked in the image"
+		return 0
+	fi
+
+	# `mise install` is idempotent: a satisfied manifest is a fast no-op, which
+	# matters because this runs on EVERY agent start, not once per container.
+	# `if ! out=$(...)` — NOT `out=$(...); rc=$?`. This file runs under `set -e`,
+	# where a failing command substitution in an assignment aborts the script
+	# immediately and the `rc=$?` line never executes. The offline path would then
+	# have killed the boot, which is the precise thing the comment above forbids:
+	# a container with no agent is worse than one with no Maven. Caught by
+	# test_offline_install_warns_but_the_agent_still_starts, not by reading it.
+	# EXPORT, so the agent and every hook inherit it. The wrapper SOURCES this
+	# script and then execs the agent, so an export here flows down — the same
+	# mechanism CLAUDE_CODE_OAUTH_TOKEN relies on. Without it the shims resolve on
+	# PATH and then fail with "No version is set for shim", because nothing tells
+	# mise which manifest is the global one. Measured in a live container.
+	export MISE_GLOBAL_CONFIG_FILE="$manifest"
+
+	local out rc=0
+	if ! out="$(mise install --yes 2>&1)"; then
+		rc=1
+	fi
+	if ((rc != 0)); then
+		# Offline is the expected non-fatal failure. Report what mise said rather
+		# than guessing which of network / bad manifest / disk it was — this
+		# script's job is to name the condition, not to diagnose it.
+		warn "toolbox: mise install failed (rc=$rc) — the agent still starts, toolchains may be missing"
+		while IFS= read -r line; do
+			[[ -n "$line" ]] && warn "  mise: $line"
+		done <<<"$(printf '%s' "$out" | tail -5)"
+		return 0
+	fi
+
+	# Regenerate shims, or a freshly-installed tool has no entry on PATH and the
+	# install "succeeded" while `mvn` is still command-not-found — a pass that
+	# leaves the reported problem exactly where it was.
+	mise reshim >/dev/null 2>&1 ||
+		warn "toolbox: mise reshim failed — installed tools may not be on PATH"
+
+	info "toolbox: materialised from $manifest"
 	return 0
 }
 
@@ -1151,6 +1249,7 @@ main() {
 	validate_env
 	sync_skills
 	sync_kit_hooks
+	sync_toolbox
 	validate_secrets
 	ensure_ssh_parity
 	ensure_github_auth

--- a/containers/oakandwave-workflow/mounts.d/40-durable-caches.toml
+++ b/containers/oakandwave-workflow/mounts.d/40-durable-caches.toml
@@ -37,3 +37,15 @@ layer = "durable-cache"
 mode = "rw"
 source = "~/.oaw/cache/<major>/ms-playwright"
 target = "/home/ubuntu/.cache/ms-playwright"
+
+# Maven local repository (#1092). Same pattern as cargo/go/uv above and the same
+# reason: a cold `mvn` re-downloads the entire dependency tree every session
+# (~30s vs ~3s warm), and a container that pays that on every start is a
+# container people stop using. It belongs in THIS layer, not the toolbox layer —
+# the toolbox holds the toolchain, this holds what the toolchain downloads.
+[[mount]]
+name = "maven-m2"
+layer = "durable-cache"
+mode = "rw"
+source = "~/.oaw/cache/<major>/m2"
+target = "/home/ubuntu/.m2"

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -176,6 +176,58 @@ degrades silently (the D7 assertion-liveness discipline):
   The discretionary-tool toolbox (R-11) is a durable, in-container-materialized
   mount decoupled from the kit release.
 
+#### R-11 in practice: the toolbox is materialized, not baked (#1092)
+
+The mount was wired from Story 1.3 and **nothing ever materialized into it**.
+bifrost hit the consequence on a Java repo: `java`, `mvn` and `docker` all
+`command not found`, so every session began by bootstrapping the world. Same
+declared-but-not-wired shape as #1076 (bootstrap never invoked), #1061 (inert
+R-14) and #1056 (trivy parsing zero manifests) — the manifest promises it, the
+runtime does not have it, and nothing says so.
+
+**The image bakes the installer and never the toolchain.** `mise` is one pinned
+static binary; a baked JDK would ride along in every agent that never touches
+Java, and bumping Maven would become a *kit release*. Avoiding exactly that is
+what R-11 is for.
+
+| | where | who owns it |
+|---|---|---|
+| installer | `mise`, baked at a pinned version | the release |
+| toolchains | `$MISE_DATA_DIR` = `~/.oaw/toolbox/mise` (durable mount) | the operator / the repo |
+| operator manifest | `~/.oaw/toolbox/mise.toml` | "every agent on this profile needs X" |
+| per-repo manifest | `<workspace>/mise.toml` | "this project needs Java 17 + Maven" |
+
+`bootstrap.sh::sync_toolbox` installs the operator manifest at boot — idempotent,
+so a satisfied manifest is a fast no-op on every agent start. The per-repo case
+needs nothing at boot: **mise's shims resolve the version from the cwd's config
+at exec time**, which is why shims are on `PATH` rather than a toolchain being
+pinned into it.
+
+Three properties are load-bearing, and each was a reported failure before it was
+a requirement:
+
+- **Shims sit on the IMAGE's `PATH`, not in a shell rc.** `docker exec` resolves
+  against the image's configured `PATH`, and non-interactive shells never read
+  `~/.bashrc` — which is why bifrost had to hand-source an env file. A hook or an
+  agent-run command must find `mvn` with no shell cooperation at all.
+- **After the kit's own bin dir, before the system dirs.** A user toolchain must
+  never shadow a kit binary (§3.4 keeps the RTE authoritative), but a
+  mise-managed JDK should beat a stray system one.
+- **Never fatal.** The wrapper *sources* bootstrap and then execs the agent, so a
+  fatal here means no agent at all. Offline, unreadable manifest, missing mise —
+  all warn and continue: a container with no Maven is bad, a container with no
+  agent is worse.
+
+`~/.m2` is handled by the **durable-cache** layer alongside cargo/go/uv, not by
+this one — the toolbox holds the toolchain, the cache holds what the toolchain
+downloads. A cold `mvn` otherwise re-fetches the whole dependency tree every
+session.
+
+**Still out of scope, deliberately: a container builder.** Docker/Podman inside
+the container is a *privilege* decision (socket mount vs rootless podman vs
+"Dockerfile work happens on the host") with a real security surface, and it must
+not be solved as a side effect of a toolchain fix.
+
 ### 3.3 settings.json: one file, merged by us (#1086)
 
 `settings.json` straddles versioned and shared. The original design (Dev Spec

--- a/docs/operations/container-toolchains.md
+++ b/docs/operations/container-toolchains.md
@@ -1,0 +1,83 @@
+# Giving a containerised agent a toolchain
+
+The image ships **no build toolchain** — no JDK, no Maven, no Node runtime beyond
+what the kit itself needs. That is deliberate (R-11): baking a JDK would put a
+Java toolchain in every agent that never touches Java, and bumping Maven would
+become a kit release.
+
+Instead the image bakes **`mise`**, and toolchains are materialised on demand
+into a durable mount that survives container recreation.
+
+## The fast answer
+
+**Per repo** — commit a `mise.toml` at the repo root:
+
+```toml
+[tools]
+java = "temurin-17"
+maven = "3.9"
+```
+
+That is all. mise's shims are on the image `PATH`, and they resolve the version
+from the current directory's config at exec time — so `mvn -v` works inside that
+workspace with no bootstrap step, no shell rc, and nothing installed by hand.
+Tools are downloaded on first use into `~/.oaw/toolbox/mise`, which is a durable
+mount: the next container gets them already there.
+
+**Per profile** — for something every agent on a profile should have, put the
+same file at `~/.oaw/toolbox/mise.toml` on the host. `bootstrap.sh` installs it
+at boot, on every agent start. A satisfied manifest is a fast no-op.
+
+## Checking it worked
+
+Ask the way an agent asks — a **non-interactive** shell:
+
+```bash
+docker exec -u ubuntu <container> sh -lc 'mvn -v'
+```
+
+Not an interactive shell, and not after sourcing anything. Non-interactive shells
+never read `~/.bashrc`, so a check that passes only in an interactive session is
+testing the wrong thing — that exact gap is why this issue was filed.
+
+## What happens when it cannot install
+
+Nothing fatal. Bootstrap **warns and continues**, and mise's own diagnosis is
+printed rather than swallowed:
+
+```
+[bootstrap] WARN: toolbox: mise install failed (rc=1) — the agent still starts, toolchains may be missing
+[bootstrap] WARN:   mise: failed to resolve host mise-versions.jdx.dev
+```
+
+A container with no Maven is bad; a container with no agent is worse. The wrapper
+sources bootstrap and then execs the agent, so a fatal here would mean no agent.
+
+## Caches
+
+`~/.m2` is a **durable-cache** mount (`40-durable-caches.toml`), alongside cargo,
+go-mod, uv and playwright. The toolbox holds the toolchain; the cache holds what
+the toolchain downloads. Without it a cold `mvn` re-fetches the whole dependency
+tree every session.
+
+Adding a mount changes the resolved volume set, so profile `extra_volumes` need
+regenerating — `scripts/ci/check-mount-drift.sh <profile>` reports the gap and
+prints the command.
+
+## What this does NOT give you
+
+**A container builder.** `docker`, `podman` and `buildah` are still absent, and
+an agent cannot self-install them: no sudo, no socket, no daemon. So building a
+repo's Dockerfiles inside the container does not work.
+
+That is a **privilege** decision — socket mount vs rootless podman vs "Dockerfile
+work happens on the host" — with a real security surface, and it is deliberately
+not solved as a side effect of a toolchain fix. It needs its own decision and its
+own issue.
+
+## Why not just `apt-get install maven` in the Dockerfile
+
+Because then every agent carries it, the image grows for everyone, and updating
+Maven means cutting a kit release — which since #1063 is a deliberate act, not a
+merge. The toolbox layer exists so a toolchain can move on the repo's schedule
+rather than the kit's.

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -1829,3 +1829,229 @@ def test_absolute_form_already_present_blocks_the_tilde_form(tmp_path: Path) -> 
 
     got = _hook_commands(J.loads((cfgdir / "settings.json").read_text()), "PostToolUse")
     assert got == [("", str(home) + "/hook.sh")], f"tilde form was added on top: {got}"
+
+
+# --- R-11 toolbox materialisation (#1092) ------------------------------------
+#
+# The mount has been declared since Story 1.3 and nothing ever materialised into
+# it. bifrost hit the consequence head-on: `java`, `mvn`, `docker` all
+# command-not-found on a Java repo, so every session started by bootstrapping the
+# world. Same declared-but-not-wired shape as #1076, #1061 and #1056.
+#
+# `mise` is stubbed here rather than really installing a JDK: these assert the
+# BOOTSTRAP's contract (when does it invoke, what does it tolerate, does it
+# reshim), not mise's. A test that downloaded a real toolchain would be slow
+# enough to get deleted, and would be testing someone else's software.
+
+
+def _stub_mise(binroot: Path, *, exit_code: int = 0, message: str = "") -> Path:
+    """A fake `mise` that records its argv so we can assert what bootstrap asked."""
+    binroot.mkdir(parents=True, exist_ok=True)
+    stub = binroot / "mise"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "$@" >> "{binroot}/calls.log"\n'
+        f'[[ -n "{message}" ]] && echo "{message}" >&2\n'
+        f"exit {exit_code}\n"
+    )
+    stub.chmod(0o755)
+    return stub
+
+
+def _run_toolbox(home: Path, toolbox: Path, binroot: Path | None = None, **env: str):
+    e = {**os.environ, "OAW_HOME": str(home), "OAW_TOOLBOX_DIR": str(toolbox)}
+    e.pop("CLAUDE_CONFIG_DIR", None)
+    if binroot is not None:
+        e["PATH"] = f"{binroot}:{e['PATH']}"
+    e.update(env)
+    return subprocess.run(
+        ["bash", str(BOOTSTRAP)], capture_output=True, text=True, timeout=60, env=e
+    )
+
+
+def test_declared_toolchain_is_materialised(tmp_path: Path) -> None:
+    """The defect itself: a declared manifest must actually be installed."""
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    toolbox = tmp_path / "toolbox"
+    toolbox.mkdir()
+    (toolbox / "mise.toml").write_text('[tools]\njava = "17"\nmaven = "3.9"\n')
+    binroot = tmp_path / "bin"
+    proc = _run_toolbox(home, toolbox, binroot=_stub_mise(binroot).parent)
+
+    assert proc.returncode == 0, proc.stderr
+    calls = (binroot / "calls.log").read_text()
+    assert "install" in calls, f"bootstrap never ran `mise install` (calls: {calls!r})"
+    assert "materialised" in proc.stderr
+
+
+def test_reshim_runs_after_install(tmp_path: Path) -> None:
+    """Without a reshim, a freshly-installed tool has no PATH entry.
+
+    The install would "succeed" while `mvn` stays command-not-found — a pass that
+    leaves the reported problem exactly where it was.
+    """
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    toolbox = tmp_path / "toolbox"
+    toolbox.mkdir()
+    (toolbox / "mise.toml").write_text('[tools]\njava = "17"\n')
+    binroot = tmp_path / "bin"
+    _run_toolbox(home, toolbox, binroot=_stub_mise(binroot).parent)
+    assert "reshim" in (binroot / "calls.log").read_text(), "install without reshim"
+
+
+def test_absent_manifest_is_info_not_a_warning(tmp_path: Path) -> None:
+    """Most agents never touch a toolchain, so no manifest is the COMMON case.
+
+    A warning on every healthy boot is how a fleet learns to stop reading
+    warnings — the same erosion this file's assertion-liveness discipline exists
+    to prevent, arriving from the opposite direction.
+    """
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    toolbox = tmp_path / "toolbox"
+    toolbox.mkdir()
+    proc = _run_toolbox(home, toolbox)
+    assert proc.returncode == 0
+    assert "toolbox: no manifest" in proc.stderr
+    assert "WARN: toolbox: no manifest" not in proc.stderr
+
+
+def test_missing_toolbox_mount_is_logged(tmp_path: Path) -> None:
+    """An absent mount is the enumerated silent-skip — it must be loud."""
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    proc = _run_toolbox(home, tmp_path / "does-not-exist")
+    assert proc.returncode == 0
+    assert "missing mount: toolbox dir not present" in proc.stderr
+
+
+def test_offline_install_warns_but_the_agent_still_starts(tmp_path: Path) -> None:
+    """A container with no Maven is bad; a container with no AGENT is worse.
+
+    The wrapper SOURCES bootstrap and then execs the CLI, so a fatal here means
+    no agent at all.
+    """
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    toolbox = tmp_path / "toolbox"
+    toolbox.mkdir()
+    (toolbox / "mise.toml").write_text('[tools]\njava = "17"\n')
+    binroot = tmp_path / "bin"
+    _stub_mise(binroot, exit_code=1, message="failed to resolve host mise-versions.jdx.dev")
+    proc = _run_toolbox(home, toolbox, binroot=binroot)
+
+    assert proc.returncode == 0, "an offline toolbox must never fail the boot"
+    assert "mise install failed" in proc.stderr
+    assert "mise-versions" in proc.stderr, "mise's own diagnosis must be surfaced, not swallowed"
+
+
+def test_manifest_without_mise_is_reported(tmp_path: Path) -> None:
+    """A declared toolchain and no installer is exactly #1092 in miniature."""
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    toolbox = tmp_path / "toolbox"
+    toolbox.mkdir()
+    (toolbox / "mise.toml").write_text('[tools]\njava = "17"\n')
+    empty = tmp_path / "emptybin"
+    empty.mkdir()
+    # PATH with no mise on it at all.
+    proc = _run_toolbox(home, toolbox, PATH=f"{empty}:/usr/bin:/bin")
+    assert proc.returncode == 0
+    assert "mise is not installed" in proc.stderr
+
+
+# --- the image half: installer baked, toolchain NOT ---------------------------
+
+DOCKERFILE = REPO_ROOT / "containers" / "oakandwave-workflow" / "Dockerfile"
+
+
+def _dockerfile_instructions() -> str:
+    """The Dockerfile with comments stripped.
+
+    Scanning the raw text asks the COMMENTARY, not the config. The block
+    explaining mise necessarily names the toolchains it can materialise ("JDK /
+    Maven / Node …"), so a raw-text check for "maven" matches the sentence that
+    says we do NOT bake Maven — and reports the defect present while the image is
+    correct. That is the same instrument-reads-its-own-advice failure as
+    bootstrap's hook validator matching its own warning text and #1063's trigger
+    test matching its own rationale; it was caught here by this very assertion
+    failing against a correct Dockerfile.
+    """
+    return "\n".join(
+        ln for ln in DOCKERFILE.read_text().splitlines() if not ln.lstrip().startswith("#")
+    )
+
+
+def test_image_bakes_the_installer_not_the_toolchain() -> None:
+    """R-11's whole point. A baked JDK rides along in every agent that never
+    touches Java, and bumping Maven becomes a kit release."""
+    instructions = _dockerfile_instructions()
+    assert "mise" in instructions, "the toolbox installer must be baked"
+    lowered = instructions.lower()
+    for forbidden in ("openjdk", "temurin", "adoptium", "maven-3", "apt-get install -y maven"):
+        assert forbidden not in lowered, (
+            f"{forbidden!r} is baked into the base image — R-11 exists to keep "
+            f"per-repo toolchains OUT of the image"
+        )
+
+
+def test_toolbox_shims_are_on_the_image_path_not_a_shell_rc() -> None:
+    """`docker exec` resolves against the IMAGE's PATH, not a shell's.
+
+    Non-interactive shells never read ~/.bashrc, which is why bifrost had to
+    hand-source an env file. A hook or an agent-run command must find `mvn` with
+    no shell cooperation at all — so the shims live in ENV PATH.
+    """
+    path_lines = [
+        ln for ln in _dockerfile_instructions().splitlines() if ln.startswith("ENV PATH=")
+    ]
+    assert path_lines, "no ENV PATH in the Dockerfile"
+    final = path_lines[-1]
+    assert "toolbox/mise/shims" in final, f"shims not on the image PATH: {final}"
+
+    entries = final.split("PATH=", 1)[1].strip('"').split(":")
+    shims = next(i for i, e in enumerate(entries) if "mise/shims" in e)
+    kit = next(i for i, e in enumerate(entries) if e.endswith("/.local/bin"))
+    assert kit < shims, (
+        "toolbox shims precede the kit's own bin dir — a user toolchain could "
+        "shadow a kit binary and §3.4 keeps the RTE authoritative"
+    )
+
+
+def test_mise_is_pinned_not_piped() -> None:
+    """A build step that executes whatever a URL serves today is not
+    reproducible; it is the supply-chain surface the pinned-tarball rule exists
+    to avoid (same rule as trivy and bao)."""
+    instructions = _dockerfile_instructions()
+    assert "ARG MISE_VERSION=" in instructions, "mise must be version-pinned"
+    assert "mise.run" not in instructions, (
+        "mise must be installed from a pinned tarball, never a piped installer"
+    )
+
+
+def test_toolbox_exports_the_global_config_so_shims_can_resolve(tmp_path: Path) -> None:
+    """A shim on PATH that cannot resolve a version is not a toolchain.
+
+    Measured live before this existed: `command -v java` returned the shim while
+    `java -version` said "No version is set for shim: java". The shims resolve
+    their version from mise's GLOBAL config, and nothing pointed at the operator
+    manifest — so the install succeeded and the tool still would not run.
+
+    The wrapper SOURCES bootstrap and then execs the agent, so exporting here is
+    what carries it to the agent and every hook — the same mechanism
+    CLAUDE_CODE_OAUTH_TOKEN depends on.
+    """
+    body = BOOTSTRAP.read_text()
+    assert re.search(r'^\texport MISE_GLOBAL_CONFIG_FILE="\$manifest"$', body, re.M), (
+        "sync_toolbox must EXPORT MISE_GLOBAL_CONFIG_FILE to the manifest it found; "
+        "a non-exported assignment dies with this shell and the agent sees nothing"
+    )
+
+
+def test_image_sets_a_global_config_floor_for_bare_docker_exec() -> None:
+    """bootstrap's export covers a non-default toolbox path, but a bare
+    `docker exec` that never ran bootstrap still needs the default to resolve."""
+    instructions = _dockerfile_instructions()
+    assert "ENV MISE_GLOBAL_CONFIG_FILE=" in instructions, (
+        "the image must name the operator manifest as mise's global config"
+    )
+    assert "ENV MISE_DATA_DIR=/home/ubuntu/.oaw/toolbox/mise" in instructions, (
+        "mise's data dir must be the DURABLE toolbox mount, or every container "
+        "re-downloads the toolchain it already had"
+    )


### PR DESCRIPTION
## Summary

The R-11 toolbox mount has been declared since Story 1.3 and **nothing ever materialised into it**. bifrost hit the consequence on a Java repo — `java`, `mvn`, `docker` all `command not found` — so every session began by bootstrapping the world. Same declared-but-not-wired shape as #1076 (bootstrap never invoked), #1061 (inert R-14), #1056 (trivy parsing zero manifests).

**The image bakes the installer and never a toolchain.** `mise` is one pinned static binary; a baked JDK would ride along in every agent that never touches Java, and bumping Maven would become a *kit release*. Avoiding exactly that is what R-11 is for.

| | where |
|---|---|
| operator manifest | `~/.oaw/toolbox/mise.toml` — installed at boot, idempotent |
| per-repo manifest | `<workspace>/mise.toml` — resolved by shims at exec time |
| toolchains | `$MISE_DATA_DIR` on the durable mount — survive container recreation |
| `~/.m2` | durable-cache layer, beside cargo/go/uv |

Shims sit on the **image's** `PATH`, after the kit's own bin dir and before the system dirs. `docker exec` resolves against the image PATH, and non-interactive shells never read `~/.bashrc` — which is why bifrost had to hand-source an env file — while a user toolchain must still never shadow a kit binary (§3.4).

**Never fatal.** The wrapper *sources* bootstrap and then execs the agent, so a fatal here means no agent at all. Offline, unreadable manifest, missing mise — all warn and continue.

## Verified in a real container, not asserted

```
virgin container            → no java (nothing baked)
after bootstrap             → toolbox: materialised from …/mise.toml
sh -c 'java -version'       → openjdk 17.0.20
sh -c 'mvn -v'              → Apache Maven 3.9.16
second boot                 → 0.108s
new container, same mount   → both present immediately
no toolbox mount            → still no java
```

Plain non-interactive `sh -c` — no sourcing, no env vars. That is the specific thing bifrost could not get.

## Three defects found in my own work

1. **`out="$(...)"` under `set -e` kills the boot.** The assignment aborts before `rc=$?` ever runs, so the offline path would have done exactly what its own comment forbids. Caught by the test, not by reading it.
2. **`${GOARCH}` 404'd the build** (curl exit 22) — mise publishes `linux-x64`, not Go's `amd64`. It has its own `MISE_ARCH` now rather than an assumption that naming conventions agree.
3. **Shims on PATH that could not resolve a version.** `command -v java` returned the shim while `java -version` said *"No version is set for shim"*. A shim that exists and cannot run is a more confusing absence than no shim. `bootstrap` now **exports** `MISE_GLOBAL_CONFIG_FILE` (the wrapper sources it, so it flows to the agent and every hook), with an image-level floor for a bare `docker exec`.

My first verification harness was also wrong — I sourced a bash script with `sh` and got `[[: not found`. The instrument, not the subject.

## Still out of scope, deliberately

A **container builder**. `docker`/`podman` remain absent and an agent cannot self-install them. That is a privilege decision — socket mount vs rootless podman vs "Dockerfile work happens on the host" — with a real security surface, and it must not be solved as a side effect of a toolchain fix.

## Linked Issues

Closes #1092

## Test Plan

- `./scripts/ci/validate.sh` — **233 passed, 0 failed**.
- `python3 -m pytest tests/ --ignore=tests/test_install.py` — **2029 passed**, 5 skipped, 64 xfailed. Both lanes; `validate.sh` does not run pytest here.
- **11 new tests**, mise stubbed so they assert *bootstrap's* contract rather than mise's — a test that downloaded a real JDK would be slow enough to get deleted.
- **Mutation-tested in two directions:** removing the `sync_toolbox` call (the #1092 shape itself) kills 5; removing the reshim kills the reshim test specifically.
- **mise's CLI verified against the real binary before relying on it** — `install --yes` and `reshim` exist, `MISE_DATA_DIR` genuinely relocates the shims dir, and `MISE_CONFIG_FILE`/`MISE_GLOBAL_CONFIG_FILE` are genuinely read. The stubs could not have told me any of that.
- Image built and container-verified 3× (the two failures above were caught this way).
- `check-mount-drift.sh` back in sync after the `~/.m2` mount — both profiles updated surgically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS