### PR TITLE
fix(contained-workflow): give skills host-fill the mount it always assumed

### DIFF
--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -171,7 +171,28 @@ sync_skills() {
 	if [[ ! -d "$host" ]]; then
 		# Missing mount: tolerate it, but say so — and do NOT create dangling
 		# links (SKETCHBOOK D5: "tolerate an absent mount without dangling links").
+		#
+		# This is now a GENUINE misconfiguration rather than the default state
+		# (#1078). The host-fill path had no mount at all until 30-user-overlay.toml
+		# gained `skills-overlay`, so this WARN fired on every boot of every agent —
+		# and a warning that is always true is one an operator learns to skip, which
+		# is the same erosion as #1061's inert R-14 and #1056's zero manifests. With
+		# the mount declared, reaching here means it was declared and did not happen,
+		# and check-mount-drift.sh polices that like every other mount.
 		warn "missing mount: host skills overlay not present ($host); skills-sync host-fill skipped"
+		scan_dangling "$image"
+		return 0
+	fi
+
+	# Mount present and EMPTY is the common, healthy case — most operators ship no
+	# extra skills, and the image already carries the kit's. Report it as info.
+	#
+	# NOT an unconditional demote of the warning above: #1078 calls that out
+	# specifically, because silencing a check without wiring the thing it checks
+	# reproduces the inert-guard shape one layer down. The two states are now
+	# distinguishable, so they get different levels — that is the whole fix.
+	if [[ -z "$(ls -A "$host" 2>/dev/null)" ]]; then
+		info "skills-sync: host overlay present and empty ($host) — nothing to fill"
 		scan_dangling "$image"
 		return 0
 	fi

--- a/containers/oakandwave-workflow/mounts.d/30-user-overlay.toml
+++ b/containers/oakandwave-workflow/mounts.d/30-user-overlay.toml
@@ -62,3 +62,27 @@ install = "symlink"
 mode = "ro"
 source = "~/.local/bin"
 target = "/home/ubuntu/.oaw/overlay/local-bin"
+
+# --- Operator skills overlay, the host-fill source (#1078) -------------------
+# bootstrap's skills-sync has always had a host-fill path — for each host skill
+# with no same-named image skill, symlink it in — and NOTHING EVER MOUNTED TO IT.
+# It was invisible until #1076 made bootstrap actually run, at which point every
+# agent boot emitted "missing mount: host skills overlay not present". A WARN on
+# every single boot is how an operator learns that bootstrap output is noise,
+# which is the same erosion as #1061's inert R-14 and #1056's zero manifests.
+#
+# DISTINCT FROM THE DEV-MODE OVERLAY, deliberately (architecture.md §2.1):
+#   dev-mode  binds a working copy OVER /home/ubuntu/.claude/skills — REPLACES
+#   host-fill lands beside it and only fills GAPS — image always wins a collision
+# Two mechanisms answering different questions; this is the second one's mount.
+#
+# ro: the container reads these to symlink them in. It must never write into the
+# operator's skill sources, and the image copy wins every name collision anyway.
+[[mount]]
+name = "skills-overlay"
+layer = "user-overlay"
+artifact = "script"
+install = "symlink"
+mode = "ro"
+source = "~/.oaw/overlay/<major>/skills"
+target = "/home/ubuntu/.oaw/.claude/skills"

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -174,7 +174,12 @@ degrades silently (the D7 assertion-liveness discipline):
   `discord-watcher` — see `mcps.json`) are **baked at stable image paths**;
   baking kills the dangling-registration bug (a stale path to a moved binary).
   The discretionary-tool toolbox (R-11) is a durable, in-container-materialized
