### PR TITLE
fix(contained-workflow): seed known_hosts instead of leaving it empty

### DIFF
--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -804,8 +804,23 @@ ensure_ssh_parity() {
 		[[ -e "$f" ]] || continue # nullglob is not set; an empty dir yields the literal
 		base="$(basename "$f")"
 		# known_hosts is the ONE thing the agent must own: it is written on every
-		# first contact with a new host, and $src is read-only.
-		[[ "$base" == known_hosts || "$base" == known_hosts.old ]] && continue
+		# first contact with a new host, and $src is read-only. So it is COPIED,
+		# never linked (#1115).
+		#
+		# Skipping it entirely — the first cut — left the agent with an EMPTY
+		# known_hosts and no way to answer a host-key prompt non-interactively:
+		# `git ls-remote git@gitlab.com:…` died with "Host key verification
+		# failed" in a fresh container. Writable but empty is its own outage.
+		#
+		# Copy-if-absent, not copy-always: once the agent has learned hosts of its
+		# own, replacing the file every boot would discard them.
+		if [[ "$base" == known_hosts || "$base" == known_hosts.old ]]; then
+			if [[ ! -e "$dst/$base" ]] && cp "$f" "$dst/$base" 2>/dev/null; then
+				chmod u+w "$dst/$base" 2>/dev/null || true
+				info "ssh: seeded ~/.ssh/$base from the mount (writable copy, not a link)"
+			fi
+			continue
+		fi
 		[[ -e "$dst/$base" || -L "$dst/$base" ]] && continue
 		ln -s "$f" "$dst/$base" 2>/dev/null && linked=$((linked + 1))
 	done

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -1403,14 +1403,42 @@ def test_ssh_parity_is_idempotent(tmp_path: Path) -> None:
     assert "already carries the mounted keyring" in proc.stderr
 
 
-def test_known_hosts_stays_writable_and_local(tmp_path: Path) -> None:
-    """known_hosts is the ONE file the agent must own — the mount is read-only."""
+def test_known_hosts_is_seeded_as_a_writable_copy(tmp_path: Path) -> None:
+    """known_hosts must be BOTH the agent's own AND carry the operator's hosts.
+
+    #1115: the first cut skipped it entirely so it would stay writable, which
+    left the agent with an EMPTY known_hosts — and a non-interactive `git` cannot
+    answer a host-key prompt. `git ls-remote git@gitlab.com:…` died with "Host
+    key verification failed" in a fresh container. Writable but empty is its own
+    outage, and every structural assertion passed while it happened.
+    """
     home, src = _home_with_ssh(tmp_path)
-    (src / "known_hosts").write_text("host-from-the-operator\n")
-    assert _run(home, OAW_SSH_SOURCE=str(src)).returncode == 0
+    (src / "known_hosts").write_text("gitlab.com ssh-ed25519 AAAAOPERATOR\n")
+    proc = _run(home, OAW_SSH_SOURCE=str(src))
+    assert proc.returncode == 0, proc.stderr
+
     kh = home / ".ssh" / "known_hosts"
-    assert not kh.is_symlink(), "known_hosts must never link into the read-only mount"
-    kh.write_text("agent-learned-this-host\n")  # must not raise
+    assert not kh.is_symlink(), "must never link into the read-only mount"
+    assert "AAAAOPERATOR" in kh.read_text(), (
+        "the operator's host keys must be carried over, or a fresh container "
+        "cannot verify any host it has not met"
+    )
+    kh.write_text(kh.read_text() + "learned.example ssh-ed25519 AAAANEW\n")  # must not raise
+
+
+def test_an_agents_own_known_hosts_is_not_overwritten(tmp_path: Path) -> None:
+    """Copy-if-absent, not copy-always — hosts the agent learned must survive.
+
+    This runs on every agent start, so copying unconditionally would discard
+    everything learned since the container came up.
+    """
+    home, src = _home_with_ssh(tmp_path)
+    (src / "known_hosts").write_text("gitlab.com ssh-ed25519 AAAAOPERATOR\n")
+    dst = home / ".ssh"
+    dst.mkdir()
+    (dst / "known_hosts").write_text("learned.example ssh-ed25519 AAAALEARNED\n")
+    assert _run(home, OAW_SSH_SOURCE=str(src)).returncode == 0
+    assert (dst / "known_hosts").read_text() == "learned.example ssh-ed25519 AAAALEARNED\n"
 
 
 def test_an_agent_created_ssh_dir_still_gets_the_keys(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

#1111 made ssh parity per-file so `~/.ssh` stays writable against the read-only mount, and excluded `known_hosts` from the links so the agent would own it. The instinct was right and the execution incomplete: the agent got an **empty** `known_hosts`, and a non-interactive `git` cannot answer a host-key prompt.

```
git ls-remote git@gitlab.com:… → Host key verification failed
```

Writable but empty is its own outage.

`known_hosts` is now **copied** from the mount rather than skipped — a real writable file carrying the operator's accumulated host keys. **Copy-if-absent, not copy-always**: this runs on every agent start, so replacing the file each boot would discard every host the agent had learned since it came up.

## How this was caught is the part worth keeping

Both assertions #1111 added **passed**:

```
[PASS] operator keyring reaches the agent's own ssh dir (9 key(s))
[PASS] the agent's ssh dir is writable (ssh can record known_hosts)
[FAIL] gitlab git unreachable: Host key verification failed
```

The failure came from the **pre-existing behavioural reach probe**. The checks I added were structural — links exist, directory writable — and **a structural assertion cannot tell you the capability works.** That is precisely the lesson #1111 was written about, reproduced inside the fix for it.

It surfaced because the v8.1.0 candidate was **preflighted before any profile was repinned**, which is the entire reason that step exists. The fleet never saw it.

## Linked Issues

Closes #1115

## Test Plan

- `./scripts/ci/validate.sh` — **233 passed, 0 failed**.
- `python3 -m pytest tests/` — **2055 passed**, 6 skipped, 64 xfailed. Full suite, one process.
- **2 new tests**: the operator's host keys are carried into a real writable file; an agent's own `known_hosts` is never overwritten (hosts learned since boot survive).
- **Mutation:** restoring the skip reproduces the regression and fails the seeding test.
- Next: cut **v8.1.1**, preflight that image, and only then repin — v8.1.0's image carries this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS