### PR TITLE
fix(contained-workflow): make ssh parity per-file and self-healing

### DIFF
--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -764,37 +764,66 @@ ensure_ssh_parity() {
 		warn "missing mount: no $src — git over SSH and remote hosts (blueshift, perkollate) unavailable"
 		return 0
 	}
-	# Already correct?
-	if [[ -L "$dst" && "$(readlink -f "$dst" 2>/dev/null)" == "$(readlink -f "$src" 2>/dev/null)" ]]; then
-		info "ssh: ~/.ssh already resolves to $src"
-		return 0
-	fi
-	# A REAL dir here is not necessarily the operator's — ssh silently creates one
-	# the first time it writes known_hosts, and then `ln -s` lands INSIDE it rather
-	# than replacing it (which is exactly how the first attempt at this failed).
-	# Only clear it when it holds nothing but ssh's own scratch.
+	# PER-FILE LINKS, not a directory symlink (#1111). Two reasons, both learned
+	# the hard way:
+	#
+	# 1. SELF-HEALING. The old form linked the whole dir and refused whenever
+	#    $dst already held anything but known_hosts — so the moment an agent
+	#    wrote ANY file there (ssh's own scratch, or a keypair it generated
+	#    because it thought it had no keys), parity was declined forever, with
+	#    nothing but a warning nobody reads at boot. Observed live: an agent
+	#    reported itself blocked on host access, generated its own keypair, and
+	#    escalated for a privilege it already had — while the operator's full
+	#    keyring sat mounted at $src the whole time. A silent parity gap does not
+	#    just block work, it generates pressure to solve the wrong problem.
+	#
+	# 2. $src IS READ-ONLY. Linking the directory means ssh cannot write
+	#    known_hosts, so every new host is either a prompt or a failure. Linking
+	#    the keys individually leaves $dst a real, writable dir that owns its own
+	#    known_hosts while every key resolves to the mount.
+	#
+	# Idempotent by construction: it adds what is missing and never removes. A
+	# second boot relinks nothing; a key added to the host keyring appears on the
+	# next boot without intervention.
 	if [[ -L "$dst" ]]; then
-		warn "ssh: $dst is a symlink to $(readlink "$dst" 2>/dev/null) — replacing it with $src"
+		# A whole-dir link from the pre-#1111 behaviour: correct for keys, but it
+		# makes known_hosts unwritable. Convert it rather than leaving it.
+		info "ssh: converting the legacy ~/.ssh symlink to per-file links (known_hosts must stay writable)"
+		rm -f "$dst" || warn "ssh: could not replace the legacy $dst symlink"
 	fi