-  mount decoupled from the kit release.
+  mount decoupled from the kit release. The operator's **skills overlay** is the
+  host-fill source for bootstrap's skills-sync (#1078) — declared from the start
+  and mounted by nothing until then, so every agent boot warned once #1076 made
+  bootstrap actually run. It lands **beside** the image skills dir, never over
+  it: mounting over it is the dev-mode overlay (§2.1), a different mechanism that
+  *replaces* rather than fills gaps.
 
 #### R-11 in practice: the toolbox is materialized, not baked (#1092)
 

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -2055,3 +2055,59 @@ def test_image_sets_a_global_config_floor_for_bare_docker_exec() -> None:
         "mise's data dir must be the DURABLE toolbox mount, or every container "
         "re-downloads the toolchain it already had"
     )
+
+
+# --- skills host-fill: the mount exists now (#1078) ---------------------------
+#
+# The host-fill path was declared from the start and NOTHING EVER MOUNTED TO IT.
+# It stayed invisible until #1076 made bootstrap actually run, and then every
+# agent boot warned. A warning that is always true is one operators learn to
+# skip — the same erosion as #1061's inert R-14 and #1056's zero manifests.
+#
+# The fix is NOT to silence it. #1078 says so explicitly ("an unconditional
+# demote reproduces the inert-guard shape one layer down"), so the two states are
+# made distinguishable instead: empty-and-mounted is info, declared-and-absent
+# stays a WARN.
+
+
+def test_present_but_empty_host_overlay_is_info_not_a_warning(tmp_path: Path) -> None:
+    """The common, healthy case. Most operators ship no extra skills."""
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    proc = _run(home)  # _make_home creates the host skills dir, empty
+    assert proc.returncode == 0, proc.stderr
+    assert "INFO: skills-sync: host overlay present and empty" in proc.stderr
+    assert "missing mount: host skills overlay" not in proc.stderr, (
+        "an empty mounted overlay must not warn — that WARN fired on every boot "
+        "of every agent and is what taught the fleet to skip bootstrap output"
+    )
+
+
+def test_absent_host_overlay_still_warns(tmp_path: Path) -> None:
+    """Now that a mount is declared, absence means it did not happen.
+
+    This must NOT be demoted along with the empty case, or the guard becomes
+    inert exactly where it finally has something real to catch.
+    """
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    (home / ".oaw" / ".claude" / "skills").rmdir()
+    (home / ".oaw" / ".claude").rmdir()
+    proc = _run(home)
+    assert proc.returncode == 0
+    # Assert the LEVEL, not just the text. The first cut matched only the
+    # message, which is byte-identical between `warn` and `info` — so a mutation
+    # that demoted this exact guard passed all three tests. Asserting a string
+    # that survives the change you are guarding against is not a guard.
+    assert "WARN: missing mount: host skills overlay not present" in proc.stderr, (
+        "declared-and-absent must stay a WARN; demoting it alongside the empty "
+        "case is the inert-guard shape #1078 explicitly forbids"
+    )
+
+
+def test_host_fill_still_fills_when_the_overlay_has_skills(tmp_path: Path) -> None:
+    """The behaviour the quiet path must not have broken."""
+    home = _make_home(tmp_path, image_skills=["alpha"], host_skills=["beta"])
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+    beta = home / ".claude" / "skills" / "beta"
+    assert beta.is_symlink() and beta.exists(), "host-fill stopped filling gaps"
+    assert "host overlay present and empty" not in proc.stderr

--- a/tests/contained-workflow/test_mounts.py
+++ b/tests/contained-workflow/test_mounts.py
@@ -287,6 +287,33 @@ def test_manifest_declares_no_user_level_settings_local(tmp_path: Path) -> None:
     )
 
 
