### PR TITLE
fix(skills): /mmr and /scpmmr should pass expected_sha to post-merge ci_wait_run

### DIFF
--- a/skills/mmr/SKILL.md
+++ b/skills/mmr/SKILL.md
@@ -73,7 +73,13 @@ Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix)
    - Comprehensive enough that `git log` alone tells the full story without opening the PR
 6. **Present for approval**: PR/MR number, title, source→target branches, the drafted squash message. Ask "May I merge this PR/MR?" and WAIT. A second `/mmr` invocation counts as approval.
 7. `pr_merge(number, squash_message)` — squash merge. Returns `merge_method`, `merge_commit_sha`, `url`.
-8. **Post-merge**: switch to target branch, pull, delete local source branch if present. Optionally `ci_wait_run(ref: "main", timeout_sec: 1800)` to confirm the main-branch pipeline lands clean — skip if the user wants to move on immediately.
+8. **Post-merge**: switch to target branch, pull, delete local source branch if present. Optionally `ci_wait_run(ref: <PR/MR target from step 1>, expected_sha: <merge_commit_sha from step 7>, timeout_sec: 1800)` to confirm the target-branch pipeline lands clean — skip if the user wants to move on immediately.
+
+   **Always pass `expected_sha`, sourced from step 7's `merge_commit_sha`.** Without it, `ci_wait_run` picks whatever run is newest *in the list at that moment* — if GitHub/GitLab hasn't dispatched the new run for the commit that just landed yet (there is always some propagation delay after a merge), it can silently grade a PREVIOUS merge's already-completed run instead, returning `ok:true, final_status:"success"` for a commit nobody asked about. Reproduced live (`mcp-server-sdlc#523`): `waited_sec:0` with the wrong `sha` in the response was the only tell — no error, no warning. `expected_sha` closes this by filtering to the exact commit before grading anything.
+
+   **Use the SAME target reference as step 1's `branch_guard` call, never a literal `"main"`.** On the KAHUNA sandbox path the merge target is `kahuna/<N>-<slug>`, not `main` (see `/scpmmr`'s sandbox note) — pairing a hardcoded `ref: "main"` with `expected_sha` would query `--branch main --commit <sha>` for a commit that lives on neither, turning a merge that landed cleanly into a spurious `ok:false` on exactly the auto-approved path with no human present to notice the mismatch and move on.
+
+   **If `merge_commit_sha` is absent from step 7's response** (the merge did not complete synchronously — see `pr_merge`'s aggregate-envelope semantics), do not call `ci_wait_run` without a sha: resolve the target branch's current HEAD after the pull and use that, or skip the wait entirely.
 9. Report success with the merge commit URL.
 
 ## Important Rules
@@ -82,6 +88,7 @@ Determine target PR/MR: use `{{args}}` if provided (strip any `!` or `#` prefix)
 - ONLY merge if `checks.summary == "all_passed"` — an allowlist, never a blocklist. `has_failures` blocks, and so does `none`, and so does any value not in this list. A blocklist of known-bad states silently permits every state you did not think of, which is exactly how this gate sat inert (cc-workflow#925). **But on `none`/unrecognised, escalate to `pr_wait_ci` first (step 3) — stop only if that also cannot confirm a pass.** Without that clause this rule reads as "block every GitHub merge", because `pr_status` returned `none` for every GitHub PR on `gh 2.45.0`.
 - `pr_wait_ci` is an allowlist too — proceed only on `passed`. **`no_checks_configured` and `no_checks_yet` are both STOPs**, not passes: they mean the probe found nothing to wait for, or found that CI has not reported yet — never that anything succeeded. (`no_checks_required` was their single ambiguous predecessor, retired in `mcp-server-sdlc` v4.0.0.)
 - NEVER merge into a protected, non-default, non-`kahuna/*` branch — `branch_guard` STOPs this (target must be the live default or a `kahuna/*` sandbox)
+- Post-merge `ci_wait_run` (step 8) MUST pass `expected_sha` (from `merge_commit_sha`) and MUST use the same target ref as step 1's `branch_guard` call, never a hardcoded `"main"` — without `expected_sha` a propagation race can silently grade a stale run (`mcp-server-sdlc#523`); a hardcoded `main` fails outright on the `kahuna/*` sandbox path, with no human present to notice
 - Always squash + delete source branch
 - Squash message replaces the entire commit history — make it comprehensive
 - Merge conflicts → STOP and report, do NOT attempt to resolve

--- a/skills/scpmmr/SKILL.md
+++ b/skills/scpmmr/SKILL.md
@@ -18,7 +18,7 @@ Combo skill chaining `/scp` → `/mmr`. Both underlying skills are rewritten to 
 Requires `/precheck` first — invoking `/scpmmr` after `/precheck` is approval to execute. If `/precheck` has not been run, run it first and wait for approval.
 
 1. Run `/scp` — creates the PR/MR via `pr_create`
-2. Run `/mmr` — targets the just-created PR/MR. Merges directly via `pr_merge` (no `--admin` flag needed; the fleet is queue-less). Post-merge `ci_wait_run(ref: "main", timeout_sec: 1800)` confirms the main-branch pipeline lands clean.
+2. Run `/mmr` — targets the just-created PR/MR. Merges directly via `pr_merge` (no `--admin` flag needed; the fleet is queue-less). Post-merge `ci_wait_run(ref: <the actual merge target — main OR kahuna/<N>-<slug> on the sandbox path, never a hardcoded literal>, expected_sha: <merge_commit_sha from pr_merge>, timeout_sec: 1800)` confirms the target-branch pipeline lands clean. **Always pass `expected_sha`** — without it, a propagation race can grade a previous merge's already-completed run instead of the one that just landed, silently (`mcp-server-sdlc#523`). **`ref` must track the real target, not a literal `"main"`** — on the sandbox path below the merge lands on `kahuna/*`, and pairing a hardcoded `main` with `expected_sha` turns a clean merge into a spurious failure with no human present to catch it; see `/mmr`'s step 8 for the full mechanism.
 3. `vox` announcement (best-effort): identity from `<project_root>/.claude/agent-identity.json` (fallback: `/tmp/claude-agent-<md5>.json`), then name/team/project/issue/PR/"merged into main"
 
 ## Important

--- a/tests/test_mmr_ci_gate.py
+++ b/tests/test_mmr_ci_gate.py
@@ -295,3 +295,58 @@ class TestDefaultDenyDoesNotBecomeATotalBlock:
             "counter-example the warning is an assertion a future editor can "
             "reasonably dismiss"
         )
