### PR TITLE
fix(tests): stop install tests fetching MCP servers nothing asserts

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -83,6 +83,41 @@ def _make_env(home: Path) -> dict[str, str]:
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _with_no_mcps(args: list[str]) -> list[str]:
+    """Prepend ``--no-mcps`` unless the caller already opted out of MCP install.
+
+    WHY (#1070). Each real ``./install`` here fetched FIVE MCP server binaries
+    over the network — measured at ~84% of install wall-clock — and **not one
+    assertion in this file examines them**. Grep for `disc-server`/`sdlc-server`:
+    the only hits are a documentation path and a comment. Ten tests were paying
+    the dominant cost of the suite for coverage that does not exist.
+
+    That cost was not merely slow. On a hosted runner it pushed ``install`` past
+    the 120s per-invocation timeout and took CI red on PR #1112 — five failures
+    on a changeset that touched nothing install-related. A gate that fails for
+    reasons unrelated to the diff teaches people to disbelieve it.
+
+    **Nothing tested today stops being tested.** The coverage this skips is held
+    somewhere strictly better: the image build runs a real, complete ``./install``
+    and fails unless every one of the five servers is registered in
+    ``~/.claude.json`` **and** its binary is executable. That is the artifact that
+    actually ships, so the division is: the image proves a full install works,
+    this file proves the BEHAVIOURS around install — prune, drift, uninstall,
+    dry-run, exclusions.
+
+    Deliberately NOT the shared-fixture approach: every test still performs its
+    own real install, so the 39-of-47-absolute-symlinks hazard that makes a naive
+    ``cp -a`` of an installed tree unsafe simply never arises.
+
+    ``--local`` already implies ``--no-mcps`` (install:219); passing both is
+    harmless, but leaving it to the implication would couple this helper to that
+    detail, so it is skipped explicitly.
+    """
+    if "--no-mcps" in args or "--local" in args:
+        return args
+    return ["--no-mcps"] + args
+
+
 def run_install(
     args: list[str],
     home: Path,
@@ -92,7 +127,7 @@ def run_install(
     Returns ``(returncode, stdout, stderr)``.
     """
     result = subprocess.run(
-        ["bash", _INSTALL_SCRIPT] + args,
+        ["bash", _INSTALL_SCRIPT] + _with_no_mcps(args),
         capture_output=True,
         text=True,
         env=_make_env(home),
@@ -776,7 +811,7 @@ def run_install_cwd(
     subprocess cwd must be set to the project directory under test.
     """
     result = subprocess.run(
-        ["bash", _INSTALL_SCRIPT] + args,
+        ["bash", _INSTALL_SCRIPT] + _with_no_mcps(args),
         capture_output=True,
         text=True,
         env=_make_env(home),


### PR DESCRIPTION
## Summary

Each real `./install` in `tests/test_install.py` fetched **five MCP server binaries over the network** — measured at ~84% of install wall-clock — and **not one assertion in the file examines them**. Grepping for `disc-server`/`sdlc-server` returns exactly two hits: a documentation *path* being checked for installation, and a comment about what `--scripts` skips.

Ten tests were paying the dominant cost of the entire suite for coverage that does not exist.

`./install --no-mcps` already existed (`install:16`, handled at `install:157`). Both install entry points now route through a helper that adds it, skipping callers that pass `--local` (which implies it at `install:219`).

| | before | after |
|---|---|---|
| `tests/test_install.py` | 471–506s | **138s** |
| whole suite *including* it | ~620s | **266s** |

The full suite now runs faster than that one file used to.

## Not only a velocity fix

On a hosted runner the cost pushed `install` past its 120s per-invocation timeout and **took CI red on PR #1112** — five failures on a changeset touching nothing install-related.

A gate that fails for reasons unrelated to the diff teaches people to disbelieve it, and the response to a flaky gate is to re-run it — which is how a real failure eventually gets waved through. Same erosion as a warning that fires on every boot (#1078) or a scan reporting zero manifests forever (#1073).

**The `timeout=120` is deliberately not raised.** That would hide the cost rather than remove it, and the timeout is what surfaced the problem.

## Coverage proven, not claimed

Emptying `DEPRECATED_PATHS` — the #1062 defect this issue's ACs name specifically — still fails **3 tests**, including `test_removed_slack_skills_are_pruned`.

And what's skipped is held somewhere strictly better: **the image build runs a real, complete `./install`** and fails unless every one of the five servers is registered in `~/.claude.json` *and* its binary is executable. That's the artifact that actually ships.

So the division of labour is the one asked for when the `/tmp` fixture plan was overruled (*"stop trying to make /tmp work, it means less than testing in the image"*):

| lane | proves |
|---|---|
| image build | a complete real install works, MCP baking included |
| `test_install.py` | the *behaviours* around install — prune, drift, uninstall, dry-run, exclusions |

## Deliberately not the shared-fixture approach

Every test still performs its **own real install**. The hazard that made the session-scoped plan unsafe — 39 of 47 symlinks are absolute, so copying an installed tree relocates the links' containers without relocating their targets — simply never arises, because nothing is shared.

## Linked Issues

Closes #1070

## Test Plan

- `./scripts/ci/validate.sh` — **233 passed, 0 failed**.
- `python3 -m pytest tests/` — **2054 passed**, 6 skipped, 64 xfailed. Full suite in one process, `test_install.py` included (it shares state and must not be split).
- Before/after wall-clock recorded above, as the ACs require. Measured on a host with 9 containers running, so the figure is not a quiet-machine best case.
- **Mutation:** `DEPRECATED_PATHS` emptied → 3 failures; reverted → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS