### PR TITLE
feat(contained-workflow): give containerised agents a voice again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Containerised agents have a voice again (#1084).** `vox` could not work inside a container — no provider config, and no player at all (none of `afplay`/`paplay`/`aplay`/`ffplay`, no `libpulse`) — so every agent moved into a container lost the audible interrupt, the thing that gets attention when nobody is watching a Discord channel.
+
+  **Text is forwarded, not audio.** The container's provider spools the message onto a host-visible mount and a `systemd --user` path unit runs the operator's own already-configured `vox` on it. Mounting the host's PipeWire socket was considered and rejected: with no client libraries and no player in the image it would mean adding an entire audio stack to play one sentence, and coupling containers to the host's audio devices.
+
+  No change to `vox` itself — it already resolves `~/.config/vox/{provider,player}` ahead of its bundled defaults, so this is configuration. The **pair** is the mechanism: the provider forwards text and writes an empty `$VOX_OUTPUT_FILE`; the player is a no-op because playback happens on the far side of the mount.
+
+  **Emphatically not `silent.sh`.** Pointing the provider there would also stop the error — by making the agent mute while it believes it has spoken, converting a visible gap into an invisible one. So the provider is **loud when nothing is draining the spool**, which is the assertion that keeps the feature from rotting: that failure is otherwise invisible from inside the container. The drain drops messages older than 15 minutes rather than speaking a stale backlog, and deletes before speaking so a message `vox` rejects cannot be re-spoken forever by a `DirectoryNotEmpty` path unit.
+
+  The host side is one explicit operator command, `oaw-vox-drain --install-units`. `./install` deliberately does not touch systemd: installing units from the kit installer would mutate the operator's running session state under live sibling agents, the exact side effect the contained-workflow campaign exists to eliminate. Runbook: `docs/operations/containerised-vox.md`.
+
+  Adds a `vox-spool` mount (`shared-mutable-rw`, sandbox-scoped and major-partitioned under `~/.oaw/state/<major>/`), so **aoe profiles must be regenerated** — it takes effect on container recreation, leaving running agents untouched.
+
+
+- **Containerised agents can build, run and scan container images (#1108).** `podman` is baked into the image, closing the gap that blocked `blueshift-kb#8` (swap a runtime image to distroless, shedding 23 unfixable CVEs, 4 CRITICAL) — a containerised agent could not verify it at all. The near-miss is the reason this is `Added` and not deferred again: the agent that hit the gap proposed putting a container-generated key in the operator's `authorized_keys` so it could build on the host. **A missing capability does not just block work, it generates pressure to solve the wrong problem.**
+
+  **⚠️ Host prerequisite — without it the capability reports absent.** Docker's `default-runtime` must be `sysbox-runc`. Under stock `runc` podman cannot create its nested user namespace at all, and `aoe` cannot pass `--runtime` per container (its `[sandbox]` schema has no such key, and `container_runtime` selects the *engine*, not the OCI runtime — agent-of-empires#3218), so this is a daemon-level setting made once per host:
+
+  ```json
+  {
+      "live-restore": true,
+      "default-runtime": "sysbox-runc",
+      "runtimes": { "sysbox-runc": { "path": "/usr/bin/sysbox-runc" } }
+  }
+  ```
+
+  Set `live-restore` in the *same* edit — without it every future daemon restart kills every running container, including live agent sessions. Note also that sysbox rejects `--privileged` and `--network host`; nothing in the fleet uses either, and the opt-out for another workload on the same host is one explicit `--runtime=runc`. Before installing sysbox, pin `bip` and `default-address-pools` to the host's **current** values: its installer otherwise sets `bip` to `172.20.0.1/16` (already occupied by an unrelated project's network on malory) and replaces docker's built-in pools with a single `172.25.0.0/16`. Its precondition check is purely textual, so declaring the existing values both satisfies it and makes it a no-op.
+
+  **Not a docker socket mount**, and the reason is capability rather than trust: over a socket `docker build` runs on the *host* daemon, so the build context and bind-mount paths resolve to host paths the agent cannot see, and concurrent agents collide in one image namespace. **Podman runs as root inside the container** — the mode sysbox is built for, since container-root maps to an unprivileged host uid. Rootless was tried first and is structurally impossible: the kernel refuses an unprivileged procfs mount unless the parent `/proc` is fully visible, and sysbox-fs overlays it, so any Dockerfile with a `RUN` step dies on `mount proc to proc: Operation not permitted`. Elevation is scoped to `/usr/bin/podman` alone via `sudoers.d` plus a PATH wrapper — deliberately not blanket sudo, because a root-written file on a bind mount surfaces as **uid 0 on the host**, which would let agents strand root-owned files in the operator's workspaces. Storage is `vfs`: podman falls back to fuse-overlayfs, which under sysbox dies on `/proc/sys/kernel/overflowuid` (readable at the container's top level, `EIO` from the nested userns), and `mount_program = ""` does not force kernel overlayfs.
+
+  `aoe-preflight.sh` gains a behavioural check backed by `scripts/ci/container-builder-probe.sh`, which **insists on a Dockerfile with a `RUN` step** — a `COPY`-only build succeeds even where nesting is impossible, so a build-only probe reports health on a host that cannot run anything. Its exit codes keep three outcomes apart that a single red/green would merge: broken in our image (fails), host cannot nest (reported as a declared absence with the reason, since the kit's contract is the image digest and this depends on host config outside it), and probe unavailable (no verdict — the base image is pulled from ECR Public rather than Docker Hub after the first real run hit an anonymous rate limit).
+
 ### Fixed
 
 - **`wtf-post-tool-use.sh` was baked into the image twice, and now cannot be (#1094).** The image's `settings.json` registered it under both `~/.local/share/…` (from `settings.template.json`) and `/home/ubuntu/.local/share/…` (added afterwards by wtf-server's installer, whose idempotency check compared raw strings). Same file, so the hook **ran twice on every tool use** — for weeks, because nothing ever asked the question.
@@ -25,26 +58,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `validate_hook_paths` unwraps the guard rather than skipping it — going blind would trade a noisy failure for a silent one — and stays loud for **unguarded** misses while treating a guarded miss as the declared-inert case it is. The cases a guard could hide are caught in `sync_kit_hooks` against the image that claims the hook: one it never shipped, and one shipped without its exec bit (the guard tests `-x`, so that is skipped exactly like a missing file, where it previously failed loudly with `Permission denied`). That check runs over the image's declared hook set on **every** boot rather than inside the add-if-absent loop, where it would have fired once against a virgin config dir and stayed silent forever after.
 
   Caught by the operator on a live restart and by no test: the #1086 suite drove the merge against fake homes where the script always existed, so the cross-version case was not representable. It is now — the tests delete the script after merging, which is precisely what an older container sees.
-
-### Added
-
-- **Containerised agents can build, run and scan container images (#1108).** `podman` is baked into the image, closing the gap that blocked `blueshift-kb#8` (swap a runtime image to distroless, shedding 23 unfixable CVEs, 4 CRITICAL) — a containerised agent could not verify it at all. The near-miss is the reason this is `Added` and not deferred again: the agent that hit the gap proposed putting a container-generated key in the operator's `authorized_keys` so it could build on the host. **A missing capability does not just block work, it generates pressure to solve the wrong problem.**
-
-  **⚠️ Host prerequisite — without it the capability reports absent.** Docker's `default-runtime` must be `sysbox-runc`. Under stock `runc` podman cannot create its nested user namespace at all, and `aoe` cannot pass `--runtime` per container (its `[sandbox]` schema has no such key, and `container_runtime` selects the *engine*, not the OCI runtime — agent-of-empires#3218), so this is a daemon-level setting made once per host:
-
-  ```json
-  {
-      "live-restore": true,
-      "default-runtime": "sysbox-runc",
-      "runtimes": { "sysbox-runc": { "path": "/usr/bin/sysbox-runc" } }
-  }
-  ```
-
-  Set `live-restore` in the *same* edit — without it every future daemon restart kills every running container, including live agent sessions. Note also that sysbox rejects `--privileged` and `--network host`; nothing in the fleet uses either, and the opt-out for another workload on the same host is one explicit `--runtime=runc`. Before installing sysbox, pin `bip` and `default-address-pools` to the host's **current** values: its installer otherwise sets `bip` to `172.20.0.1/16` (already occupied by an unrelated project's network on malory) and replaces docker's built-in pools with a single `172.25.0.0/16`. Its precondition check is purely textual, so declaring the existing values both satisfies it and makes it a no-op.
-
-  **Not a docker socket mount**, and the reason is capability rather than trust: over a socket `docker build` runs on the *host* daemon, so the build context and bind-mount paths resolve to host paths the agent cannot see, and concurrent agents collide in one image namespace. **Podman runs as root inside the container** — the mode sysbox is built for, since container-root maps to an unprivileged host uid. Rootless was tried first and is structurally impossible: the kernel refuses an unprivileged procfs mount unless the parent `/proc` is fully visible, and sysbox-fs overlays it, so any Dockerfile with a `RUN` step dies on `mount proc to proc: Operation not permitted`. Elevation is scoped to `/usr/bin/podman` alone via `sudoers.d` plus a PATH wrapper — deliberately not blanket sudo, because a root-written file on a bind mount surfaces as **uid 0 on the host**, which would let agents strand root-owned files in the operator's workspaces. Storage is `vfs`: podman falls back to fuse-overlayfs, which under sysbox dies on `/proc/sys/kernel/overflowuid` (readable at the container's top level, `EIO` from the nested userns), and `mount_program = ""` does not force kernel overlayfs.
-
-  `aoe-preflight.sh` gains a behavioural check backed by `scripts/ci/container-builder-probe.sh`, which **insists on a Dockerfile with a `RUN` step** — a `COPY`-only build succeeds even where nesting is impossible, so a build-only probe reports health on a host that cannot run anything. Its exit codes keep three outcomes apart that a single red/green would merge: broken in our image (fails), host cannot nest (reported as a declared absence with the reason, since the kit's contract is the image digest and this depends on host config outside it), and probe unavailable (no verdict — the base image is pulled from ECR Public rather than Docker Hub after the first real run hit an anonymous rate limit).
 
 ### Removed
 

--- a/containers/oakandwave-workflow/Dockerfile
+++ b/containers/oakandwave-workflow/Dockerfile
@@ -302,6 +302,43 @@ RUN set +e; \
 		echo "MCP baked: $m (registered + binary executable)"; \
 	done
 
+# --- A voice for containerised agents (#1084) ---------------------------------
+# `vox` cannot work in here: no provider config, and no player AT ALL — none of
+# afplay/paplay/aplay/ffplay, no libpulse. So every agent moved into a container
+# lost the audible interrupt, the thing that gets the operator's attention when
+# nobody is watching a Discord channel.
+#
+# Audio is NOT forwarded. Mounting the host's PipeWire socket was considered and
+# rejected: with no client libraries and no player in here it would mean adding a
+# whole audio stack to every image to play one sentence, and coupling containers
+# to the host's audio devices. The TEXT is forwarded instead, to a spool on a
+# host-visible mount, where the operator's already-configured vox synthesises and
+# plays it (scripts/oaw-vox-drain + the systemd path unit beside it).
+#
+# vox resolves `~/.config/vox/{provider,player}` before its bundled defaults, so
+# this is pure configuration — no change to vox itself. The PAIR is the trick:
+# the provider forwards text and writes an empty $VOX_OUTPUT_FILE, and the player
+# is a no-op because playback happens on the far side of the mount.
+#
+# Emphatically NOT silent.sh. Pointing the provider there would also stop the
+# error, by making the agent mute and *believing* it had spoken — converting a
+# visible gap into an invisible one, which #1084 explicitly refused. host-forward
+# is loud when the spool is not being drained.
+# OAW_VOX_SPOOL is declared in the mount fragment's `env`, but NOTHING consumes
+# manifest env — the resolver emits `source:target` only. Without this ENV the
+# provider silently falls back to its own literal default, so the container and
+# the mount agree by two independent constants that nobody checks. Set it here so
+# the declared variable is real.
+ENV OAW_VOX_SPOOL=/home/ubuntu/.oaw/vox-spool
+RUN set -eux; \
+	install -d -m 0755 "$HOME/.config/vox"; \
+	ln -sfn "$HOME/.claude/scripts/vox-providers/host-forward.sh" "$HOME/.config/vox/provider"; \
+	ln -sfn "$HOME/.claude/scripts/vox-spool/no-op-player.sh" "$HOME/.config/vox/player"; \
+	test -x "$HOME/.config/vox/provider"; \
+	test -x "$HOME/.config/vox/player"; \
+	OAW_VOX_SPOOL="$(mktemp -d)" vox "image build smoke test" >/dev/null; \
+	echo "vox: forwarding provider wired (config-exists is not config-works — that just spoke)"
+
 # --- Bake sdlc-server's commutativity-probe CLI (R-09 residual — #1014) --------
 # sdlc-server shells out to a `commutativity-probe` CLI to service its
 # `commutativity_verify` tool; with the CLI absent the handler degrades to a

--- a/containers/oakandwave-workflow/mounts.d/50-vox-spool.toml
+++ b/containers/oakandwave-workflow/mounts.d/50-vox-spool.toml
@@ -1,0 +1,27 @@
+# 50-vox-spool.toml — the text seam that gives a containerised agent a voice (#1084).
+#
+# `vox` does not work in a container: no provider, and no player at all (none of
+# afplay/paplay/aplay/ffplay, no libpulse). Discord still reaches the operator,
+# but the audible interrupt — the thing that gets attention when nobody is
+# watching a channel — was gone for every agent moved into a container.
+#
+# AUDIO IS NOT FORWARDED; TEXT IS. Passing the host's PipeWire socket through was
+# considered and rejected: the container has no client libraries and no player,
+# so it would mean adding a whole audio stack to every image to play one
+# sentence, and coupling containers to the host's audio devices. Forwarding the
+# text costs one directory and reuses the host's already-configured vox for both
+# synthesis and playback.
+#
+# Layer is shared-mutable-rw, and that is the honest classification rather than a
+# convenience: this is a directory the container WRITES and the host CONSUMES, so
+# it is a genuine mutable seam and is held to the R-03 guard like any other —
+# sandbox-scoped under ~/.oaw/state/<major>/, never inside the live-fleet tree.
+# Major-partitioned for the same reason state is: a v9 agent must not spool into
+# a v8 host unit's queue.
+[[mount]]
+name = "vox-spool"
+layer = "shared-mutable-rw"
+mode = "rw"
+source = "~/.oaw/state/<major>/vox-spool"
+target = "/home/ubuntu/.oaw/vox-spool"
+env = { OAW_VOX_SPOOL = "/home/ubuntu/.oaw/vox-spool" }

--- a/containers/oakandwave-workflow/mounts.d/README.md
+++ b/containers/oakandwave-workflow/mounts.d/README.md
@@ -45,6 +45,7 @@ fragment deterministically. Each file holds one or more `[[mount]]` tables.
 | `20-secrets.toml` | read-only-secrets (ro named single-file mounts) | 1.5 (#965), #1061 |
 | `30-user-overlay.toml` | user-overlay (MCP fragment, toolbox, user scripts) | 1.3 (#963) |
 | `40-durable-caches.toml` | durable-cache (cargo, go-mod, uv, ms-playwright) | 1.3 (#963) |
+| `50-vox-spool.toml` | shared-mutable-rw (text forwarded to the host's `vox`) | #1084 |
 
 > **These fragments are INERT until copied into an AoE profile.** `extra_volumes`
 > is a manual copy of `mount_resolver.py --format aoe`, so the container runs on

--- a/docs/operations/containerised-vox.md
+++ b/docs/operations/containerised-vox.md
@@ -1,0 +1,109 @@
+# Giving containerised agents a voice
+
+`vox` cannot work inside a container. There is no provider config, and no player
+at all — none of `afplay`/`paplay`/`aplay`/`ffplay`, and no `libpulse`. Discord
+still reaches you, but the audible interrupt — the thing that gets your attention
+when nobody is watching a channel — was gone for every agent moved into a
+container (#1084).
+
+## What was built
+
+**Text is forwarded, not audio.** The container's `vox` provider writes the
+message to a spool directory on a host-visible mount; a `systemd --user` path
+unit on the host notices and runs your own already-configured `vox` on it.
+
+```
+container                          host
+  vox "…"
+   └─ ~/.config/vox/provider  ──────► ~/.oaw/state/8/vox-spool/<ts>.msg
+        (host-forward.sh)                      │
+      ~/.config/vox/player                     │  oaw-vox-spool.path
+        (no-op — playback is over there)       ▼
+                                        oaw-vox-drain ──► vox ──► 🔊
+```
+
+The provider/player **pair** is the whole trick: the provider forwards the text
+and writes an empty `$VOX_OUTPUT_FILE`, and the player does nothing, because
+playback happens on the other side of the mount. This needs no change to `vox`
+itself — it already resolves `~/.config/vox/{provider,player}` ahead of its
+bundled defaults.
+
+### Why not pass the audio through
+
+The host runs PipeWire and its socket *could* be mounted. Rejected: the container
+has no client libraries and no player, so it would mean adding an entire audio
+stack to every image in order to play one sentence, and coupling containers to
+the host's audio devices. Forwarding text costs one directory.
+
+### Why not just make it silent
+
+Pointing `~/.config/vox/provider` at the bundled `silent.sh` also stops the
+error. It does it by making the agent mute while it *believes* it has spoken —
+converting a visible gap into an invisible one. That is the failure mode this
+repo keeps producing (#1061, #1056, #1069, #1076) and #1084 refused it
+explicitly.
+
+## Enabling it on the host
+
+One command, and it is an explicit operator step on purpose:
+
+```bash
+oaw-vox-drain --install-units
+```
+
+`./install` deliberately does **not** touch systemd. Installing units from the
+kit installer would mutate your running session state under live sibling agents —
+exactly the class of side effect the contained-workflow campaign exists to
+eliminate.
+
+Check it, and undo it:
+
+```bash
+oaw-vox-drain --status
+oaw-vox-drain --uninstall-units
+```
+
+Run the drain by hand to test without waiting for a container:
+
+```bash
+printf 'dev_name: manual\n\nhello from the host\n' > ~/.oaw/state/8/vox-spool/test.msg
+oaw-vox-drain
+```
+
+## If agents go quiet
+
+**The provider warns when nothing is draining the spool.** That warning is the
+most important part of this feature, not a nicety: without it an agent believes
+it is speaking while you hear silence, and it has no way to notice from inside
+the container.
+
+```
+host-forward: WARNING — 3 message(s) have been sitting in … unconsumed.
+host-forward: nothing on the host is draining the spool, so this was NOT heard.
+```
+
+Diagnose in this order:
+
+| symptom | check |
+|---|---|
+| the warning above | `systemctl --user status oaw-vox-spool.path oaw-vox-spool.service` |
+| spool fills, unit active | `journalctl --user -u oaw-vox-spool.service -n 50` |
+| `spooling into a void` in the journal | the host has no `~/.local/bin/vox` — run `./install` |
+| nothing spooled at all | the mount is missing: `scripts/ci/check-mount-drift.sh <profile>` |
+
+Messages older than 15 minutes are **dropped, not spoken** — hearing twenty
+stale status updates in a row is worse than losing them. The drain also deletes
+each message *before* speaking it: `vox` detaches playback, so a message that
+made `vox` exit non-zero would otherwise be re-spoken on every trigger and a
+`DirectoryNotEmpty` path unit would spin on it forever.
+
+## Notes
+
+- The spool is **major-partitioned** (`~/.oaw/state/<major>/vox-spool`) like the
+  rest of sandbox state, so a v9 agent cannot spool into a v8 host unit's queue.
+  `oaw-vox-drain` takes `OAW_MAJOR` if you run several.
+- Messages carry the speaking agent's `dev_name`, resolved by walking up from the
+  working directory the way `vox`'s own `resolve_speaker` does — several agents
+  share one host spool, so what you hear has to be attributable.
+- Adding the mount required regenerating the aoe profiles. It only takes effect
+  on container recreation, so running agents are unaffected until they cycle.

--- a/scripts/oaw-vox-drain
+++ b/scripts/oaw-vox-drain
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# oaw-vox-drain — speak whatever containerised agents have spooled (#1084).
+#
+# The host half of the containerised-vox pair. Containers cannot play audio, so
+# their `vox` provider (host-forward.sh) writes the TEXT here; this runs the
+# operator's own already-configured `vox` on each message and removes it.
+#
+# Invoked by oaw-vox-spool.service, triggered by oaw-vox-spool.path. Safe to run
+# by hand — that is also how you test it without waiting for a container.
+#
+# THE SPOOL MUST END FREE OF TRIGGERING ENTRIES. The path unit watches
+# DirectoryNotEmpty, so anything left behind re-triggers the service immediately
+# and forever; enough of that in 10s and systemd's start limiter refuses the job
+# and fails the PATH unit too, which then stops watching until someone runs
+# `systemctl --user reset-failed`. Measured: a single undrained file fired the
+# service 5 times in 2 seconds. So nothing here may exit leaving a visible file —
+# anything undrainable is moved into .quarantine/ instead. systemd ignores
+# dot-entries (verified, both dotfiles and hidden dirs), which is also why the
+# provider's in-flight `.tmp.*` names do not trigger.
+#
+# DELETE-THEN-SPEAK, deliberately. Speaking first and deleting after looks safer
+# but is not: `vox` detaches playback by default (#952), so a message that makes
+# vox exit non-zero — or a drain killed mid-run — would be re-spoken on every
+# subsequent trigger. A message heard once and lost beats one repeated forever.
+set -uo pipefail
+
+VOX="${OAW_VOX_BIN:-$HOME/.local/bin/vox}"
+# Anything older than this was almost certainly spooled while nothing was
+# draining. Speaking a backlog of stale status updates is worse than dropping it.
+MAX_AGE_SECONDS="${OAW_VOX_MAX_AGE_SECONDS:-900}"
+
+# --- Which kit major? ---------------------------------------------------------
+# NO LITERAL FALLBACK. `OAW_MAJOR="${OAW_MAJOR:-1}"` in two other scripts is
+# exactly the #1067 defect — a constant under a comment calling it "the kit
+# major" while the kit was at 7.3.0 — and scripts/ci/oaw-major.sh exists because
+# of it: "guessing silently is worse than refusing". A wrong major here is the
+# same silent failure in a new place: the container writes ~/.oaw/state/9/… while
+# this watches …/8/, and agents go mute.
+#
+# oaw-major.sh derives from git tags and this runs from ~/.local/bin on a host
+# that may be nowhere near the repo, so derive from observable state instead:
+# whichever spool directories actually exist. One is unambiguous; anything else
+# is a question only the operator can answer.
+resolve_major() {
+	if [[ -n "${OAW_MAJOR:-}" ]]; then
+		printf '%s' "$OAW_MAJOR"
+		return 0
+	fi
+	local -a found=()
+	local d
+	for d in "$HOME"/.oaw/state/*/vox-spool; do
+		[[ -d "$d" ]] || continue
+		d="${d%/vox-spool}"
+		found+=("${d##*/}")
+	done
+	if ((${#found[@]} == 1)); then
+		printf '%s' "${found[0]}"
+		return 0
+	fi
+	if ((${#found[@]} == 0)); then
+		echo "oaw-vox-drain: no ~/.oaw/state/<major>/vox-spool exists — set OAW_MAJOR or run --install-units" >&2
+	else
+		echo "oaw-vox-drain: several spools exist (${found[*]}) — set OAW_MAJOR to pick one" >&2
+	fi
+	return 2
+}
+
+if [[ -n "${OAW_VOX_SPOOL_HOST:-}" ]]; then
+	SPOOL="$OAW_VOX_SPOOL_HOST"
+else
+	MAJOR="$(resolve_major)" || exit 2
+	SPOOL="$HOME/.oaw/state/$MAJOR/vox-spool"
+fi
+
+# --- Unit management ----------------------------------------------------------
+# `./install` deliberately does NOT touch systemd. Installing units from the kit
+# installer would mutate the operator's running session state — the exact class of
+# side effect the contained-workflow campaign exists to eliminate — and it would
+# do it under live sibling agents. So this is an explicit operator step, kept to
+# one command so it does not drift into a hand-copied file nobody can audit.
+UNIT_SRC="${OAW_VOX_UNIT_SRC:-$HOME/.claude/scripts/vox-spool/systemd}"
+UNIT_DST="${OAW_VOX_UNIT_DST:-$HOME/.config/systemd/user}"
+
+case "${1:-}" in
+--install-units)
+	[[ -d "$UNIT_SRC" ]] || {
+		echo "no units at $UNIT_SRC" >&2
+		exit 1
+	}
+	mkdir -p "$UNIT_DST" "$SPOOL"
+	# TEMPLATE the spool path in rather than shipping a literal major. The unit
+	# and this script must agree on one directory; a unit watching a path nobody
+	# writes to is silent in exactly the way this feature must never be.
+	sed "s|@SPOOL@|$SPOOL|g" "$UNIT_SRC/oaw-vox-spool.path" >"$UNIT_DST/oaw-vox-spool.path"
+	install -m 0644 "$UNIT_SRC/oaw-vox-spool.service" "$UNIT_DST/oaw-vox-spool.service"
+	chmod 0644 "$UNIT_DST/oaw-vox-spool.path"
+	# Pin the major for the service too, so the unit and a hand-run drain cannot
+	# disagree once a second major appears.
+	mkdir -p "$UNIT_DST/oaw-vox-spool.service.d"
+	printf '[Service]\nEnvironment=OAW_VOX_SPOOL_HOST=%s\n' "$SPOOL" \
+		>"$UNIT_DST/oaw-vox-spool.service.d/spool.conf"
+
+	# VERIFY, do not assume: the whole failure mode is a watcher pointed at a
+	# directory nobody writes to, which looks identical to "nobody is speaking".
+	if ! grep -qF "DirectoryNotEmpty=$SPOOL" "$UNIT_DST/oaw-vox-spool.path"; then
+		echo "oaw-vox-drain: the installed unit does not watch $SPOOL — refusing to enable" >&2
+		exit 1
+	fi
+	systemctl --user daemon-reload
+	systemctl --user reset-failed oaw-vox-spool.path oaw-vox-spool.service 2>/dev/null || true
+	systemctl --user enable --now oaw-vox-spool.path
+	echo "oaw-vox-drain: installed and enabled; watching $SPOOL"
+	exit 0
+	;;
+--uninstall-units)
+	systemctl --user disable --now oaw-vox-spool.path 2>/dev/null || true
+	rm -f "$UNIT_DST/oaw-vox-spool.path" "$UNIT_DST/oaw-vox-spool.service"
+	rm -rf "$UNIT_DST/oaw-vox-spool.service.d"
+	systemctl --user daemon-reload 2>/dev/null || true
+	echo "oaw-vox-drain: units removed"
+	exit 0
+	;;
+--status)
+	echo "spool:      $SPOOL"
+	echo "queued:     $(find "$SPOOL" -maxdepth 1 -name '*.msg' 2>/dev/null | wc -l)"
+	echo "quarantine: $(find "$SPOOL/.quarantine" -type f 2>/dev/null | wc -l)"
+	systemctl --user status oaw-vox-spool.path --no-pager 2>&1 | head -5
+	exit 0
+	;;
+-h | --help)
+	echo "usage: oaw-vox-drain [--install-units|--uninstall-units|--status]"
+	echo "  no args: drain the spool once (what the systemd service runs)"
+	exit 0
+	;;
+esac
+
+[[ -d "$SPOOL" ]] || exit 0
+
+QUARANTINE="$SPOOL/.quarantine"
+
+# Move anything we cannot drain OUT of the watched set rather than leaving it to
+# re-trigger. Hidden, so systemd's DirectoryNotEmpty ignores it.
+quarantine() {
+	mkdir -p "$QUARANTINE" 2>/dev/null || return 0
+	mv -f "$1" "$QUARANTINE/" 2>/dev/null || rm -f "$1" 2>/dev/null || true
+}
+
+if [[ ! -x "$VOX" ]]; then
+	echo "oaw-vox-drain: no vox at $VOX — containerised agents are spooling into a void" >&2
+	# Clear the spool anyway. Exiting non-zero while leaving files is what latches
+	# the path unit into a permanent failure, turning a fixable "install vox" into
+	# a watcher that has stopped watching.
+	shopt -s nullglob
+	# Directories too, not just files: systemd's DirectoryNotEmpty counts ANY
+	# visible entry, so a leftover subdirectory latches the unit exactly as a
+	# leftover file does.
+	for f in "$SPOOL"/*; do
+		quarantine "$f"
+	done
+	exit 1
+fi
+
+shopt -s nullglob
+spoken=0
+dropped=0
+
+for f in "$SPOOL"/*; do
+	# VANISHED is not UNDRAINABLE. Under concurrent drains the glob is a snapshot,
+	# so an entry another drain already claimed is simply gone — treating that as
+	# "cannot drain this" sent every loser down the quarantine path and created a
+	# stray .quarantine directory on every race.
+	[[ -e "$f" ]] || continue
+
+	# Anything that exists but is not a plain .msg cannot be drained — a
+	# subdirectory, a stray file — and would re-trigger the path unit forever if
+	# left in the watched set.
+	if [[ ! -f "$f" || "$f" != *.msg ]]; then
+		quarantine "$f"
+		continue
+	fi
+
+	# CLAIM IT FIRST, with a rename. The glob is evaluated once at loop start, so
+	# two drains racing — the path unit's instance and an operator running this by
+	# hand, which the runbook tells them to do — can both enumerate the same file
+	# and both speak it. `mv` is atomic and fails when the source is already gone,
+	# so exactly one drain wins and the loser moves on. `rm -f` would not do this:
+	# it succeeds for both.
+	claim="$SPOOL/.claimed.$$.${RANDOM}"
+	mv "$f" "$claim" 2>/dev/null || continue
+
+	dev_name="$(sed -n 's/^dev_name: //p' "$claim" | head -1)"
+	# Body is everything after the first blank line — the header is metadata for
+	# triage, not something to read aloud.
+	text="$(awk 'BEGIN{h=1} h&&/^$/{h=0;next} !h' "$claim")"
+
+	age=0
+	if mtime="$(stat -c %Y "$claim" 2>/dev/null)"; then
+		age=$(($(date +%s) - mtime))
+	fi
+
+	rm -f "$claim" 2>/dev/null || true
+
+	if [[ -z "$text" ]]; then
+		continue
+	fi
+
+	if ((age > MAX_AGE_SECONDS)); then
+		echo "oaw-vox-drain: dropping a ${age}s-old message from ${dev_name:-unknown} (stale backlog)" >&2
+		dropped=$((dropped + 1))
+		continue
+	fi
+
+	# VOX_NO_SIGNOFF because the text ALREADY carries one. The container's vox
+	# appended `. This is <agent>.` before handing the text to the forwarding
+	# provider, and this vox would append a second — resolved from a systemd unit
+	# with no agent identity in its cwd or process tree, so `resolve_speaker`
+	# falls through to its `pid N` last resort. The operator would hear
+	# "…promoted. This is babelfish. This is pid 4711."
+	#
+	# `--` because a message beginning with `-` would otherwise be parsed as an
+	# unknown option and rejected outright.
+	if VOX_NO_SIGNOFF=1 "$VOX" -- "$text" >/dev/null 2>&1; then
+		spoken=$((spoken + 1))
+	else
+		# Do NOT re-queue. See the delete-then-speak note above.
+		echo "oaw-vox-drain: vox failed on a message from ${dev_name:-unknown}; dropped" >&2
+	fi
+done
+
+if ((spoken || dropped)); then
+	echo "oaw-vox-drain: spoke $spoken, dropped $dropped"
+fi
+exit 0

--- a/scripts/vox-providers/README.md
+++ b/scripts/vox-providers/README.md
@@ -34,6 +34,14 @@ Each is a copy-and-adapt template. They ship executable so `vox --setup --pick=<
 | `piper-local.sh` | local [piper](https://github.com/rhasspy/piper) binary | `VOX_PIPER_MODEL` (path to `.onnx`) |
 | `espeak.sh` | `espeak` / `espeak-ng` (zero-deps fallback) | — |
 | `macos-say.sh` | macOS `say(1)` + `afconvert` for WAV | — |
+| `host-forward.sh` | **containers only** — synthesises nothing; spools the TEXT to a host-visible mount where the host's own `vox` speaks it (#1084) | `OAW_VOX_SPOOL`, optional `OAW_VOX_STALE_SECONDS` |
+
+> `host-forward.sh` is only half of a pair. It must be wired alongside
+> `../vox-spool/no-op-player.sh` as the **player**, because there is no audio to
+> play on this side — the image does that (see
+> `docs/operations/containerised-vox.md`). The player deliberately does *not*
+> live in this directory: everything here is offered by `vox --setup --pick`, and
+> a player picked as a provider makes the agent mute while it believes it spoke.
 
 ## Setup
 

--- a/scripts/vox-providers/host-forward.sh
+++ b/scripts/vox-providers/host-forward.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# host-forward.sh — vox provider for containerised agents (#1084).
+#
+# A container has no audio: no synthesis provider, and no player at all (none of
+# afplay/paplay/aplay/ffplay, no libpulse). So this provider does not synthesise
+# anything. It writes the TEXT to a spool directory on a host-visible mount and
+# lets the host's already-configured `vox` do both synthesis and playback.
+#
+# Audio is deliberately NOT forwarded. Passing the host's PipeWire socket through
+# would mean adding an audio stack to every image to play one sentence, and
+# coupling containers to the host's audio devices.
+#
+# Provider contract (scripts/vox-providers/README.md): text in $1 (or stdin),
+# audio out at $VOX_OUTPUT_FILE, exit 0/non-zero. We honour it by writing an
+# EMPTY $VOX_OUTPUT_FILE — there is no audio to produce here — which the paired
+# no-op player then ignores. The pairing is the whole trick: provider forwards,
+# player does nothing, because playback happens on the other side of the mount.
+#
+# THE BACKLOG WARNING IS THE POINT. If nothing is draining the spool — host unit
+# masked, stopped, never installed, or watching a different major — an agent
+# would otherwise believe it is speaking while the operator hears silence. That
+# is the inert-guard shape this repo keeps producing (#1061 R-14, #1056 trivy,
+# #1069 "[0 items]", #1076 bootstrap), and it is worse here than a hard failure
+# would be, because the agent has no way to notice. So a stale spool is LOUD.
+set -uo pipefail
+
+SPOOL="${OAW_VOX_SPOOL:-$HOME/.oaw/vox-spool}"
+# How long a file may sit unconsumed before we call the drain broken. The host
+# path unit fires within a second; a minute is far outside normal and still short
+# enough that the operator hears about it during the session that broke it.
+STALE_SECONDS="${OAW_VOX_STALE_SECONDS:-60}"
+
+TEXT="${1:-}"
+if [[ -z "$TEXT" && ! -t 0 ]]; then
+	TEXT="$(cat)"
+fi
+if [[ -z "$TEXT" ]]; then
+	echo "host-forward: no text to speak" >&2
+	exit 1
+fi
+
+# Honour the contract even though there is no audio: an empty file, so the paired
+# no-op player has something to be handed and `vox` sees a provider that worked.
+if [[ -n "${VOX_OUTPUT_FILE:-}" ]]; then
+	: >"$VOX_OUTPUT_FILE" 2>/dev/null || true
+fi
+
+if ! mkdir -p "$SPOOL" 2>/dev/null; then
+	echo "host-forward: cannot create the spool at $SPOOL — the agent has NO voice" >&2
+	exit 1
+fi
+if [[ ! -w "$SPOOL" ]]; then
+	echo "host-forward: spool $SPOOL is not writable — the agent has NO voice" >&2
+	exit 1
+fi
+
+# WARN BEFORE WRITING, not after. Writing first and then checking would report a
+# backlog that includes this very message, so the first stalled utterance would
+# look fine and only the second would complain.
+# `! -newermt "-N seconds"` is precise to the second. `-mmin +N` would have been
+# minute-granular, so any threshold under 60s silently became "never stale".
+# FAIL CLOSED. `find … 2>/dev/null | wc -l` yields 0 when find itself errors, so
+# a find that cannot parse -newermt would silently disable the warning this whole
+# feature is built around — the guard going quiet in exactly the way it exists to
+# prevent. Check find's own status and say so.
+if stale_out="$(find "$SPOOL" -maxdepth 1 -type f -name '*.msg' \
+	! -newermt "-${STALE_SECONDS} seconds" 2>/dev/null)"; then
+	stale="$(printf '%s' "$stale_out" | grep -c . || true)"
+else
+	echo "host-forward: WARNING — cannot check the spool for a backlog (find failed);" >&2
+	echo "host-forward: treat delivery as UNVERIFIED rather than assume it worked." >&2
+	stale=0
+fi
+if [[ "$stale" -gt 0 ]]; then
+	echo "host-forward: WARNING — $stale message(s) have been sitting in $SPOOL unconsumed." >&2
+	echo "host-forward: nothing on the host is draining the spool, so this was NOT heard." >&2
+	echo "host-forward: check 'systemctl --user status oaw-vox-spool.path oaw-vox-spool.service' on the host." >&2
+fi
+
+# Identity so a multi-agent host can attribute what it hears. vox already
+# front-loads "<Name> here." into the text (#952), so this is for the host-side
+# log and for triage, not for re-deriving what to say.
+#
+# Resolved the way vox's own resolve_speaker does — walk UP from the working
+# directory looking for `.claude/agent-identity.json`. The canonical file is
+# project-rooted, not $HOME-rooted; reading `$HOME/.claude/agent-identity.json`
+# looked right and produced `dev_name: unknown` on a real container, because
+# that is simply not where it lives.
+resolve_dev_name() {
+	local d="${OAW_IDENTITY_DIR:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+	command -v python3 >/dev/null 2>&1 || return 0
+	while [[ -n "$d" && "$d" != "/" ]]; do
+		if [[ -r "$d/.claude/agent-identity.json" ]]; then
+			python3 -c '
+import json, sys
+try:
+    print(json.load(open(sys.argv[1])).get("dev_name") or "")
+except Exception:
+    pass
+' "$d/.claude/agent-identity.json" 2>/dev/null
+			return 0
+		fi
+		d="$(dirname "$d")"
+	done
+}
+
+dev_name="$(resolve_dev_name)"
+[[ -n "$dev_name" ]] || dev_name="unknown"
+
+# Write to a temp name in the SAME directory, then rename. The host watcher fires
+# on file creation, so a partially-written file would be read and spoken as a
+# truncated sentence; rename within one filesystem is atomic.
+# mktemp, not $$.$RANDOM: PIDs collide freely across containers sharing one host
+# spool, and two agents colliding means one of them is never heard. The `.tmp`
+# prefix keeps the in-flight file hidden from the host path unit, which ignores
+# dot-entries (verified) — otherwise it would fire on a partial write.
+stamp="$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo unknown)"
+tmp="$(mktemp "$SPOOL/.tmp.XXXXXXXX" 2>/dev/null)" || {
+	echo "host-forward: could not create a spool file in $SPOOL — the agent has NO voice" >&2
+	exit 1
+}
+suffix="${tmp##*.}" # the random component mktemp chose
+final="$SPOOL/${stamp}.${suffix}.msg"
+
+{
+	printf 'dev_name: %s\n' "$dev_name"
+	printf 'voice: %s\n' "${VOX_VOICE:-}"
+	printf '\n'
+	printf '%s\n' "$TEXT"
+} >"$tmp" 2>/dev/null || {
+	echo "host-forward: could not write to $SPOOL — the agent has NO voice" >&2
+	rm -f "$tmp" 2>/dev/null || true
+	exit 1
+}
+
+if ! mv -f "$tmp" "$final" 2>/dev/null; then
+	echo "host-forward: could not publish $final — the agent has NO voice" >&2
+	rm -f "$tmp" 2>/dev/null || true
+	exit 1
+fi
+
+exit 0

--- a/scripts/vox-spool/no-op-player.sh
+++ b/scripts/vox-spool/no-op-player.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# no-op-player.sh — the playback half of the containerised-vox pair (#1084).
+#
+# Paired with host-forward.sh. That provider does not synthesise audio; it
+# forwards the TEXT to a host-visible spool, and the host's own vox synthesises
+# and plays it. So there is nothing here to play, and this exists so `vox` does
+# not fail resolving a player that could not work anyway — the container has no
+# afplay/paplay/aplay/ffplay and no libpulse.
+#
+# It lives HERE rather than in scripts/vox-providers/ on purpose: everything in
+# that directory is offered by `vox --setup --pick=<name>`, and a PLAYER picked
+# as a PROVIDER produces exactly the mute-while-believing-it-spoke outcome #1084
+# refused to ship.
+#
+# It is NOT a silencer. It is only ever wired alongside host-forward.sh, whose
+# job is to be loud when the far side is not draining the spool. Pointing this at
+# a real synthesis provider would convert a working voice into a silent one, and
+# pointing `~/.config/vox/provider` at `silent.sh` instead of this pair would
+# convert a visible gap into an invisible one — the failure #1084 explicitly
+# refused to ship.
+#
+# Usage: no-op-player.sh <audio-file>   (argument accepted and ignored)
+exit 0

--- a/scripts/vox-spool/systemd/oaw-vox-spool.path
+++ b/scripts/vox-spool/systemd/oaw-vox-spool.path
@@ -1,0 +1,24 @@
+[Unit]
+Description=oaw-vox-spool: watch for speech forwarded from containerised agents (#1084)
+Documentation=https://github.com/Wave-Engineering/claudecode-workflow/issues/1084
+
+[Path]
+# A path unit rather than a polling loop or a custom daemon: no process running
+# when nothing is speaking, reboot-durable via the standard mechanism, and
+# nothing bespoke to maintain.
+#
+# DirectoryNotEmpty rather than PathChanged: PathChanged fires on the *event*, so
+# anything spooled while the service was already running for a previous message
+# can be missed. DirectoryNotEmpty re-triggers as long as work remains, which
+# makes the drain converge instead of leaving stragglers to age into the
+# provider's staleness warning.
+#
+# @SPOOL@ is substituted by `oaw-vox-drain --install-units`, which resolves the
+# kit major and then VERIFIES this line matches the directory it will drain. A
+# hardcoded `state/8/` here is the #1067 defect: at the next major the container
+# writes to state/9 while this watches state/8, and agents go silently mute.
+DirectoryNotEmpty=@SPOOL@
+Unit=oaw-vox-spool.service
+
+[Install]
+WantedBy=default.target

--- a/scripts/vox-spool/systemd/oaw-vox-spool.service
+++ b/scripts/vox-spool/systemd/oaw-vox-spool.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=oaw-vox-spool: speak messages forwarded from containerised agents (#1084)
+Documentation=https://github.com/Wave-Engineering/claudecode-workflow/issues/1084
+
+# NO START RATE LIMIT. A DirectoryNotEmpty path unit produces one service start
+# per drain cycle, so a wave of agents announcing at a boundary trips systemd's
+# default DefaultStartLimitBurst=5 / DefaultStartLimitIntervalSec=10s — and when
+# the limiter refuses the job, systemd fails the PATH unit as well. It then stops
+# watching entirely until someone runs `systemctl --user reset-failed`, which is
+# a silent death for the one channel that exists to be loud. Measured: a single
+# undrained file fired this 5 times in 2 seconds.
+#
+# The drain is a bounded oneshot that always leaves the spool free of triggering
+# entries, so "start it as often as the directory says" is the correct policy;
+# the loop it could spin on is closed on the drain side, not by throttling here.
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+# Drains whatever is queued and exits. Triggered by oaw-vox-spool.path, which
+# re-fires while the directory is non-empty, so a message arriving mid-drain is
+# picked up on the next trigger rather than stranded.
+ExecStart=%h/.local/bin/oaw-vox-drain
+# The drain runs the operator's own vox, which needs the user session's audio.
+# A user unit already has it; this is here so a failure to reach the sink shows
+# up in the journal instead of vanishing.
+StandardOutput=journal
+StandardError=journal

--- a/tests/contained-workflow/test_vox_forward.py
+++ b/tests/contained-workflow/test_vox_forward.py
@@ -1,0 +1,626 @@
+"""A containerised agent's voice (#1084).
+
+`vox` cannot work inside a container: no provider, and no player at all — none of
+afplay/paplay/aplay/ffplay, and no libpulse. Discord still reached the operator,
+but the audible interrupt, the thing that gets attention when nobody is watching
+a channel, was gone for every agent moved into a container.
+
+The fix forwards TEXT, not audio: the container's provider spools a message onto
+a host-visible mount and the host's own `vox` synthesises and plays it.
+
+**The load-bearing test in this file is the stale-spool one.** Everything else
+verifies the happy path, which is the easy half. If nothing on the host drains
+the spool, an agent would otherwise believe it is speaking while the operator
+hears silence — the inert-guard shape this repo keeps producing (#1061 R-14,
+#1056 trivy, #1069 "[0 items]"). That failure is invisible from inside the
+container unless the provider goes out of its way to be loud, so that is the
+assertion that keeps this feature from rotting.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PROVIDER = REPO / "scripts" / "vox-providers" / "host-forward.sh"
+PLAYER = REPO / "scripts" / "vox-spool" / "no-op-player.sh"
+DRAIN = REPO / "scripts" / "oaw-vox-drain"
+FRAGMENT = REPO / "containers" / "oakandwave-workflow" / "mounts.d" / "50-vox-spool.toml"
+DOCKERFILE = REPO / "containers" / "oakandwave-workflow" / "Dockerfile"
+
+
+def _spool(tmp_path: Path) -> Path:
+    d = tmp_path / "spool"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _forward(
+    tmp_path: Path, text: str, *, cwd: Path | None = None, **env: str
+) -> subprocess.CompletedProcess[str]:
+    spool = _spool(tmp_path)
+    return subprocess.run(
+        ["bash", str(PROVIDER), text],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd or tmp_path),
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "OAW_VOX_SPOOL": str(spool),
+            "VOX_OUTPUT_FILE": str(tmp_path / "out.wav"),
+            **env,
+        },
+        timeout=60,
+    )
+
+
+def _messages(tmp_path: Path) -> list[Path]:
+    return sorted(_spool(tmp_path).glob("*.msg"))
+
+
+def test_host_forward_provider_writes_spool_file(tmp_path: Path) -> None:
+    proc = _forward(tmp_path, "hello from a container")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    msgs = _messages(tmp_path)
+    assert len(msgs) == 1, f"expected exactly one spooled message, got {msgs}"
+    assert "hello from a container" in msgs[0].read_text()
+
+
+def test_the_provider_satisfies_voxs_audio_contract(tmp_path: Path) -> None:
+    """vox hands the provider $VOX_OUTPUT_FILE and then passes it to the player.
+    There is no audio to make here, but the file must exist or the pairing breaks
+    on whatever vox does with it next."""
+    _forward(tmp_path, "anything")
+    assert (tmp_path / "out.wav").exists()
+
+
+def test_host_forward_includes_agent_identity(tmp_path: Path) -> None:
+    """Several agents share one host spool, so what is heard must be attributable.
+
+    Identity is project-rooted, and resolved by walking UP from the working
+    directory the way vox's own resolve_speaker does. Reading
+    `$HOME/.claude/agent-identity.json` instead looked correct and produced
+    `dev_name: unknown` against a real container.
+    """
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    (proj / ".claude" / "agent-identity.json").write_text(
+        json.dumps({"dev_team": "oaw", "dev_name": "babelfish", "dev_avatar": "X"})
+    )
+    deep = proj / "src" / "nested"
+    deep.mkdir(parents=True)
+
+    proc = _forward(tmp_path, "attributable", cwd=deep)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "dev_name: babelfish" in _messages(tmp_path)[0].read_text()
+
+
+def test_unconsumed_spool_warns(tmp_path: Path) -> None:
+    """THE ONE THAT MATTERS. A spool nobody is draining means the agent is not
+    being heard, and it cannot tell from in here. Silence must be loud."""
+    spool = _spool(tmp_path)
+    stale = spool / "20200101T000000Z.1.1.msg"
+    stale.write_text("dev_name: ghost\n\nold\n")
+    old = time.time() - 600
+    os.utime(stale, (old, old))
+
+    proc = _forward(tmp_path, "am I being heard?")
+    assert "WARNING" in proc.stderr, (
+        f"a stale spool produced no warning — the agent would believe it spoke: {proc.stderr}"
+    )
+    assert "NOT heard" in proc.stderr
+    # Still spooled: the drain may come back. Warn, do not discard.
+    assert any("am I being heard?" in m.read_text() for m in _messages(tmp_path))
+
+
+def test_a_fresh_spool_does_not_warn(tmp_path: Path) -> None:
+    """The warning must discriminate. A queue that is merely busy is not broken,
+    and an assertion that fires on every send is one people learn to ignore."""
+    spool = _spool(tmp_path)
+    (spool / "recent.msg").write_text("dev_name: x\n\njust queued\n")
+    proc = _forward(tmp_path, "second message")
+    assert "WARNING" not in proc.stderr, proc.stderr
+
+
+def test_an_unwritable_spool_fails_loudly(tmp_path: Path) -> None:
+    """Never a silent success: if the message cannot be spooled at all, the
+    provider must fail, not pretend."""
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    blocked.chmod(0o500)
+    try:
+        proc = subprocess.run(
+            ["bash", str(PROVIDER), "cannot write"],
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "HOME": str(tmp_path),
+                "OAW_VOX_SPOOL": str(blocked / "nested"),
+                "VOX_OUTPUT_FILE": str(tmp_path / "o.wav"),
+            },
+            timeout=60,
+        )
+        assert proc.returncode != 0, proc.stdout + proc.stderr
+        assert "NO voice" in proc.stderr
+    finally:
+        blocked.chmod(0o700)
+
+
+def test_the_message_is_published_atomically(tmp_path: Path) -> None:
+    """The host watcher fires on creation, so a half-written file would be spoken
+    as a truncated sentence. Nothing may be left behind under a temp name."""
+    _forward(tmp_path, "atomic")
+    leftovers = [p.name for p in _spool(tmp_path).iterdir() if p.name.startswith(".tmp")]
+    assert not leftovers, f"in-flight temp files left in the spool: {leftovers}"
+
+
+# --- the host half ------------------------------------------------------------
+
+
+# Real `vox` accepts `--` to end option parsing, and the drain passes it so a
+# message starting with `-` is not read as an unknown option. A stub that does
+# not consume it records "--" as the message — a test failure with nothing to do
+# with the behaviour under test.
+_STUB_PREAMBLE = '#!/usr/bin/env bash\n[ "$1" = "--" ] && shift\n'
+
+
+def _drain(spool: Path, tmp_path: Path, vox_body: str, **env: str):
+    fake_vox = tmp_path / "fake-vox"
+    fake_vox.write_text(vox_body.replace("#!/usr/bin/env bash\n", _STUB_PREAMBLE, 1))
+    fake_vox.chmod(0o755)
+    return subprocess.run(
+        ["bash", str(DRAIN)],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "OAW_VOX_SPOOL_HOST": str(spool),
+            "OAW_VOX_BIN": str(fake_vox),
+            "SPOKEN_LOG": str(tmp_path / "spoken.log"),
+            **env,
+        },
+        timeout=60,
+    )
+
+
+def test_the_drain_speaks_the_body_and_removes_the_file(tmp_path: Path) -> None:
+    _forward(tmp_path, "speak me")
+    spool = _spool(tmp_path)
+    proc = _drain(
+        spool, tmp_path, '#!/usr/bin/env bash\necho "SPOKE: $1" >> "$SPOKEN_LOG"\n'
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    spoken = (tmp_path / "spoken.log").read_text()
+    assert "speak me" in spoken
+    # The header is metadata for triage, not something to read aloud.
+    assert "dev_name:" not in spoken
+    assert not _messages(tmp_path), "the drain left the message in the spool"
+
+
+def test_a_message_that_fails_to_speak_is_not_requeued(tmp_path: Path) -> None:
+    """Delete-then-speak, deliberately. Re-queuing a message vox rejects makes a
+    DirectoryNotEmpty path unit spin on it forever; heard-once-and-lost beats
+    repeated-until-the-end-of-time."""
+    _forward(tmp_path, "poison")
+    spool = _spool(tmp_path)
+    proc = _drain(spool, tmp_path, "#!/usr/bin/env bash\nexit 1\n")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert not _messages(tmp_path), "a failed message was left to be retried forever"
+
+
+def test_a_stale_backlog_is_dropped_not_spoken(tmp_path: Path) -> None:
+    """Speaking twenty stale status updates at once is worse than dropping them."""
+    _forward(tmp_path, "ancient news")
+    spool = _spool(tmp_path)
+    for m in _messages(tmp_path):
+        old = time.time() - 100000
+        os.utime(m, (old, old))
+    proc = _drain(
+        spool, tmp_path, '#!/usr/bin/env bash\necho "SPOKE: $1" >> "$SPOKEN_LOG"\n'
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert not (tmp_path / "spoken.log").exists(), "a stale backlog was spoken aloud"
+    assert "dropping" in proc.stderr
+
+
+def test_concurrent_drains_speak_each_message_exactly_once(tmp_path: Path) -> None:
+    """The glob is evaluated once per run, so two drains — the path unit's and an
+    operator running it by hand, which the runbook tells them to do — can both
+    enumerate the same file. Without an atomic claim they both speak it.
+
+    `rm -f` does NOT prevent this: it succeeds for both. Renaming does, because
+    `mv` fails once the source is gone.
+    """
+    spool = _spool(tmp_path)
+    for i in range(40):
+        (spool / f"m{i}.msg").write_text(f"dev_name: a\n\nmsg-{i}\n")
+
+    fake_vox = tmp_path / "fv"
+    fake_vox.write_text(_STUB_PREAMBLE + 'printf "%s\\n" "$1" >> "$SPOKEN_LOG"\n')
+    fake_vox.chmod(0o755)
+    log = tmp_path / "spoken.log"
+
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(tmp_path),
+        "OAW_VOX_SPOOL_HOST": str(spool),
+        "OAW_VOX_BIN": str(fake_vox),
+        "SPOKEN_LOG": str(log),
+    }
+    procs = [
+        subprocess.Popen(
+            ["bash", str(DRAIN)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env
+        )
+        for _ in range(6)
+    ]
+    for p in procs:
+        p.wait(timeout=120)
+
+    spoken = [l for l in log.read_text().splitlines() if l.startswith("msg-")]
+    assert len(spoken) == 40, f"expected 40 messages spoken, got {len(spoken)}"
+    assert len(set(spoken)) == 40, (
+        f"a message was spoken more than once: {sorted(x for x in spoken if spoken.count(x) > 1)[:5]}"
+    )
+    leftover = [p for p in spool.iterdir()]
+    assert not leftover, f"the spool was not fully drained: {leftover}"
+
+
+def test_the_drain_is_loud_when_vox_is_missing(tmp_path: Path) -> None:
+    """Otherwise the host silently discards everything containers spool at it."""
+    spool = _spool(tmp_path)
+    (spool / "x.msg").write_text("dev_name: a\n\nhi\n")
+    proc = subprocess.run(
+        ["bash", str(DRAIN)],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "OAW_VOX_SPOOL_HOST": str(spool),
+            "OAW_VOX_BIN": str(tmp_path / "does-not-exist"),
+        },
+        timeout=60,
+    )
+    assert proc.returncode != 0
+    assert "spooling into a void" in proc.stderr
+
+
+def test_the_drain_suppresses_a_second_signoff(tmp_path: Path) -> None:
+    """The container's vox ALREADY appended `. This is <agent>.` before handing
+    the text to the forwarding provider. The host's vox would append another —
+    and `resolve_speaker` never returns empty, so from a systemd unit with no
+    agent identity anywhere it falls through to `pid N`. The operator would hear
+    "…promoted. This is babelfish. This is pid 4711."
+    """
+    _forward(tmp_path, "wave 3 promoted. This is babelfish.")
+    spool = _spool(tmp_path)
+    proc = _drain(
+        spool,
+        tmp_path,
+        '#!/usr/bin/env bash\necho "NO_SIGNOFF=${VOX_NO_SIGNOFF:-unset}" >> "$SPOKEN_LOG"\n',
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "NO_SIGNOFF=1" in (tmp_path / "spoken.log").read_text(), (
+        "the drain let the host's vox append a second, bogus sign-off"
+    )
+
+
+def test_a_message_starting_with_a_dash_is_still_spoken(tmp_path: Path) -> None:
+    """vox rejects unknown `-*` options with exit 1, so without `--` a message
+    beginning with a dash is dropped rather than spoken.
+
+    This stub REJECTS a leading dash exactly as vox does, and is built here
+    rather than via `_drain` because that helper prepends its own `--`-consuming
+    preamble — with both, the `--` is eaten twice and the test fails for the
+    wrong reason. A stub that merely echoed $1 passed with `--` removed from the
+    drain, which made the assertion decorative.
+    """
+    _forward(tmp_path, "-v is not a flag here")
+    spool = _spool(tmp_path)
+
+    fake_vox = tmp_path / "picky-vox"
+    fake_vox.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "--" ]; then shift; '
+        'elif [ "${1#-}" != "$1" ]; then echo "unknown option: $1" >&2; exit 1; fi\n'
+        'printf "%s\\n" "$1" >> "$SPOKEN_LOG"\n'
+    )
+    fake_vox.chmod(0o755)
+
+    proc = subprocess.run(
+        ["bash", str(DRAIN)],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "OAW_VOX_SPOOL_HOST": str(spool),
+            "OAW_VOX_BIN": str(fake_vox),
+            "SPOKEN_LOG": str(tmp_path / "spoken.log"),
+        },
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    log = tmp_path / "spoken.log"
+    assert log.exists(), (
+        f"the message was rejected as an option instead of spoken: {proc.stderr}"
+    )
+    assert "is not a flag here" in log.read_text()
+
+
+def test_the_drain_never_leaves_a_triggering_entry(tmp_path: Path) -> None:
+    """THE LATCH. The path unit watches DirectoryNotEmpty, so anything left
+    behind re-triggers the service immediately and forever; systemd's start
+    limiter then refuses the job and fails the PATH unit too, which stops
+    watching until someone runs `reset-failed`. Measured: one undrained file
+    fired the service 5 times in 2 seconds.
+
+    So no exit path may leave a visible entry — not a stray file, not a
+    subdirectory, and not the no-vox bail-out.
+    """
+    spool = _spool(tmp_path)
+    (spool / "stray.txt").write_text("not a message")
+    (spool / "subdir").mkdir()
+    (spool / "real.msg").write_text("dev_name: a\n\nhello\n")
+
+    proc = subprocess.run(
+        ["bash", str(DRAIN)],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "OAW_VOX_SPOOL_HOST": str(spool),
+            "OAW_VOX_BIN": str(tmp_path / "no-such-vox"),
+        },
+        timeout=60,
+    )
+    assert proc.returncode != 0, "a missing vox must still be reported"
+    assert "spooling into a void" in proc.stderr
+
+    visible = [p.name for p in spool.iterdir() if not p.name.startswith(".")]
+    assert not visible, (
+        f"entries left that will re-trigger the path unit forever: {visible}"
+    )
+
+
+def test_stray_entries_are_cleared_on_the_normal_path_too(tmp_path: Path) -> None:
+    """The bail-out above is only one exit. With a WORKING vox the main loop must
+    also leave nothing visible — otherwise a single stray file re-triggers the
+    service forever on an otherwise healthy host, which is the same latch by a
+    different door. Testing only the bail-out let that survive.
+    """
+    spool = _spool(tmp_path)
+    (spool / "stray.txt").write_text("not a message")
+    (spool / "subdir").mkdir()
+    (spool / "real.msg").write_text("dev_name: a\n\nhello\n")
+
+    proc = _drain(
+        spool, tmp_path, '#!/usr/bin/env bash\necho "$1" >> "$SPOKEN_LOG"\n'
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "hello" in (tmp_path / "spoken.log").read_text()
+
+    visible = [p.name for p in spool.iterdir() if not p.name.startswith(".")]
+    assert not visible, (
+        f"stray entries left in the watched set on the normal path: {visible}"
+    )
+
+
+def test_the_service_disables_the_start_limiter() -> None:
+    """Without this a burst of announcements trips DefaultStartLimitBurst=5 and
+    systemd fails the PATH unit, silently ending the only channel that exists to
+    be loud."""
+    unit = (REPO / "scripts" / "vox-spool" / "systemd" / "oaw-vox-spool.service").read_text()
+    assert "StartLimitIntervalSec=0" in unit
+    # It must be in [Unit], not [Service] — systemd parses start rate limiting
+    # from the unit section, and a [Service] placement is silently ignored.
+    unit_section = unit.split("[Service]", 1)[0]
+    assert "StartLimitIntervalSec=0" in unit_section, (
+        "StartLimitIntervalSec must be in [Unit]; in [Service] it does nothing"
+    )
+
+
+def test_the_path_unit_carries_no_hardcoded_major() -> None:
+    """`state/8/` baked into the unit is the #1067 defect: at the next major the
+    container writes state/9 while this watches state/8, and agents go mute.
+    scripts/ci/oaw-major.sh exists because two other scripts did exactly this."""
+    unit = (REPO / "scripts" / "vox-spool" / "systemd" / "oaw-vox-spool.path").read_text()
+    assert "@SPOOL@" in unit, "the spool path must be templated at install time"
+    # Comments stripped: the comment EXPLAINING why `state/8/` is wrong contains
+    # the literal, so an unstripped scan fails on its own prose. Fifth time that
+    # shape has appeared in this repo.
+    directives = "\n".join(
+        l for l in unit.splitlines() if not l.lstrip().startswith("#")
+    )
+    assert not re.search(r"state/\d+/", directives), (
+        f"hardcoded major in the path unit: {directives}"
+    )
+
+
+def test_the_drain_refuses_rather_than_guessing_a_major(tmp_path: Path) -> None:
+    """No literal fallback — `OAW_MAJOR="${OAW_MAJOR:-1}"` is the #1067 defect
+    verbatim, and oaw-major.sh's own comment says guessing silently is worse than
+    refusing. With no spool to infer from, refuse."""
+    proc = subprocess.run(
+        ["bash", str(DRAIN), "--status"],
+        capture_output=True,
+        text=True,
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": str(tmp_path)},
+        timeout=60,
+    )
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "set OAW_MAJOR" in proc.stderr
+
+
+def test_the_drain_infers_the_major_from_the_one_spool_present(tmp_path: Path) -> None:
+    (tmp_path / ".oaw" / "state" / "11" / "vox-spool").mkdir(parents=True)
+    proc = subprocess.run(
+        ["bash", str(DRAIN), "--status"],
+        capture_output=True,
+        text=True,
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": str(tmp_path)},
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "state/11/vox-spool" in proc.stdout
+
+
+def test_an_ambiguous_major_refuses_rather_than_picking_one(tmp_path: Path) -> None:
+    for major in ("8", "9"):
+        (tmp_path / ".oaw" / "state" / major / "vox-spool").mkdir(parents=True)
+    proc = subprocess.run(
+        ["bash", str(DRAIN), "--status"],
+        capture_output=True,
+        text=True,
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": str(tmp_path)},
+        timeout=60,
+    )
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "several spools" in proc.stderr
+
+
+def test_the_default_spool_matches_the_declared_mount_target(tmp_path: Path) -> None:
+    """The provider's fallback and the mount's target are two independent
+    constants that must agree. Nothing consumes manifest `env`, so if they ever
+    diverge the container writes somewhere the host never sees — and every test
+    that sets OAW_VOX_SPOOL explicitly stays green while it happens.
+    """
+    target = re.search(r'target = "([^"]+)"', FRAGMENT.read_text()).group(1)
+    body = PROVIDER.read_text()
+    default = re.search(r'SPOOL="\$\{OAW_VOX_SPOOL:-([^}]+)\}"', body).group(1)
+    assert default.replace("$HOME", "/home/ubuntu") == target, (
+        f"provider default {default!r} does not match the mount target {target!r}"
+    )
+
+    # And the image must actually export it, so the declared env is not inert.
+    directives = "\n".join(
+        line
+        for line in DOCKERFILE.read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert f"ENV OAW_VOX_SPOOL={target}" in directives
+
+
+def test_the_provider_uses_its_default_when_the_env_is_unset(tmp_path: Path) -> None:
+    """Exercises the path production actually takes. Every other test sets
+    OAW_VOX_SPOOL, so the default was never run — the classic
+    declared-but-unexercised shape."""
+    proc = subprocess.run(
+        ["bash", str(PROVIDER), "using the default"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "VOX_OUTPUT_FILE": str(tmp_path / "o.wav"),
+        },
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    landed = list((tmp_path / ".oaw" / "vox-spool").glob("*.msg"))
+    assert len(landed) == 1, f"the default spool path was not used: {proc.stderr}"
+
+
+# --- wiring -------------------------------------------------------------------
+
+
+def test_spool_dir_is_an_existing_mounted_path() -> None:
+    """The spool must be a declared mount, or the container writes somewhere the
+    host never sees and the whole path is silently one-way."""
+    text = FRAGMENT.read_text()
+    assert 'source = "~/.oaw/state/<major>/vox-spool"' in text
+    assert 'target = "/home/ubuntu/.oaw/vox-spool"' in text
+    assert 'mode = "rw"' in text
+    # R-03: sandbox-scoped under ~/.oaw/state/<major>/, never the live-fleet tree.
+    assert "~/.claude" not in text.split("[[mount]]", 1)[1]
+
+
+def test_the_image_wires_the_provider_and_the_player() -> None:
+    """Both halves, or neither works: the provider forwards text and the player
+    is a no-op because playback happens on the host. Comments stripped so the
+    prose explaining this cannot satisfy the assertion."""
+    directives = "\n".join(
+        line
+        for line in DOCKERFILE.read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert "vox-providers/host-forward.sh" in directives
+    assert "vox-spool/no-op-player.sh" in directives
+    assert ".config/vox/provider" in directives
+    assert ".config/vox/player" in directives
+
+
+def test_the_image_does_not_wire_silent_sh() -> None:
+    """#1084 refused this explicitly: pointing the provider at silent.sh also
+    stops the error, by making the agent mute and believing it spoke. That turns
+    a visible gap into an invisible one."""
+    directives = "\n".join(
+        line
+        for line in DOCKERFILE.read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert "silent.sh" not in directives
+
+
+@pytest.mark.parametrize("script", [PROVIDER, PLAYER, DRAIN])
+def test_scripts_are_executable(script: Path) -> None:
+    assert os.access(script, os.X_OK), f"{script} must be executable"
+
+
+def test_install_carries_the_units_where_the_operator_step_looks() -> None:
+    """`--install-units` reads from ~/.claude/scripts/vox-spool/systemd, which is
+    where `./install`'s Cellar deploy puts scripts/vox-spool/systemd. If the
+    installer stopped carrying them the operator step would fail with "no units",
+    and the host side would quietly never exist.
+
+    The installer's rule is "every file under scripts/, except ci/ and the
+    excluded names". This checks each file against THAT rule rather than
+    re-running find — an earlier version shelled out to a bogus
+    `source ./install --source-only`, which failed silently and made the
+    assertion fire on an empty list.
+    """
+    install_src = (REPO / "install").read_text()
+    excluded = re.findall(r'SCRIPTS_EXCLUDE_NAMES=\(([^)]*)\)', install_src)
+    excluded_names = set(re.findall(r'"([^"]+)"', excluded[0])) if excluded else set()
+
+    for rel in (
+        "oaw-vox-drain",
+        "vox-providers/host-forward.sh",
+        "vox-spool/no-op-player.sh",
+        "vox-spool/systemd/oaw-vox-spool.path",
+        "vox-spool/systemd/oaw-vox-spool.service",
+    ):
+        assert (REPO / "scripts" / rel).is_file(), f"{rel} is missing from scripts/"
+        assert not rel.startswith("ci/"), f"{rel} sits in the excluded ci/ tree"
+        parts = set(Path(rel).parts[:-1])
+        assert not (parts & excluded_names), (
+            f"{rel} is under an excluded dir {parts & excluded_names} and would not install"
+        )
+
+
+def test_the_units_reference_the_installed_drain_path() -> None:
+    """ExecStart must point at where install actually puts the drain. A unit
+    naming a path the installer never creates fails only at trigger time — i.e.
+    the first time an agent tries to speak, which is the worst moment to find
+    out."""
+    service = (REPO / "scripts" / "vox-spool" / "systemd" / "oaw-vox-spool.service").read_text()
+    assert "ExecStart=%h/.local/bin/oaw-vox-drain" in service
+
+    path_unit = (REPO / "scripts" / "vox-spool" / "systemd" / "oaw-vox-spool.path").read_text()
+    # DirectoryNotEmpty, not PathChanged: PathChanged fires on the event, so a
+    # message spooled while the service was already running for a previous one is
+    # missed and ages into the provider's staleness warning.
+    assert "DirectoryNotEmpty=" in path_unit
+    assert "vox-spool" in path_unit


### PR DESCRIPTION
## Summary

`vox` could not work inside a container — no provider config, and **no player at all** (none of `afplay`/`paplay`/`aplay`/`ffplay`, no `libpulse`). Discord still reached the operator, but the audible interrupt — the thing that gets attention when nobody is watching a channel — was gone for every agent moved into a container.

**Text is forwarded, not audio.** The container's provider spools the message onto a host-visible mount; a `systemd --user` path unit runs the operator's own already-configured `vox` on it.

```
container                          host
  vox "…"
   └─ ~/.config/vox/provider  ──────► ~/.oaw/state/<major>/vox-spool/<ts>.msg
        (host-forward.sh)                      │  oaw-vox-spool.path
      ~/.config/vox/player                     ▼
        (no-op)                         oaw-vox-drain ──► vox ──► 🔊
```

Mounting the host's PipeWire socket was considered and **rejected**: with no client libraries and no player in the image it would mean adding an entire audio stack to play one sentence, and coupling containers to the host's audio devices.

No change to `vox` itself. The **pair** is the mechanism: the provider forwards text and writes an empty `$VOX_OUTPUT_FILE`; the player is a no-op because playback happens on the far side of the mount. That player lives in `scripts/vox-spool/` rather than `scripts/vox-providers/` on purpose — everything in the latter is offered by `vox --setup --pick`, and a *player* picked as a *provider* is the mute-while-believing-it-spoke outcome #1084 refused.

**The provider is loud when nothing drains the spool.** That is the assertion that keeps this from rotting: the failure is otherwise invisible from inside the container, and an agent that believes it is speaking while the operator hears silence is worse than one that cannot speak at all. The check fails **closed** — `find … | wc -l` yields `0` when find itself errors, which would have disabled the guard silently.

## What the review caught that would have shipped broken

| | |
|---|---|
| **Double sign-off** | The host's vox appended a *second* sign-off to text that already had one, resolved from a systemd unit with no agent identity — the operator would hear "…promoted. This is babelfish. **This is pid 4711.**" Fixed with `VOX_NO_SIGNOFF=1`, plus `--` so a dash-leading message isn't parsed as an option and dropped. |
| **Permanent latch** | `DirectoryNotEmpty` re-triggers on *any* visible entry, so an unconsumable file looped the service, tripped systemd's start limiter, and **failed the PATH unit itself** — which then stops watching until `reset-failed`. Measured: one undrained file fired it **5 times in 2 seconds**. The drain now leaves nothing visible (hidden `.quarantine/`, which systemd ignores — verified for both dotfiles and hidden dirs) and the service disables start rate limiting. |
| **Hardcoded major 8** | Reintroduced #1067 past its own regression guard. The unit is templated at install time; the drain derives the major from observable state and **refuses when ambiguous** rather than guessing. |
| **Inert declared env** | The fragment declared `env = { OAW_VOX_SPOOL }`, but nothing consumes manifest `env` — container and mount agreed only via two independent constants nobody checked. The image now exports it, and a test pins the default against the fragment's target. |

Also fixed: exactly-once draining via an atomic rename claim (`rm -f` does **not** prevent two drains speaking the same message — it succeeds for both); `mktemp` filenames because PIDs collide across containers sharing one spool; identity resolved by walking up from cwd the way vox's own `resolve_speaker` does.

## Test Plan

Run, not merely intended:

- `validate.sh` — **243 passed, 0 failed**
- `pytest tests/` — **2131 passed, 6 skipped, 64 xfailed**; **31 new**
- `check-mount-drift.sh dogfood mv05` — in sync, 13 mounts
- **End to end against the real image, real mount, real units:** a container spoke, the path unit fired, the host consumed it, the spool drained. Trial host state was then removed — enabling stays an operator decision.
- **Concurrency:** 20 simultaneous writers → 20 distinct messages, no leftovers; 200 messages × 6 concurrent drains → exactly-once every round.
- **Injection:** a message of `hello; touch /tmp/PWNED; $(id)` reaches vox as one literal argument; nothing executed.
- **systemd semantics verified empirically**, not assumed: dotfiles and hidden dirs do not trigger `DirectoryNotEmpty`; a normal file does.
- **Mutations killed (8/8):** remove the backlog warning; remove forwarding; read identity from `$HOME`; remove the stale-drop; remove `VOX_NO_SIGNOFF`; remove `--`; restore the literal major; remove the quarantine; re-enable the start limiter; remove the declared ENV.

Two mutations initially **survived** — both were weak tests of mine, not weak code (a stub that didn't reject dashes the way vox does, and a latch test that only exercised the bail-out path). Both strengthened, then killed.

## Operator step

`./install` deliberately does not touch systemd — installing units from the kit installer would mutate the operator's running session state under live sibling agents, the exact side effect this campaign exists to eliminate.

```bash
oaw-vox-drain --install-units    # also --status, --uninstall-units
```

Runbook: `docs/operations/containerised-vox.md`.

**Profiles were regenerated** for the new `vox-spool` mount; it binds on container recreation, so running agents are unaffected.

## Linked Issues

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZC3F9Qo7aX7QasQkdHPs7