+def test_skills_overlay_mount_exists_for_host_fill() -> None:
+    """bootstrap's host-fill had NO mount behind it (#1078).
+
+    Declared from the start, mounted by nothing — invisible until #1076 made
+    bootstrap actually run, at which point every agent boot warned. A warning
+    that is always true is one operators learn to skip.
+
+    Asserted against the RESOLVED manifest, not the fragment text: a fragment
+    that parses but does not resolve would satisfy a text check and still leave
+    bootstrap warning on every boot.
+    """
+    resolved = mr.resolve_manifest(MAJOR, home=FAKE_HOME, mounts_dir=MANIFEST_DIR)
+    by_target = {m.target: m for m in resolved}
+    overlay = by_target.get("/home/ubuntu/.oaw/.claude/skills")
+    assert overlay is not None, (
+        "nothing targets the host-fill source — bootstrap warns on every boot"
+    )
+    assert overlay.to_docker_volume().endswith(":ro"), (
+        "the container must never write into the operator's skill sources"
+    )
+    assert overlay.target != "/home/ubuntu/.claude/skills", (
+        "host-fill must land BESIDE the image skills dir, never over it — "
+        "mounting over it is the dev-mode overlay, a different mechanism that "
+        "REPLACES rather than fills gaps"
+    )
+
+
 def test_manifest_dir_exists() -> None:
     """DM sanity: the manifest directory and the fragments Story 1.3 owns are
     checked in. A superset check (not exact equality) so a sibling wave story —


### PR DESCRIPTION
## Summary

bootstrap's skills-sync has always had a **host-fill** path — for each host skill with no same-named image skill, symlink it in — and **nothing ever mounted to it**. It stayed invisible until #1076 made bootstrap actually run, at which point every agent boot emitted:

```
[bootstrap] WARN: missing mount: host skills overlay not present (/home/ubuntu/.oaw/.claude/skills)
```

A warning that is always true is one an operator learns to skip — the same erosion as #1061's inert R-14 and #1056's zero manifests.

## Wired, not silenced

`30-user-overlay.toml` gains `skills-overlay`:

```
~/.oaw/overlay/<major>/skills → /home/ubuntu/.oaw/.claude/skills   (ro)
```

**Read-only:** the container reads these to symlink them in and must never write into the operator's skill sources. The image copy wins every name collision regardless.

**Beside the image skills dir, never over it.** Mounting over `/home/ubuntu/.claude/skills` is the **dev-mode overlay** — a deliberately different mechanism (architecture.md §2.1) that *replaces* rather than fills gaps. Conflating them would silently disable the image's own skills. There's a test asserting the target is not that path.

The two states are now distinguishable, which is the actual fix:

| state | level |
|---|---|
| mounted and empty | `info` — the common, healthy case; most operators ship no extra skills |
| declared and absent | `WARN` — a genuine misconfiguration now, policed by the drift guard like every other mount |

#1078 calls out the alternative specifically: *"an unconditional demote reproduces the inert-guard shape one layer down."* Silencing a check without wiring the thing it checks is not a fix.

## A defect in my own test

`test_absent_host_overlay_still_warns` asserted the **message** — and the message is byte-identical between `warn` and `info`, since only the level prefix differs. So when I mutated the code to demote that exact guard — the precise thing this issue forbids — **all three tests passed.**

I'd written a guard that survives the change it exists to catch. The assertions now pin `WARN:` and `INFO:` explicitly, and the mutation is caught.

## Linked Issues

Closes #1078

## Test Plan

- `./scripts/ci/validate.sh` — **233 passed, 0 failed**.
- `python3 -m pytest tests/ --ignore=tests/test_install.py` — **2033 passed**, 5 skipped, 64 xfailed. Both lanes.
- **4 new tests**, covering: mounted-and-empty is info, declared-and-absent stays WARN, host-fill still fills when the overlay has skills (the behaviour the quiet path must not have broken), and the mount actually resolves.
- The manifest assertion is made against the **resolved** manifest, not the fragment text — a fragment that parses but does not resolve would satisfy a text check and leave bootstrap warning on every boot.
- **Mutation-tested both halves:** removing the mount fails the manifest test; demoting the absent-mount WARN fails the level assertion (after it was fixed to be able to).
- `check-mount-drift.sh` in sync at 12 mounts; both profiles updated surgically and the host overlay dir created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS