### PR TITLE
fix(tests): seal HOME in the bootstrap suite; drop the redundant URL rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,46 @@ are worth keeping apart:
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **The test suite wrote the operator's real `~/.gitconfig` on every run (#1130).**
+  `tests/contained-workflow/test_bootstrap.py` drives the real `bootstrap.sh` by
+  subprocess with `OAW_HOME` redirected to a tempdir — but not `HOME`.
+  `ensure_github_auth` runs `git config --global`, and git reads `$HOME`, so every
+  run rewrote the host config, silently reinstating a `url.…insteadOf` rewrite the
+  operator had deliberately removed after a token leak forced a roll. Reproduced
+  with a canary `HOME`: one test, one `.gitconfig`, byte-identical to the block on
+  the host.
+
+  **Two things made this worse than a stray write.** It is invisible —
+  `git remote -v` and `git remote get-url` both report the *rewritten* URL, so 32
+  repos stored as `git@github.com:…` were authenticating with a broadly-scoped PAT
+  and nothing said so (only the `ssh://git@github.com/…` spelling escapes the
+  rewrite). And it contaminated our own reasoning: `CHANGELOG.md`, the `bootstrap.sh`
+  comment, and a test docstring all justified keeping the rewrite by citing that
+  `~/.gitconfig` as evidence of operator intent — evidence we had written ~29 hours
+  earlier. A leak that corrupts files is recoverable; one that corrupts your evidence
+  argues for its own continuation.
+
+  Fixed by `_sealed_env`, which seals `HOME`, `XDG_CONFIG_HOME` and `OAW_HOME`
+  together and is now the only sanctioned way to drive the bootstrap;
+  `test_beacon_is_silent_on_stdout` likewise no longer runs against the ambient
+  `HOME`. Guarded by `test_bootstrap_never_writes_the_operator_home`, which asserts
+  the operator's home is **empty** — not merely free of `.gitconfig`, since the next
+  leak will have a different filename. Mutation-tested: removing the `HOME` seal
+  turns it red with exactly `.gitconfig`.
+
+- **Removed the github URL rewrite from the container (#1130).** With the evidence
+  for it withdrawn, the question was re-asked on the container's own merits and the
+  answer is no. #1082's diagnosis (container git broken) was right; the cause was
+  that the mounted keys were unreachable to the runtime user, fixed by #1085 plus
+  `ensure_ssh_parity`. Measured in a live container: `ssh -T` succeeds for both
+  forges and `git ls-remote ssh://git@github.com/…` resolves. A rewrite only
+  redirects a working SSH path onto a token that also carries full API scope. The
+  credential helper stays — inert for SSH remotes, correct for a genuine `https://`
+  one. `test_git_transport_matches_the_host_per_forge`, which pinned the wrong
+  premise, is replaced by
+  `test_git_transport_is_ssh_for_both_forges_with_no_url_rewrite`.
 
 ## [8.3.0] - 2026-08-19
 
@@ -101,7 +140,7 @@ _Nothing yet._
 
 - **Container SSH parity — the operator's keys were mounted and invisible (#1089).** aoe mounts `~/.ssh` to `/root/.ssh` (keys plus a host→identity config) and agents use them constantly: git over SSH for both forges, and troubleshooting remote installs (blueshift, perkollate, `agent-smith-ca`), where no token substitutes. The agent runs as `ubuntu` with `HOME=/home/ubuntu`, so `ssh` looked in an empty `/home/ubuntu/.ssh`, fell back to default identity names, and failed `Permission denied (publickey)`. Before #1085 made `/root` traversable it could not have worked at all. `ensure_ssh_parity` links `~/.ssh` to the mounted keys — idempotent, clears `ssh`'s own `known_hosts` scratch dir (which silently appears and made a naive `ln -s` land *inside* it), and refuses loudly to clobber a real `~/.ssh`. Measured after: `ssh -T git@gitlab.com` → *Welcome to GitLab*, and `git ls-remote git@…` succeeds on **both** forges.
 
-  **This also corrects #1082 and retires machinery it added.** That fix concluded, from `gh api user` passing while `git push` failed, that git needed HTTPS+token, and added `url.https://github.com/.insteadOf` plus `credential.helper = !gh auth git-credential`. The diagnosis was half right — git transport *was* broken — and the remedy was wrong: git failed because the mounted keys were unreachable, not because a credential was missing. Routing git onto HTTPS+token worked, but it **changed behaviour rather than restoring it** and bypassed keys provisioned on purpose. The github rewrite was **restored** after review: the operator's own `~/.gitconfig` carries `url.https://github.com/.insteadof` and the gh credential helper, so HTTPS+PAT *is* what a host session uses for github — #1082 was right, and removing it diverged. gitlab has no host rewrite and stays SSH. The premise "the host uses SSH for git" was true for one forge and generalised to both; a test now pins **both** halves, since pinning either alone is what went wrong. Documented rationale claiming the container deliberately has no `~/.ssh` was **inference from a permissions bug presented as design intent**, and is corrected in `architecture.md` rather than quietly dropped.
+  **This also corrects #1082 and retires machinery it added.** That fix concluded, from `gh api user` passing while `git push` failed, that git needed HTTPS+token, and added `url.https://github.com/.insteadOf` plus `credential.helper = !gh auth git-credential`. The diagnosis was half right — git transport *was* broken — and the remedy was wrong: git failed because the mounted keys were unreachable, not because a credential was missing. Routing git onto HTTPS+token worked, but it **changed behaviour rather than restoring it** and bypassed keys provisioned on purpose. The github rewrite was **restored** after review: the operator's own `~/.gitconfig` carries `url.https://github.com/.insteadof` and the gh credential helper, so HTTPS+PAT *is* what a host session uses for github — #1082 was right, and removing it diverged. **[CORRECTED by #1130 — this sentence is wrong, and wrong in an instructive way. That `~/.gitconfig` was written by our own test suite: it sealed `$OAW_HOME` but not `$HOME`, so every run of `tests/contained-workflow/test_bootstrap.py` executed `git config --global` against the operator's real home. The rewrite entered `bootstrap.sh` on 2026-07-31 and this claim was written ~29 hours later, so the "evidence" was almost certainly our own side effect read back as host intent. It is also moot: SSH covers git for both forges in the container (`ensure_ssh_parity`), verified live. The rewrite is removed and the leak sealed.]** gitlab has no host rewrite and stays SSH. The premise "the host uses SSH for git" was true for one forge and generalised to both; a test now pins **both** halves, since pinning either alone is what went wrong. Documented rationale claiming the container deliberately has no `~/.ssh` was **inference from a permissions bug presented as design intent**, and is corrected in `architecture.md` rather than quietly dropped.
 
   `glab` gains an API credential (file, mode 600, `git_protocol: ssh` matching the host) from the whole-dir secrets mount, unblocking MR/CI work. Its token shape guard accepts `.` — real `glpat-` tokens contain dots, and the first cut rejected the operator's actual token while a dot-free fixture passed. The operator's `~/.local/bin` (139 utilities) is also mounted read-only at `/home/ubuntu/.oaw/overlay/local-bin` and **appended** to PATH — never prepended, since the kit's own bin holds the claude wrapper (#1076) and the MCP binaries, and shadowing it would silently un-bootstrap every agent. Profiles must be regenerated or `check-mount-drift.sh` fails and the mount silently does not happen (the #1069 class).
 

--- a/containers/oakandwave-workflow/bootstrap.sh
+++ b/containers/oakandwave-workflow/bootstrap.sh
@@ -1360,25 +1360,38 @@ ensure_github_auth() {
 	chmod 600 "$hosts"
 	info "github: wrote $hosts (mode 600, file modality — NOT exported to env)"
 
-	# RESTORED after being wrongly removed (#1089). The host's own ~/.gitconfig has
-	# exactly this, verified:
+	# NO URL REWRITE (#1130). An earlier revision set
+	# `url.https://github.com/.insteadOf = git@github.com:` here, so every
+	# `git@github.com:` remote silently resolved to HTTPS and authenticated with the
+	# PAT instead of the mounted SSH key.
 	#
-	#   url.https://github.com/.insteadof      git@github.com:
-	#   credential.https://github.com.helper   !gh auth git-credential
+	# It was justified by "the host's own ~/.gitconfig has exactly this, verified".
+	# That evidence was self-inflicted: this suite drives bootstrap.sh for real, and
+	# until #1130 it sealed only $OAW_HOME — not $HOME — so `git config --global`
+	# below wrote the OPERATOR'S real ~/.gitconfig on every test run. The config was
+	# then read back as proof of host intent. We were citing our own side effect.
 	#
-	# so HTTPS+PAT *is* what a host session uses for github git — #1082 was right.
-	# An earlier draft removed it on the premise "the host uses SSH for git". That is
-	# true for GITLAB (the host has no gitlab rewrite) and FALSE for github; it was
-	# generalised from one forge to both. Removing it made the container authenticate
-	# github git as the SSH key identity while the host uses the PAT identity — a
-	# different credential, audit trail and permission set. Under the parity
-	# principle that is a regression, not a simplification.
+	# The rewrite is also unnecessary. #1082's diagnosis (container git is broken)
+	# was right; its cause was that the mounted keys were UNREACHABLE to the runtime
+	# user, fixed by #1085 (traversable /root) + ensure_ssh_parity below. Measured in
+	# a live container after that fix:
+	#
+	#   ssh -T git@github.com            -> Hi bakeb7j0!
+	#   ssh -T git@gitlab.com            -> Welcome to GitLab, @brbaker-alog!
+	#   git ls-remote ssh://git@github.com/...  -> resolves
+	#
+	# SSH covers git for BOTH forges, which is what a host session does. A rewrite
+	# that redirects a working SSH path onto a broadly-scoped token is strictly worse:
+	# the token also carries full API scope, and the redirect is invisible to
+	# `git remote -v`.
+	#
+	# The credential helper STAYS. It is inert while remotes are SSH, and it is the
+	# right mechanism for a repo that genuinely carries an `https://` remote — the
+	# rewrite is what hijacked remotes that did not.
 	if command -v git >/dev/null 2>&1; then
 		git config --global --replace-all \
 			"credential.https://github.com.helper" '!gh auth git-credential' || true
-		git config --global --replace-all \
-			"url.https://github.com/.insteadOf" "git@github.com:" || true
-		info "github: git configured HTTPS+PAT for github.com (matching the host's ~/.gitconfig)"
+		info "github: credential helper set for genuine https remotes (git over SSH needs no rewrite)"
 	fi
 
 }

--- a/docs/contained-workflow/architecture.md
+++ b/docs/contained-workflow/architecture.md
@@ -633,8 +633,11 @@ removed. Retained here for the record:
 - `credential.https://github.com.helper = !gh auth git-credential`
 - `url.https://github.com/.insteadOf = git@github.com:`
 
-Only together do they work: the helper supplies the token, the rewrite makes the
-SSH remote use HTTPS so the helper is consulted at all.
+Only together did they work: the helper supplies the token, and the rewrite is what
+made an SSH remote use HTTPS so the helper was consulted at all. **Only the helper
+survives** — the rewrite was removed for good in #1130 (see §3.6.2), where it turned
+out to be both unnecessary (SSH covers git for both forges) and self-justifying (the
+`~/.gitconfig` cited as evidence for it had been written by our own test suite).
 
 **Timing note:** the credential is written when *bootstrap* runs, i.e. when the
 agent starts. A bare `docker exec … gh` before any agent has run will find no
@@ -705,18 +708,42 @@ Measured after: `ssh -T git@gitlab.com` → *Welcome to GitLab*, and
 > the container **differ** from the host — however defensible in isolation — is a
 > regression against that goal, not a hardening.
 
-**Git transport is per-forge, because the host treats them differently.** Verified
-against the operator's `~/.gitconfig`: github has
-`url.https://github.com/.insteadof git@github.com:` plus
-`credential.https://github.com.helper !gh auth git-credential`, and gitlab has **no**
-rewrite. So a host session uses **HTTPS+PAT for github** and **SSH for gitlab**, and
-the container now does the same.
+**Git transport is SSH for both forges. There is no URL rewriting. (#1130)**
 
-An earlier draft of this section removed the github rewrite on the premise "the host
-uses SSH for git" — true for gitlab, false for github, generalised from one forge to
-both. That made the container authenticate github git as the SSH *key* identity while
-the host uses the *PAT* identity: different credential, audit trail and effective
-permissions. Restored, with a test pinning both halves.
+An earlier revision of this section claimed transport was *per-forge* — HTTPS+PAT for
+github, SSH for gitlab — and verified that "against the operator's `~/.gitconfig`,"
+which carried a github rewrite and no gitlab one.
+
+**That verification was circular, and the conclusion was wrong.** The suite drives
+`bootstrap.sh` for real, and until #1130 it sealed only `$OAW_HOME`, not `$HOME`. So
+`ensure_github_auth`'s `git config --global` wrote the **operator's real
+`~/.gitconfig`** on every test run. The asymmetry read as host intent was our own
+side effect: we set github's rewrite and never set a gitlab one, then found exactly
+that shape and cited it as independent evidence. Timeline: the rewrite entered
+`bootstrap.sh` on 2026-07-31; the "verified against the operator's gitconfig" claim
+was written ~29 hours later.
+
+What is actually true, measured in a live container after `ensure_ssh_parity`:
+
+```
+ssh -T git@github.com                   -> Hi <user>!
+ssh -T git@gitlab.com                   -> Welcome to GitLab, @<user>!
+git ls-remote ssh://git@github.com/...  -> resolves
+```
+
+SSH covers git for **both** forges, which is what a host session does. A rewrite adds
+nothing and costs plenty: it redirects a working SSH path onto a token that also
+carries full API scope, and it is invisible to `git remote -v` (which reports the
+*rewritten* URL, so a remote stored as `git@github.com:…` reads as SSH while
+authenticating over HTTPS). The credential helper stays — inert for SSH remotes,
+correct for a genuine `https://` one. Only the rewrite was the defect.
+
+**The lesson worth carrying beyond this bug:** a test suite that writes outside its
+tempdir does not merely risk clobbering a file. It can manufacture the evidence you
+later reason from. `_sealed_env` seals every home-ish variable, and
+`test_bootstrap_never_writes_the_operator_home` asserts the operator's home is empty
+after a run — mutation-tested, since a guard only ever run against the fixed tree is
+an assertion that happens to be true.
 
 ### 3.7 First-run onboarding state (#1079)
 

--- a/scripts/ci/aoe-preflight.sh
+++ b/scripts/ci/aoe-preflight.sh
@@ -180,13 +180,17 @@ else
 	fail "gh not authenticated" "no push, no PR, no merge, no /scpmmr"
 fi
 # ASSERT THE BEHAVIOUR, NOT THE MECHANISM. The first cut asserted a git
-# credential helper existed — machinery #1082 added and #1089 removed, because
-# git transport is SSH here exactly as on the host. A check pinned to one
-# implementation fails when the implementation is corrected, which is what it did.
-# What matters is that git can reach a forge at all.
+# credential helper existed — a mechanism check that broke when the mechanism
+# changed. What matters is that git can reach a forge at all.
+#
+# #1082 added BOTH a credential helper and a `url…insteadOf` rewrite. Only the
+# REWRITE was removed (#1130); the helper stays, inert for SSH remotes and correct
+# for a genuine https one. Transport here is SSH for github as well as gitlab —
+# see #1130 for why the earlier "github is HTTPS+PAT" reading was our own test
+# suite's side effect read back as host intent.
 GITREACH="$(x sh -c 'timeout 40 git ls-remote git@github.com:Wave-Engineering/claudecode-workflow.git HEAD 2>&1 | head -1')"
 if printf '%s' "$GITREACH" | grep -qE '^[0-9a-f]{40}'; then
-	pass "git transport works (github: HTTPS+PAT, as on the host)"
+	pass "git transport works (github: SSH, as on the host)"
 else
 	fail "git cannot reach the forge: ${GITREACH:-no output}" \
 		"an agent that cannot fetch cannot verify an MR before merging it"
@@ -222,8 +226,10 @@ else
 		"a directory symlink onto the read-only mount does this"
 fi
 
-# gitlab uses a DIFFERENT transport (SSH — the host has no gitlab rewrite), so
-# testing github alone proves only half the parity claim.
+# BOTH forges use SSH (#1130 removed the github URL rewrite; there was never a
+# gitlab one). Testing github alone still proves only half the parity claim —
+# the mounted keyring must serve both, and an ssh config that maps only one host
+# fails exactly here.
 GLREACH="$(x sh -c 'timeout 40 git ls-remote git@gitlab.com:gitlab-org/cli.git HEAD 2>&1 | head -1')"
 if printf '%s' "$GLREACH" | grep -qE '^[0-9a-f]{40}'; then
 	pass "gitlab git transport works (SSH, as on the host)"

--- a/tests/contained-workflow/test_bootstrap.py
+++ b/tests/contained-workflow/test_bootstrap.py
@@ -113,9 +113,38 @@ def _make_home(
     return home
 
 
-def _run(home: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+def _sealed_env(home: Path, **overrides: str) -> dict[str, str]:
+    """Environment for driving the real ``bootstrap.sh`` without touching the host.
+
+    ``OAW_HOME`` redirects everything the bootstrap resolves *for itself*. It does
+    NOT redirect what the tools it INVOKES resolve. ``ensure_github_auth`` runs
+    ``git config --global``, and git reads ``$HOME`` / ``$XDG_CONFIG_HOME`` — so a
+    suite that seals only ``OAW_HOME`` writes the operator's real ``~/.gitconfig``
+    on every run.
+
+    It did exactly that for three weeks (#1130). Worse, the config it planted was
+    later read back and cited in a CHANGELOG entry and a test docstring as
+    independent evidence of what the operator wanted. A leak that only corrupts
+    files is recoverable; one that corrupts your evidence is not.
+
+    So: seal every home-ish variable, not only the one we named. Anything driving
+    the real bootstrap MUST build its env here rather than hand-rolling
+    ``{**os.environ, "OAW_HOME": ...}`` — that literal is the bug, and a new call
+    site copying it is how the leak comes back.
+    """
     env = dict(os.environ)
     env["OAW_HOME"] = str(home)
+    env["HOME"] = str(home)
+    env["XDG_CONFIG_HOME"] = str(home / ".config")
+    # Two more that redirect writes OUT of the tempdir and that the guard test
+    # cannot see, because it only inspects the stand-in operator home:
+    #   GIT_CONFIG_GLOBAL outranks $HOME for git itself, so it defeats the seal above.
+    #   GLAB_CONFIG_DIR is honoured directly by ensure_gitlab_auth, which would then
+    #   write a fixture token into the operator's real glab config.
+    # Neither is normally set — scrub them anyway. The cost is two lines; the cost
+    # of the last unsealed variable was three weeks of silently rewriting ~/.gitconfig.
+    env.pop("GIT_CONFIG_GLOBAL", None)
+    env.pop("GLAB_CONFIG_DIR", None)
     # SCRUB the ambient value. Run this suite INSIDE an aoe container — which is
     # the whole point of the dogfood ring — and every test here would resolve the
     # CLI config to the real, host-mounted, FLEET-SHARED /root/.claude/.claude.json:
@@ -124,7 +153,12 @@ def _run(home: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
     # mcpServers merged in permanently, since the merge is add-if-absent).
     # _run_cfgdir is the only place this may be set.
     env.pop("CLAUDE_CONFIG_DIR", None)
-    env.update(env_overrides)
+    env.update(overrides)
+    return env
+
+
+def _run(home: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = _sealed_env(home, **env_overrides)
     return subprocess.run(
         ["bash", str(BOOTSTRAP)],
         capture_output=True,
@@ -881,7 +915,7 @@ def test_trust_is_recorded_for_the_ACTUAL_working_directory(tmp_path: Path) -> N
         ["bash", str(BOOTSTRAP)],
         capture_output=True,
         text=True,
-        env={**os.environ, "OAW_HOME": str(home)},
+        env=_sealed_env(home),
         cwd=str(workspace),
         timeout=60,
     )
@@ -988,6 +1022,59 @@ def _home_with_pat(tmp_path: Path, token: str = "ghp_TESTTOKEN") -> Path:
     )
 
 
+def test_bootstrap_never_writes_the_operator_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE GUARD (#1130). The suite must not write outside its tempdir.
+
+    ``operator_home`` stands in for the real ``~``: it is what ``$HOME`` points at
+    when the suite starts. ``_sealed_env`` must override that with the per-test
+    tempdir, so a bootstrap run leaves it untouched.
+
+    Why this exists rather than a comment. For three weeks the suite sealed
+    ``OAW_HOME`` and not ``HOME``; ``ensure_github_auth`` ran ``git config
+    --global``; git read ``$HOME``; and every single run rewrote the operator's
+    real ``~/.gitconfig`` — silently reinstating a URL rewrite he had deliberately
+    removed after a token leak. Nothing failed, because nothing was looking.
+
+    ASSERT EMPTINESS, not the absence of one filename. Checking only for
+    ``.gitconfig`` would pass the day some new bootstrap step writes ``.netrc``,
+    and the next leak would be as invisible as this one was.
+
+    MUTATION-TESTED: delete ``env["HOME"] = str(home)`` from ``_sealed_env`` and
+    this test must go red. A guard only ever run against the fixed tree is not a
+    guard — it is an assertion that happens to be true.
+    """
+    operator_home = tmp_path / "operator-home"
+    operator_home.mkdir()
+    monkeypatch.setenv("HOME", str(operator_home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    # A PAT present is what drives ensure_github_auth down the git-config path —
+    # the exact route that leaked. A run without one would pass vacuously.
+    home = _home_with_pat(tmp_path)
+    proc = _run(home)
+    assert proc.returncode == 0, proc.stderr
+
+    # POSITIVE half first: prove the git-config path actually executed. Without
+    # this the guard passes vacuously the day ensure_github_auth returns early
+    # (empty token, shape-guard rejection, `command -v git` false, or the
+    # "hosts.yml already carries a token" branch) — an empty denominator wearing
+    # a pass's clothes, which is the exact shape this file polices elsewhere.
+    # It also pins WHERE the write landed, not only where it did not.
+    assert (home / ".gitconfig").is_file(), (
+        "bootstrap never reached `git config --global` — this guard proved nothing. "
+        "Check that the PAT fixture still drives ensure_github_auth down that path."
+    )
+
+    leaked = sorted(child.name for child in operator_home.iterdir())
+    assert leaked == [], (
+        "bootstrap wrote into the operator's home directory: "
+        f"{leaked}. Everything the bootstrap and the tools it invokes touch must "
+        "resolve inside the per-test tempdir — see _sealed_env."
+    )
+
+
 def test_github_credential_is_written_as_a_file(tmp_path: Path) -> None:
     home = _home_with_pat(tmp_path)
     proc = _run(home)
@@ -1022,7 +1109,7 @@ def test_github_token_is_never_exported_to_the_environment(tmp_path: Path) -> No
         ["bash", "-c", f'. "{BOOTSTRAP}" >/dev/null 2>&1; env'],
         capture_output=True,
         text=True,
-        env={**os.environ, "OAW_HOME": str(home)},
+        env=_sealed_env(home),
         cwd=str(tmp_path),
         timeout=60,
     )
@@ -1106,7 +1193,7 @@ def test_github_pat_cannot_be_projected_into_the_environment(tmp_path: Path) -> 
     proc = subprocess.run(
         ["bash", "-c", f'. "{BOOTSTRAP}" >/dev/null 2>&1; env'],
         capture_output=True, text=True,
-        env={**os.environ, "OAW_HOME": str(home)}, cwd=str(tmp_path), timeout=60,
+        env=_sealed_env(home), cwd=str(tmp_path), timeout=60,
     )
     assert "ghp_MUSTNOTLEAK" not in proc.stdout, "deny-list bypassed — PAT reached the env"
 
@@ -1145,7 +1232,7 @@ def _run_cfgdir(home: Path, cfgdir: Path, cwd: Path, **env: str):
     return subprocess.run(
         ["bash", str(BOOTSTRAP)],
         capture_output=True, text=True, timeout=60, cwd=str(cwd),
-        env={**os.environ, "OAW_HOME": str(home), "CLAUDE_CONFIG_DIR": str(cfgdir), **env},
+        env=_sealed_env(home, CLAUDE_CONFIG_DIR=str(cfgdir), **env),
     )
 
 
@@ -1548,7 +1635,7 @@ def test_gitlab_token_is_never_exported_to_the_environment(tmp_path: Path) -> No
     proc = subprocess.run(
         ["bash", "-c", f'. "{BOOTSTRAP}" >/dev/null 2>&1; env'],
         capture_output=True, text=True, timeout=60,
-        env={**os.environ, "OAW_HOME": str(home)}, cwd=str(tmp_path),
+        env=_sealed_env(home), cwd=str(tmp_path),
     )
     assert "glpat-LEAKCANARY" not in proc.stdout
 
@@ -1634,53 +1721,66 @@ def test_operator_local_bin_is_read_only() -> None:
     assert 'mode = "ro"' in block, "operator bin mount must be read-only"
 
 
-def test_git_transport_matches_the_host_per_forge() -> None:
-    """Parity is PER FORGE — the host does not treat them alike.
+def test_git_transport_is_ssh_for_both_forges_with_no_url_rewrite() -> None:
+    """git in the container goes over SSH, for BOTH forges, with no URL rewriting.
 
-    Verified against the operator's real ~/.gitconfig:
+    Replaces ``test_git_transport_matches_the_host_per_forge`` (#1130), which
+    asserted the opposite for github and justified it in its docstring by citing
+    the operator's ``~/.gitconfig``. That evidence was written by this very suite:
+    it sealed ``$OAW_HOME`` but not ``$HOME``, so ``git config --global`` in
+    ``ensure_github_auth`` wrote the operator's real config on every run. The test
+    pinned a conclusion drawn from our own side effect.
 
-        url.https://github.com/.insteadof       git@github.com:
-        credential.https://github.com.helper    !gh auth git-credential
-        (no gitlab rewrite at all)
+    What is actually true, measured in a live container after ``ensure_ssh_parity``:
 
-    So a host session uses **HTTPS+PAT for github** and **SSH for gitlab**.
+        ssh -T git@github.com                   -> Hi bakeb7j0!
+        ssh -T git@gitlab.com                   -> Welcome to GitLab, @brbaker-alog!
+        git ls-remote ssh://git@github.com/...  -> resolves
 
-    An earlier draft of #1089 removed the github rewrite on the premise "the host
-    uses SSH for git" — true for gitlab, false for github, generalised from one
-    forge to both. That made the container authenticate github git as the SSH key
-    identity while the host uses the PAT identity: different credential, different
-    audit trail, different effective permissions. Under the parity principle that
-    is a regression, not a simplification.
+    So a rewrite would only redirect a working SSH path onto a broadly-scoped
+    token — invisibly, since ``git remote -v`` reports the rewritten URL.
 
-    This test pins BOTH halves, because pinning either alone is what went wrong.
+    The credential helper is deliberately still asserted present: it is inert for
+    SSH remotes and correct for a genuine ``https://`` one. Only the rewrite was
+    the defect.
     """
     body = (
         REPO_ROOT / "containers" / "oakandwave-workflow" / "bootstrap.sh"
     ).read_text()
-    assert 'url.https://github.com/.insteadOf' in body, (
-        "github rewrite missing — the host HAS it; removing it diverges from parity"
+
+    # Assert on the CALL, not on prose: this file's own comments discuss the
+    # rewrite at length, so a substring check against the whole body would match
+    # the explanation of why it is gone.
+    # Case-INSENSITIVE, on the bare word. Git config names are case-insensitive, so
+    # `url.…insteadof` is legal and identical — and `pushInsteadOf` (the natural
+    # reach for "push over HTTPS, fetch over SSH") does not contain the literal
+    # ".insteadOf" at all. A substring check on the exact camelCase spelling would
+    # wave through both.
+    rewrites = [
+        l.strip()
+        for l in body.splitlines()
+        if re.search(r"insteadof", l, re.I) and not l.lstrip().startswith("#")
+    ]
+    assert rewrites == [], (
+        f"a URL rewrite is being configured: {rewrites}. git over SSH works for "
+        "both forges; a rewrite silently moves it onto the PAT."
     )
-    assert "gh auth git-credential" in body, "github credential helper missing"
-    assert "url.https://gitlab.com/.insteadOf" not in body, (
-        "gitlab rewrite added — the host has NO gitlab rewrite; gitlab git is SSH"
-    )
+
+    # Anchored to the CALL, not the raw body: eleven lines above, this test insists
+    # on exactly that discipline, and bootstrap.sh's prose now discusses the helper
+    # by name. A bare substring check would go green on a comment alone.
+    assert re.search(
+        r"^\s*git config --global .*\n?.*gh auth git-credential", body, re.M
+    ), ("github credential helper is not CONFIGURED — needed for a genuine https remote")
+
     # Assert the CALL, not the definition. `"ensure_ssh_parity" in body` is
     # satisfied by the function existing while main never invokes it — the
     # declared-but-not-wired shape this repo keeps producing (#1076 most of all).
     # Caught by mutation: removing the call from main left that assertion green.
-    assert re.search(r"^\tensure_ssh_parity$", body, re.M), (
-        "ensure_ssh_parity is defined but not CALLED from main: gitlab git and "
-        "every remote host (blueshift, perkollate, agent-smith-ca) depend on it"
+    assert re.search(r"^\s*ensure_ssh_parity\s*$", body, re.M), (
+        "ensure_ssh_parity is never CALLED — the keys stay invisible and git over "
+        "SSH fails, which is the failure the rewrite was papering over"
     )
-
-
-# --- kit hook wiring into the settings the CLI reads (#1086) ------------------
-#
-# R-06 says hook wiring is versioned with the release. Under aoe it was not: the
-# CLI reads $CLAUDE_CONFIG_DIR/settings.json and never the image's own copy. That
-# went unnoticed because the shared file had been seeded from a host carrying the
-# same kit, so an equivalent hook set was already sitting in it and hooks DID fire.
-# What could not happen was version movement — and nothing reported that.
 
 
 _GUARD_RE = re.compile(r"^\[ -x (?P<path>\S+) \] \|\| exit 0; (?P<cmd>.*)$", re.S)
@@ -2185,13 +2285,24 @@ def test_beacon_writes_its_marker_by_running(tmp_path: Path) -> None:
     assert marker.read_text().strip(), "the marker is empty — no timestamp recorded"
 
 
-def test_beacon_is_silent_on_stdout() -> None:
+def test_beacon_is_silent_on_stdout(tmp_path: Path) -> None:
     """SessionStart stdout becomes additionalContext in the agent's window. A
-    beacon that spends context would tax every session for the life of the kit."""
-    home = os.environ.get("HOME", "/tmp")
+    beacon that spends context would tax every session for the life of the kit.
+
+    Uses a tempdir HOME, not the ambient one (#1130). This previously ran the
+    beacon with ``HOME`` = the operator's real home, so asserting "silent on
+    stdout" had the side effect of writing ``~/.claude/.kit-hooks-alive`` on the
+    host every run. The marker is a kit file and harmless in itself — but a suite
+    that writes outside its tempdir at all is one refactor away from writing
+    something that is not harmless, which is precisely how the ~/.gitconfig leak
+    happened. The beacon needs ``$HOME/.claude`` to exist; it does not need it to
+    be the operator's.
+    """
+    home = tmp_path / "beaconhome"
+    (home / ".claude").mkdir(parents=True)
     proc = subprocess.run(
         ["bash", str(BEACON)], capture_output=True, text=True, timeout=30,
-        env={**os.environ, "HOME": home},
+        env={**os.environ, "HOME": str(home)},
     )
     assert proc.stdout == "", f"beacon wrote to stdout: {proc.stdout!r}"
 
@@ -2292,8 +2403,7 @@ def _stub_mise(binroot: Path, *, exit_code: int = 0, message: str = "") -> Path:
 
 
 def _run_toolbox(home: Path, toolbox: Path, binroot: Path | None = None, **env: str):
-    e = {**os.environ, "OAW_HOME": str(home), "OAW_TOOLBOX_DIR": str(toolbox)}
-    e.pop("CLAUDE_CONFIG_DIR", None)
+    e = _sealed_env(home, OAW_TOOLBOX_DIR=str(toolbox))
     if binroot is not None:
         e["PATH"] = f"{binroot}:{e['PATH']}"
     e.update(env)


### PR DESCRIPTION
## Summary

`tests/contained-workflow/test_bootstrap.py` drives the real `bootstrap.sh` by subprocess with `OAW_HOME` redirected to a tempdir — but not `HOME`. `ensure_github_auth` runs `git config --global`, and git reads `$HOME`. So **every run of the suite rewrote the operator's real `~/.gitconfig`**, silently reinstating a `url.https://github.com/.insteadOf = git@github.com:` rewrite he had deliberately removed after a GitHub token leak forced a roll.

Reproduced with a canary `HOME`: one test, one `.gitconfig`, byte-identical to the block on the host.

## Why it was worse than a stray write

**It is invisible.** `git remote -v` and `git remote get-url` both report the *rewritten* URL, so 32 repos stored as `git@github.com:…` were authenticating with a broadly-scoped PAT — which also carries full API scope — and nothing said so. Only the `ssh://git@github.com/…` spelling escapes the rewrite. My own first attempt to count the affected repos returned `0`, because I used the command that applies it.

**It contaminated our own evidence.** `CHANGELOG.md`, the `bootstrap.sh` comment and a test docstring all justified keeping the rewrite by citing that `~/.gitconfig` as independent proof of operator intent:

| when | what |
|---|---|
| 2026-07-22 | tests begin driving `bootstrap.sh` by subprocess (`2500e85`) |
| 2026-07-31 07:22 | `insteadOf` enters `bootstrap.sh` (`a279903`, #1083) — **from here, any test run plants it** |
| 2026-08-01 12:21 | `53c85a5` cites "the operator's own `~/.gitconfig` carries it, **verified**" — **~29h later** |

A leak that corrupts files is recoverable. One that corrupts your evidence argues for its own continuation.

## Changes

- **`_sealed_env(home, **overrides)`** seals `HOME`, `XDG_CONFIG_HOME` and `OAW_HOME` together, and scrubs `GIT_CONFIG_GLOBAL` (which outranks `$HOME` for git, so it would defeat the seal *and* be invisible to the guard) and `GLAB_CONFIG_DIR` (which would write a fixture token into the real glab config). It is now the only sanctioned way to drive the bootstrap; every call site uses it.
- **`test_beacon_is_silent_on_stdout`** no longer runs against the ambient `HOME` — a second leak, writing `~/.claude/.kit-hooks-alive` on the host every run.
- **`test_bootstrap_never_writes_the_operator_home`** (guard) asserts the stand-in operator home is **empty** — not merely free of `.gitconfig`, since the next leak will have a different filename — **and** that the git-config path actually ran, so it cannot pass over an empty denominator.
- **Removed `url.…insteadOf` from `ensure_github_auth`.** With the evidence withdrawn, the container question was re-asked on its own merits and the answer is no. #1082's diagnosis (container git broken) was right; the cause was that the mounted keys were unreachable to the runtime user, fixed by #1085 + `ensure_ssh_parity`. Measured in the live container `aoe-sandbox-38786f40`:

  ```
  ssh -T git@github.com                   -> Hi bakeb7j0!
  ssh -T git@gitlab.com                   -> Welcome to GitLab, @brbaker-alog!
  git ls-remote ssh://git@github.com/...  -> resolves
  ```

  **The credential helper stays** — inert for SSH remotes, correct for a genuine `https://` one. Only the rewrite hijacked remotes that hadn't asked for it.
- **`test_git_transport_matches_the_host_per_forge`** → **`test_git_transport_is_ssh_for_both_forges_with_no_url_rewrite`**, matching `insteadof` case-insensitively so `insteadof` and `pushInsteadOf` cannot slip through.
- **`scripts/ci/aoe-preflight.sh`** no longer tells operators "github: HTTPS+PAT" — the one operator-facing surface, and precisely the sort of message that gets read back later as evidence.
- **`CHANGELOG.md` / `architecture.md`** corrected. The wrong CHANGELOG sentence is annotated in place rather than erased, per house style.

## Linked Issues

Closes #1130

## Test Plan

- `./scripts/ci/validate.sh` — **247 passed, 0 failed**
- `./scripts/ci/test.sh` — **2162 passed, 0 failed**, 6 skipped, 64 xfailed
- **The proof that matters:** `~/.gitconfig` md5 `3978371252365ac2f6ff3987a4ef5839` / mtime `2026-08-19 05:31:50` **identical before and after** a full run of both suites — the exact path that poisoned it. Independently re-run by a second agent with the same result.
- Canary `HOME`: after the entire `tests/contained-workflow/` suite, the canary directory has **zero entries**.
- **Guard mutation-tested in both directions:** drop `env["HOME"]` → red; make the git-config path unreachable (`if false;`) → red on the vacuity assert with its exact message; restore → green.
- Container claims verified against the live container, not inferred from comments.

## Notes

One flagged, not claimed: `test_vox_forward::test_concurrent_drains_speak_each_message_exactly_once` failed **once** under full-suite load. It is untouched by this branch, passes 3/3 in isolation, and the suite has since gone 424/424 twice and 2162/2162. I did not reproduce it on `main` under equivalent load, so it is reported as observed-once rather than asserted pre-existing.

Removing the two lines from the operator's `~/.gitconfig` is deliberately **not** in this PR — his file, his call, and pointless before this lands.