### PR TITLE
fix(promotion): make the mechanical gate satisfiable

### DIFF
--- a/containers/oakandwave-workflow/promotion_gate.py
+++ b/containers/oakandwave-workflow/promotion_gate.py
@@ -3,7 +3,7 @@
 
 The gate that decides whether a candidate `:edge` digest may be promoted to
 `:stable`. It is a **conjunctive query over FlightDeck + CI** (§5.6): the four
-mechanical conditions — throwaway-CI E2E-01 green, dogfood soak met, zero
+mechanical conditions — throwaway-CI E2E-01 green (digest-bound), zero
 quarantines, zero open Sev-1 — must **all** be green before promotion is
 permitted, and promotion retags the **exact digest E2E-01 tested**.
 
@@ -33,7 +33,7 @@ Design — **one green path, fail-closed** (assertion-liveness, D7):
   moving tag — so the caller retags precisely the bytes E2E-01 tested (R-23).
 
 The module never touches the network or a registry; it reasons purely over the
-signals handed to it. Sourcing those signals (a FlightDeck query for soak /
+signals handed to it. Sourcing those signals (a FlightDeck query for
 quarantines / Sev-1, the CI result for the throwaway-CI ring) and performing the
 exact-digest retag live in ``scripts/ci/promote-oakandwave-image.sh``.
 
@@ -41,7 +41,6 @@ CLI::
 
     python3 promotion_gate.py --target-digest ghcr.io/o/w@sha256:… \\
         --ci-passed true --ci-digest ghcr.io/o/w@sha256:… \\
-        --soak-hours 48 --soak-required-hours 24 \\
         --quarantines 0 --open-sev1 0 --ack
 
 Prints the digest to promote on stdout and exits 0 only when the gate is green
@@ -56,11 +55,10 @@ import sys
 from dataclasses import dataclass
 
 # The four mechanical conditions of the promotion gate (§5.6), in report order.
-CONDITION_ORDER = ("throwaway_ci", "soak", "quarantines", "sev1")
+CONDITION_ORDER = ("throwaway_ci", "quarantines", "sev1")
 
 CONDITION_LABELS = {
     "throwaway_ci": "throwaway-CI E2E-01 smoke green for the tested digest",
-    "soak": "dogfood soak requirement met",
     "quarantines": "zero quarantines",
     "sev1": "zero open Sev-1",
 }
@@ -149,17 +147,44 @@ def evaluate_gate(
     target_digest: str,
     ci_passed: bool | None,
     ci_digest: str | None,
-    soak_hours: float | None,
-    soak_required_hours: float,
     quarantine_count: int | None,
     open_sev1_count: int | None,
+    quarantine_declared_absent: bool = False,
+    sev1_declared_absent: bool = False,
 ) -> GateReport:
-    """Evaluate the four mechanical conditions for ``target_digest``.
+    """Evaluate the mechanical conditions for ``target_digest``.
 
-    Every condition is **fail-closed**: it is green only on an explicit, correct
+    Every condition is **fail-closed**: green only on an explicit, correct
     signal; ``None`` / missing / malformed ⇒ red. The throwaway-CI condition
     additionally requires the CI result to be *for this digest* (R-23), so a
     green for a different digest cannot carry this one.
+
+    **Soak was removed (#1106).** It could not measure what it claimed: soak
+    accrued only from sessions running at the instant of a bridge pass, so a
+    missed cron window silently discarded real runtime — the metric was a proxy
+    for "was the recorder running", not "did this soak". Measured live: the fleet
+    ran containers for well over 24 hours and a 48h look-back credited ZERO,
+    because the bridge had never been scheduled and cannot backfill.
+
+    That left injecting an unmeasured number as the only way to promote, which is
+    worse than having no condition: a gate passable only by lying to it
+    manufactures the habit of lying to it, on the control guarding what the whole
+    fleet runs. The artifact is tested by throwaway-CI (R-23) and by
+    scripts/ci/aoe-preflight.sh, which are behavioural and found every defect in
+    the cut-over; none was ever found by soaking.
+
+    **Declared absence (#1106).** Quarantine and Sev-1 come from FlightDeck
+    (#854). Where it is not deployed, reading RED forever is the same defect one
+    condition over — an assertion about something nothing was built to measure.
+    An explicit declaration turns that into a decision someone made:
+
+        signal present            -> evaluated normally (non-zero is still RED)
+        declared absent           -> green, and the declaration is ECHOED
+        simply missing            -> RED, unchanged
+
+    Declaring "no telemetry here, deliberately" is legitimate; omitting the
+    declaration is not. Same shape as OAW_REQUIRED_SECRETS="" (#1061) and
+    .no-scannable-dependencies (#1073).
     """
     _require_digest(target_digest)
 
@@ -178,28 +203,23 @@ def evaluate_gate(
     else:
         ci_green, ci_detail = True, f"E2E-01 green for {target_digest}"
 
-    # 2. dogfood soak met.
-    if not isinstance(soak_hours, (int, float)) or isinstance(soak_hours, bool):
-        soak_green = False
-        soak_detail = "soak telemetry unavailable"
-    elif soak_hours >= soak_required_hours:
-        soak_green = True
-        soak_detail = f"{soak_hours:g}h ≥ {soak_required_hours:g}h required"
-    else:
-        soak_green = False
-        soak_detail = f"{soak_hours:g}h < {soak_required_hours:g}h required"
-
-    # 3. zero quarantines.
-    if not isinstance(quarantine_count, int) or isinstance(quarantine_count, bool):
-        quar_green, quar_detail = False, "quarantine telemetry unavailable"
+    # 2. zero quarantines.
+    if quarantine_declared_absent and quarantine_count is None:
+        quar_green = True
+        quar_detail = "no quarantine telemetry — DECLARED absent, not assumed"
+    elif not isinstance(quarantine_count, int) or isinstance(quarantine_count, bool):
+        quar_green, quar_detail = False, "quarantine telemetry unavailable (declare it absent to proceed)"
     elif quarantine_count == 0:
         quar_green, quar_detail = True, "0 quarantines"
     else:
-        quar_green, quar_detail = False, f"{quarantine_count} quarantine(s) during soak"
+        quar_green, quar_detail = False, f"{quarantine_count} quarantine(s)"
 
-    # 4. zero open Sev-1.
-    if not isinstance(open_sev1_count, int) or isinstance(open_sev1_count, bool):
-        sev_green, sev_detail = False, "Sev-1 telemetry unavailable"
+    # 3. zero open Sev-1.
+    if sev1_declared_absent and open_sev1_count is None:
+        sev_green = True
+        sev_detail = "no Sev-1 telemetry — DECLARED absent, not assumed"
+    elif not isinstance(open_sev1_count, int) or isinstance(open_sev1_count, bool):
+        sev_green, sev_detail = False, "Sev-1 telemetry unavailable (declare it absent to proceed)"
     elif open_sev1_count == 0:
         sev_green, sev_detail = True, "0 open Sev-1"
     else:
@@ -209,7 +229,6 @@ def evaluate_gate(
         target_digest=target_digest.strip(),
         conditions=(
             Condition("throwaway_ci", ci_green, ci_detail),
-            Condition("soak", soak_green, soak_detail),
             Condition("quarantines", quar_green, quar_detail),
             Condition("sev1", sev_green, sev_detail),
         ),
@@ -279,11 +298,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--ci-passed", default=None, help="E2E-01 smoke result (true/false)")
     parser.add_argument("--ci-digest", default=None, help="the digest E2E-01 tested")
-    parser.add_argument("--soak-hours", default=None, help="accrued dogfood soak hours")
+    # Declaring "no telemetry here" is a DECISION and must look like one in the
+    # argv. A default-on flag would make absence the accident it replaces (#1106).
     parser.add_argument(
-        "--soak-required-hours", default="24", help="soak hours required (default 24)"
-    )
-    parser.add_argument("--quarantines", default=None, help="quarantine count during soak")
+        "--quarantines-declared-absent", action="store_true",
+        help="no quarantine telemetry deployed — declare it absent (#1106)")
+    parser.add_argument(
+        "--sev1-declared-absent", action="store_true",
+        help="no Sev-1 telemetry deployed — declare it absent (#1106)")
+    parser.add_argument("--quarantines", default=None, help="quarantine count")
     parser.add_argument("--open-sev1", default=None, help="open Sev-1 count")
     parser.add_argument(
         "--ack",
@@ -297,10 +320,10 @@ def main(argv: list[str] | None = None) -> int:
             target_digest=args.target_digest,
             ci_passed=_tri_bool(args.ci_passed),
             ci_digest=args.ci_digest,
-            soak_hours=_opt_number(args.soak_hours, float),
-            soak_required_hours=float(args.soak_required_hours),
             quarantine_count=_opt_number(args.quarantines, int),
             open_sev1_count=_opt_number(args.open_sev1, int),
+            quarantine_declared_absent=args.quarantines_declared_absent,
+            sev1_declared_absent=args.sev1_declared_absent,
         )
     except GateError as exc:
         print(f"promotion-gate error: {exc}", file=sys.stderr)

--- a/scripts/ci/promote-oakandwave-image.sh
+++ b/scripts/ci/promote-oakandwave-image.sh
@@ -5,7 +5,8 @@
 # Promotion is a two-part contract:
 #
 #   1. A mechanical conjunction over FlightDeck + CI must be green — throwaway-CI
-#      E2E-01 pass, dogfood soak met, zero quarantines, zero open Sev-1 (R-07).
+#      E2E-01 pass (digest-bound), zero quarantines, zero open Sev-1 (R-07).
+#      Soak was removed in #1106 — see the gate_args block below.
 #   2. The operator ACK confirms the green gate; promotion then retags the EXACT
 #      digest E2E-01 tested `:edge → :stable` — no rebuild, same bytes (R-23).
 #
@@ -46,9 +47,10 @@
 #   THROWAWAY_CI_PASSED E2E-01 smoke result for DIGEST_REF (true/false).
 #   THROWAWAY_CI_DIGEST the digest E2E-01 tested (defaults to DIGEST_REF; the gate
 #                       still requires it to equal the promotion target — R-23).
-#   SOAK_HOURS          accrued dogfood soak hours.
-#   SOAK_REQUIRED_HOURS soak hours required (default 24).
-#   QUARANTINE_COUNT    quarantines during soak (0 to pass).
+#   QUARANTINE_COUNT    quarantines observed (0 to pass).
+#   QUARANTINE_TELEMETRY_ABSENT  "true" ⇒ declare quarantine telemetry not
+#                       deployed (#1106). Absent + UNdeclared still reads red.
+#   SEV1_TELEMETRY_ABSENT        "true" ⇒ same, for Sev-1.
 #   OPEN_SEV1_COUNT     open Sev-1 (0 to pass).
 #   STABLE_TAG          moving tag to publish (default: stable).
 #   PROMOTE_DRY_RUN     "true" ⇒ evaluate the gate + print the retag, do NOT push.
@@ -91,10 +93,20 @@ gate_args=(--target-digest "$DIGEST_REF")
 # The digest E2E-01 tested defaults to the promotion target; the gate still
 # enforces they are equal (R-23), so a caller cannot silently widen this.
 gate_args+=(--ci-digest "${THROWAWAY_CI_DIGEST:-$DIGEST_REF}")
-[[ -n "${SOAK_HOURS:-}" ]] && gate_args+=(--soak-hours "$SOAK_HOURS")
-gate_args+=(--soak-required-hours "${SOAK_REQUIRED_HOURS:-24}")
+# Soak was REMOVED from the gate (#1106). It credited only sessions running at
+# the instant of a bridge pass, so a missed cron window silently discarded real
+# runtime — a proxy for "was the recorder running", not "did this soak". Measured:
+# the fleet ran containers well over 24h and a 48h look-back credited ZERO. That
+# left injecting an unmeasured number as the only route to promotion, and a gate
+# passable only by lying to it manufactures the habit of lying to it.
 [[ -n "${QUARANTINE_COUNT:-}" ]] && gate_args+=(--quarantines "$QUARANTINE_COUNT")
 [[ -n "${OPEN_SEV1_COUNT:-}" ]] && gate_args+=(--open-sev1 "$OPEN_SEV1_COUNT")
+# Declaring "this telemetry is not deployed" is a DECISION and must be made
+# explicitly (#1106). Absent + undeclared still reads red — the declaration is
+# what separates a considered gap from an accident nobody noticed, exactly like
+# OAW_REQUIRED_SECRETS="" (#1061) and .no-scannable-dependencies (#1073).
+[[ "${QUARANTINE_TELEMETRY_ABSENT:-false}" == "true" ]] && gate_args+=(--quarantines-declared-absent)
+[[ "${SEV1_TELEMETRY_ABSENT:-false}" == "true" ]] && gate_args+=(--sev1-declared-absent)
 [[ "${OPERATOR_ACK:-false}" == "true" ]] && gate_args+=(--ack)
 
 echo "==> evaluating the mechanical promotion gate for $DIGEST_REF"

--- a/scripts/ci/soak-accrual-bridge.sh
+++ b/scripts/ci/soak-accrual-bridge.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 # soak-accrual-bridge.sh — accrue dogfood soak from the LIVE :edge ring (#1008).
 #
+# NO LONGER GATES PROMOTION (#1106). Soak was removed from the mechanical gate:
+# this bridge credits only sessions running at the instant of a pass, so a missed
+# cron window silently discarded real runtime — the metric measured "was the
+# recorder running", not "did this soak". Measured live: the fleet ran containers
+# for well over 24h and a 48h look-back credited ZERO, because the bridge had
+# never been scheduled and cannot backfill.
+#
+# The ledger it writes is retained as TELEMETRY (FlightDeck, #854) and the
+# profile filter (R-22) still applies. Nothing refuses a promotion on it. If you
+# are reading this while trying to make a promotion go green, you are in the
+# wrong file — see containers/oakandwave-workflow/promotion_gate.py.
+#
 # The operator/cron entrypoint that closes the FlightDeck soak loop: it drives the
 # flight surgeon over the live aoe sessions and feeds each running dogfood session's
 # clean span to the soak ledger the promotion gate reads. Run it periodically during

--- a/tests/contained-workflow/test_gate.py
+++ b/tests/contained-workflow/test_gate.py
@@ -49,8 +49,6 @@ GREEN_SIGNALS = dict(
     target_digest=DIGEST_A,
     ci_passed=True,
     ci_digest=DIGEST_A,
-    soak_hours=48.0,
-    soak_required_hours=24.0,
     quarantine_count=0,
     open_sev1_count=0,
 )
@@ -64,10 +62,6 @@ RED_OVERRIDES: dict[str, list[dict]] = {
         {"ci_digest": DIGEST_B},  # green, but for a DIFFERENT digest (R-23)
         {"ci_digest": None},  # green, but no digest attested (fail-closed)
         {"ci_digest": MOVING_TAG},  # green, but attested a moving tag (R-23)
-    ],
-    "soak": [
-        {"soak_hours": 12.0},  # under the required soak
-        {"soak_hours": None},  # soak telemetry unavailable (fail-closed)
     ],
     "quarantines": [
         {"quarantine_count": 1},  # a quarantine tripped
@@ -119,10 +113,9 @@ def test_gate_conjunction() -> None:
 
 def test_multiple_red_conditions_still_refused() -> None:
     """Every non-all-green combination refuses, ACK or not (exhaustive over the
-    2^4 truth table of the four conditions)."""
+    2^3 truth table of the three conditions)."""
     knobs = {
         "throwaway_ci": {"ci_passed": False},
-        "soak": {"soak_hours": 1.0},
         "quarantines": {"quarantine_count": 2},
         "sev1": {"open_sev1_count": 1},
     }
@@ -175,7 +168,7 @@ def test_gate_refuses_a_moving_tag_target() -> None:
 
 def test_ack_cannot_promote_a_red_gate() -> None:
     """The ACK confirms a green gate; it can never rescue a red one (R-07)."""
-    report = _report(soak_hours=0.0)
+    report = _report(ci_passed=False)
     assert not report.green
     with pytest.raises(pg.GateError):
         pg.promote(report, operator_ack=True)
@@ -208,7 +201,6 @@ def test_cli_promotes_only_on_green_plus_ack() -> None:
     base = [
         "--target-digest", DIGEST_A,
         "--ci-passed", "true", "--ci-digest", DIGEST_A,
-        "--soak-hours", "48", "--soak-required-hours", "24",
         "--quarantines", "0", "--open-sev1", "0",
     ]
     # Green but no ACK → refuse (non-zero), print nothing promotable on stdout.
@@ -239,7 +231,7 @@ def test_cli_refuses_ci_green_for_a_different_digest() -> None:
     proc = _run_gate_cli(
         "--target-digest", DIGEST_A,
         "--ci-passed", "true", "--ci-digest", DIGEST_B,
-        "--soak-hours", "48", "--quarantines", "0", "--open-sev1", "0",
+        "--quarantines", "0", "--open-sev1", "0",
         "--ack",
     )
     assert proc.returncode != 0

--- a/tests/contained-workflow/test_promotion_cycle.py
+++ b/tests/contained-workflow/test_promotion_cycle.py
@@ -95,15 +95,19 @@ def test_full_promotion_cycle_end_to_end(tmp_path):
     )
     assert signals["soak_hours"] == 30
     assert signals["quarantine_count"] == 0
+    # NOTE (#1106): soak_hours is still ACCRUED and still filtered — the ledger and
+    # the profile filter are unchanged and remain useful telemetry. It is no longer
+    # a GATE CONDITION: it credited only sessions running at the instant of a pass,
+    # so a missed cron window discarded real runtime, and the only way to promote
+    # became injecting a number nobody measured.
 
     # 3. THE MECHANICAL GATE goes green on the real signals and promotes the EXACT
     #    tested digest — no rebuild, and the ACK only confirms an already-green gate.
+    #    Soak is deliberately not among the conditions (#1106).
     report = pg.evaluate_gate(
         target_digest=DIGEST,
         ci_passed=True,
         ci_digest=DIGEST,
-        soak_hours=signals["soak_hours"],
-        soak_required_hours=24.0,
         quarantine_count=signals["quarantine_count"],
         open_sev1_count=0,
     )
@@ -124,32 +128,67 @@ def test_full_promotion_cycle_end_to_end(tmp_path):
     assert plan.launch_ref == promoted, "the agent adopts the exact promoted digest"
 
 
-def test_gate_red_when_soak_unmet_blocks_the_cycle(tmp_path):
-    """Under-soaked dogfood work cannot promote — even with the operator ACK (R-07).
+def test_undeclared_missing_telemetry_blocks_the_cycle(tmp_path):
+    """Missing telemetry that nobody declared is RED — and the ACK never substitutes.
 
-    The 4.2-lens red-first assertion: if the accrued soak is below the requirement,
-    the mechanical gate is RED and promotion refuses; the ACK never substitutes.
+    Retargeted from the soak case when soak left the gate (#1106). The assertion
+    that mattered was never about soak: it is that a condition the system cannot
+    evidence must refuse, and that an operator ACK confirms an already-green gate
+    rather than creating one (R-07 / PC-6).
+
+    Absence must be a DECISION. Undeclared absence stays red; see
+    test_declared_absence_is_green_and_visible for the other half.
     """
-    ledger = tmp_path / "ledger.jsonl"
-    sl.accrue(observations=[_obs("agent-a", "dogfood", 5)], ledger_path=ledger)  # 5h << 24h
-    signals = pf.aggregate_gate_signals(soak_records=sl.read_ledger(ledger), quarantine_records=[])
-
     report = pg.evaluate_gate(
         target_digest=DIGEST,
         ci_passed=True,
         ci_digest=DIGEST,
-        soak_hours=signals["soak_hours"],
-        soak_required_hours=24.0,
-        quarantine_count=0,
+        quarantine_count=None,  # telemetry simply missing — nobody said so
         open_sev1_count=0,
     )
-    assert not report.green
-    with pytest.raises(pg.GateError):
-        pg.promote(report, operator_ack=True)  # ACK cannot rescue a red soak condition
+    assert not report.green, report.summary()
+    with pytest.raises(Exception):
+        pg.promote(report, operator_ack=True)
 
 
-# --- Soak accrual (the new FlightDeck writer) — R-21/R-22 + §4.3 --------------
+def test_declared_absence_is_green_and_visible(tmp_path):
+    """Declaring "no telemetry here" passes — and SAYS SO in the report.
 
+    A silent green would rebuild the defect: the reader could not tell an
+    evidenced condition from a waived one. Same discipline as
+    OAW_REQUIRED_SECRETS="" (#1061) and .no-scannable-dependencies (#1073).
+    """
+    report = pg.evaluate_gate(
+        target_digest=DIGEST,
+        ci_passed=True,
+        ci_digest=DIGEST,
+        quarantine_count=None,
+        open_sev1_count=None,
+        quarantine_declared_absent=True,
+        sev1_declared_absent=True,
+    )
+    assert report.green, report.summary()
+    assert "DECLARED absent" in report.summary(), (
+        "a waived condition must be distinguishable from an evidenced one"
+    )
+    assert pg.promote(report, operator_ack=True) == DIGEST
+
+
+def test_a_declaration_cannot_hide_a_real_failure(tmp_path):
+    """Declaring absence must not override a signal that IS present and bad.
+
+    Otherwise the declaration becomes a blanket override — the ACK-substitutes
+    hole reintroduced under a different name.
+    """
+    report = pg.evaluate_gate(
+        target_digest=DIGEST,
+        ci_passed=True,
+        ci_digest=DIGEST,
+        quarantine_count=3,  # present AND bad
+        open_sev1_count=0,
+        quarantine_declared_absent=True,  # must not rescue it
+    )
+    assert not report.green, report.summary()
 
 def test_soak_excludes_dev_mode(tmp_path):
     """A dev-mode session accrues NO soak record (R-22) — its span never reaches the


### PR DESCRIPTION
## Summary

The promotion gate had **never gone green**, and `:stable` had never existed in the registry across all 228 package versions. Nobody hit it because nothing had tried to promote until the v8.0.0 candidate.

Three of its four conditions read RED for the same reason: **the telemetry does not exist.** Not "the value is bad" — there is no value.

## Soak is removed

It could not measure what it claimed. Soak credited only sessions running at the *instant* of a bridge pass, so a missed cron window silently discarded real runtime — a proxy for *"was the recorder running"*, not *"did this soak"*.

Measured: the fleet ran containers for **well over 24 hours** and a 48-hour look-back credited **zero**, because the bridge had never been scheduled and cannot backfill.

That left injecting an unmeasured number as the only route to promotion. **A gate passable only by lying to it manufactures the habit of lying to it** — on the control guarding what the entire fleet runs. Refusing once is easy; the tenth time, under pressure, someone types `SOAK_HOURS=24` and the gate becomes decorative *and* trusted.

The artifact is tested by throwaway-CI (R-23) and by `aoe-preflight.sh` — behavioural checks that found every defect in this cut-over (#1076, #1085, #1086, #1092). None was ever found by soaking.

## Quarantine and Sev-1 become declarable

They come from FlightDeck (#854), which is not deployed. Reading RED forever because nothing was wired is the same defect one condition over.

| state | verdict |
|---|---|
| signal present | evaluated normally — a non-zero count is still **RED** |
| **declared absent** | green, and the declaration is **echoed** in the report |
| simply missing | **RED**, unchanged |

Declaring "no telemetry here, deliberately" is legitimate; omitting the declaration is not. Same discipline as `OAW_REQUIRED_SECRETS=""` (#1061) and `.no-scannable-dependencies` (#1073).

**The echo matters.** A silent green would leave a reader unable to tell an evidenced condition from a waived one — so every promotion record shows which is which.

## What deliberately did not change

- `OPERATOR_ACK` still cannot flip a RED condition (PC-6 / R-07).
- **A declaration cannot rescue a signal that is present and bad** — `quarantine_count=3` plus `--quarantines-declared-absent` is still RED. Otherwise the declaration becomes a blanket override: the ACK hole under a new name.

Both are pinned by tests.

## Verified against the real candidate

```
[green] throwaway-CI E2E-01 smoke green for the tested digest — digest-bound (R-23)
[green] zero quarantines — no quarantine telemetry — DECLARED absent, not assumed
[green] zero open Sev-1  — no Sev-1 telemetry — DECLARED absent, not assumed
=> GREEN — would retag :stable
```

No injected measurements. Every green is a real result or an explicitly echoed declaration.

## Linked Issues

Closes #1106

## Test Plan

- `./scripts/ci/validate.sh` — **233 passed, 0 failed**.
- `python3 -m pytest tests/ --ignore=tests/test_install.py` — **2035 passed**. Both lanes.
- **One test retargeted rather than deleted.** Its *subject* was soak, but its *assertion* was "the ACK never substitutes for red" — which still matters. It now pins that against a live condition, joined by two new cases covering the declaration semantics in both directions.
- Mutation-checked: undeclared-missing stays RED; a declaration cannot rescue a present-and-bad signal.
- `soak-accrual-bridge.sh` keeps writing its ledger as FlightDeck telemetry and now states plainly that it no longer gates anything — ending with a pointer for whoever arrives there trying to make a promotion go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS