### PR TITLE
feat(contained-workflow): bake a container builder into the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Containerised agents can build, run and scan container images (#1108).** `podman` is baked into the image, closing the gap that blocked `blueshift-kb#8` (swap a runtime image to distroless, shedding 23 unfixable CVEs, 4 CRITICAL) — a containerised agent could not verify it at all. The near-miss is the reason this is `Added` and not deferred again: the agent that hit the gap proposed putting a container-generated key in the operator's `authorized_keys` so it could build on the host. **A missing capability does not just block work, it generates pressure to solve the wrong problem.**
+
+  **⚠️ Host prerequisite — without it the capability reports absent.** Docker's `default-runtime` must be `sysbox-runc`. Under stock `runc` podman cannot create its nested user namespace at all, and `aoe` cannot pass `--runtime` per container (its `[sandbox]` schema has no such key, and `container_runtime` selects the *engine*, not the OCI runtime — agent-of-empires#3218), so this is a daemon-level setting made once per host:
+
+  ```json
+  {
+      "live-restore": true,
+      "default-runtime": "sysbox-runc",
+      "runtimes": { "sysbox-runc": { "path": "/usr/bin/sysbox-runc" } }
+  }
+  ```
+
+  Set `live-restore` in the *same* edit — without it every future daemon restart kills every running container, including live agent sessions. Note also that sysbox rejects `--privileged` and `--network host`; nothing in the fleet uses either, and the opt-out for another workload on the same host is one explicit `--runtime=runc`. Before installing sysbox, pin `bip` and `default-address-pools` to the host's **current** values: its installer otherwise sets `bip` to `172.20.0.1/16` (already occupied by an unrelated project's network on malory) and replaces docker's built-in pools with a single `172.25.0.0/16`. Its precondition check is purely textual, so declaring the existing values both satisfies it and makes it a no-op.
+
+  **Not a docker socket mount**, and the reason is capability rather than trust: over a socket `docker build` runs on the *host* daemon, so the build context and bind-mount paths resolve to host paths the agent cannot see, and concurrent agents collide in one image namespace. **Podman runs as root inside the container** — the mode sysbox is built for, since container-root maps to an unprivileged host uid. Rootless was tried first and is structurally impossible: the kernel refuses an unprivileged procfs mount unless the parent `/proc` is fully visible, and sysbox-fs overlays it, so any Dockerfile with a `RUN` step dies on `mount proc to proc: Operation not permitted`. Elevation is scoped to `/usr/bin/podman` alone via `sudoers.d` plus a PATH wrapper — deliberately not blanket sudo, because a root-written file on a bind mount surfaces as **uid 0 on the host**, which would let agents strand root-owned files in the operator's workspaces. Storage is `vfs`: podman falls back to fuse-overlayfs, which under sysbox dies on `/proc/sys/kernel/overflowuid` (readable at the container's top level, `EIO` from the nested userns), and `mount_program = ""` does not force kernel overlayfs.
+
+  `aoe-preflight.sh` gains a behavioural check backed by `scripts/ci/container-builder-probe.sh`, which **insists on a Dockerfile with a `RUN` step** — a `COPY`-only build succeeds even where nesting is impossible, so a build-only probe reports health on a host that cannot run anything. Its exit codes keep three outcomes apart that a single red/green would merge: broken in our image (fails), host cannot nest (reported as a declared absence with the reason, since the kit's contract is the image digest and this depends on host config outside it), and probe unavailable (no verdict — the base image is pulled from ECR Public rather than Docker Hub after the first real run hit an anonymous rate limit).
+
 ### Removed
 
 - **Slack support, entirely — `/ping`, `/pong`, and `slackbot-send` (#1062).** Both skills were wholly Slack-specific (`#ai-dev`, Slack mrkdwn) with no Discord path, and unused. Removed with them: the `~/.secrets/slack-bot-token` dependency (`deps.json`), the `slack-bot-token` entry in the image build's expected-missing whitelist, the `slack@claude-plugins-official` marketplace plugin (enabled by default with **zero consumers** — its only documented purpose was OAuth on first `/ping`/`/pong` use, so it was costing context every session for a dead integration), and the README's "Slack Setup" section, which instructed new users to provision a bot token for a skill that no longer exists.

--- a/containers/oakandwave-workflow/Dockerfile
+++ b/containers/oakandwave-workflow/Dockerfile
@@ -48,6 +48,81 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends ca-certificates curl tar xz-utils unzip \
 	&& rm -rf /var/lib/apt/lists/*
 
+# --- Container builder: podman (#1108) ----------------------------------------
+# Agents must be able to build, run and scan container images from inside their
+# own sandbox. blueshift-kb#8 (swap a runtime image to distroless, shedding 23
+# unfixable CVEs) could not be verified without it, and the agent that hit the
+# gap tried to route around the boundary rather than stop — a missing capability
+# generates pressure to solve the wrong problem.
+#
+# NOT a docker socket mount. Over a socket, `docker build` executes on the HOST
+# daemon, so the build context and every bind-mount path resolve to host paths
+# the agent cannot see, and concurrent agents collide in one shared image
+# namespace. It is broken for the job, independent of any trust argument.
+#
+# `nftables` is NOT optional despite being invisible at build time: without it
+# `podman build` still succeeds and `podman run` fails with
+# `netavark: nftables error: unable to execute "nft"`.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		podman crun conmon netavark passt nftables iptables uidmap fuse-overlayfs sudo \
+	&& rm -rf /var/lib/apt/lists/*
+
+# HOST REQUIREMENT: podman needs the `sysbox-runc` OCI runtime as docker's
+# default-runtime. Under stock runc the nested user namespace is refused outright
+# ("cannot clone: Operation not permitted"). aoe cannot pass --runtime per
+# container — its [sandbox] schema has no such key, and `container_runtime`
+# selects the ENGINE (docker/podman), not the OCI runtime — so this is a
+# daemon-level setting (agent-of-empires#3218). The capability is therefore
+# REPORTED by aoe-preflight.sh, never assumed: an adopter without sysbox gets a
+# declared, explained absence rather than a red gate for something they did not
+# ask for.
+#
+# Podman runs as ROOT inside the container, which is the mode sysbox is designed
+# for: sysbox maps container-root to an unprivileged host uid, so this is not
+# host root. Rootless was tried first and is structurally impossible here — the
+# kernel refuses an unprivileged procfs mount unless the parent /proc is fully
+# visible, and sysbox-fs overlays /proc to virtualise it, so any Dockerfile with
+# a RUN step dies on `mount proc to proc: Operation not permitted`.
+#
+# vfs, deliberately: podman selects fuse-overlayfs when it cannot use kernel
+# overlayfs, and under sysbox that fails on `/proc/sys/kernel/overflowuid`
+# (present at the container's top level, EIO from the nested userns). Setting
+# `mount_program = ""` does not force kernel overlayfs — podman ignores it. vfs
+# copies every layer, so it is slower and hungrier, but agents build small
+# verification images and the store lives in the container's own writable layer,
+# so it cannot grow without bound on the host.
+RUN install -d -m 0755 /etc/containers \
+	&& printf '%s\n' \
+		'[storage]' \
+		'driver = "vfs"' \
+		> /etc/containers/storage.conf
+
+# The agent runs as uid-1000 `ubuntu`. Elevation is scoped to podman ALONE, not
+# blanket sudo. Measured reason, not caution: a root-written file on a bind mount
+# surfaces as uid 0 on the HOST (sysbox does not idmap it back to the operator),
+# so general sudo would let agents strand root-owned files in the operator's own
+# workspaces. This is parity, not new privilege — agents ran on the host as a user
+# with passwordless sudo, and `docker run -v` there produced root-owned files the
+# same way, because the host daemon ran as root.
+#
+# The wrapper keeps `podman ...` working unqualified, mirroring the `claude`
+# wrapper precedent below; an agent should not have to know about the elevation.
+RUN set -eux; \
+	printf '%s\n' 'ubuntu ALL=(root) NOPASSWD: /usr/bin/podman' \
+		> /etc/sudoers.d/oaw-podman; \
+	chmod 0440 /etc/sudoers.d/oaw-podman; \
+	visudo -cf /etc/sudoers.d/oaw-podman; \
+	printf '%s\n' \
+		'#!/bin/bash' \
+		'# Podman must run as root inside the sysbox container (see Dockerfile).' \
+		'# Re-exec under the scoped sudoers rule unless already root.' \
+		'if [ "$(id -u)" -eq 0 ]; then exec /usr/bin/podman "$@"; fi' \
+		'exec sudo -n /usr/bin/podman "$@"' \
+		> /usr/local/bin/podman; \
+	chmod 0755 /usr/local/bin/podman; \
+	su ubuntu -c '/usr/local/bin/podman --version'
+
 # --- Go -----------------------------------------------------------------------
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" -o /tmp/go.tar.gz \
 	&& tar -C /usr/local -xzf /tmp/go.tar.gz \

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -228,10 +228,12 @@ this one — the toolbox holds the toolchain, the cache holds what the toolchain
 downloads. A cold `mvn` otherwise re-fetches the whole dependency tree every
 session.
 
-**Still out of scope, deliberately: a container builder.** Docker/Podman inside
-the container is a *privilege* decision (socket mount vs rootless podman vs
-"Dockerfile work happens on the host") with a real security surface, and it must
-not be solved as a side effect of a toolchain fix.
+**The container builder is not part of this layer — see §3.8.** It was carved out
+of the toolbox work deliberately, so that "which runtime can agents build with"
+was decided on its own evidence rather than as a side effect of a toolchain fix.
+That decision landed in #1108: `podman` is now baked into the image. The toolbox
+still holds only *language* toolchains, materialised on demand into the durable
+mount; the builder is a baked capability with a host prerequisite.
 
 ### 3.3 settings.json: one file, merged by us (#1086)
 
@@ -733,6 +735,61 @@ Verified behaviourally on the built image: a fresh container with no manual
 config, in an arbitrary workspace path, reaches a prompt 3/3; setting
 `OAW_NO_AUTO_TRUST=1` brings the trust dialog back, which is the positive control
 proving the mechanism is doing the work.
+
+### 3.8 The container builder — podman, and the one host requirement (#1108)
+
+Agents build, run and scan container images from inside their own sandbox. The
+motivating case was `blueshift-kb#8` (swap a runtime image to distroless, shedding
+23 unfixable CVEs), which a containerised agent could not verify at all.
+
+**Not a docker socket mount.** Over a socket, `docker build` executes on the *host*
+daemon, so the build context and every bind-mount path resolve to host paths the
+agent cannot see, and concurrent agents collide in one shared image namespace. It
+is broken for the job — that is the reason, independent of any trust argument.
+Agents are inside the trust boundary and the container is not a security boundary;
+the ONE driver for containerisation is install isolation (§1).
+
+**Podman runs as root inside the container.** That is the mode sysbox is built for:
+container-root maps to an unprivileged host uid (`uid_map: 0 165536 65536`), so
+"root" here is not host root. Rootless was attempted first and is *structurally*
+impossible: the kernel refuses an unprivileged procfs mount unless the parent
+`/proc` is fully visible, and sysbox-fs overlays `/proc` to virtualise it, so any
+Dockerfile carrying a `RUN` step dies on `mount proc to proc: Operation not
+permitted`. No subuid or storage tuning reaches that.
+
+**Elevation is scoped to podman alone**, via a `sudoers.d` rule for
+`/usr/bin/podman` plus a wrapper on PATH, so an agent's unqualified `podman ...`
+works without knowing about it. Deliberately not blanket sudo, and for a measured
+reason rather than caution: a root-written file on a bind mount surfaces as **uid 0
+on the host** — sysbox does not idmap it back to the operator — so general sudo
+would let agents strand root-owned files in the operator's own workspaces. This
+does not reduce parity: `docker run -v` on the host produced root-owned files the
+same way, because the host daemon ran as root.
+
+**Storage is `vfs`.** Podman falls back to fuse-overlayfs when it cannot use kernel
+overlayfs, and under sysbox that dies on `/proc/sys/kernel/overflowuid` — readable
+at the container's top level, `Input/output error` from the nested userns where
+fuse-overlayfs runs. `mount_program = ""` does not force kernel overlayfs; podman
+ignores it. `vfs` copies every layer, so it is slower and hungrier, but agent builds
+are small and the store lives in the container's own writable layer, so it cannot
+grow without bound on the host.
+
+**The host requirement, and why it is reported rather than asserted.** This needs
+docker's `default-runtime` set to `sysbox-runc`. That is *host daemon
+configuration*, which sits outside the "image digest IS the release" boundary (R-05),
+and `aoe` cannot pass `--runtime` per container — its `[sandbox]` schema has no such
+key, and `container_runtime` selects the *engine* (docker/podman), not the OCI
+runtime (agent-of-empires#3218). So `aoe-preflight.sh` **reports** the capability at
+`[INFO]` when the host cannot provide it, naming the reason, instead of failing. A
+red gate would punish every adopter for a capability they never asked for; a silent
+absence would be rediscovered by each agent mid-task, which is the failure mode that
+produced the near-miss recorded on #1108. `scripts/ci/container-builder-probe.sh`
+draws the distinction with exit codes: `3` the image is broken (ours), `4` the host
+cannot nest (declared), `5` no verdict (registry unreachable).
+
+The probe insists on a Dockerfile with a `RUN` step. A `COPY`-only build succeeds
+even where nesting is impossible, because nothing ever executes — a build-only probe
+reports health on a host that cannot run anything at all.
 
 ## 4. Boundaries and invariants
 

--- a/docs/operations/container-toolchains.md
+++ b/docs/operations/container-toolchains.md
@@ -64,16 +64,47 @@ Adding a mount changes the resolved volume set, so profile `extra_volumes` need
 regenerating — `scripts/ci/check-mount-drift.sh <profile>` reports the gap and
 prints the command.
 
-## What this does NOT give you
+## The container builder is separate — and it needs one thing from the host
 
-**A container builder.** `docker`, `podman` and `buildah` are still absent, and
-an agent cannot self-install them: no sudo, no socket, no daemon. So building a
-repo's Dockerfiles inside the container does not work.
+`podman` ships in the image (#1108), so an agent can build, run and scan container
+images without host assistance. It is not part of the toolbox: the toolbox
+materialises *language* toolchains on demand into a durable mount, while the
+builder is a baked capability.
 
-That is a **privilege** decision — socket mount vs rootless podman vs "Dockerfile
-work happens on the host" — with a real security surface, and it is deliberately
-not solved as a side effect of a toolchain fix. It needs its own decision and its
-own issue.
+**It requires docker's `default-runtime` to be `sysbox-runc` on the host.** Under
+stock `runc` podman cannot create the nested user namespace at all, and `aoe`
+cannot pass `--runtime` per container — its `[sandbox]` schema has no such key,
+and `container_runtime` selects the *engine* (docker/podman), not the OCI runtime
+(agent-of-empires#3218). So this is a daemon-level setting, made once per host:
+
+```bash
+# /etc/docker/daemon.json
+{
+    "default-runtime": "sysbox-runc",
+    "runtimes": { "sysbox-runc": { "path": "/usr/bin/sysbox-runc" } }
+}
+```
+
+Two things worth knowing before enabling it on a host that runs other work:
+
+- **sysbox rejects `--privileged` and `--network host`.** Nothing in the OaW fleet
+  uses either, but another project on the same host might. The failure is loud and
+  the opt-out is one explicit `--runtime=runc` on that container.
+- **Set `live-restore: true` in the same edit.** Without it every future daemon
+  restart kills every running container, including live agent sessions. With it,
+  the restart that enables sysbox is the last one that costs anything.
+
+Also pin `bip` and `default-address-pools` to the host's *current* values before
+installing sysbox. Its installer otherwise rewrites both — it sets `bip` to
+`172.20.0.1/16` (which on malory was already occupied by another project's
+network) and replaces docker's built-in address pools with a single
+`172.25.0.0/16`. Its precondition check is purely textual, so declaring the
+existing values both satisfies it and makes it a no-op.
+
+**Verifying it.** `scripts/ci/aoe-preflight.sh <profile>` reports the capability.
+A host without sysbox gets `[INFO] container builder unavailable ...` with the
+reason — a declared absence, not a failure, because the kit's contract is the
+image digest and this depends on host configuration outside it.
 
 ## Why not just `apt-get install maven` in the Dockerfile
 

--- a/scripts/ci/aoe-preflight.sh
+++ b/scripts/ci/aoe-preflight.sh
@@ -59,6 +59,15 @@ fail() {
 	[[ -n "${2:-}" ]] && printf '         %s\n' "$2" >&2
 	FAILED=$((FAILED + 1))
 }
+# A capability that depends on HOST configuration cannot be a red gate: the kit's
+# premise is that the image digest is the release, and an adopter who never asked
+# for that capability must not get a failing preflight for its absence. Report it,
+# with the reason, so it is a declared absence rather than one each agent
+# rediscovers mid-task.
+info() {
+	printf '  [INFO] %s\n' "$1"
+	[[ -n "${2:-}" ]] && printf '         %s\n' "$2"
+}
 
 echo "==> launching via aoe (profile: $PROFILE, workspace: $WS)"
 SESSION_ID="$(timeout 180 aoe -p "$PROFILE" add --sandbox --launch "$WS" 2>&1 |
@@ -309,6 +318,42 @@ else
 			"the CLI reads \$CLAUDE_CONFIG_DIR/settings.json; bootstrap's sync_kit_hooks must merge the image's hooks into it"
 	fi
 fi
+
+# --- 9. the container builder builds AND RUNS (#1108) -------------------------
+# The probe lives in the kit (it is COPY'd to $KIT_SRC) rather than inline here,
+# and it insists on a Dockerfile with a RUN step: a COPY-only build succeeds even
+# under a runtime that cannot nest a process at all, so "podman is installed" and
+# "podman works" are different claims. Its exit codes separate "capability
+# missing" (ours to fix) from "host cannot nest" (declared, not failed) from
+# "probe unavailable" (no verdict).
+BUILDER_MSG="$(x /opt/oakandwave-workflow/scripts/ci/container-builder-probe.sh)"
+BUILDER_RC=$?
+case "$BUILDER_RC" in
+0)
+	pass "container builder works (${BUILDER_MSG})"
+	;;
+3)
+	fail "container builder broken in the image: ${BUILDER_MSG}" \
+		"podman and its networking deps (incl. nftables) ship in the image — this is a kit regression, not a host one"
+	;;
+4)
+	info "container builder unavailable on this host: ${BUILDER_MSG}" \
+		"needs docker's default-runtime set to sysbox-runc; aoe cannot pass --runtime per container (agent-of-empires#3218)"
+	;;
+5)
+	info "container builder not verified: ${BUILDER_MSG}" \
+		"the probe could not reach a registry — this is not a verdict either way"
+	;;
+*)
+	# The probe only ever exits 0/3/4/5, so anything else came from `docker exec`
+	# itself — 127 (the probe is not in the image), 126 (present but not
+	# executable), 125 (container failure). Reporting those as "could not reach a
+	# registry" would state a false cause AND pass green, which is the opposite
+	# polarity to every other check in this file.
+	fail "could not run the builder probe (rc=${BUILDER_RC}): ${BUILDER_MSG}" \
+		"the probe ships in the image at \$KIT_SRC — a non-probe exit code means it is missing or not executable"
+	;;
+esac
 
 echo
 if ((FAILED)); then

--- a/scripts/ci/container-builder-probe.sh
+++ b/scripts/ci/container-builder-probe.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Can this container actually build and RUN a container image? (#1108)
+#
+# Behavioural, not structural. `command -v podman` proves a binary is installed;
+# it does not prove the kernel will let it start a process. The two diverge
+# sharply here: a Dockerfile with only COPY steps builds fine under a runtime
+# that cannot nest at all, because nothing ever executes. So this probe insists
+# on a RUN step and on running the result.
+#
+# Exit codes are distinct on purpose — "the capability is missing" and "the probe
+# could not run" must not collapse into one red result:
+#   0  capability present     (built and ran)
+#   3  broken in OUR image    — podman absent, networking incomplete, wrong output
+#   4  runtime cannot nest    — host lacks default-runtime sysbox-runc
+#   5  probe unavailable      — no registry/network; verdict unknown, not failed
+set -uo pipefail
+
+# Docker Hub rate-limits anonymous pulls hard enough to make this probe flaky —
+# it returned "toomanyrequests" on the very first real run. ECR Public mirrors the
+# same official images without an anonymous limit. Overridable so an air-gapped
+# adopter can point at whatever they can actually reach.
+BASE_IMAGE="${OAW_BUILDER_PROBE_BASE:-public.ecr.aws/docker/library/alpine:3.20}"
+TAG=oaw-builder-probe:preflight
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+
+if ! command -v podman >/dev/null 2>&1; then
+	echo "podman is not installed in this image"
+	exit 3
+fi
+
+WORK=$(mktemp -d) || {
+	echo "cannot create a work dir"
+	exit 5
+}
+trap 'rm -f "$LOG"; rm -rf "$WORK"' EXIT
+
+cat >"$WORK/Dockerfile" <<DF
+FROM ${BASE_IMAGE}
+RUN echo built-in-sandbox > /provenance.txt
+CMD ["cat", "/provenance.txt"]
+DF
+
+if ! podman build -q -t "$TAG" "$WORK" >"$LOG" 2>&1; then
+	# The nesting failure has a specific signature. Anything else is more likely
+	# an unreachable registry than a missing capability, so do not claim a verdict.
+	if grep -qE 'mount .?proc.? to .?proc.?|cannot clone|Operation not permitted|newuidmap' "$LOG"; then
+		echo "the OCI runtime will not let podman nest: $(grep -oE 'mount .?proc.? to .?proc.?[^"]*|cannot clone[^"]*' "$LOG" | head -1)"
+		exit 4
+	fi
+	echo "could not build the probe image (registry unreachable?): $(tail -1 "$LOG")"
+	exit 5
+fi
+
+if ! OUT=$(podman run --rm "$TAG" 2>"$LOG"); then
+	if grep -qE 'nftables|netavark|unable to execute' "$LOG"; then
+		echo "built, but could not run it — container networking is incomplete: $(tail -1 "$LOG")"
+		exit 3
+	fi
+	echo "built, but could not run it: $(tail -1 "$LOG")"
+	exit 4
+fi
+
+# By this point podman has ALREADY built and run a container carrying a RUN step,
+# so nesting demonstrably works. A wrong payload therefore cannot be a host
+# problem — reporting it as one (exit 4) would downgrade the single case where the
+# capability provably works but misbehaves into a non-failing host excuse.
+if [[ "$OUT" != "built-in-sandbox" ]]; then
+	echo "ran, but produced unexpected output: $OUT"
+	exit 3
+fi
+
+podman rmi -f "$TAG" >/dev/null 2>&1
+echo "built and ran a container image"
+exit 0

--- a/tests/contained-workflow/test_container_builder.py
+++ b/tests/contained-workflow/test_container_builder.py
@@ -1,0 +1,195 @@
+"""The container builder (#1108): probe behaviour and image declarations.
+
+The probe's whole value is that it separates three outcomes a single red/green
+would collapse: the capability is missing and it is OURS to fix (exit 3), the
+HOST cannot nest containers so the absence is declared rather than failed (exit
+4), and the probe could not reach a registry so there is no verdict at all (exit
+5). Each is asserted here against a stubbed ``podman``, because the real one
+needs a sysbox host and a network.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PROBE = REPO / "scripts" / "ci" / "container-builder-probe.sh"
+DOCKERFILE = REPO / "containers" / "oakandwave-workflow" / "Dockerfile"
+
+
+def _run_probe(tmp_path: Path, podman_script: str | None) -> subprocess.CompletedProcess[str]:
+    """Drive the real probe with a stub ``podman`` (or none) ahead on PATH."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    if podman_script is not None:
+        stub = bindir / "podman"
+        stub.write_text(podman_script)
+        stub.chmod(0o755)
+
+    # System tools the probe needs (excluding podman, which we're stubbing).
+    # PATH is REPLACED, not prepended to, so anything missing here silently
+    # resolves to nothing inside a command substitution. `head` was missing
+    # while this comment claimed the list was exhaustive — the probe uses
+    # `head -1` on the exit-4 path, so its diagnostic was quietly empty.
+    for tool in ("bash", "mktemp", "rm", "grep", "tail", "head", "cat"):
+        src = shutil.which(tool)
+        assert src, f"{tool} must exist to drive the probe"
+        dest = bindir / tool
+        if not dest.exists():
+            dest.symlink_to(src)
+
+    env = dict(os.environ, PATH=str(bindir))
+    return subprocess.run(
+        ["bash", str(PROBE)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+def test_podman_absent_is_our_regression(tmp_path: Path) -> None:
+    """No podman at all is a kit regression (3), never a host excuse (4)."""
+    proc = _run_probe(tmp_path, None)
+    assert proc.returncode == 3, proc.stdout + proc.stderr
+    assert "not installed" in proc.stdout
+
+
+def test_nesting_refusal_is_a_host_absence_not_a_failure(tmp_path: Path) -> None:
+    """The signature that means "this host has no sysbox" must map to 4, so the
+    preflight reports a declared absence instead of failing an adopter."""
+    proc = _run_probe(
+        tmp_path,
+        "#!/bin/bash\n"
+        'if [ "$1" = "build" ]; then\n'
+        # SINGLE-quoted echo. Written double-quoted first, where the backticks
+        # podman actually emits became command substitutions: the stub ran `proc`
+        # twice and printed "mount  to :", so this test passed via the regex's
+        # `Operation not permitted` alternative and never exercised the branch it
+        # names. The probe's `.?` exists precisely to tolerate those backticks.
+        "  echo 'error running container: mount `proc` to `proc`: Operation not permitted' >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    assert "will not let podman nest" in proc.stdout
+    # The diagnostic must name the reason, not trail off empty — an empty reason
+    # is what the double-quoted fixture silently produced.
+    assert "mount `proc` to `proc`" in proc.stdout, (
+        f"the reported reason should quote the runtime's own error: {proc.stdout!r}"
+    )
+
+
+def test_unreachable_registry_yields_no_verdict(tmp_path: Path) -> None:
+    """A build failure that is NOT the nesting signature must not be reported as
+    a missing capability — an offline runner is not a broken image."""
+    proc = _run_probe(
+        tmp_path,
+        '#!/bin/bash\n'
+        'if [ "$1" = "build" ]; then\n'
+        '  echo "Error: initializing source docker://alpine:3.20: pinging container registry: dial tcp: lookup registry-1.docker.io: no such host" >&2\n'
+        '  exit 125\n'
+        'fi\n'
+        'exit 0\n',
+    )
+    assert proc.returncode == 5, proc.stdout + proc.stderr
+    assert "registry unreachable" in proc.stdout
+
+
+def test_build_succeeds_but_run_fails_on_networking_is_ours(tmp_path: Path) -> None:
+    """The nftables gap: build passes, run fails. It ships in OUR image, so it
+    must be 3 — this is the case that would have escaped a build-only probe."""
+    proc = _run_probe(
+        tmp_path,
+        '#!/bin/bash\n'
+        'if [ "$1" = "run" ]; then\n'
+        '  echo "Error: netavark: nftables error: unable to execute \\"nft\\": No such file or directory" >&2\n'
+        '  exit 126\n'
+        'fi\n'
+        'exit 0\n',
+    )
+    assert proc.returncode == 3, proc.stdout + proc.stderr
+    assert "networking is incomplete" in proc.stdout
+
+
+def test_capability_present(tmp_path: Path) -> None:
+    proc = _run_probe(
+        tmp_path,
+        '#!/bin/bash\n'
+        'if [ "$1" = "run" ]; then echo built-in-sandbox; fi\n'
+        'exit 0\n',
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "built and ran" in proc.stdout
+
+
+def test_wrong_output_is_ours_not_a_host_excuse(tmp_path: Path) -> None:
+    """A podman that exits 0 and prints the wrong thing must not score a PASS —
+    and must be 3, not 4. By that point it has already built AND run a container
+    with a RUN step, so nesting provably works and the host cannot be at fault.
+    Reporting 4 would route the one provably-working-but-wrong case to a
+    non-failing "unavailable on this host" INFO."""
+    proc = _run_probe(
+        tmp_path,
+        "#!/bin/bash\n"
+        'if [ "$1" = "run" ]; then echo something-else; fi\n'
+        "exit 0\n",
+    )
+    assert proc.returncode == 3, proc.stdout + proc.stderr
+    assert "unexpected output" in proc.stdout
+
+
+def test_probe_requires_a_run_step_in_its_dockerfile() -> None:
+    """A COPY-only build succeeds even where nesting is impossible, so a probe
+    without a RUN step would report health on a host that cannot run anything.
+    That is the exact false pass this probe exists to avoid."""
+    body = PROBE.read_text()
+    # The heredoc is unquoted (<<DF) so ${BASE_IMAGE} expands; do not re-pin the
+    # quoted form here or this test breaks on an unrelated edit, as it just did.
+    recipe = body.split("<<DF\n", 1)[1].split("\nDF\n", 1)[0]
+    assert "RUN " in recipe, "the probe's Dockerfile must execute a process"
+    assert "FROM " in recipe, "the probe's Dockerfile must have a base"
+
+
+# --- image declarations -------------------------------------------------------
+# Structural, and deliberately so: these guard DECLARATIONS in the Dockerfile
+# against silent removal. Comment lines are stripped first, so an assertion can
+# never be satisfied by the prose that explains it.
+
+
+def _dockerfile_directives() -> str:
+    return "\n".join(
+        line
+        for line in DOCKERFILE.read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+@pytest.mark.parametrize(
+    "package",
+    ["podman", "nftables", "crun", "conmon", "netavark", "sudo"],
+)
+def test_image_installs_builder_package(package: str) -> None:
+    """nftables in particular: without it `podman build` still passes and only
+    `podman run` fails, so its absence hides until an agent tries to use it."""
+    assert package in _dockerfile_directives()
+
+
+def test_elevation_is_scoped_to_podman_not_blanket_sudo() -> None:
+    """Blanket sudo would let agents strand root-owned files on the operator's
+    bind mounts (a root write surfaces as uid 0 on the HOST, not idmapped back)."""
+    directives = _dockerfile_directives()
+    assert "ubuntu ALL=(root) NOPASSWD: /usr/bin/podman" in directives
+    assert "NOPASSWD: ALL" not in directives
+
+
+def test_storage_driver_is_vfs() -> None:
+    """overlay cannot work under sysbox: podman falls back to fuse-overlayfs,
+    which dies on /proc/sys/kernel/overflowuid from the nested userns."""
+    assert 'driver = "vfs"' in _dockerfile_directives()


### PR DESCRIPTION
## Summary

Containerised agents can now build, run and scan container images from inside their own sandbox. `blueshift-kb#8` (swap a runtime image to distroless, shedding 23 unfixable CVEs, 4 CRITICAL) could not be verified at all without it — and the agent that hit the gap proposed putting a container-generated key in the operator's `authorized_keys` so it could build on the host. **A missing capability does not just block work, it generates pressure to solve the wrong problem.**

## Changes

- **`Dockerfile`** — install `podman`, `crun`, `conmon`, `netavark`, `passt`, `nftables`, `iptables`, `uidmap`, `fuse-overlayfs`, `sudo`; pin the `vfs` storage driver; add a `sudoers.d` rule scoped to `/usr/bin/podman` **alone** plus a PATH wrapper so an agent's unqualified `podman ...` works.
- **`scripts/ci/container-builder-probe.sh`** (new) — behavioural probe, exit codes `0/3/4/5`.
- **`scripts/ci/aoe-preflight.sh`** — check 9, with a new `info()` level.
- **`tests/contained-workflow/test_container_builder.py`** (new) — 15 tests against a stubbed podman.
- **Docs** — architecture §3.8 (and §3.2 corrected, which still declared this out of scope), operations guide, CHANGELOG.

## Why not a docker socket mount

Not a trust argument — it is **broken for the job**. Over a socket, `docker build` executes on the *host* daemon, so the build context and every bind-mount path resolve to host paths the agent cannot see, and concurrent agents collide in one shared image namespace.

## Why root-inside-the-container, not rootless

That is the mode sysbox is built for: container-root maps to an unprivileged host uid (`uid_map: 0 165536 65536`). Rootless was tried first and is **structurally impossible** — the kernel refuses an unprivileged procfs mount unless the parent `/proc` is fully visible, and sysbox-fs overlays `/proc` to virtualise it, so any Dockerfile with a `RUN` step dies on `mount proc to proc: Operation not permitted`.

Elevation is scoped to podman alone, deliberately not blanket sudo, for a measured reason: a root-written file on a bind mount surfaces as **uid 0 on the host** (sysbox does not idmap it back), which would let agents strand root-owned files in the operator's own workspaces. This is parity, not new privilege — `docker run -v` on the host produced root-owned files the same way.

Storage is `vfs`: podman falls back to fuse-overlayfs, which under sysbox dies on `/proc/sys/kernel/overflowuid` (readable at the container's top level, `EIO` from the nested userns). `mount_program = ""` does not force kernel overlayfs — podman ignores it.

## ⚠️ Host prerequisite

Docker's `default-runtime` must be `sysbox-runc`. `aoe` cannot pass `--runtime` per container (agent-of-empires#3218), so it is a daemon-level setting. Because that sits **outside** the "image digest IS the release" boundary, preflight **reports** the capability rather than asserting it — an adopter without sysbox gets a declared, explained absence, not a red gate for something they never asked for.

Applied on malory: sysbox-ce 0.7.1, `default-runtime` flipped, `live-restore: true`. `bip`/`default-address-pools` were pinned to current values first — sysbox's installer otherwise sets `bip` to `172.20.0.1/16`, already occupied by `squawkie-talkie_default` on this host.

## Test Plan

Run, not merely intended:

- `validate.sh` — **235 passed, 0 failed**
- `pytest tests/contained-workflow/` — **337 passed, 2 skipped**
- New Dockerfile layers built on top of the live image; build-time check printed `podman version 5.7.0` **as `ubuntu` through the wrapper**
- Real probe run as `ubuntu` against those layers under sysbox → **exit 0, "built and ran a container image"**
- Full acceptance path measured separately: **build → run → run-with-network → `trivy` scan**, all pass
- **A/B control:** the identical script under stock `runc` fails with `cannot clone: Operation not permitted` — sysbox is load-bearing, confirmed rather than assumed
- Mutation-tested: reverting the wrong-output exit code, removing the probe's `RUN` step, and breaking the nesting regex are each **killed** by the suite
- `aoe-preflight.sh dogfood` — 14/14 under sysbox; all 13 running containers survived the daemon restart via live-restore

Code review returned 6 findings, all fixed — including a preflight catch-all that reported a missing probe as a *registry* problem **and passed green**, and a test fixture whose backticks were command substitution, so it never emitted the signature it claimed to test.

## Linked Issues

Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZC3F9Qo7aX7QasQkdHPs7