+
+
+class TestPostMergeCiWaitUsesExpectedSha:
+    """Step 8's `ci_wait_run` call must be race-hardened (cc-workflow#1124).
+
+    `ci_wait_run` picks whatever run is newest *in the list at the moment it
+    is called* when no `expected_sha` is given — if the new run for the
+    commit that just merged hasn't been dispatched yet (there is always some
+    propagation delay), it can silently grade a PREVIOUS merge's
+    already-completed run instead, returning `ok:true` for a commit nobody
+    asked about. `mcp-server-sdlc#523` reproduced this live: `waited_sec:0`
+    with the wrong `sha` was the only tell.
+    """
+
+    def test_expected_sha_is_required(self, mmr_text: str) -> None:
+        assert re.search(
+            r"[Aa]lways pass `expected_sha`", mmr_text
+        ), "step 8 must require expected_sha on every ci_wait_run call"
+        assert "mcp-server-sdlc#523" in mmr_text, (
+            "the skill must cite the live reproduction; without a concrete "
+            "counter-example the rule reads as caution a future editor can "
+            "reasonably relax"
+        )
+
+    def test_ref_is_not_a_hardcoded_main_literal(self, mmr_text: str) -> None:
+        """Pairing expected_sha with a hardcoded ref: "main" is worse than the
+        bug it fixes on the KAHUNA sandbox path: the merge lands on
+        `kahuna/<N>-<slug>`, so `--branch main --commit <sha>` matches
+        nothing and a clean merge reports ok:false — with no human present
+        on that auto-approved path to notice the mismatch and move on.
+        """
+        assert not re.search(r'ci_wait_run\(ref:\s*"main"', mmr_text), (
+            "ci_wait_run's ref must not be a hardcoded \"main\" literal — it "
+            "must track the same target branch_guard validated in step 1, "
+            "which is `main` OR a `kahuna/*` sandbox target"
+        )
+        assert re.search(r"never a hardcoded `\"main\"`", mmr_text), (
+            "the skill must state explicitly why a literal main is unsafe here"
+        )
+
+    def test_missing_merge_commit_sha_has_a_stated_fallback(
+        self, mmr_text: str
+    ) -> None:
+        """merge_commit_sha is optional on the pr_merge response (absent when
+        the merge did not complete synchronously) — 'always pass expected_sha'
+        must not silently degrade to 'call ci_wait_run without it' when the
+        field happens to be missing, which is exactly the #523 shape again.
+        """
+        assert re.search(
+            r"[Ii]f `merge_commit_sha` is absent", mmr_text
+        ), "the skill must state what to do when merge_commit_sha is missing"
+        assert re.search(r"do not call `?ci_wait_run`? without a sha", mmr_text, re.I), (
+            "the skill must explicitly forbid calling ci_wait_run without a "
+            "sha as the fallback, not just describe the absent case"
+        )


### PR DESCRIPTION
## Summary
`ci_wait_run` picks whatever run is newest in the list at the moment it's called when no `expected_sha` is given. If the new run for the commit that just merged hasn't been dispatched yet (there is always some propagation delay), it can silently grade a PREVIOUS merge's already-completed run instead, returning `ok:true` for a commit nobody asked about. Reproduced live tonight (`mcp-server-sdlc#523`): `waited_sec:0` with the wrong `sha` was the only tell — no error, no warning.

## Changes
- `/mmr` step 8 and `/scpmmr` step 2 now thread `expected_sha` (from `pr_merge`'s `merge_commit_sha`) through the post-merge `ci_wait_run` call.
- Code review caught a regression in the first draft: hardcoding `ref: "main"` next to the new `expected_sha` filter would have turned the KAHUNA sandbox path (merges to `kahuna/*`, auto-approved, no human present) from wrong-but-silently-green into a hard failure on every sandbox merge. Fixed to reference the same target `branch_guard` validated in step 1, never a literal.
- Added a stated fallback for when `merge_commit_sha` is legitimately absent (merge did not complete synchronously).
- Pinned the rule with a `TestPostMergeCiWaitUsesExpectedSha` regression class in `tests/test_mmr_ci_gate.py`, following that file's established prose-pinning convention (per `cc-workflow#925`).

## Linked Issues
Closes #1124

## Test Plan
- 3 new tests in `TestPostMergeCiWaitUsesExpectedSha`, all passing; full `test_mmr_ci_gate.py` suite: 17/17.
- `./scripts/ci/validate.sh`: 237 passed / 10 failed — verified against baseline `main` (stashed the change, reran, identical count) — zero new failures.
- Code review: 1 important finding (the sandbox-path regression above) fixed; 2 minor findings (rule not pinned in "Important Rules", no stated fallback for missing `merge_commit_sha`) fixed.
