### PR TITLE
docs(wtf): point the skill at the relocated recorder store

### DIFF
--- a/docs/contained-workflow/cutover-prerequisites.md
+++ b/docs/contained-workflow/cutover-prerequisites.md
@@ -12,7 +12,7 @@ own canary.
 
 Derived 2026-07-30. Tracking issues: #1061 (secrets), #1062 (drop Slack),
 #1063 (image cadence), #1064 (session durability),
-`mcp-server-wtf`#29 (`.wtf/` relocation).
+`mcp-server-wtf`#29 (recorder store relocated into `.claude/` — **landed**, `733a3fa`).
 
 ---
 

--- a/skills/wtf-happened/SKILL.md
+++ b/skills/wtf-happened/SKILL.md
@@ -42,7 +42,7 @@ followed by a numbered timeline of classified events.
 
 If a runbook was generated, note the file path:
 
-> Runbook written to `.wtf/runbook.md`
+> Runbook written to `.claude/wtf/runbook.md`
 
 ### 3. Offer next steps
 
@@ -50,4 +50,4 @@ After presenting the timeline, briefly suggest:
 
 - `/wtf now "<observation>"` to keep recording
 - `wtf_freshell` to archive and start a new incident
-- `/view .wtf/runbook.md` to review the generated runbook
+- `/view .claude/wtf/runbook.md` to review the generated runbook


### PR DESCRIPTION
## Summary

`mcp-server-wtf`#29 moved the flight-recorder store to `<project>/.claude/wtf/` so incident timelines survive container replacement (landed as `733a3fa`). Its acceptance criteria included *"any path references in cc-workflow"* — outstanding here because **cc-workflow owns the skills** (the MCP repo delivers tools only), so the copy an agent actually loads is this one.

**The stale instruction was wrong, not merely dated.** `/view .wtf/runbook.md` opens nothing on any project created after `733a3fa`, and an agent following it gets an empty result with no explanation — the same *"looks empty rather than broken"* shape the hook half of #29 was about, one layer out.

## Changes

- `skills/wtf-happened/SKILL.md` — both references now name `.claude/wtf/runbook.md`.
- `docs/contained-workflow/cutover-prerequisites.md` — marks `mcp-server-wtf`#29 as landed. A prerequisites list still showing a satisfied prerequisite as outstanding is the stale-signal noise this cut-over keeps closing.

## Linked Issues

Closes #1104

Completes the cross-repo half of `mcp-server-wtf`#29 — a cross-repo `Closes` does not close an issue in another repo, so it was tracked separately rather than assumed done.

## Test Plan

- `./scripts/ci/validate.sh` — 233 passed, 0 failed.
- `python3 -m pytest tests/ --ignore=tests/test_install.py` — 2033 passed. Both lanes.
- Grep-verified no `.wtf/` path instruction survives anywhere in `skills/`.
- The path now named matches what `mcp-server-wtf`'s `store.ts` actually resolves to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS