### PR TITLE
chore(release): roll the CHANGELOG and cut v8.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ are worth keeping apart:
   `release.yml` builds from PR titles on every `v*` tag — with one hole: **7.1.3** is a real tag
   (`bae1b8d`) that never got a GitHub Release, so it has no record anywhere but `git log`.
 
-## [Unreleased]
+## [8.3.1] - 2026-08-20
 
 ### Fixed
 
@@ -47,6 +47,30 @@ are worth keeping apart:
   the operator's home is **empty** — not merely free of `.gitconfig`, since the next
   leak will have a different filename. Mutation-tested: removing the `HOME` seal
   turns it red with exactly `.gitconfig`.
+
+- **Operators: check your own `~/.gitconfig` (#1130).** The fix stops the leak; it does
+  not clean up what three weeks of test runs already wrote. Any host that ran this
+  suite still carries the planted block, invisibly routing `git@github.com:` remotes
+  onto the PAT — and `git remote -v` will not show it, because it reports the
+  *rewritten* URL:
+
+  ```sh
+  git config --global --get-regexp '^url\.'          # planted? (git remote -v won't tell you)
+  git config --get remote.origin.url                  # the RAW stored remote
+  git ls-remote --get-url origin                      # where git will ACTUALLY connect
+  ```
+
+  To remove it:
+
+  ```sh
+  git config --global --unset-all url."https://github.com/".insteadOf
+  ```
+
+  Leave `credential.https://github.com.helper` alone — it is inert for SSH remotes and
+  correct for a genuine `https://` one. **Container git is unaffected:** aoe mounts the
+  host gitconfig at `/root/.gitconfig` while the agent runs as `ubuntu` with
+  `HOME=/home/ubuntu`, and there is no gitconfig parity step, so the host block never
+  reached container git.
 
 - **Removed the github URL rewrite from the container (#1130).** With the evidence
   for it withdrawn, the question was re-asked on the container's own merits and the


### PR DESCRIPTION
## Summary

Cut **v8.3.1**, a patch release carrying #1130 (`c65cd57`) — the only commit on `main` since v8.3.0.

**The tag is the delivery mechanism that matters here.** The load-bearing half of #1130 is `containers/oakandwave-workflow/bootstrap.sh`, which ships in the **container image**, not the host kit — and `oakandwave-workflow-image.yml` builds on `v*` tags only. Without a tag the fixed bootstrap never reaches a container. None of #1130's five files are deployed by `./install`: it ships a fixed list of kit-canonical docs that does not include `docs/contained-workflow/architecture.md`, and `tests/`, `scripts/ci/` and `containers/` aren't installed at all.

**Patch, not minor.** Both entries are defect repairs — a test-isolation fix with no shipped surface, and the withdrawal of a remedy that itself landed as a fix (#1082). No new capability, no interface change, no new mount (contrast v8.3.0, which added `vox-spool` and required profile regeneration). Review also confirmed it has no mechanical consequence either way: `containers/oakandwave-workflow/adoption.py:196-213` treats minor and patch identically.

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [8.3.1] - 2026-08-20`.
- **Added an Operators section** the fix itself doesn't cover. Sealing the leak does not clean up what three weeks of test runs already wrote: any host that ran this suite still carries the planted `url.…insteadOf` block, invisibly routing `git@github.com:` remotes onto the PAT. `git remote -v` will not reveal it, because it reports the *rewritten* URL. The section gives the detection commands and the one-line unset, says explicitly to leave `credential.https://github.com.helper` alone, and records that **container git was never affected** — aoe mounts the host gitconfig at `/root/.gitconfig` while the agent runs as `ubuntu` with `HOME=/home/ubuntu`, and there is no gitconfig parity step.

## Linked Issues

Closes #1132

## Test Plan

- `./scripts/ci/validate.sh` — **247 passed, 0 failed** (re-run after the CHANGELOG edit that landed post-launch of the validation job)
- `./scripts/ci/test.sh` — **2162 passed, 0 failed**, 6 skipped, 64 xfailed
- `~/.gitconfig` md5 identical before and after the run — #1130's fix still holding
- **The remediation commands were verified, not just proofread**: planted `url.https://github.com/.insteadOf` in a throwaway `GIT_CONFIG_GLOBAL`, confirmed `--unset-all` clears it. (The planted key reads back as lowercase `insteadof`, which is exactly why #1130's replacement test matches case-insensitively.)

## Review notes

No findings at or above the bar. Review independently established that **no other file records the kit version** — no `VERSION` file, no version constant, no compare-link section; every consumer derives it from the tag (`github.ref_name`, `$CI_COMMIT_TAG`, `git describe`). So a CHANGELOG-only roll plus `v8.3.1` is complete.

One below-bar note was acted on (the Operators section above). One flagged and deliberately not fixed: `CHANGELOG.fragment.md` is a stale orphan ~600 issues out of date that nothing consumes — a decoy for anyone later hunting a fragment-staging convention that no longer exists. Not this release's job.

## Post-merge

Tagging `v8.3.1` is what mints the GitHub Release and the `:v8.3.1` registry tag. I'll verify the **published image actually contains the fixed `bootstrap.sh`** — a green workflow is not the same as a correct artifact.