### PR TITLE
chore(registry): a prune that cannot delete what the fleet is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`registry-prune.sh` — clear the GHCR backlog without deleting what the fleet is running (#1100).** 248 versions had accumulated, 155 of them untagged. The standard GHCR recipe is "delete all untagged versions", and running it would have deleted the live fleet's image: a profile pins a **bare digest**, which is correct — it is what makes a release immutable (R-05/R-23) — but leaves no tag behind, so a pinned, actively-running image is indistinguishable from garbage to any tag-based rule. **Untagged does not mean unused**, and the failure is delayed and disconnected: nothing breaks at prune time, it breaks at the next container launch.
+
+  The keep-set is computed from what is actually referenced — profile pins, named tags, a rollback window of the last N manifests, and each survivor's cosign `.sig`/`.att` (a signature orphaned from its subject verifies nothing). **Dry-run by default**; `--apply` is a separate act. It **refuses** on an empty pin list or an empty registry listing rather than concluding there is nothing to protect — the two states in which it would propose deleting everything.
+
+  The rollback window exists because releases are not identifiable in the registry: the build pushes only `:edge`, never `:vX.Y.Z`, and `:stable` has never been created, so v8.1.1's image looks like any intermediate push. Retention is therefore host-side only — the pins live in `~/.config/agent-of-empires/`, so a scheduled Action would run with an empty pin list. Policy documented in `docs/operations/image-release-cadence.md`.
+
 - **Containerised agents have a voice again (#1084).** `vox` could not work inside a container — no provider config, and no player at all (none of `afplay`/`paplay`/`aplay`/`ffplay`, no `libpulse`) — so every agent moved into a container lost the audible interrupt, the thing that gets attention when nobody is watching a Discord channel.
 
   **Text is forwarded, not audio.** The container's provider spools the message onto a host-visible mount and a `systemd --user` path unit runs the operator's own already-configured `vox` on it. Mounting the host's PipeWire socket was considered and rejected: with no client libraries and no player in the image it would mean adding an entire audio stack to play one sentence, and coupling containers to the host's audio devices.

--- a/docs/operations/image-release-cadence.md
+++ b/docs/operations/image-release-cadence.md
@@ -103,15 +103,80 @@ policy cannot see the operator's profile pins and would eventually delete one ou
 from under a running fleet — the failure arriving at the *next container launch*,
 long after the prune, with nothing connecting the two.
 
-**Always enumerate the pins first:**
+### The retention policy (#1100)
+
+**Use `scripts/ci/registry-prune.sh`. Do not hand-roll a delete.** It computes the
+keep-set from what is *actually referenced*, never from tags:
+
+| kept | why |
+|---|---|
+| every digest pinned by an aoe profile | the fleet is running it |
+| whatever `:edge` / `:stable` / any **named** tag points at | it is addressable |
+| the last **5** image manifests (`--keep-recent`) | a rollback window |
+| each survivor's `.sig` / `.att` | a signature orphaned from its subject verifies nothing, and a subject without its signature cannot be verified |
+
+Everything else is clutter. It is **dry-run by default**; `--apply` is a separate,
+deliberate act, because deleting published artifacts is irreversible and
+outward-facing.
+
+Four refusals are the point of the tool, not politeness:
+
+- **No profile pins found → it refuses.** An empty protect-list makes every other
+  check vacuous, and "nothing is in use" is exactly the reading that deletes a
+  running fleet.
+- **An empty registry listing → it refuses**, rather than concluding there is
+  nothing to protect from an instrument that returned nothing.
+- **A pin missing from the listing → it refuses.** The listing is then incomplete
+  — truncated pagination, a permissions gap, the wrong package — and a partial
+  listing is dangerous in a specific way: things whose protecting reference was
+  not seen look unreferenced. *"I could not see it"* and *"it is not there"* are
+  different claims, and only one is safe to act on.
+- **A digest it cannot resolve is KEPT, not deleted**, and if `docker` is
+  unavailable it refuses outright — parentage it cannot establish is not a
+  licence to delete.
+
+### The pinned digest is an INDEX, not a leaf
+
+This is the #1100 trap one layer down, and the reason the tool resolves manifests
+at all. buildx pushes an **image index**; its children are the per-arch manifest
+and a provenance attestation, and GHCR lists **each child as its own version** —
+untagged, unpinned, matching no cosign tag. Measured on the current pin:
+
+```
+7896722d  (index — what the profile pins, tagged :edge)
+├── 001185d8  amd64 image manifest      ← its own GHCR version, untagged
+└── 73d1c4d5  attestation manifest      ← its own GHCR version, untagged
+```
+
+**Deleting a child makes the pinned image unpullable** — and, as ever here, not at
+prune time but at the next container launch. Of 248 versions, **104 are index
+children**. The first cut of this script protected only the index; the children
+survived by being recent enough to fall inside the rollback window, which is luck
+rather than protection. The keep-set is now a closure: every descendant of
+anything kept, plus every cosign artifact of anything kept, iterated to a fixed
+point.
+
+**Can automation see the pins? Only if it runs where the pins are.** The script
+reads `~/.config/agent-of-empires/profiles/*/config.toml`, which exists on the
+operator's host and nowhere else — so this must **not** be wired to a scheduled
+GitHub Action, which would run with an empty pin list and hit the refusal (or
+worse, be "fixed" by removing it). Retention stays a host-side operator step until
+releases carry registry tags.
+
+**The rollback window exists because releases are not identifiable in the
+registry.** The build pushes only `:edge` — no `:vX.Y.Z` — so v8.1.1's image is
+indistinguishable from any intermediate push. Until that changes, "the most recent
+N manifests" is the only honest anchor for history. Tagging releases in the
+registry would let retention key on something meaningful and is the real fix.
+
+**Always enumerate the pins first** (the script does this, and prints them):
 
 ```bash
 grep -h default_image ~/.config/agent-of-empires/profiles/*/config.toml
 ```
 
 Everything in that list must survive, plus the current `:edge`, plus whatever
-`:stable` points at, plus each survivor's `.sig` and `.att` artifacts (a signature
-orphaned from its subject verifies nothing).
+`:stable` points at, plus each survivor's `.sig` and `.att` artifacts.
 
 ### `:stable` does not exist yet
 

--- a/scripts/ci/registry-prune.sh
+++ b/scripts/ci/registry-prune.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# registry-prune.sh — prune accumulated GHCR versions WITHOUT deleting anything
+# the fleet is running (#1100).
+#
+# THE TRAP THIS EXISTS TO AVOID. The standard GHCR cleanup recipe is "delete all
+# untagged versions". Running it here would have deleted the image the live fleet
+# was on:
+#
+#   profile dogfood → …/oakandwave-workflow@sha256:7e615dd0…
+#   that digest in GHCR: tags=[]        ← UNTAGGED
+#
+# A profile pins a BARE DIGEST. Pinning by digest is correct — it is what makes a
+# release immutable (R-05/R-23) — but it leaves no tag behind, so a pinned,
+# actively-running image is indistinguishable from garbage to any tag-based
+# retention rule. **Untagged does not mean unused.**
+#
+# And the failure is delayed and disconnected: nothing breaks at prune time. It
+# breaks at the next container launch on that profile, with nothing linking the
+# two events.
+#
+# So the keep-set is computed from what is ACTUALLY REFERENCED, not from tags:
+#   1. every digest pinned by an aoe profile        (the fleet)
+#   2. whatever :edge and any other NAMED tag point at
+#   3. the cosign .sig / .att artifacts of everything in 1 and 2 — a signature
+#      orphaned from its subject verifies nothing, and deleting the subject while
+#      keeping the signature (or vice versa) is worse than deleting neither
+#
+# DRY RUN BY DEFAULT. Deleting published artifacts is irreversible and
+# outward-facing; --apply is a separate, deliberate act.
+#
+# Usage:
+#   registry-prune.sh                      # dry run: show keep vs delete
+#   registry-prune.sh --apply              # actually delete (irreversible)
+#   registry-prune.sh --profiles-root DIR  # override where pins are read from
+#
+# Exit: 0 ok; 2 refused (could not establish what to protect); 1 a delete failed.
+set -uo pipefail
+
+ORG="${OAW_REGISTRY_ORG:-Wave-Engineering}"
+PACKAGE="${OAW_REGISTRY_PACKAGE:-oakandwave-workflow}"
+PROFILES_ROOT="${AOE_PROFILE_ROOT:-$HOME/.config/agent-of-empires/profiles}"
+APPLY=false
+# A ROLLBACK WINDOW. Keeping only what is referenced right now is correct and not
+# sufficient: it leaves no previous image to fall back to when the current one
+# turns out bad, and the release images are not distinguishable from intermediate
+# `:edge` pushes because the build only ever pushes `:edge` — no `:vX.Y.Z`, and
+# `:stable` has never been created. Until releases carry registry tags, "the most
+# recent N manifests" is the only honest anchor for history.
+KEEP_RECENT="${OAW_REGISTRY_KEEP_RECENT:-5}"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--apply)
+		APPLY=true
+		shift
+		;;
+	--keep-recent)
+		KEEP_RECENT="${2:?--keep-recent needs a count}"
+		shift 2
+		;;
+	--profiles-root)
+		PROFILES_ROOT="${2:?--profiles-root needs a path}"
+		shift 2
+		;;
+	--package)
+		PACKAGE="${2:?--package needs a name}"
+		shift 2
+		;;
+	--org)
+		ORG="${2:?--org needs a name}"
+		shift 2
+		;;
+	-h | --help)
+		sed -n '2,30p' "$0"
+		exit 0
+		;;
+	*)
+		echo "registry-prune: unknown flag $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+command -v gh >/dev/null 2>&1 || {
+	echo "registry-prune: gh not found" >&2
+	exit 2
+}
+
+# --- 1. What is the fleet running? -------------------------------------------
+# RED-FIRST. An empty pin list would make every protection below vacuous — the
+# script would happily compute "nothing is in use" and propose deleting the lot.
+# That is the single most dangerous state this can be in, so it refuses.
+# Only pins that reference THIS package. A profile may legitimately pin a
+# different image (a locally-built one, another package), and demanding those
+# appear in this package's listing would be a false alarm.
+mapfile -t PINS < <(
+	grep -rhoE "default_image[^\"]*\"[^\"]*${PACKAGE}[^\"]*@sha256:[0-9a-f]{64}" \
+		"$PROFILES_ROOT"/*/config.toml 2>/dev/null |
+		grep -oE 'sha256:[0-9a-f]{64}' | sort -u
+)
+if ((${#PINS[@]} == 0)); then
+	echo "registry-prune: NO profile pins found under $PROFILES_ROOT" >&2
+	echo "registry-prune: refusing — an empty protect-list makes every check below" >&2
+	echo "registry-prune: vacuous, and 'nothing is in use' is exactly the reading" >&2
+	echo "registry-prune: that deletes a running fleet. Point --profiles-root at" >&2
+	echo "registry-prune: the real profiles, or confirm the fleet is genuinely idle." >&2
+	exit 2
+fi
+
+echo "==> fleet pins (must survive): ${#PINS[@]}"
+printf '    %s\n' "${PINS[@]}"
+
+# --- 2. What is in the registry? ---------------------------------------------
+VERSIONS_JSON="$(mktemp)"
+trap 'rm -f "$VERSIONS_JSON"' EXIT
+if ! gh api --paginate "/orgs/$ORG/packages/container/$PACKAGE/versions" \
+	--jq '.[] | {id, name, tags: (.metadata.container.tags // []), created: .created_at}' \
+	>"$VERSIONS_JSON" 2>"$VERSIONS_JSON.err"; then
+	echo "registry-prune: could not list versions for $ORG/$PACKAGE" >&2
+	# Surface gh's own diagnostic: a 403 (missing read:packages), a 404 (wrong
+	# org/package) and a rate limit are different problems and collapsing them
+	# into one generic line sends people down the wrong path.
+	sed 's/^/registry-prune:   /' "$VERSIONS_JSON.err" >&2
+	echo "registry-prune: the token needs read:packages (and delete:packages for --apply)" >&2
+	exit 2
+fi
+if [[ ! -s "$VERSIONS_JSON" ]]; then
+	echo "registry-prune: the registry listing came back EMPTY — refusing rather than" >&2
+	echo "registry-prune: concluding there is nothing to protect" >&2
+	exit 2
+fi
+
+# COMPLETENESS. Every pin for this package must appear in the listing. If one
+# does not, the listing is incomplete — truncated pagination, a permissions gap,
+# the wrong package — and a partial listing is dangerous in a specific way:
+# things whose protecting reference was not seen look unreferenced. A signature
+# whose subject fell outside the page reads as an orphan and gets pruned.
+#
+# "I could not see it" and "it is not there" are different claims, and only one
+# of them is safe to act on.
+missing=0
+for pin in "${PINS[@]}"; do
+	if ! grep -qF "\"$pin\"" "$VERSIONS_JSON"; then
+		echo "registry-prune: pinned digest $pin is NOT in the registry listing" >&2
+		missing=$((missing + 1))
+	fi
+done
+if ((missing)); then
+	echo "registry-prune: refusing — $missing pin(s) unaccounted for means the listing is" >&2
+	echo "registry-prune: incomplete, and a partial listing makes protected things look" >&2
+	echo "registry-prune: like garbage. Re-run when the full listing is available." >&2
+	exit 2
+fi
+
+# --- 3. Resolve index children ------------------------------------------------
+# A pinned digest is usually an INDEX, not a leaf. buildx pushes an image index
+# whose children are the per-arch manifest and a provenance attestation, and GHCR
+# lists each child as its own package version — untagged, unpinned, and matching
+# no cosign tag. Deleting a child of a live index makes the pinned image
+# UNPULLABLE, and like every other failure in this area it surfaces at the next
+# container launch rather than at prune time.
+#
+# Measured on the current pin: mediaType image.index.v1+json, 2 children. They
+# survived the first cut of this script only because they happened to be recent
+# enough to fall inside the rollback window — luck, not protection.
+#
+# If children cannot be resolved, this REFUSES. Not knowing whether a version is
+# someone's child is not a licence to delete it.
+command -v docker >/dev/null 2>&1 || {
+	echo "registry-prune: docker not found — cannot resolve index children, refusing" >&2
+	exit 2
+}
+echo "==> resolving manifests (to find index children)…"
+
+# --- 4. Decide, and print the reasoning ---------------------------------------
+PLAN="$(mktemp)"
+trap 'rm -f "$VERSIONS_JSON" "$PLAN"' EXIT
+
+OAW_PINS="$(printf '%s\n' "${PINS[@]}")" OAW_KEEP_RECENT="$KEEP_RECENT" \
+OAW_IMAGE_REF="ghcr.io/${ORG,,}/${PACKAGE}" \
+	python3 - "$VERSIONS_JSON" "$PLAN" <<'PY'
+import json, os, subprocess, sys
+
+versions = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+pins = {p.strip() for p in os.environ["OAW_PINS"].splitlines() if p.strip()}
+keep_recent = int(os.environ.get("OAW_KEEP_RECENT", "5"))
+ref = os.environ["OAW_IMAGE_REF"]
+
+# cosign publishes its artifacts as TAGS on their own versions, named after the
+# subject digest with ':' swapped for '-'. That is the only link back, so it is
+# how a signature is matched to the thing it signs.
+#
+# ASSUMPTION, worth stating: this is cosign's tag scheme (default through v2.x).
+# Under OCI 1.1 referrers mode, signatures are UNTAGGED manifests carrying a
+# `subject` field instead — invisible to this matcher and pruned as garbage,
+# silently unsigning a live image. Revisit if cosign is moved to that mode.
+def subject_of(tags):
+    for t in tags:
+        if t.endswith((".sig", ".att")) and t.startswith("sha256-"):
+            return "sha256:" + t[len("sha256-"):].rsplit(".", 1)[0]
+    return None
+
+
+_manifest_cache = {}
+
+
+def children_of(digest):
+    """Digests this one references, or None if it could not be resolved."""
+    if digest in _manifest_cache:
+        return _manifest_cache[digest]
+    try:
+        raw = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", "--raw", f"{ref}@{digest}"],
+            capture_output=True, text=True, timeout=120,
+        )
+        if raw.returncode != 0:
+            _manifest_cache[digest] = None
+            return None
+        doc = json.loads(raw.stdout)
+    except Exception:
+        _manifest_cache[digest] = None
+        return None
+    kids = [m["digest"] for m in (doc.get("manifests") or []) if m.get("digest")]
+    _manifest_cache[digest] = kids
+    return kids
+
+
+by_digest = {v["name"]: v for v in versions}
+cosign = {v["name"] for v in versions if subject_of(v["tags"])}
+
+# Resolve every non-cosign version once. Expensive (one call each) but this runs
+# rarely and by hand, and the alternative is guessing about parentage while
+# holding a delete list.
+all_children = set()
+unresolved = set()
+for v in versions:
+    if v["name"] in cosign:
+        continue
+    kids = children_of(v["name"])
+    if kids is None:
+        unresolved.add(v["name"])
+    else:
+        all_children.update(kids)
+
+keep, why = set(), {}
+
+
+def protect(vid, reason):
+    keep.add(vid)
+    why.setdefault(vid, reason)
+
+
+for v in versions:
+    if v["name"] in pins:
+        protect(v["id"], "pinned by an aoe profile")
+    named = [t for t in v["tags"] if not (t.startswith("sha256-") and t.endswith((".sig", ".att")))]
+    if named:
+        protect(v["id"], f"tagged {','.join(named)}")
+
+# Rollback window: the last N things a profile could actually pin. Cosign
+# artifacts are excluded (not roll-back targets), and so are index CHILDREN — a
+# child is not a release, and counting them silently shrinks the real window.
+candidates = [
+    v for v in versions
+    if v["name"] not in cosign and v["name"] not in all_children
+]
+for v in sorted(candidates, key=lambda x: x["created"], reverse=True)[:keep_recent]:
+    protect(v["id"], "within the rollback window")
+
+# CLOSURE. Keep every descendant of a kept index, and every cosign artifact of
+# anything kept — including artifacts of children. Iterate to a fixed point
+# rather than snapshotting once: a signature can attach to a child, and a child
+# can itself be an index.
+changed = True
+while changed:
+    changed = False
+    kept_digests = {v["name"] for v in versions if v["id"] in keep}
+    for d in list(kept_digests):
+        for kid in (children_of(d) or []):
+            kv = by_digest.get(kid)
+            if kv and kv["id"] not in keep:
+                protect(kv["id"], f"child of a kept index ({d[:19]}…)")
+                changed = True
+    for v in versions:
+        subj = subject_of(v["tags"])
+        if subj and subj in kept_digests and v["id"] not in keep:
+            protect(v["id"], f"cosign artifact for {subj[:19]}…")
+            changed = True
+
+# Anything we could not resolve is kept. "I could not tell" is not "safe to
+# delete" — it may be a child of something live.
+for v in versions:
+    if v["name"] in unresolved and v["id"] not in keep:
+        protect(v["id"], "UNRESOLVED — kept because parentage could not be established")
+
+delete = [v for v in versions if v["id"] not in keep]
+
+print(f"==> registry holds {len(versions)} versions "
+      f"({len(cosign)} cosign artifacts, {len(all_children)} index children)")
+print(f"==> KEEP {len(keep)}")
+for v in sorted((v for v in versions if v["id"] in keep), key=lambda x: x["created"], reverse=True):
+    print(f"    {v['name']}  {','.join(v['tags']) or '<untagged>'}  — {why[v['id']]}")
+
+# PRINT THE PLAN, not just its size. A tool whose premise is "irreversible,
+# verify what you are protecting" must let an operator answer "is digest X in the
+# delete set?" — printing a count only made that impossible, and made every test
+# that tried to assert on it vacuous.
+print(f"==> DELETE {len(delete)}")
+for v in sorted(delete, key=lambda x: x["created"], reverse=True):
+    print(f"    {v['name']}  {','.join(v['tags']) or '<untagged>'}  {v['created']}")
+
+with open(sys.argv[2], "w") as fh:
+    for v in delete:
+        fh.write(f"{v['id']}\t{v['name']}\t{','.join(v['tags'])}\n")
+
+if not keep:
+    print("registry-prune: keep-set is EMPTY — refusing", file=sys.stderr)
+    raise SystemExit(2)
+PY
+rc=$?
+((rc == 0)) || exit "$rc"
+
+DELETE_COUNT="$(wc -l <"$PLAN")"
+
+# --- 5. Apply, or explain how to ----------------------------------------------
+if [[ "$APPLY" != true ]]; then
+	echo
+	echo "==> DRY RUN — nothing deleted."
+	echo "    $DELETE_COUNT version(s) would be removed. Re-run with --apply to do it."
+	echo "    Deleting published artifacts is irreversible; this is deliberately a"
+	echo "    separate act from computing the plan."
+	exit 0
+fi
+
+# A flag alone is a weak gate for an irreversible, outward-facing delete of this
+# size — nothing above required a dry run first, so without this an operator can
+# destroy every unprotected published artifact having never seen the list. The
+# plan is printed above; make them type the count back.
+if [[ -z "${OAW_REGISTRY_ASSUME_YES:-}" ]]; then
+	echo
+	echo "==> About to IRREVERSIBLY delete $DELETE_COUNT published version(s) from"
+	echo "    ghcr.io/${ORG,,}/${PACKAGE}. The full plan is printed above."
+	printf '    Type the number of versions to delete to confirm: '
+	read -r confirm
+	if [[ "$confirm" != "$DELETE_COUNT" ]]; then
+		echo "registry-prune: got '$confirm', expected '$DELETE_COUNT' — aborting" >&2
+		exit 2
+	fi
+fi
+
+echo
+echo "==> APPLYING: deleting $DELETE_COUNT version(s)"
+failed=0
+while IFS=$'\t' read -r vid name tags; do
+	if gh api -X DELETE "/orgs/$ORG/packages/container/$PACKAGE/versions/$vid" >/dev/null 2>&1; then
+		printf '    deleted %s %s\n' "${name:0:19}…" "$tags"
+	else
+		printf '    FAILED  %s %s\n' "${name:0:19}…" "$tags" >&2
+		failed=$((failed + 1))
+	fi
+done <"$PLAN"
+
+if ((failed)); then
+	echo "registry-prune: $failed deletion(s) failed" >&2
+	exit 1
+fi
+echo "==> done"

--- a/tests/contained-workflow/test_registry_prune.py
+++ b/tests/contained-workflow/test_registry_prune.py
@@ -1,0 +1,419 @@
+"""Pruning the registry without deleting what the fleet is running (#1100).
+
+The standard GHCR cleanup recipe is "delete all untagged versions". Running it
+here would have deleted the live fleet's image: a profile pins a BARE DIGEST,
+which is correct — it is what makes a release immutable (R-05/R-23) — but leaves
+no tag behind, so a pinned, actively-running image is indistinguishable from
+garbage to any tag-based rule. **Untagged does not mean unused.**
+
+And the failure is delayed and disconnected: nothing breaks at prune time. It
+breaks at the next container launch, with nothing linking the two events. So the
+load-bearing tests here are the ones that prove a pinned-but-untagged digest
+survives, and that an empty protect-list refuses rather than proposing to delete
+everything.
+
+`gh` is stubbed on PATH rather than the listing being injected through a back
+door, so the script's real registry path runs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PRUNE = REPO / "scripts" / "ci" / "registry-prune.sh"
+
+PIN = "sha256:" + "a" * 64
+OLD = "sha256:" + "b" * 64
+ORPHAN_SUBJ = "sha256:" + "c" * 64
+
+
+def _version(vid: int, digest: str, tags: list[str], created: str) -> dict:
+    return {
+        "id": vid,
+        "name": digest,
+        "metadata": {"container": {"tags": tags}},
+        "created_at": created,
+    }
+
+
+def _setup(
+    tmp_path: Path,
+    versions: list[dict],
+    pins: list[str] | None = None,
+    children: dict[str, list[str]] | None = None,
+) -> dict:
+    """A fake profiles root, a `gh` stub serving `versions`, and a `docker` stub
+    serving manifests.
+
+    The docker stub is not optional decoration: the script resolves every
+    non-cosign digest to find index children, and an unresolvable digest is KEPT
+    (parentage unknown is not licence to delete). Without the stub every fixture
+    would be unresolvable and every delete-plan assertion would pass vacuously.
+    """
+    profiles = tmp_path / "profiles" / "dogfood"
+    profiles.mkdir(parents=True)
+    if pins is None:
+        pins = [PIN]
+    # The ref must name the package: pin extraction is scoped to THIS package so
+    # a profile pinning some other image is not demanded to appear in this
+    # listing. A bare "ghcr.io/x/y@…" fixture therefore matches nothing.
+    body = "[sandbox]\n" + "".join(
+        f'default_image = "ghcr.io/wave-engineering/oakandwave-workflow@{p}"\n'
+        for p in pins
+    )
+    (profiles / "config.toml").write_text(body)
+
+    listing = tmp_path / "versions.json"
+    listing.write_text(json.dumps(versions))
+
+    manifests = tmp_path / "manifests.json"
+    manifests.write_text(json.dumps(children or {}))
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    deleted = tmp_path / "deleted.log"
+
+    docker = bindir / "docker"
+    docker.write_text(
+        "#!/usr/bin/env bash\n"
+        '# args: buildx imagetools inspect --raw <ref>@<digest>\n'
+        'ref="${!#}"; digest="${ref##*@}"\n'
+        f'python3 -c \'\nimport json,sys\nkids=json.load(open("{manifests}")).get(sys.argv[1], [])\n'
+        'print(json.dumps({"mediaType": "application/vnd.oci.image.index.v1+json",\n'
+        '                  "manifests": [{"digest": d} for d in kids]}))\n'
+        "' \"$digest\"\n"
+    )
+    docker.chmod(0o755)
+    gh = bindir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        # DELETE is recorded, never performed.
+        'if [[ "$*" == *"-X DELETE"* ]]; then\n'
+        f'  printf "%s\\n" "$*" >> "{deleted}"\n'
+        "  exit 0\n"
+        "fi\n"
+        # The listing call: emit one JSON object per line, as --jq would.
+        'if [[ "$*" == *"/versions"* ]]; then\n'
+        f'  python3 -c \'\nimport json,sys\nfor v in json.load(open("{listing}")):\n'
+        '    print(json.dumps({"id": v["id"], "name": v["name"],\n'
+        '                      "tags": v["metadata"]["container"]["tags"],\n'
+        '                      "created": v["created_at"]}))\n\'\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    gh.chmod(0o755)
+    return {
+        "profiles_root": tmp_path / "profiles",
+        "bindir": bindir,
+        "deleted": deleted,
+    }
+
+
+def _run(
+    env_paths: dict, *args: str, assume_yes: bool = False
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": f"{env_paths['bindir']}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "HOME": str(env_paths["profiles_root"].parent),
+    }
+    if assume_yes:
+        env["OAW_REGISTRY_ASSUME_YES"] = "1"
+    return subprocess.run(
+        ["bash", str(PRUNE), "--profiles-root", str(env_paths["profiles_root"]), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        timeout=120,
+    )
+
+
+def test_a_pinned_but_untagged_digest_is_never_deleted(tmp_path: Path) -> None:
+    """THE #1100 TRAP. This is the exact shape that would have taken the fleet
+    down: the running image carries no tag at all."""
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, [], "2026-08-01T00:00:00Z"),  # pinned, UNTAGGED
+            _version(2, OLD, [], "2026-07-01T00:00:00Z"),
+        ],
+    )
+    proc = _run(paths)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "pinned by an aoe profile" in proc.stdout
+    assert "KEEP 2" in proc.stdout or "KEEP 1" in proc.stdout
+    # And it must not appear in the delete plan at all.
+    assert "DELETE 0" in proc.stdout or PIN not in proc.stdout.split("DELETE")[-1]
+
+
+def test_an_empty_pin_list_refuses_rather_than_deleting_everything(tmp_path: Path) -> None:
+    """An empty protect-list makes every downstream check vacuous, and 'nothing
+    is in use' is precisely the reading that deletes a running fleet."""
+    paths = _setup(tmp_path, [_version(1, PIN, [], "2026-08-01T00:00:00Z")], pins=[])
+    proc = _run(paths)
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "refusing" in proc.stderr
+    assert not paths["deleted"].exists()
+
+
+def test_an_empty_registry_listing_refuses(tmp_path: Path) -> None:
+    """Zero versions back from the API is an instrument failure, not a clean
+    registry — concluding 'nothing to protect' from it is the same shape."""
+    paths = _setup(tmp_path, [])
+    proc = _run(paths)
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    # The SPECIFIC guard, not just "some refusal happened": a later keep-set-empty
+    # check also refuses here, so asserting on the shared word "EMPTY" could not
+    # tell which one fired and passed with this guard deleted.
+    assert "registry listing came back EMPTY" in proc.stderr, proc.stderr
+
+
+def test_cosign_artifacts_of_a_kept_digest_survive(tmp_path: Path) -> None:
+    """A subject without its signature cannot be verified, and a signature
+    without its subject verifies nothing — they live and die together."""
+    sig = "sha256-" + PIN.split(":")[1] + ".sig"
+    att = "sha256-" + PIN.split(":")[1] + ".att"
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, [], "2026-08-01T00:00:00Z"),
+            _version(2, "sha256:" + "d" * 64, [sig], "2026-08-01T00:01:00Z"),
+            _version(3, "sha256:" + "e" * 64, [att], "2026-08-01T00:02:00Z"),
+        ],
+    )
+    proc = _run(paths)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stdout.count("cosign artifact for") == 2
+    assert "DELETE 0" in proc.stdout
+
+
+def test_an_orphaned_signature_is_pruned(tmp_path: Path) -> None:
+    """A signature whose subject is gone protects nothing and is exactly the
+    accumulated clutter this issue is about."""
+    orphan = "sha256-" + ORPHAN_SUBJ.split(":")[1] + ".sig"
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, [], "2026-08-01T00:00:00Z"),
+            _version(2, "sha256:" + "f" * 64, [orphan], "2026-07-01T00:00:00Z"),
+        ],
+    )
+    proc = _run(paths, "--keep-recent", "1")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "DELETE 1" in proc.stdout
+
+
+def test_the_rollback_window_keeps_recent_manifests(tmp_path: Path) -> None:
+    """Keeping only what is referenced right now leaves nothing to roll back to
+    when the current image turns out bad — and release images are not
+    distinguishable from intermediate :edge pushes, because the build only ever
+    pushes :edge.
+
+    The pin is deliberately the OLDEST here so it cannot also fall inside the
+    window: a manifest that is both pinned and recent reports the pin reason
+    (first reason wins), which made an earlier version of this test count 2 and
+    call the code broken when it was the fixture that was ambiguous.
+    """
+    versions = [_version(1, PIN, [], "2026-07-01T00:00:00Z")]  # oldest
+    for i in range(2, 9):
+        versions.append(_version(i, f"sha256:{i:064x}", [], f"2026-08-{i:02d}T00:00:00Z"))
+    paths = _setup(tmp_path, versions)
+    proc = _run(paths, "--keep-recent", "3")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stdout.count("within the rollback window") == 3
+    assert "KEEP 4" in proc.stdout, proc.stdout  # 3 recent + the pin
+
+
+def test_cosign_artifacts_do_not_consume_the_rollback_window(tmp_path: Path) -> None:
+    """Counting .sig/.att toward the window would silently halve it — each image
+    carries two of them, so a window of 5 would really be a window of 1 or 2."""
+    versions = [_version(1, PIN, [], "2026-07-01T00:00:00Z")]  # oldest, see above
+    vid = 2
+    for i in range(3):
+        d = f"sha256:{i:064x}"
+        versions.append(_version(vid, d, [], f"2026-08-{10 + i:02d}T00:00:00Z"))
+        vid += 1
+        versions.append(
+            _version(
+                vid,
+                f"sha256:{vid:064x}",
+                ["sha256-" + d.split(":")[1] + ".sig"],
+                f"2026-08-{10 + i:02d}T00:01:00Z",
+            )
+        )
+        vid += 1
+    paths = _setup(tmp_path, versions)
+    proc = _run(paths, "--keep-recent", "3")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    # Assert the OUTCOME, not the reason count. Counting reasons passed even when
+    # the window was filled with signatures instead of images, because three
+    # things were protected either way. What actually matters is that no image is
+    # left unprotected: 3 manifests + their 3 signatures + the pin = everything.
+    assert "DELETE 0" in proc.stdout, proc.stdout
+
+
+def test_dry_run_deletes_nothing(tmp_path: Path) -> None:
+    """Deleting published artifacts is irreversible and outward-facing, so
+    computing the plan and performing it are deliberately separate acts."""
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, [], "2026-08-01T00:00:00Z"),
+            _version(2, OLD, [], "2026-07-01T00:00:00Z"),
+        ],
+    )
+    proc = _run(paths, "--keep-recent", "1")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "DRY RUN" in proc.stdout
+    assert not paths["deleted"].exists(), "a dry run issued DELETE calls"
+
+
+def test_apply_deletes_only_the_planned_versions(tmp_path: Path) -> None:
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, [], "2026-08-01T00:00:00Z"),
+            _version(2, OLD, [], "2026-07-01T00:00:00Z"),
+        ],
+    )
+    proc = _run(paths, "--keep-recent", "1", "--apply", assume_yes=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    calls = paths["deleted"].read_text().splitlines()
+    assert len(calls) == 1, f"expected exactly one delete, got: {calls}"
+    assert "/versions/2" in calls[0], calls[0]
+    assert "/versions/1" not in calls[0], "the pinned version was deleted"
+
+
+def test_a_pin_missing_from_the_listing_refuses(tmp_path: Path) -> None:
+    """"I could not see it" and "it is not there" are different claims.
+
+    A truncated or permission-limited listing makes protected things look
+    unreferenced — a signature whose subject fell outside the page reads as an
+    orphan and gets pruned. If a pin for this package is unaccounted for, the
+    listing is incomplete and nothing may be deleted on the strength of it.
+    """
+    paths = _setup(
+        tmp_path,
+        [_version(1, OLD, [], "2026-08-01T00:00:00Z")],  # the PIN is absent
+    )
+    proc = _run(paths)
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "NOT in the registry listing" in proc.stderr
+    assert not paths["deleted"].exists()
+
+
+def test_a_pin_for_another_package_is_not_demanded(tmp_path: Path) -> None:
+    """A profile may legitimately pin a different image — a locally-built one, or
+    another package. Demanding those appear in THIS package's listing would be a
+    false alarm that blocks every prune."""
+    profiles = tmp_path / "profiles" / "other"
+    profiles.mkdir(parents=True)
+    (profiles / "config.toml").write_text(
+        '[sandbox]\ndefault_image = "localhost/some-other-image@' + ORPHAN_SUBJ + '"\n'
+    )
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, [], "2026-08-01T00:00:00Z"),
+            _version(2, OLD, [], "2026-07-01T00:00:00Z"),
+        ],
+    )
+    proc = _run(paths, "--keep-recent", "1")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_apply_without_confirmation_aborts(tmp_path: Path) -> None:
+    """A flag alone is a weak gate for an irreversible, outward-facing delete.
+    Nothing forces a dry run first, so without this an operator can destroy every
+    unprotected published artifact having never seen the list."""
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, [], "2026-08-01T00:00:00Z"),
+            _version(2, OLD, [], "2026-07-01T00:00:00Z"),
+        ],
+    )
+    proc = _run(paths, "--keep-recent", "1", "--apply")  # no confirmation supplied
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "aborting" in proc.stderr
+    assert not paths["deleted"].exists(), "it deleted without confirmation"
+
+
+def test_children_of_a_kept_index_are_never_deleted(tmp_path: Path) -> None:
+    """THE #1100 TRAP, ONE LAYER DOWN. A pinned digest is usually an INDEX, not a
+    leaf: buildx pushes an index whose children are the per-arch manifest and a
+    provenance attestation, and GHCR lists each child as its own version —
+    untagged, unpinned, matching no cosign tag. Deleting a child of a live index
+    makes the pinned image UNPULLABLE.
+
+    Measured on the real registry: the pin resolves to an image index with 2
+    children. They survived the first cut of this script only because they were
+    recent enough to fall inside the rollback window — luck, not protection.
+    """
+    child_a = "sha256:" + "1" * 64
+    child_b = "sha256:" + "2" * 64
+    paths = _setup(
+        tmp_path,
+        [
+            _version(1, PIN, ["edge"], "2026-08-01T00:00:00Z"),
+            _version(2, child_a, [], "2026-08-01T00:00:01Z"),
+            _version(3, child_b, [], "2026-08-01T00:00:02Z"),
+            _version(4, OLD, [], "2020-01-01T00:00:00Z"),
+        ],
+        children={PIN: [child_a, child_b]},
+    )
+    proc = _run(paths, "--keep-recent", "1")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stdout.count("child of a kept index") == 2, proc.stdout
+    # The children must be in KEEP, and only the genuinely-unreferenced OLD goes.
+    assert "DELETE 1" in proc.stdout, proc.stdout
+    delete_section = proc.stdout.split("==> DELETE")[-1]
+    assert child_a not in delete_section and child_b not in delete_section
+
+
+def test_index_children_do_not_consume_the_rollback_window(tmp_path: Path) -> None:
+    """A child is not a release, so counting them shrinks the real window — with
+    2 children per push, a window of 5 would really be a window of 1 or 2."""
+    # PIN is deliberately OLDEST so it cannot also occupy a window slot: a
+    # version that is both pinned and recent reports the pin reason (first reason
+    # wins), which makes a reason-count assertion ambiguous.
+    versions = [_version(1, PIN, ["edge"], "2020-01-01T00:00:00Z")]
+    children = {}
+    vid = 2
+    for i in range(3):
+        idx = f"sha256:{i:064x}"
+        kid = f"sha256:{100 + i:064x}"
+        versions.append(_version(vid, idx, [], f"2026-08-0{5 + i}T00:00:00Z")); vid += 1
+        versions.append(_version(vid, kid, [], f"2026-08-0{5 + i}T00:00:01Z")); vid += 1
+        children[idx] = [kid]
+    paths = _setup(tmp_path, versions, children=children)
+    proc = _run(paths, "--keep-recent", "3")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    # 3 indexes in the window (not 1 index + 2 children), each dragging its child.
+    assert proc.stdout.count("within the rollback window") == 3, proc.stdout
+    assert "DELETE 0" in proc.stdout, proc.stdout
+
+
+def test_an_unresolvable_digest_is_kept_not_deleted(tmp_path: Path) -> None:
+    """"I could not tell" is not "safe to delete" — an unresolvable version may
+    be a child of something live."""
+    paths = _setup(tmp_path, [_version(1, PIN, ["edge"], "2026-08-01T00:00:00Z"),
+                              _version(2, OLD, [], "2020-01-01T00:00:00Z")])
+    # Break the resolver.
+    (paths["bindir"] / "docker").write_text("#!/usr/bin/env bash\nexit 1\n")
+    (paths["bindir"] / "docker").chmod(0o755)
+    proc = _run(paths, "--keep-recent", "1")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "UNRESOLVED" in proc.stdout
+    assert "DELETE 0" in proc.stdout
+
+
+def test_the_script_is_executable() -> None:
+    assert os.access(PRUNE, os.X_OK)


### PR DESCRIPTION
## Summary

248 GHCR versions had accumulated. The standard cleanup recipe is *"delete all untagged versions"*, and running it would have deleted the live fleet's image: an aoe profile pins a **bare digest** — correct, it is what makes a release immutable (R-05/R-23) — but that leaves no tag behind, so a pinned, actively-running image is indistinguishable from garbage to any tag-based rule. **Untagged does not mean unused.** And the failure is delayed and disconnected: nothing breaks at prune time, it breaks at the next container launch.

**Nothing is deleted by this PR.** Executing the prune is a separate, operator-approved act — a merge grant is not authorization to delete published artifacts.

## The critical finding: the pinned digest is an INDEX, not a leaf

The same trap, one layer down — caught in review and then **measured**:

```
7896722d  (index — what the profile pins, tagged :edge)
├── 001185d8  amd64 image manifest      ← its own GHCR version, untagged
└── 73d1c4d5  attestation manifest      ← its own GHCR version, untagged
```

buildx pushes an image index; GHCR lists **each child as its own version**, untagged, unpinned, matching no cosign tag. **Deleting a child makes the pinned image unpullable.** Of 248 versions, **104 are index children**.

My first cut protected only the index. Its children survived — but as *"within the rollback window"*, i.e. by being recent enough. **Luck, not protection.** An older release's children would have been deleted. The keep-set is now a fixed-point closure over children and cosign artifacts.

## How the keep-set is computed

From what is **actually referenced**, never from tags:

| kept | why |
|---|---|
| digests pinned by an aoe profile | the fleet is running it |
| whatever `:edge` / any **named** tag points at | it is addressable |
| last N manifests (`--keep-recent 5`) | a rollback window |
| **every descendant of anything kept** | a child of a live index is not garbage |
| each survivor's `.sig` / `.att` | a signature orphaned from its subject verifies nothing |

Children and cosign artifacts are excluded from the window count — a child is not a release, and with 2+ per push, counting them silently shrinks the window.

## Four refusals

Each covers a state where the tool would otherwise propose deleting things it must not:

- **No profile pins** — an empty protect-list is vacuous, and "nothing is in use" is exactly the reading that deletes a running fleet.
- **Empty registry listing** — an instrument that saw nothing is not a clean registry.
- **A pin absent from the listing** — the listing is incomplete, and a partial listing makes protected things look unreferenced. *"I could not see it"* and *"it is not there"* are different claims.
- **A digest it cannot resolve is KEPT**, and without `docker` it refuses outright — parentage it cannot establish is not a licence to delete.

`--apply` also requires typing the delete count back. A flag alone is a weak gate when nothing forces a dry run first.

## Test Plan

- `validate.sh` — **245 passed, 0 failed**
- `pytest tests/` — **2147 passed**; **16 new**, driving the real script with stubbed `gh` *and* `docker` (the docker stub is load-bearing: without it every fixture is unresolvable and every delete assertion passes vacuously)
- **Live dry run** against the real registry: 248 versions → KEEP 25, DELETE 223, with v8.1.1 and every index child protected
- **Measured, not assumed:** `imagetools inspect --raw` confirmed the pin is an OCI index with 2 children
- **Mutations killed (11/11):** remove pin protection; remove the empty-pin refusal; remove cosign co-retention; remove the empty-listing refusal; remove the dry-run default; count sig/att in the window; remove the completeness check; **remove index-child protection**; count children in the window; delete-what-it-cannot-resolve; remove the confirmation gate

Earlier rounds had two mutations survive and both were weak assertions of mine, not weak code — an `assert X or Y` whose second disjunct could never fail, and a reason-count that passed whichever kind of version filled the window. Both rewritten to assert outcomes.

## Retention policy

Documented in `docs/operations/image-release-cadence.md`. **Host-side only** — the pins live in `~/.config/agent-of-empires/`, so this must not be wired to a scheduled Action, which would run with an empty pin list and hit the refusal (or worse, be "fixed" by removing it).

The rollback window exists because **releases are not identifiable in the registry**: the build pushes only `:edge`, never `:vX.Y.Z`, and `:stable` has never been created — so v8.1.1's image looks like any intermediate push. Tagging releases in the registry is the real fix and deserves its own issue.

## Linked Issues

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZC3F9Qo7aX7QasQkdHPs7