-	if [[ -e "$dst" && ! -L "$dst" ]]; then
-		local stray
-		# `|| true`: under set -e a find failure would abort bootstrap — and the
-		# wrapper SOURCES this, so that means no agent at all.
-		stray="$(find "$dst" -mindepth 1 -maxdepth 1 ! -name known_hosts ! -name 'known_hosts.old' -print -quit 2>/dev/null || true)"
-		if [[ -n "$stray" ]]; then
-			warn "ssh: $dst exists with real content ($stray) — leaving it alone; mounted keys at $src are NOT in use"
-			return 0
-		fi
-		rm -rf "$dst" || {
-			warn "ssh: could not clear $dst — mounted keys at $src are NOT in use"
-			return 0
-		}
-	fi
-	if ln -sfn "$src" "$dst" 2>/dev/null; then
-		info "ssh: linked ~/.ssh -> $src (keys + host config now visible to the agent)"
+	mkdir -p "$dst" 2>/dev/null || {
+		warn "ssh: could not create $dst — mounted keys at $src are NOT in use"
+		return 0
+	}
+	# ssh refuses to use a group/world-readable ~/.ssh, and would then look like
+	# "no keys" all over again.
+	chmod 700 "$dst" 2>/dev/null || true
+
+	local linked=0 f base
+	for f in "$src"/*; do
+		[[ -e "$f" ]] || continue # nullglob is not set; an empty dir yields the literal
+		base="$(basename "$f")"
+		# known_hosts is the ONE thing the agent must own: it is written on every
+		# first contact with a new host, and $src is read-only.
+		[[ "$base" == known_hosts || "$base" == known_hosts.old ]] && continue
+		[[ -e "$dst/$base" || -L "$dst/$base" ]] && continue
+		ln -s "$f" "$dst/$base" 2>/dev/null && linked=$((linked + 1))
+	done
+
+	if ((linked > 0)); then
+		info "ssh: linked $linked key/config file(s) from $src into ~/.ssh (known_hosts stays writable)"
 	else
-		warn "ssh: could not link ~/.ssh -> $src; git over SSH and remote hosts will fail"
+		info "ssh: ~/.ssh already carries the mounted keyring"
 	fi
+
+	# ASSERT THE OUTCOME, not the mechanism. Counting symlinks proves we ran; it
+	# does not prove the agent has a usable identity. If nothing resembling a
+	# private key landed, say so loudly at boot — the alternative is an agent
+	# discovering it much later, at a git push, with no path back to the cause.
+	if ! find "$dst" -maxdepth 1 \( -name 'id_*' ! -name '*.pub' \) -print -quit 2>/dev/null | grep -q .; then
+		warn "ssh: no private key visible in ~/.ssh after parity — git over SSH and remote hosts will fail"
+	fi
+	return 0
 }
 
 # --- GitLab API credential (#1089) --------------------------------------------

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -590,6 +590,35 @@ this check produced a false alarm.
 
 ### 3.6.2 SSH parity — the keys are provided on purpose (#1089)
 
+**The keyring is mounted WHOLE, and that is a decision (2026-08-01).** The
+operator uses every key at different times and there is no reliable way to slice
+them per agent, so `~/.ssh` is bind-mounted entire — the same call as the
+whole-directory secrets mount (#1090). Agents are inside the trust boundary
+already; the container exists so a `./install` cannot rewrite shared hooks and
+settings underneath a live session, **not** to limit what an agent can reach.
+
+**Parity is per-file, not a directory symlink (#1111).** Two failures forced it:
+
+- The mount is **read-only**, so linking the directory leaves ssh unable to write
+  `known_hosts` — every first contact with a new host becomes a prompt or a
+  failure in a non-interactive session.
+- The old form declined whenever `~/.ssh` already held anything but
+  `known_hosts`. The moment an agent wrote a single file there, parity was
+  refused **permanently**, with only a boot warning. Observed live: an agent
+  found no `~/.ssh`, concluded it had no host access, generated its own keypair,
+  and escalated for a privilege it already had — while the operator's full
+  keyring sat mounted the whole time.
+
+That second one is the lesson worth keeping: **a silent parity gap does not just
+block work, it generates pressure to solve the wrong problem.** The agent's
+proposal — authorise a container-minted key on the host — would have widened
+privileges to obtain something already granted.
+
+Parity therefore *adds what is missing and never removes*, and `aoe-preflight.sh`
+asserts the **outcome** (a usable key on the path ssh searches, and a writable
+`~/.ssh`) rather than the mechanism. Every structural check passed throughout the
+incident; only a behavioural one would have caught it.
+
 aoe mounts the operator's `~/.ssh` to `/root/.ssh`: keys **and** a host→identity
 config. Agents use them constantly — git over SSH for both forges, and
 troubleshooting remote installs (blueshift, perkollate, `agent-smith-ca`), where

--- a/scripts/ci/aoe-preflight.sh
+++ b/scripts/ci/aoe-preflight.sh
@@ -183,6 +183,36 @@ else
 		"an agent that cannot fetch cannot verify an MR before merging it"
 fi
 
+# --- SSH parity: the agent's OWN ~/.ssh, not just the mount (#1111) -----------
+# The mount being present proves nothing about whether the AGENT can see it. In
+# the live failure the keyring was correctly mounted at /root/.ssh the entire
+# time while ~/.ssh held one file the agent had created — so it reported itself
+# blocked on host access, generated a keypair, and escalated for a privilege it
+# already had. Every structural check passed throughout.
+#
+# So ask the question the agent asks: is there a usable private key on the path
+# ssh will actually search? A count, not an exit status — an exec failure would
+# otherwise read as "absent" and pass, the opposite polarity to every other check.
+SSHKEYS="$(x sh -c 'ls -1 ~/.ssh/ 2>/dev/null | grep -cE "^id_|\.id_|_ed25519$|_rsa$" || true' | tr -d '\r')"
+if [[ ! "$SSHKEYS" =~ ^[0-9]+$ ]]; then
+	fail "could not read the agent's ssh dir (got: $SSHKEYS)"
+elif ((SSHKEYS == 0)); then
+	fail "no ssh key visible in the agent's own ssh dir" \
+		"the mount can be perfect and the agent still blind — that is #1111"
+else
+	pass "operator keyring reaches the agent's own ssh dir ($SSHKEYS key(s))"
+fi
+
+# known_hosts must be WRITABLE — the mount is read-only, so a whole-dir symlink
+# leaves ssh unable to record a new host, and every first contact becomes a
+# prompt or a failure in a non-interactive session.
+if x sh -c 'touch ~/.ssh/.preflight-probe 2>/dev/null && rm -f ~/.ssh/.preflight-probe'; then
+	pass "the agent's ssh dir is writable (ssh can record known_hosts)"
+else
+	fail "the agent's ssh dir is not writable — ssh cannot record known_hosts" \
+		"a directory symlink onto the read-only mount does this"
+fi
+
 # gitlab uses a DIFFERENT transport (SSH — the host has no gitlab rewrite), so
 # testing github alone proves only half the parity claim.
 GLREACH="$(x sh -c 'timeout 40 git ls-remote git@gitlab.com:gitlab-org/cli.git HEAD 2>&1 | head -1')"

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -1377,49 +1377,113 @@ def _home_with_ssh(tmp_path: Path) -> tuple[Path, Path]:
 
 
 def test_mounted_ssh_keys_are_made_visible_to_the_agent(tmp_path: Path) -> None:
+    """The keys land in ~/.ssh as links, and ~/.ssh stays a REAL, writable dir.
+
+    Per-file rather than a directory symlink (#1111): the mount is READ-ONLY, so
+    a whole-dir link leaves ssh unable to write known_hosts — every new host then
+    becomes a prompt or a failure.
+    """
     home, src = _home_with_ssh(tmp_path)
     proc = _run(home, OAW_SSH_SOURCE=str(src))
     assert proc.returncode == 0, proc.stderr
-    link = home / ".ssh"
-    assert link.is_symlink(), "~/.ssh must resolve to the mounted keys"
-    assert link.resolve() == src.resolve()
-    assert (link / "config").exists(), "the host->identity config must be reachable"
+    dst = home / ".ssh"
+    assert dst.is_dir() and not dst.is_symlink(), (
+        "~/.ssh must stay a real dir so known_hosts remains writable"
+    )
+    assert (dst / "config").is_symlink(), "the host->identity config must be reachable"
+    assert (dst / "gitlab.id_ed25519").resolve() == (src / "gitlab.id_ed25519").resolve()
+    assert oct(dst.stat().st_mode)[-3:] == "700", "ssh refuses a loose ~/.ssh"
 
 
-def test_ssh_link_is_idempotent(tmp_path: Path) -> None:
+def test_ssh_parity_is_idempotent(tmp_path: Path) -> None:
+    """Runs on every agent start, so a satisfied state must relink nothing."""
     home, src = _home_with_ssh(tmp_path)
     assert _run(home, OAW_SSH_SOURCE=str(src)).returncode == 0
     proc = _run(home, OAW_SSH_SOURCE=str(src))
-    assert "already resolves" in proc.stderr
+    assert "already carries the mounted keyring" in proc.stderr
 
 
-def test_sshs_own_known_hosts_scratch_dir_is_replaced(tmp_path: Path) -> None:
-    """ssh silently creates ~/.ssh the first time it writes known_hosts.
+def test_known_hosts_stays_writable_and_local(tmp_path: Path) -> None:
+    """known_hosts is the ONE file the agent must own — the mount is read-only."""
+    home, src = _home_with_ssh(tmp_path)
+    (src / "known_hosts").write_text("host-from-the-operator\n")
+    assert _run(home, OAW_SSH_SOURCE=str(src)).returncode == 0
+    kh = home / ".ssh" / "known_hosts"
+    assert not kh.is_symlink(), "known_hosts must never link into the read-only mount"
+    kh.write_text("agent-learned-this-host\n")  # must not raise
 
-    That is how the first attempt at this failed: `ln -s` landed INSIDE the
-    freshly-created directory instead of replacing it, so the keys stayed
-    invisible while the command reported success.
+
+def test_an_agent_created_ssh_dir_still_gets_the_keys(tmp_path: Path) -> None:
+    """THE LIVE FAILURE (#1111), red-first.
+
+    The old guard declined whenever ~/.ssh held anything but known_hosts. So the
+    instant an agent wrote a file there — ssh scratch, or a keypair it generated
+    because it believed it had no keys — parity was refused forever, with only a
+    boot warning nobody reads.
+
+    Observed: an agent reported itself blocked on host access, generated its own
+    keypair, and escalated for a privilege it already had, while the operator's
+    full keyring sat mounted the whole time. A silent parity gap does not just
+    block work — it generates pressure to solve the wrong problem.
     """
     home, src = _home_with_ssh(tmp_path)
-    scratch = home / ".ssh"
-    scratch.mkdir()
-    (scratch / "known_hosts").write_text("gitlab.com ssh-ed25519 AAAA\n")
+    dst = home / ".ssh"
+    dst.mkdir()
+    (dst / "id_agent_generated").write_text("SELF-MINTED\n")
+    (dst / "known_hosts").write_text("somehost\n")
+
     proc = _run(home, OAW_SSH_SOURCE=str(src))
-    assert proc.returncode == 0
-    assert (home / ".ssh").is_symlink(), "a known_hosts-only dir must not block the link"
+    assert proc.returncode == 0, proc.stderr
+    assert (dst / "gitlab.id_ed25519").is_symlink(), (
+        "an agent-created ~/.ssh must NOT block the operator's keys — this is the bug"
+    )
+    assert (dst / "id_agent_generated").read_text() == "SELF-MINTED\n", (
+        "parity adds what is missing and never destroys what is there"
+    )
 
 
-def test_a_real_ssh_dir_is_never_clobbered(tmp_path: Path) -> None:
-    """Destroying an operator's private keys would be unrecoverable."""
+def test_operator_keys_in_a_real_ssh_dir_are_never_destroyed(tmp_path: Path) -> None:
+    """Destroying a private key would be unrecoverable. Add, never remove."""
     home, src = _home_with_ssh(tmp_path)
     real = home / ".ssh"
     real.mkdir()
     (real / "id_ed25519").write_text("OPERATOR KEY\n")
+    assert _run(home, OAW_SSH_SOURCE=str(src)).returncode == 0
+    assert (real / "id_ed25519").read_text() == "OPERATOR KEY\n"
+    assert not (real / "id_ed25519").is_symlink(), "an existing file is never replaced"
+    assert (real / "config").is_symlink(), "…but missing ones are still supplied"
+
+
+def test_a_legacy_whole_dir_symlink_is_converted(tmp_path: Path) -> None:
+    """Containers provisioned by the pre-#1111 code have ~/.ssh as a dir symlink.
+
+    Correct for keys, but it makes known_hosts unwritable, so it is migrated
+    rather than left in place.
+    """
+    home, src = _home_with_ssh(tmp_path)
+    (home / ".ssh").symlink_to(src)
+    proc = _run(home, OAW_SSH_SOURCE=str(src))
+    assert proc.returncode == 0, proc.stderr
+    dst = home / ".ssh"
+    assert dst.is_dir() and not dst.is_symlink(), "the legacy dir-symlink must be converted"
+    assert (dst / "gitlab.id_ed25519").is_symlink()
+    assert "converting the legacy" in proc.stderr
+
+
+def test_parity_without_a_usable_key_is_loud(tmp_path: Path) -> None:
+    """Assert the OUTCOME, not the mechanism.
+
+    Counting symlinks proves the function ran; it does not prove the agent has a
+    usable identity. Without this, an agent discovers the gap much later at a git
+    push, with no path back to the cause.
+    """
+    home = _make_home(tmp_path, secrets={".env": 'OAW_REQUIRED_SECRETS=""\n'})
+    src = tmp_path / "ssh-src"
+    src.mkdir()
+    (src / "config").write_text("Host *\n")  # config but NO private key
     proc = _run(home, OAW_SSH_SOURCE=str(src))
     assert proc.returncode == 0
-    assert not (home / ".ssh").is_symlink(), "must not replace a real ~/.ssh"
-    assert (real / "id_ed25519").read_text() == "OPERATOR KEY\n"
-    assert "leaving it alone" in proc.stderr, "the skip must be loud, not silent"
+    assert "no private key visible" in proc.stderr
 
 
 def test_gitlab_api_credential_is_written_as_a_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`ensure_ssh_parity` linked the operator's keyring as **one directory symlink** and declined whenever `~/.ssh` already held anything but `known_hosts`. Two failures came out of that, and only one was the reported symptom.

## The latent bug

The moment an agent wrote a single file into `~/.ssh`, parity was refused **permanently** — with nothing but a boot warning nobody reads. And an agent that cannot see keys *will* write there, because generating a keypair is the obvious next move when you believe you have none.

Observed live: an agent found no `~/.ssh`, concluded it had no host access, generated its own keypair, and escalated to have that key authorised on the host — while the operator's full keyring sat mounted at `/root/.ssh` the whole time and `ssh -i /root/.ssh/id_ed25519 bakerb@malory` worked.

**A silent parity gap does not just block work — it generates pressure to solve the wrong problem.** The proposed fix was to *widen privileges* to obtain something already granted.

## The second reason the directory link was wrong

The mount is **read-only**, so linking the directory leaves ssh unable to write `known_hosts`. Every first contact with a new host becomes a prompt or a failure in a non-interactive session.

## What changed

Parity links **per-file** into a real, writable `~/.ssh`. It **adds what is missing and never removes what is there**:

- an existing key is skipped, never replaced (destroying a private key would be unrecoverable)
- `known_hosts` stays local and writable
- a legacy whole-dir symlink is migrated rather than left
- a key added to the host keyring appears on the next boot with no intervention

Idempotent **by construction** rather than by a guard that can wedge.

It also asserts the **outcome** at boot: if no usable private key is visible after parity, say so loudly. Counting symlinks proves the function ran; it does not prove the agent has an identity — and the alternative is discovering that much later at a `git push`, with no path back to the cause.

`aoe-preflight.sh` gains the same discipline behaviourally: a usable key on the path ssh actually searches, and a writable ssh dir. **Every structural check passed throughout the incident** — `ls /root/.ssh` was green while the agent was blind. That is exactly why the assertion had to change kind.

## Four existing tests rewritten, not adjusted

They pinned the whole-dir behaviour **including the guard that caused the bug**. One asserted `"leaving it alone" in proc.stderr` — the defect asserted as a requirement.

## Documentation

architecture.md §3.6.2 now records that the keyring is mounted **whole by decision** (2026-08-01, same call as the whole-directory secrets mount #1090): the operator uses every key at different times, there is no reliable way to slice them per agent, and **agents are inside the trust boundary already**. The container exists so an `./install` cannot rewrite shared hooks and settings under a live session — *not* to limit what an agent can reach.

## Linked Issues

Closes #1111

## Test Plan

- `./scripts/ci/validate.sh` — **233 passed, 0 failed**.
- `python3 -m pytest tests/ --ignore=tests/test_install.py` — **2038 passed**. Both lanes.
- **7 tests** covering: per-file links with `~/.ssh` still a real dir at `700`, idempotence, `known_hosts` local and writable, an agent-created `~/.ssh` still receiving the keys (the live failure, red-first), existing keys never destroyed, legacy symlink migration, and a loud warning when no usable key results.
- **Mutation-tested:** restoring the old stray-guard reproduces the exact live failure and kills both regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS